### PR TITLE
node: use uint32 roaring bitmaps in LogIndex stage

### DIFF
--- a/silkworm/node/db/bitmap.cpp
+++ b/silkworm/node/db/bitmap.cpp
@@ -20,187 +20,39 @@
 
 #include <silkworm/core/common/cast.hpp>
 #include <silkworm/infra/common/binary_search.hpp>
+#include <silkworm/infra/common/ensure.hpp>
 #include <silkworm/infra/concurrency/signal_handler.hpp>
 
 namespace silkworm::db::bitmap {
 
-void IndexLoader::merge_bitmaps(RWTxn& txn, size_t key_size, etl::Collector* bitmaps_collector) {
-    const Bytes last_shard_suffix{db::block_key(UINT64_MAX)};
-    const size_t optimal_shard_size{
-        db::max_value_size_for_leaf_page(*txn, key_size + /*shard upper_bound*/ sizeof(uint64_t))};
-
-    db::PooledCursor target(txn, index_config_);
-    etl::LoadFunc load_func{[&last_shard_suffix, &optimal_shard_size](const etl::Entry& entry,
-                                                                      RWCursorDupSort& index_cursor,
-                                                                      MDBX_put_flags_t put_flags) -> void {
-        auto new_bitmap{db::bitmap::parse(entry.value)};  // Bitmap being merged
-
-        // Check whether we have any previous shard to merge with
-        Bytes shard_key{
-            entry.key
-                .substr(0, entry.key.size() - sizeof(uint16_t)) /* remove etl ordering suffix */
-                .append(last_shard_suffix)};                    /* and append const suffix for last key */
-
-        if (auto index_data{index_cursor.find(db::to_slice(shard_key), /*throw_notfound=*/false)}; index_data.done) {
-            // Merge previous and current bitmap
-            new_bitmap |= db::bitmap::parse(index_data.value);
-            index_cursor.erase();  // Delete currently found record as it'll be rewritten
-        }
-
-        // Consume bitmap splitting in shards
-        while (!new_bitmap.isEmpty()) {
-            auto shard{db::bitmap::cut_left(new_bitmap, optimal_shard_size)};
-            const BlockNum suffix{new_bitmap.isEmpty() /* consumed to last chunk */ ? UINT64_MAX
-                                                                                    : shard.maximum()};
-            endian::store_big_u64(&shard_key[shard_key.size() - sizeof(BlockNum)], suffix);
-            Bytes shard_bytes{db::bitmap::to_bytes(shard)};
-            mdbx::slice k{db::to_slice(shard_key)};
-            mdbx::slice v{db::to_slice(shard_bytes)};
-            mdbx::error::success_or_throw(index_cursor.put(k, &v, put_flags));
-        }
-    }};
-
-    bitmaps_collector->load(target,
-                            load_func,
-                            target.empty() ? MDBX_put_flags_t::MDBX_APPEND : MDBX_put_flags_t::MDBX_UPSERT);
-    bitmaps_collector->clear();
+template<typename BlockUpperBound>
+Bytes upper_bound_suffix(BlockUpperBound value) {
+    // Cannot use db::block_key because we need block number serialized in sizeof(BlockUpperBound) bytes
+    Bytes shard_suffix(sizeof(BlockUpperBound), '\0');
+    intx::be::unsafe::store<BlockUpperBound>(&shard_suffix[0], value);
+    return shard_suffix;
 }
 
-void IndexLoader::unwind_bitmaps(RWTxn& txn, BlockNum to, const std::map<Bytes, bool>& keys) {
-    using namespace std::chrono_literals;
-    auto log_time{std::chrono::steady_clock::now()};
-
-    db::PooledCursor target(txn, index_config_);
-    for (const auto& [key, created] : keys) {
-        // Log and abort check
-        if (const auto now{std::chrono::steady_clock::now()}; log_time <= now) {
-            if (SignalHandler::signalled()) {
-                throw std::runtime_error("Operation cancelled");
-            }
-
-            std::unique_lock log_lck(log_mtx_);
-            current_key_ = abridge(to_hex(key, true), kAddressLength);
-            log_time = now + 5s;
-        }
-
-        if (created) {
-            // Key was created in the batch we're unwinding
-            // Delete all its history
-            db::cursor_erase_prefix(target, key);
-            continue;
-        }
-
-        // Locate previous incomplete shard. There's always one if account has been touched at least once in
-        // changeset !
-        const Bytes shard_key{key + db::block_key(UINT64_MAX)};
-        auto index_data{target.find(db::to_slice(shard_key), false)};
-        while (index_data) {
-            const auto index_data_key_view{db::from_slice(index_data.key)};
-            if (!index_data_key_view.starts_with(key)) {
-                break;
-            }
-
-            auto db_bitmap{db::bitmap::parse(index_data.value)};
-            if (db_bitmap.maximum() <= to) {
-                break;
-            }
-
-            while (!db_bitmap.isEmpty() && db_bitmap.maximum() > to) {
-                db_bitmap.remove(db_bitmap.maximum());
-            }
-
-            if (db_bitmap.isEmpty()) {
-                // Delete this record and move to previous shard (if any)
-                target.erase();
-                index_data = target.to_previous(false);
-                continue;
-            }
-
-            // Replace current record with the new bitmap ensuring is marked as last shard
-            target.erase();
-            Bytes shard_bytes{db::bitmap::to_bytes(db_bitmap)};
-            target.insert(db::to_slice(shard_key), db::to_slice(shard_bytes));
-            break;
-        }
-    }
-
-    std::unique_lock log_lck(log_mtx_);
-    current_key_.clear();
+template <typename RoaringMap>
+RoaringMap parse_impl(const mdbx::slice& data) {
+    return RoaringMap::readSafe(data.char_ptr(), data.length());
 }
 
-void IndexLoader::prune_bitmaps(RWTxn& txn, BlockNum threshold) {
-    using namespace std::chrono_literals;
-    auto log_time{std::chrono::steady_clock::now()};
-
-    db::PooledCursor target(txn, index_config_);
-    auto target_data{target.to_first(/*throw_notfound=*/false)};
-    while (target_data) {
-        const auto data_key_view{db::from_slice(target_data.key)};
-        // Log and abort check
-        if (const auto now{std::chrono::steady_clock::now()}; log_time <= now) {
-            if (SignalHandler::signalled()) {
-                throw std::runtime_error("Operation cancelled");
-            }
-            std::unique_lock log_lck(log_mtx_);
-            current_key_ = abridge(to_hex(data_key_view, true), kAddressLength);
-            log_time = now + 5s;
-        }
-
-        // Suffix indicates the upper bound of the shard.
-        const auto suffix{endian::load_big_u64(&data_key_view[data_key_view.size() - sizeof(BlockNum)])};
-
-        // If below pruning threshold simply delete the record
-        if (suffix <= threshold) {
-            target.erase();
-        } else {
-            // Read current bitmap
-            auto bitmap{db::bitmap::parse(target_data.value)};
-            bool shard_shrunk{false};
-            while (!bitmap.isEmpty() && bitmap.minimum() <= threshold) {
-                bitmap.remove(bitmap.minimum());
-                shard_shrunk = true;
-            }
-            if (bitmap.isEmpty() || shard_shrunk) {
-                if (!bitmap.isEmpty()) {
-                    Bytes new_shard_data{db::bitmap::to_bytes(bitmap)};
-                    target.update(db::to_slice(data_key_view), db::to_slice(new_shard_data));
-                } else {
-                    target.erase();
-                }
-            }
-        }
-
-        target_data = target.to_next(/*throw_notfound=*/false);
-    }
-
-    std::unique_lock log_lck(log_mtx_);
-    current_key_.clear();
+template <typename RoaringMap>
+RoaringMap parse_impl(const ByteView data) {
+    return RoaringMap::readSafe(byte_ptr_cast(&data[0]), data.size());
 }
 
-void IndexLoader::flush_bitmaps_to_etl(absl::btree_map<Bytes, roaring::Roaring64Map>& bitmaps,
-                                       etl::Collector* collector, uint16_t flush_count) {
-    for (auto& [key, bitmap] : bitmaps) {
-        Bytes etl_key(key.size() + sizeof(uint16_t), '\0');
-        std::memcpy(&etl_key[0], key.data(), key.size());
-        endian::store_big_u16(&etl_key[key.size()], flush_count);
-        collector->collect({etl_key, db::bitmap::to_bytes(bitmap)});
-    }
-    bitmaps.clear();
-}
+template <typename RoaringMap>
+void remove_range_impl(RoaringMap& bm, uint64_t min, uint64_t max);
 
-std::optional<uint64_t> seek(const roaring::Roaring64Map& bitmap, uint64_t n) {
-    auto it{bitmap.begin()};
-    if (it.move(n)) {
-        return *it;
-    }
-    return std::nullopt;
-}
-
-static void remove_range_impl(roaring::Roaring& bm, uint64_t min, uint64_t max) {
+template <>
+[[maybe_unused]] void remove_range_impl<roaring::Roaring>(roaring::Roaring& bm, uint64_t min, uint64_t max) {
     roaring::api::roaring_bitmap_remove_range(&bm.roaring, min, max);
 }
 
-static void remove_range_impl(roaring::Roaring64Map& bm, uint64_t min, uint64_t max) {
+template <>
+[[maybe_unused]] void remove_range_impl(roaring::Roaring64Map& bm, uint64_t min, uint64_t max) {
     for (uint64_t k = min; k < max; ++k) {
         bm.remove(k);
     }
@@ -229,15 +81,227 @@ RoaringMap cut_left_impl(RoaringMap& bm, uint64_t size_limit) {
     RoaringMap res(roaring::api::roaring_bitmap_from_range(from, from + cutting_point, 1));
     res &= bm;
     res.runOptimize();
-    remove_range_impl(bm, from, from + cutting_point);
+    remove_range_impl<RoaringMap>(bm, from, from + cutting_point);
     return res;
+}
+
+template <typename RoaringMap, typename BlockUpperBound>
+void IndexLoader::merge_bitmaps_impl(RWTxn& txn, size_t key_size, etl::Collector* bitmaps_collector) {
+    // Cannot use db::block_key because we need block number serialized in sizeof(BlockUpperBound) bytes
+    Bytes last_shard_suffix{upper_bound_suffix(std::numeric_limits<BlockUpperBound>::max())};
+
+    const size_t optimal_shard_size{
+        db::max_value_size_for_leaf_page(*txn, key_size + /*shard upper_bound*/ sizeof(BlockUpperBound))};
+
+    db::PooledCursor target(txn, index_config_);
+    etl::LoadFunc load_func{[&last_shard_suffix, &optimal_shard_size](const etl::Entry& entry,
+                                                                      RWCursorDupSort& index_cursor,
+                                                                      MDBX_put_flags_t put_flags) -> void {
+        auto new_bitmap{db::bitmap::parse_impl<RoaringMap>(entry.value)};  // Bitmap being merged
+
+        // Check whether we have any previous shard to merge with
+        Bytes shard_key{
+            entry.key
+                .substr(0, entry.key.size() - sizeof(uint16_t)) /* remove etl ordering suffix */
+                .append(last_shard_suffix)};                    /* and append const suffix for last key */
+
+        if (auto index_data{index_cursor.find(db::to_slice(shard_key), /*throw_notfound=*/false)}; index_data.done) {
+            // Merge previous and current bitmap
+            new_bitmap |= db::bitmap::parse_impl<RoaringMap>(index_data.value);
+            index_cursor.erase();  // Delete currently found record as it'll be rewritten
+        }
+
+        // Consume bitmap splitting in shards
+        while (!new_bitmap.isEmpty()) {
+            auto shard{db::bitmap::cut_left_impl<RoaringMap>(new_bitmap, optimal_shard_size)};
+            const bool consumed_to_last_chunk{new_bitmap.isEmpty()};
+            const BlockUpperBound suffix{consumed_to_last_chunk ? std::numeric_limits<BlockUpperBound>::max() : shard.maximum()};
+            intx::be::unsafe::store<BlockUpperBound>(&shard_key[shard_key.size() - sizeof(BlockUpperBound)], suffix);
+            Bytes shard_bytes{db::bitmap::to_bytes(shard)};
+            mdbx::slice k{db::to_slice(shard_key)};
+            mdbx::slice v{db::to_slice(shard_bytes)};
+            mdbx::error::success_or_throw(index_cursor.put(k, &v, put_flags));
+        }
+    }};
+
+    bitmaps_collector->load(target,
+                            load_func,
+                            target.empty() ? MDBX_put_flags_t::MDBX_APPEND : MDBX_put_flags_t::MDBX_UPSERT);
+    bitmaps_collector->clear();
+}
+
+template <typename RoaringMap, typename BlockUpperBound>
+void IndexLoader::unwind_bitmaps_impl(RWTxn& txn, BlockNum to, const std::map<Bytes, bool>& keys) {
+    using namespace std::chrono_literals;
+    auto log_time{std::chrono::steady_clock::now()};
+
+    db::PooledCursor target(txn, index_config_);
+    for (const auto& [key, created] : keys) {
+        // Log and abort check
+        if (const auto now{std::chrono::steady_clock::now()}; log_time <= now) {
+            if (SignalHandler::signalled()) {
+                throw std::runtime_error("Operation cancelled");
+            }
+
+            std::unique_lock log_lck(log_mtx_);
+            current_key_ = abridge(to_hex(key, true), kAddressLength);
+            log_time = now + 5s;
+        }
+
+        if (created) {
+            // Key was created in the batch we're unwinding
+            // Delete all its history
+            db::cursor_erase_prefix(target, key);
+            continue;
+        }
+
+        // Locate previous incomplete shard. There's always one if account has been touched at least once in changeset
+        const Bytes shard_key{key + upper_bound_suffix(std::numeric_limits<BlockUpperBound>::max())};
+        auto index_data{target.find(db::to_slice(shard_key), false)};
+        while (index_data) {
+            const auto index_data_key_view{db::from_slice(index_data.key)};
+            if (!index_data_key_view.starts_with(key)) {
+                break;
+            }
+
+            auto db_bitmap{db::bitmap::parse_impl<RoaringMap>(index_data.value)};
+            if (db_bitmap.maximum() <= to) {
+                break;
+            }
+
+            while (!db_bitmap.isEmpty() && db_bitmap.maximum() > to) {
+                db_bitmap.remove(db_bitmap.maximum());
+            }
+
+            if (db_bitmap.isEmpty()) {
+                // Delete this record and move to previous shard (if any)
+                target.erase();
+                index_data = target.to_previous(false);
+                continue;
+            }
+
+            // Replace current record with the new bitmap ensuring is marked as last shard
+            target.erase();
+            Bytes shard_bytes{db::bitmap::to_bytes(db_bitmap)};
+            target.insert(db::to_slice(shard_key), db::to_slice(shard_bytes));
+            break;
+        }
+    }
+
+    std::unique_lock log_lck(log_mtx_);
+    current_key_.clear();
+}
+
+void IndexLoader::merge_bitmaps32(RWTxn& txn, size_t key_size, etl::Collector* bitmaps_collector) {
+    merge_bitmaps_impl<roaring::Roaring, uint32_t>(txn, key_size, bitmaps_collector);
+}
+
+void IndexLoader::merge_bitmaps(RWTxn& txn, size_t key_size, etl::Collector* bitmaps_collector) {
+    merge_bitmaps_impl<roaring::Roaring64Map, uint64_t>(txn, key_size, bitmaps_collector);
+}
+
+void IndexLoader::unwind_bitmaps32(RWTxn& txn, BlockNum to, const std::map<Bytes, bool>& keys) {
+    unwind_bitmaps_impl<roaring::Roaring, uint32_t>(txn, to, keys);
+}
+
+void IndexLoader::unwind_bitmaps(RWTxn& txn, BlockNum to, const std::map<Bytes, bool>& keys) {
+    unwind_bitmaps_impl<roaring::Roaring64Map, uint64_t>(txn, to, keys);
+}
+
+template <typename RoaringMap, typename BlockUpperBound>
+void IndexLoader::prune_bitmaps_impl(RWTxn& txn, BlockNum threshold) {
+    using namespace std::chrono_literals;
+    auto log_time{std::chrono::steady_clock::now()};
+
+    db::PooledCursor target(txn, index_config_);
+    auto target_data{target.to_first(/*throw_notfound=*/false)};
+    while (target_data) {
+        const auto data_key_view{db::from_slice(target_data.key)};
+        // Log and abort check
+        if (const auto now{std::chrono::steady_clock::now()}; log_time <= now) {
+            if (SignalHandler::signalled()) {
+                throw std::runtime_error("Operation cancelled");
+            }
+            std::unique_lock log_lck(log_mtx_);
+            current_key_ = abridge(to_hex(data_key_view, true), kAddressLength);
+            log_time = now + 5s;
+        }
+
+        // Suffix indicates the upper bound of the shard.
+        ensure(data_key_view.size() >= sizeof(BlockUpperBound), "invalid key size " + std::to_string(data_key_view.size()));
+        const auto suffix{intx::be::unsafe::load<BlockUpperBound>(&data_key_view[data_key_view.size() - sizeof(BlockUpperBound)])};
+
+        // If below pruning threshold simply delete the record
+        if (suffix <= threshold) {
+            target.erase();
+        } else {
+            // Read current bitmap
+            auto bitmap{db::bitmap::parse_impl<RoaringMap>(target_data.value)};
+            bool shard_shrunk{false};
+            while (!bitmap.isEmpty() && bitmap.minimum() <= threshold) {
+                bitmap.remove(bitmap.minimum());
+                shard_shrunk = true;
+            }
+            if (bitmap.isEmpty() || shard_shrunk) {
+                if (!bitmap.isEmpty()) {
+                    Bytes new_shard_data{db::bitmap::to_bytes(bitmap)};
+                    target.update(db::to_slice(data_key_view), db::to_slice(new_shard_data));
+                } else {
+                    target.erase();
+                }
+            }
+        }
+
+        target_data = target.to_next(/*throw_notfound=*/false);
+    }
+
+    std::unique_lock log_lck(log_mtx_);
+    current_key_.clear();
+}
+
+void IndexLoader::prune_bitmaps32(RWTxn& txn, BlockNum threshold) {
+    prune_bitmaps_impl<roaring::Roaring, uint32_t>(txn, threshold);
+}
+
+void IndexLoader::prune_bitmaps(RWTxn& txn, BlockNum threshold) {
+    prune_bitmaps_impl<roaring::Roaring64Map, uint64_t>(txn, threshold);
+}
+
+template <typename RoaringMap>
+void flush_bitmaps_impl(absl::btree_map<Bytes, RoaringMap>& bitmaps, etl::Collector* collector, uint16_t flush_count) {
+    for (auto& [key, bitmap] : bitmaps) {
+        Bytes etl_key(key.size() + sizeof(uint16_t), '\0');
+        std::memcpy(&etl_key[0], key.data(), key.size());
+        endian::store_big_u16(&etl_key[key.size()], flush_count);
+        collector->collect({etl_key, db::bitmap::to_bytes(bitmap)});
+    }
+    bitmaps.clear();
+}
+
+void IndexLoader::flush_bitmaps_to_etl(absl::btree_map<Bytes, roaring::Roaring64Map>& bitmaps,
+                                       etl::Collector* collector, uint16_t flush_count) {
+    flush_bitmaps_impl(bitmaps, collector, flush_count);
+}
+
+void IndexLoader::flush_bitmaps_to_etl(absl::btree_map<Bytes, roaring::Roaring>& bitmaps,
+                                       etl::Collector* collector, uint16_t flush_count) {
+    flush_bitmaps_impl(bitmaps, collector, flush_count);
+}
+
+std::optional<uint64_t> seek(const roaring::Roaring64Map& bitmap, uint64_t n) {
+    auto it{bitmap.begin()};
+    if (it.move(n)) {
+        return *it;
+    }
+    return std::nullopt;
 }
 
 roaring::Roaring cut_left(roaring::Roaring& bm, uint64_t size_limit) { return cut_left_impl(bm, size_limit); }
 
 roaring::Roaring64Map cut_left(roaring::Roaring64Map& bm, uint64_t size_limit) { return cut_left_impl(bm, size_limit); }
 
-Bytes to_bytes(roaring::Roaring64Map& bitmap) {
+template <typename RoaringMap>
+Bytes bitmap_to_bytes(RoaringMap& bitmap) {
     if (!bitmap.isEmpty()) {
         Bytes ret(bitmap.getSizeInBytes(), '\0');
         bitmap.write(byte_ptr_cast(&ret[0]));
@@ -246,11 +310,20 @@ Bytes to_bytes(roaring::Roaring64Map& bitmap) {
     return {};
 }
 
+Bytes to_bytes(roaring::Roaring64Map& bitmap) {
+    return bitmap_to_bytes(bitmap);
+}
+
+Bytes to_bytes(roaring::Roaring& bitmap) {
+    return bitmap_to_bytes(bitmap);
+}
+
 roaring::Roaring64Map parse(const mdbx::slice& data) {
-    return roaring::Roaring64Map::readSafe(data.char_ptr(), data.length());
+    return parse_impl<roaring::Roaring64Map>(data);
 }
 
 roaring::Roaring64Map parse(const ByteView data) {
-    return roaring::Roaring64Map::readSafe(byte_ptr_cast(&data[0]), data.size());
+    return parse_impl<roaring::Roaring64Map>(data);
 }
+
 }  // namespace silkworm::db::bitmap

--- a/silkworm/node/db/bitmap.cpp
+++ b/silkworm/node/db/bitmap.cpp
@@ -25,7 +25,7 @@
 
 namespace silkworm::db::bitmap {
 
-template<typename BlockUpperBound>
+template <typename BlockUpperBound>
 Bytes upper_bound_suffix(BlockUpperBound value) {
     // Cannot use db::block_key because we need block number serialized in sizeof(BlockUpperBound) bytes
     Bytes shard_suffix(sizeof(BlockUpperBound), '\0');

--- a/silkworm/node/db/bitmap.hpp
+++ b/silkworm/node/db/bitmap.hpp
@@ -51,17 +51,20 @@ class IndexLoader {
     //! \param key_size [in] : The actual length of key in the list of bitmap shards (the index)
     //! \param collector [in] : A pointer to the etl::collector holding the bitmaps to be merged
     void merge_bitmaps(RWTxn& txn, size_t key_size, etl::Collector* bitmaps_collector);
+    void merge_bitmaps32(RWTxn& txn, size_t key_size, etl::Collector* bitmaps_collector);
 
     //! \brief Provided a list of keys for which the unwind should be applied this removes right values from shards
     //! \param txn [in] : An MDBX transaction holder
     //! \param to [in] : The block height we should unwind index to
     //! \param keys [in] : The keys of index we should unwind
     void unwind_bitmaps(RWTxn& txn, BlockNum to, const std::map<Bytes, bool>& keys);
+    void unwind_bitmaps32(RWTxn& txn, BlockNum to, const std::map<Bytes, bool>& keys);
 
     //! \brief Traverses all the index and for each bitmap removes left values <= threshold
     //! \param txn [in] : An MDBX transaction holder
     //! \param threshold [in] : The block height before which bitmaps values need to be pruned
     void prune_bitmaps(RWTxn& txn, BlockNum threshold);
+    void prune_bitmaps32(RWTxn& txn, BlockNum threshold);
 
     //! \brief Returns the hex representation of currently processed key
     [[nodiscard]] std::string get_current_key() const {
@@ -69,8 +72,7 @@ class IndexLoader {
         return current_key_;
     }
 
-    //! \brief Flushes a collected map of Bitmaps into an etl::Collector taking care of proper keys sorting
-    //! for subsequent load
+    //! \brief Flushes a collected map of Bitmaps into an etl::Collector taking care of proper keys sorting for subsequent load
     //! \param bitmaps [in] : A map of keys and related bitmaps
     //! \param collector [in] : The collector to flush to
     //! \param flush_count [in]
@@ -79,8 +81,19 @@ class IndexLoader {
     //! they've been collected. uint16_t maxes 65K flushes
     static void flush_bitmaps_to_etl(absl::btree_map<Bytes, roaring::Roaring64Map>& bitmaps,
                                      etl::Collector* collector, uint16_t flush_count);
+    static void flush_bitmaps_to_etl(absl::btree_map<Bytes, roaring::Roaring>& bitmaps,
+                                     etl::Collector* collector, uint16_t flush_count);
 
   private:
+    template <typename RoaringMap, typename BlockUpperBound>
+    void merge_bitmaps_impl(RWTxn& txn, size_t key_size, etl::Collector* bitmaps_collector);
+
+    template <typename RoaringMap, typename BlockUpperBound>
+    void unwind_bitmaps_impl(RWTxn& txn, BlockNum to, const std::map<Bytes, bool>& keys);
+
+    template <typename RoaringMap, typename BlockUpperBound>
+    void prune_bitmaps_impl(RWTxn& txn, BlockNum threshold);
+
     const db::MapConfig& index_config_;  // The bucket config holding the index of maps
     mutable std::mutex log_mtx_;         // To get progress status
     std::string current_key_;            // Key being processed
@@ -97,13 +110,16 @@ roaring::Roaring64Map cut_left(roaring::Roaring64Map& bitmap, uint64_t size_limi
 // Remove from a bitmap and return its biggest left part not exceeding a given size
 roaring::Roaring cut_left(roaring::Roaring& bitmap, uint64_t size_limit);
 
-//! \brief Returns Bytes of Roaring64Map data
+//! \brief Return bytes of Roaring64Map data
 Bytes to_bytes(roaring::Roaring64Map& bitmap);
 
-//! \brief Returns Roaring64Map from MDBX's slice;
+//! \brief Return bytes of Roaring data
+Bytes to_bytes(roaring::Roaring& bitmap);
+
+//! \brief Parse 64-bit roaring bitmap from MDBX slice
 roaring::Roaring64Map parse(const mdbx::slice& data);
 
-//! \brief Returns Roaring64Map from Bytes/Byteview;
+//! \brief Parse 64-bit roaring bitmap from ByteView
 roaring::Roaring64Map parse(const ByteView data);
 
 }  // namespace silkworm::db::bitmap


### PR DESCRIPTION
For binary compatibility with Erigon 2 database