### PR TITLE
node: fix payload offset for non-legacy transaction in TransactionSnapshot

### DIFF
--- a/silkworm/node/snapshot/snapshot.hpp
+++ b/silkworm/node/snapshot/snapshot.hpp
@@ -187,7 +187,9 @@ class TransactionSnapshot : public Snapshot {
     void reopen_index() override;
 
   protected:
-    static DecodingResult decode_txn(const Snapshot::WordItem& item, Transaction& tx);
+    static std::pair<ByteView, ByteView> slice_tx_data(const WordItem& item);
+    static ByteView slice_tx_payload(ByteView tx_rlp);
+    static DecodingResult decode_txn(const WordItem& item, Transaction& tx);
 
     using Walker = std::function<bool(uint64_t i, ByteView senders_data, ByteView txn_rlp)>;
     void for_each_txn(uint64_t base_txn_id, uint64_t txn_count, const Walker& walker) const;

--- a/silkworm/node/snapshot/snapshot_test.cpp
+++ b/silkworm/node/snapshot/snapshot_test.cpp
@@ -55,9 +55,9 @@ class Snapshot_ForTest : public Snapshot {
 
 class TransactionSnapshot_ForTest : public TransactionSnapshot {
   public:
+    using TransactionSnapshot::decode_txn;
     using TransactionSnapshot::slice_tx_data;
     using TransactionSnapshot::slice_tx_payload;
-    using TransactionSnapshot::decode_txn;
 };
 
 template <class Rep, class Period>


### PR DESCRIPTION
This contains also:
- some refactoring to avoid unnecessary code duplication
- more unit tests