### PR TITLE
conan: improve searching of conan executable

### DIFF
--- a/third_party/cmake-conan/conan.cmake
+++ b/third_party/cmake-conan/conan.cmake
@@ -913,7 +913,7 @@ macro(conan_check)
         message(STATUS "Conan: checking conan executable")
     endif()
 
-    find_program(CONAN_CMD conan)
+    find_program(CONAN_CMD conan PATHS ~/.local/bin)
     if(NOT CONAN_CMD AND CONAN_REQUIRED)
         message(FATAL_ERROR "Conan executable not found! Please install conan.")
     endif()


### PR DESCRIPTION
On some configurations/platforms cmake doesn't find conan when installed locally.
It is possible to specify directories to search in addition to the default locations using PATHS in find_program.

So this PR proposes to change:

`find_program(CONAN_CMD conan)`

in

`find_program(CONAN_CMD conan PATHS ~/.local/bin)`

as proposed [here](https://github.com/conan-io/cmake-conan/pull/359)