### PR TITLE
rpcdaemon: move state creation to worker thread in TraceCallExecutor::trace_operations

### DIFF
--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -32,7 +32,6 @@ tests_with_big_json = [
 ]
 
 api_not_compared = [
-   "ots_getInternalOperations",
    "trace_rawTransaction",
    "parity_getBlockReceipts",
    "erigon_watchTheBurn",


### PR DESCRIPTION
Bugfix implemented, resolving the program freezing glitch during calls to ots_getInternalOperations API using remote database.