### PR TITLE
sync: handle spec timeout for Engine API endpoints

### DIFF
--- a/cmd/test/CMakeLists.txt
+++ b/cmd/test/CMakeLists.txt
@@ -16,6 +16,7 @@
 
 find_package(Catch2 REQUIRED)
 find_package(magic_enum REQUIRED)
+find_package(GTest REQUIRED)
 
 # Silkworm Core Tests
 file(GLOB_RECURSE SILKWORM_CORE_TESTS CONFIGURE_DEPENDS "${SILKWORM_MAIN_SRC_DIR}/core/*_test.cpp")
@@ -57,7 +58,7 @@ if(NOT SILKWORM_CORE_ONLY)
   if(SILKWORM_SANITIZE)
     target_compile_definitions(sync_test PRIVATE GRPC_ASAN_SUPPRESSED GRPC_TSAN_SUPPRESSED)
   endif()
-  target_link_libraries(sync_test silkworm_node silkworm_sync Catch2::Catch2)
+  target_link_libraries(sync_test silkworm_node silkworm_sync Catch2::Catch2 GTest::gmock)
 
   # Ethereum EL Tests (https://github.com/ethereum/tests)
   find_package(CLI11 REQUIRED)

--- a/silkworm/node/test/mock_execution_client.hpp
+++ b/silkworm/node/test/mock_execution_client.hpp
@@ -1,0 +1,63 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <optional>
+#include <vector>
+
+#include <silkworm/infra/concurrency/task.hpp>
+
+#include <boost/asio/io_context.hpp>
+#include <gmock/gmock.h>
+
+#include <silkworm/core/common/base.hpp>
+#include <silkworm/core/types/block.hpp>
+#include <silkworm/core/types/hash.hpp>
+#include <silkworm/node/stagedsync/client.hpp>
+#include <silkworm/node/stagedsync/types.hpp>
+
+namespace silkworm::test {
+
+//! \brief MockBlockExchange is the gMock mock class for execution::Client.
+class MockClient : public execution::Client {
+  public:
+    MOCK_METHOD((boost::asio::io_context&), get_executor, (), (override));
+
+    MOCK_METHOD((Task<void>), insert_headers, (const execution::BlockVector&), (override));
+    MOCK_METHOD((Task<void>), insert_bodies, (const execution::BlockVector&), (override));
+    MOCK_METHOD((Task<void>), insert_blocks, (const execution::BlockVector&), (override));
+
+    MOCK_METHOD((Task<execution::ValidationResult>), validate_chain, (Hash), (override));
+
+    MOCK_METHOD((Task<execution::ForkChoiceApplication>), update_fork_choice, (Hash, std::optional<Hash>), (override));
+
+    MOCK_METHOD((Task<BlockNum>), block_progress, (), (override));
+    MOCK_METHOD((Task<BlockId>), last_fork_choice, (), (override));
+
+    MOCK_METHOD((Task<std::optional<BlockHeader>>), get_header, (Hash), (override));
+    MOCK_METHOD((Task<std::optional<BlockHeader>>), get_header, (BlockNum, Hash), (override));
+    MOCK_METHOD((Task<std::optional<BlockBody>>), get_body, (Hash), (override));
+    MOCK_METHOD((Task<std::optional<BlockBody>>), get_body, (BlockNum), (override));
+
+    MOCK_METHOD((Task<bool>), is_canonical, (Hash), (override));
+    MOCK_METHOD((Task<std::optional<BlockNum>>), get_block_num, (Hash), (override));
+
+    MOCK_METHOD((Task<std::vector<BlockHeader>>), get_last_headers, (BlockNum), (override));
+    MOCK_METHOD((Task<std::optional<TotalDifficulty>>), get_header_td, (Hash, std::optional<BlockNum>), (override));
+};
+
+}  // namespace silkworm::test

