### PR TITLE
Fix tests under debug (remove failing assert)

### DIFF
--- a/silkworm/core/execution/evm.cpp
+++ b/silkworm/core/execution/evm.cpp
@@ -468,7 +468,6 @@ evmc_tx_context EvmHost::get_tx_context() const noexcept {
     context.block_coinbase = evm_.beneficiary;
     assert(header.number <= INT64_MAX);  // EIP-1985
     context.block_number = static_cast<int64_t>(header.number);
-    assert(header.timestamp <= INT64_MAX);  // EIP-1985
     context.block_timestamp = static_cast<int64_t>(header.timestamp);
     assert(header.gas_limit <= INT64_MAX);  // EIP-1985
     context.block_gas_limit = static_cast<int64_t>(header.gas_limit);


### PR DESCRIPTION
Post-fix to PR #1472. Some execution-spec tests use timestamps > INT64_MAX.