--- a/silkworm/sync/block_exchange.hpp
+++ b/silkworm/sync/block_exchange.hpp
@@ -33,7 +33,7 @@ namespace silkworm {
 class SentryClient;
 
 //! \brief Implement the logic needed to download headers and bodies
-class BlockExchange final : public ActiveComponent {
+class BlockExchange : public ActiveComponent {
   public:
     BlockExchange(SentryClient&, const db::ROAccess&, const ChainConfig&);
     ~BlockExchange() override;

--- a/silkworm/sync/engine_api_backend.cpp
+++ b/silkworm/sync/engine_api_backend.cpp
@@ -16,26 +16,30 @@
 
 #include "engine_api_backend.hpp"
 
+#include <chrono>
+
+using namespace std::chrono_literals;
+
 namespace silkworm::chainsync {
 
 Task<rpc::PayloadStatus> EngineApiBackend::engine_new_payload(const rpc::ExecutionPayload& payload) {
-    co_return co_await pos_sync_.new_payload(payload);
+    co_return co_await pos_sync_.new_payload(payload, 8s);
 }
 
 Task<rpc::ExecutionPayloadAndValue> EngineApiBackend::engine_get_payload(uint64_t payload_id) {
-    co_return co_await pos_sync_.get_payload(payload_id);
+    co_return co_await pos_sync_.get_payload(payload_id, 1s);
 }
 
 Task<rpc::ForkChoiceUpdatedReply> EngineApiBackend::engine_forkchoice_updated(const rpc::ForkChoiceUpdatedRequest& fcu_request) {
-    co_return co_await pos_sync_.fork_choice_update(fcu_request.fork_choice_state, fcu_request.payload_attributes);
+    co_return co_await pos_sync_.fork_choice_update(fcu_request.fork_choice_state, fcu_request.payload_attributes, 8s);
 }
 
 Task<rpc::ExecutionPayloadBodies> EngineApiBackend::engine_get_payload_bodies_by_hash(const std::vector<Hash>& block_hashes) {
-    co_return co_await pos_sync_.get_payload_bodies_by_hash(block_hashes);
+    co_return co_await pos_sync_.get_payload_bodies_by_hash(block_hashes, 10s);
 }
 
 Task<rpc::ExecutionPayloadBodies> EngineApiBackend::engine_get_payload_bodies_by_range(BlockNum start, uint64_t count) {
-    co_return co_await pos_sync_.get_payload_bodies_by_range(start, count);
+    co_return co_await pos_sync_.get_payload_bodies_by_range(start, count, 10s);
 }
 
 Task<evmc::address> EngineApiBackend::etherbase() {

--- a/silkworm/sync/internals/body_sequence.cpp
+++ b/silkworm/sync/internals/body_sequence.cpp
@@ -59,7 +59,7 @@ size_t BodySequence::outstanding_requests(time_point_t tp) const {
     return (requested_bodies + kMaxBlocksPerMessage - 1) / kMaxBlocksPerMessage;
 }
 
-Penalty BodySequence::accept_requested_bodies(BlockBodiesPacket66& packet, const PeerId&) {
+Penalty BodySequence::accept_requested_bodies(BlockBodiesPacket66& packet, const PeerId& peer) {
     Penalty penalty = NoPenalty;
     BlockNum start_block = std::numeric_limits<BlockNum>::max();
     size_t count = 0;
@@ -99,6 +99,9 @@ Penalty BodySequence::accept_requested_bodies(BlockBodiesPacket66& packet, const
         }
 
         BodyRequest& request = exact_request->second;
+        if (!body.withdrawals) {
+            SILK_WARN << "BodySequence: body " << request.block_height << " w/o withdrawals received from peer " << to_hex(human_readable_id(peer));
+        }
         if (!request.ready) {
             request.body = std::move(body);
             request.ready = true;

--- a/silkworm/sync/internals/body_sequence_test.cpp
+++ b/silkworm/sync/internals/body_sequence_test.cpp
@@ -22,6 +22,7 @@
 
 #include <silkworm/core/chain/genesis.hpp>
 #include <silkworm/core/common/cast.hpp>
+#include <silkworm/infra/test_util/log.hpp>
 #include <silkworm/node/db/genesis.hpp>
 #include <silkworm/node/test/context.hpp>
 #include <silkworm/sync/sentry_client.hpp>
@@ -45,6 +46,7 @@ TEST_CASE("body downloading", "[silkworm][sync][BodySequence]") {
     using namespace std::chrono_literals;
     using intx::operator""_u256;
 
+    test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
     test::Context context;
     context.add_genesis_data();
 

--- a/silkworm/sync/sync_pos.cpp
+++ b/silkworm/sync/sync_pos.cpp
@@ -27,11 +27,14 @@
 #include <silkworm/infra/common/ensure.hpp>
 #include <silkworm/infra/common/measure.hpp>
 #include <silkworm/infra/common/stopwatch.hpp>
+#include <silkworm/infra/concurrency/awaitable_wait_for_one.hpp>
+#include <silkworm/infra/concurrency/timeout.hpp>
 #include <silkworm/silkrpc/protocol/errors.hpp>
 
 namespace silkworm::chainsync {
 
 using namespace boost::asio;
+using namespace concurrency::awaitable_wait_for_one;
 
 class PayloadValidationError : public std::logic_error {
   public:
@@ -173,7 +176,7 @@ std::tuple<bool, Hash> PoSSync::has_valid_ancestor(const Hash&) {
     return {true, Hash()};  // todo: implement, return if it is valid or the first valid ancestor
 }
 
-Task<rpc::PayloadStatus> PoSSync::new_payload(const rpc::ExecutionPayload& payload) {
+Task<rpc::PayloadStatus> PoSSync::new_payload(const rpc::ExecutionPayload& payload, std::chrono::milliseconds timeout) {
     // Implementation of engine_new_payloadVx method
     using namespace execution;
     constexpr evmc::bytes32 kZeroHash = 0x0000000000000000000000000000000000000000000000000000000000000000_bytes32;
@@ -185,7 +188,9 @@ Task<rpc::PayloadStatus> PoSSync::new_payload(const rpc::ExecutionPayload& paylo
         auto block = make_execution_block(payload);  // as per the EngineAPI spec
 
         Hash block_hash = block->header.hash();
-        if (payload.block_hash != block_hash) co_return rpc::PayloadStatus::InvalidBlockHash;
+        if (payload.block_hash != block_hash) {
+            co_return rpc::PayloadStatus::InvalidBlockHash;
+        }
         log::Info() << "PoSSync: new_payload block_hash=" << block_hash << " block_number: " << block->header.number;
 
         auto [valid, last_valid] = has_valid_ancestor(block_hash);
@@ -206,7 +211,7 @@ Task<rpc::PayloadStatus> PoSSync::new_payload(const rpc::ExecutionPayload& paylo
             // if found, add it to the chain_fork_view_ and calc total difficulty
             parent_td = co_await exec_engine_.get_header_td(block->header.parent_hash, block->header.number - 1);
             // TODO(canepat) either remove caching here or use a distinct cache (the same ChainForkView eats on itself)
-            // chain_fork_view_.add(*parent, *parent_td);
+            chain_fork_view_.add(*parent, *parent_td);
         }  // maybe we can simplify the code above returning Syncing if parent_td is not found on  chain_fork_view
 
         // do sanity checks
@@ -225,7 +230,7 @@ Task<rpc::PayloadStatus> PoSSync::new_payload(const rpc::ExecutionPayload& paylo
         log::Trace() << "PoSSync: new_payload block_number=" << *inserted << " inserted";
 
         // NOTE: from here the method execution can be cancelled
-        auto verification = co_await exec_engine_.validate_chain(block_hash);
+        auto verification = co_await (exec_engine_.validate_chain(block_hash) || concurrency::timeout(timeout));
 
         if (std::holds_alternative<ValidChain>(verification)) {
             // VALID
@@ -252,6 +257,9 @@ Task<rpc::PayloadStatus> PoSSync::new_payload(const rpc::ExecutionPayload& paylo
     } catch (const PayloadValidationError& e) {
         log::Info() << "PoSSync: new_payload payload validation error: " << e.what();
         co_return rpc::PayloadStatus{rpc::PayloadStatus::kInvalid, no_latest_valid_hash, e.what()};
+    } catch (const concurrency::TimeoutExpiredError& tee) {
+        log::Warning() << "PoSSync: new_payload timeout expired: " << tee.what();
+        co_return rpc::PayloadStatus::Syncing;
     } catch (const boost::system::system_error& e) {
         log::Error() << "PoSSync: error processing payload: " << e.what();
         throw;
@@ -261,18 +269,17 @@ Task<rpc::PayloadStatus> PoSSync::new_payload(const rpc::ExecutionPayload& paylo
     }
 }
 
-Task<rpc::ForkChoiceUpdatedReply> PoSSync::fork_choice_update(
-    const rpc::ForkChoiceState& state,
-    const std::optional<rpc::PayloadAttributes>& attributes) {
+Task<rpc::ForkChoiceUpdatedReply> PoSSync::fork_choice_update(const rpc::ForkChoiceState& state,
+                                                              const std::optional<rpc::PayloadAttributes>& attributes,
+                                                              std::chrono::milliseconds timeout) {
     // Implementation of engine_forkchoiceUpdatedVx method
     using namespace execution;
     constexpr evmc::bytes32 kZeroHash = 0x0000000000000000000000000000000000000000000000000000000000000000_bytes32;
     auto terminal_total_difficulty = block_exchange_.chain_config().terminal_total_difficulty;
     auto no_latest_valid_hash = std::nullopt;
-    auto no_payload_id = std::nullopt;
     try {
         if (!state.head_block_hash) {
-            co_return rpc::ForkChoiceUpdatedReply{{rpc::PayloadStatus::kInvalid, no_latest_valid_hash, "invalid head block hash"}, no_payload_id};
+            co_return rpc::ForkChoiceUpdatedReply{{rpc::PayloadStatus::kInvalid, no_latest_valid_hash, "invalid head block hash"}};
         }
         log::Info() << "PoSSync: fork_choice_update head_block_hash=" << to_hex(state.head_block_hash)
                     << " safe_block_hash=" << to_hex(state.safe_block_hash) << " finalized_block_hash=" << to_hex(state.finalized_block_hash);
@@ -281,12 +288,12 @@ Task<rpc::ForkChoiceUpdatedReply> PoSSync::fork_choice_update(
         auto head_header = co_await exec_engine_.get_header(head_header_hash);  // todo: decide whether to use chain_fork_view_ cache instead
         if (!head_header) {
             auto [valid, last_valid] = has_valid_ancestor(head_header_hash);
-            if (!valid) co_return rpc::ForkChoiceUpdatedReply{{rpc::PayloadStatus::kInvalid, last_valid, "bad ancestor"}, no_payload_id};
+            if (!valid) co_return rpc::ForkChoiceUpdatedReply{{rpc::PayloadStatus::kInvalid, last_valid, "bad ancestor"}};
 
             log::Info() << "PoSSync: fork_choice_update head header not found => SYNCING";
             // send payload to the block exchange to extend the chain up to it
             // block_exchange_.new_target_block(head_header_hash);  // todo: implement this!
-            co_return rpc::ForkChoiceUpdatedReply{rpc::PayloadStatus::Syncing, no_payload_id};
+            co_return rpc::ForkChoiceUpdatedReply{rpc::PayloadStatus::Syncing};
         }
 
         // BlockId head{head_header->number, head_header_hash};
@@ -294,19 +301,19 @@ Task<rpc::ForkChoiceUpdatedReply> PoSSync::fork_choice_update(
         auto parent = co_await exec_engine_.get_header(head_header->parent_hash);  // todo: decide whether to use chain_fork_view_ cache instead
         if (!parent) {
             log::Info() << "PoSSync: fork_choice_update parent header not found => SYNCING";
-            co_return rpc::ForkChoiceUpdatedReply{rpc::PayloadStatus::Syncing, no_payload_id};
+            co_return rpc::ForkChoiceUpdatedReply{rpc::PayloadStatus::Syncing};
         }
         auto parent_td = chain_fork_view_.get_total_difficulty(head_header->number - 1, head_header->parent_hash);
         if (!parent_td) {
             log::Info() << "PoSSync: fork_choice_update TD not found for parent block number=" << (head_header->number - 1)
                         << " hash=" << to_hex(head_header->parent_hash) << " => SYNCING";
-            co_return rpc::ForkChoiceUpdatedReply{rpc::PayloadStatus::Syncing, no_payload_id};
+            co_return rpc::ForkChoiceUpdatedReply{rpc::PayloadStatus::Syncing};
         }
 
         do_sanity_checks(*head_header, /**parent,*/ *parent_td);
 
         // NOTE: from here the method execution can be cancelled
-        auto verification = co_await exec_engine_.validate_chain(head_header_hash);  // does nothing if previously validated
+        auto verification = co_await (exec_engine_.validate_chain(head_header_hash) || concurrency::timeout(timeout));  // does nothing if previously validated
 
         if (std::holds_alternative<InvalidChain>(verification)) {
             // INVALID
@@ -316,13 +323,13 @@ Task<rpc::ForkChoiceUpdatedReply> PoSSync::fork_choice_update(
                                          ? kZeroHash
                                          : invalid_chain.latest_valid_head;
             log::Info() << "PoSSync: fork_choice_update INVALID latest_valid_hash=" << latest_valid_hash;
-            co_return rpc::ForkChoiceUpdatedReply{{rpc::PayloadStatus::kInvalid, latest_valid_hash}, no_payload_id};
+            co_return rpc::ForkChoiceUpdatedReply{{rpc::PayloadStatus::kInvalid, latest_valid_hash}};
         } else if (!std::holds_alternative<ValidChain>(verification)) {
             // ERROR
             const auto validation_error = std::get<ValidationError>(verification);
             log::Info() << "PoSSync: fork_choice_update INVALID latest_valid_hash=" << validation_error.latest_valid_head
                         << " missing_block=" << validation_error.missing_block;
-            co_return rpc::ForkChoiceUpdatedReply{{rpc::PayloadStatus::kInvalid, no_latest_valid_hash, "unknown execution error"}, no_payload_id};
+            co_return rpc::ForkChoiceUpdatedReply{{rpc::PayloadStatus::kInvalid, no_latest_valid_hash, "unknown execution error"}};
         }
 
         // VALID
@@ -331,8 +338,12 @@ Task<rpc::ForkChoiceUpdatedReply> PoSSync::fork_choice_update(
         std::optional<Hash> finalized_block_hash =
             state.finalized_block_hash != kZeroHash ? std::optional<Hash>{state.finalized_block_hash} : std::nullopt;
 
-        auto application = co_await exec_engine_.update_fork_choice(state.head_block_hash, finalized_block_hash);
+        const auto fcu_application = co_await (
+            exec_engine_.update_fork_choice(state.head_block_hash, finalized_block_hash) || concurrency::timeout(timeout));
+        ensure(std::holds_alternative<ForkChoiceApplication>(fcu_application), "PoSSync: unexpected awaitable operators outcome");
+        const auto application{std::get<ForkChoiceApplication>(fcu_application)};
         log::Info() << "PoSSync: fork_choice_update " << (application.success ? "OK" : "KO")
+                    << " latest_valid_hash=" << (application.success ? to_hex(state.head_block_hash) : application.current_head.to_hex())
                     << " current_head=" << application.current_head << " current_height=" << application.current_height;
         if (!application.success) {
             // at the moment application doesn't carry information to disambiguate between invalid head and
@@ -347,10 +358,10 @@ Task<rpc::ForkChoiceUpdatedReply> PoSSync::fork_choice_update(
                 if (!is_canonical) throw boost::system::system_error{rpc::to_system_code(rpc::ErrorCode::kInvalidForkChoiceState)};
             }
 
-            co_return rpc::ForkChoiceUpdatedReply{{rpc::PayloadStatus::kInvalid, application.current_head, "invalid fork choice update"}, no_payload_id};
+            co_return rpc::ForkChoiceUpdatedReply{{rpc::PayloadStatus::kInvalid, application.current_head, "invalid fork choice update"}};
         }
 
-        uint64_t buildProcessId = 0;
+        std::optional<uint64_t> buildProcessId;
         if (attributes) {
             // payload build process
             if (attributes->timestamp <= head_header->timestamp) {
@@ -363,6 +374,9 @@ Task<rpc::ForkChoiceUpdatedReply> PoSSync::fork_choice_update(
 
         co_return rpc::ForkChoiceUpdatedReply{{rpc::PayloadStatus::kValid, state.head_block_hash}, buildProcessId};
 
+    } catch (const concurrency::TimeoutExpiredError& tee) {
+        log::Info() << "PoSSync: new_payload timeout expired: " << tee.what();
+        co_return rpc::ForkChoiceUpdatedReply{rpc::PayloadStatus::Syncing};
     } catch (const boost::system::system_error& e) {
         log::Error() << "PoSSync: error processing fork-choice: " << e.what();
         throw;
@@ -372,13 +386,13 @@ Task<rpc::ForkChoiceUpdatedReply> PoSSync::fork_choice_update(
     }
 }
 
-Task<rpc::ExecutionPayloadAndValue> PoSSync::get_payload(uint64_t /*payloadId*/) {
+Task<rpc::ExecutionPayloadAndValue> PoSSync::get_payload(uint64_t /*payloadId*/, std::chrono::milliseconds /*timeout*/) {
     // Implementation of engine_getPayloadVx method
     ensure_invariant(false, "get_payload not implemented");
     co_return rpc::ExecutionPayloadAndValue{};
 }
 
-Task<rpc::ExecutionPayloadBodies> PoSSync::get_payload_bodies_by_hash(const std::vector<Hash>& block_hashes) {
+Task<rpc::ExecutionPayloadBodies> PoSSync::get_payload_bodies_by_hash(const std::vector<Hash>& block_hashes, std::chrono::milliseconds /*timeout*/) {
     rpc::ExecutionPayloadBodies payload_bodies;
     payload_bodies.resize(block_hashes.size());
     for (const auto& bh : block_hashes) {
@@ -404,7 +418,7 @@ Task<rpc::ExecutionPayloadBodies> PoSSync::get_payload_bodies_by_hash(const std:
     co_return payload_bodies;
 }
 
-Task<rpc::ExecutionPayloadBodies> PoSSync::get_payload_bodies_by_range(BlockNum start, uint64_t count) {
+Task<rpc::ExecutionPayloadBodies> PoSSync::get_payload_bodies_by_range(BlockNum start, uint64_t count, std::chrono::milliseconds /*timeout*/) {
     rpc::ExecutionPayloadBodies payload_bodies;
     payload_bodies.resize(count);
     for (BlockNum number{start}; number < start + count; ++number) {

--- a/silkworm/sync/sync_pos.cpp
+++ b/silkworm/sync/sync_pos.cpp
@@ -341,7 +341,7 @@ Task<rpc::ForkChoiceUpdatedReply> PoSSync::fork_choice_update(const rpc::ForkCho
         const auto fcu_application = co_await (
             exec_engine_.update_fork_choice(state.head_block_hash, finalized_block_hash) || concurrency::timeout(timeout));
         ensure(std::holds_alternative<ForkChoiceApplication>(fcu_application), "PoSSync: unexpected awaitable operators outcome");
-        const auto application{std::get<ForkChoiceApplication>(fcu_application)};
+        auto application{std::get<ForkChoiceApplication>(fcu_application)};
         log::Info() << "PoSSync: fork_choice_update " << (application.success ? "OK" : "KO")
                     << " latest_valid_hash=" << (application.success ? to_hex(state.head_block_hash) : application.current_head.to_hex())
                     << " current_head=" << application.current_head << " current_height=" << application.current_height;

--- a/silkworm/sync/sync_pos.hpp
+++ b/silkworm/sync/sync_pos.hpp
@@ -43,11 +43,11 @@ class PoSSync : public ChainSync {
     Task<void> download_blocks(); /*[[long_running]]*/
 
     // public interface called by the external PoS client
-    Task<rpc::PayloadStatus> new_payload(const rpc::ExecutionPayload&);
-    Task<rpc::ForkChoiceUpdatedReply> fork_choice_update(const rpc::ForkChoiceState&, const std::optional<rpc::PayloadAttributes>&);
-    Task<rpc::ExecutionPayloadAndValue> get_payload(uint64_t payloadId);
-    Task<rpc::ExecutionPayloadBodies> get_payload_bodies_by_hash(const std::vector<Hash>& block_hashes);
-    Task<rpc::ExecutionPayloadBodies> get_payload_bodies_by_range(BlockNum start, uint64_t count);
+    Task<rpc::PayloadStatus> new_payload(const rpc::ExecutionPayload&, std::chrono::milliseconds timeout);
+    Task<rpc::ForkChoiceUpdatedReply> fork_choice_update(const rpc::ForkChoiceState&, const std::optional<rpc::PayloadAttributes>&, std::chrono::milliseconds timeout);
+    Task<rpc::ExecutionPayloadAndValue> get_payload(uint64_t payloadId, std::chrono::milliseconds timeout);
+    Task<rpc::ExecutionPayloadBodies> get_payload_bodies_by_hash(const std::vector<Hash>& block_hashes, std::chrono::milliseconds timeout);
+    Task<rpc::ExecutionPayloadBodies> get_payload_bodies_by_range(BlockNum start, uint64_t count, std::chrono::milliseconds timeout);
 
   private:
     static std::shared_ptr<Block> make_execution_block(const rpc::ExecutionPayload& payload);

--- a/silkworm/sync/sync_pos_test.cpp
+++ b/silkworm/sync/sync_pos_test.cpp
@@ -1,0 +1,91 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "sync_pos.hpp"
+
+#include <silkworm/infra/concurrency/task.hpp>
+
+#include <boost/asio/steady_timer.hpp>
+#include <boost/asio/this_coro.hpp>
+#include <catch2/catch.hpp>
+#include <gmock/gmock.h>
+
+#include <silkworm/node/stagedsync/client.hpp>
+#include <silkworm/node/test/mock_execution_client.hpp>
+#include <silkworm/silkrpc/test/context_test_base.hpp>
+#include <silkworm/sync/block_exchange.hpp>
+#include <silkworm/sync/sentry_client.hpp>
+#include <silkworm/sync/test/mock_block_exchange.hpp>
+
+namespace silkworm::chainsync {
+
+struct PoSSyncTest : public rpc::test::ContextTestBase {
+    SentryClient sentry_client_{io_context_.get_executor(), nullptr};  // TODO(canepat) mock
+    mdbx::env_managed chaindata_env_{};
+    db::ROAccess db_access_{chaindata_env_};
+    test::MockBlockExchange block_exchange_{sentry_client_, db_access_, kGoerliConfig};
+    test::MockClient execution_client_;
+    PoSSync sync_{block_exchange_, execution_client_};
+};
+
+Task<void> sleep(std::chrono::milliseconds duration) {
+    auto executor = co_await boost::asio::this_coro::executor;
+    boost::asio::steady_timer timer(executor);
+    timer.expires_after(duration);
+    co_await timer.async_wait(boost::asio::use_awaitable);
+}
+
+TEST_CASE_METHOD(PoSSyncTest, "PoSSync::new_payload timeout") {
+    using namespace std::chrono_literals;
+    using testing::_;
+    using testing::InvokeWithoutArgs;
+
+    rpc::ExecutionPayload payload{
+        .number = 1,
+        .timestamp = 0x05,
+        .gas_limit = 0x1c9c380,
+        .gas_used = 0x0,
+        .suggested_fee_recipient = 0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b_address,
+        .state_root = 0xca3149fa9e37db08d1cd49c9061db1002ef1cd58db2210f2115c8c989b2bdf45_bytes32,
+        .receipts_root = 0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421_bytes32,
+        .parent_hash = 0x3b8fb240d288781d4aac94d3fd16809ee413bc99294a085798a589dae51ddd4a_bytes32,
+        .block_hash = 0x3559e851470f6e7bbed1db474980683e8c315bfce99b2a6ef47c057c04de7858_bytes32,
+        .prev_randao = 0x0000000000000000000000000000000000000000000000000000000000000000_bytes32,
+        .base_fee = 0x7,
+    };
+
+    EXPECT_CALL(execution_client_, get_header(payload.number - 1, Hash{payload.parent_hash}))
+        .WillOnce(InvokeWithoutArgs([]() -> Task<std::optional<BlockHeader>> {
+            co_return BlockHeader{};
+        }));
+    EXPECT_CALL(execution_client_, get_header_td(Hash{payload.parent_hash}, std::make_optional(payload.number - 1)))
+        .WillOnce(InvokeWithoutArgs([&]() -> Task<std::optional<TotalDifficulty>> {
+            co_return kGoerliConfig.terminal_total_difficulty;
+        }));
+    EXPECT_CALL(execution_client_, insert_blocks(_))
+        .WillOnce(InvokeWithoutArgs([]() -> Task<void> { co_return; }));
+    EXPECT_CALL(execution_client_, get_block_num(Hash{payload.block_hash}))
+        .WillOnce(InvokeWithoutArgs([&]() -> Task<std::optional<BlockNum>> { co_return payload.number; }));
+    EXPECT_CALL(execution_client_, validate_chain(Hash{payload.block_hash}))
+        .WillOnce(InvokeWithoutArgs([&]() -> Task<execution::ValidationResult> {
+            co_await sleep(1h);  // simulate exaggeratedly long-running task
+            co_return execution::ValidChain{};
+        }));
+
+    CHECK(spawn_and_wait(sync_.new_payload(payload, 1ms)).status == rpc::PayloadStatus::kSyncing);
+}
+
+}  // namespace silkworm::chainsync

--- a/silkworm/sync/test/mock_block_exchange.hpp
+++ b/silkworm/sync/test/mock_block_exchange.hpp
@@ -1,0 +1,59 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include <gmock/gmock.h>
+
+#include <silkworm/core/chain/config.hpp>
+#include <silkworm/core/common/base.hpp>
+#include <silkworm/core/types/block.hpp>
+#include <silkworm/core/types/hash.hpp>
+#include <silkworm/node/db/mdbx.hpp>
+#include <silkworm/sync/block_exchange.hpp>
+#include <silkworm/sync/messages/message.hpp>
+#include <silkworm/sync/sentry_client.hpp>
+
+namespace silkworm::test {
+
+//! \brief MockBlockExchange is the gMock mock class for BlockExchange.
+class MockBlockExchange : public BlockExchange {
+  public:
+    MockBlockExchange(SentryClient& client, const db::ROAccess& dba, const ChainConfig& config)
+        : BlockExchange(client, dba, config) {}
+
+    MOCK_METHOD((void), initial_state, (std::vector<BlockHeader>));
+
+    MOCK_METHOD((void), download_blocks, (BlockNum, Target_Tracking));
+    MOCK_METHOD((void), new_target_block, (std::shared_ptr<Block>));
+    MOCK_METHOD((void), stop_downloading, ());
+
+    MOCK_METHOD((ResultQueue&), result_queue, (Hash));
+
+    MOCK_METHOD((bool), in_sync, (), (const));
+    MOCK_METHOD((BlockNum), current_height, (), (const));
+
+    MOCK_METHOD((void), accept, (std::shared_ptr<Message>));
+    MOCK_METHOD((void), execution_loop, ());
+
+    MOCK_METHOD((const ChainConfig&), chain_config, (), (const));
+    MOCK_METHOD((SentryClient&), sentry, (), (const));
+};
+
+}  // namespace silkworm::test


### PR DESCRIPTION
sync: add warning log for missing withdrawals in body received by peer