### PR TITLE
rpcdaemon: modify base class of clique consensus

### DIFF
--- a/silkworm/core/protocol/clique_rule_set.hpp
+++ b/silkworm/core/protocol/clique_rule_set.hpp
@@ -16,20 +16,26 @@
 
 #pragma once
 
-#include <silkworm/core/protocol/ethash_rule_set.hpp>
+#include <silkworm/core/protocol/base_rule_set.hpp>
 
 namespace silkworm::protocol {
 
 // Warning: most Clique (EIP-225) logic is not implemented yet.
 // This rule set is just a dummy!
-class CliqueRuleSet : public EthashRuleSet {
+class CliqueRuleSet : public BaseRuleSet {
   public:
-    explicit CliqueRuleSet(const ChainConfig& chain_config) : EthashRuleSet(chain_config) {}
+    explicit CliqueRuleSet(const ChainConfig& chain_config) : BaseRuleSet(chain_config, false) {}
 
     //! \brief Validates the seal of the header
     ValidationResult validate_seal(const BlockHeader& header) final;
 
+    void initialize(EVM&) final {}
+
+    void finalize(IntraBlockState&, const Block&) final {}
+
     evmc::address get_beneficiary(const BlockHeader& header) final;
+
+    intx::uint256 difficulty(const BlockHeader&, const BlockHeader&) final { return 1; }
 };
 
 }  // namespace silkworm::protocol

--- a/silkworm/silkrpc/core/evm_trace_test.cpp
+++ b/silkworm/silkrpc/core/evm_trace_test.cpp
@@ -2593,19 +2593,6 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_block") {
             "transactionHash": "0x849ca3076047d76288f2d15b652f18e80622aa6163eff0a216a446d0a4a5288e",
             "transactionPosition": 0,
             "type": "create"
-        },
-        {
-            "action": {
-            "author": "0x0000000000000000000000000000000000000000",
-            "rewardType": "block",
-            "value": "0x1bc16d674ec80000"
-            },
-            "blockHash": "0x527198f474c1f1f1d01129d3a17ecc17895d85884a31b05ef0ecd480faee1592",
-            "blockNumber": 1024165,
-            "result": null,
-            "subtraces": 0,
-            "traceAddress": [],
-            "type": "reward"
         }
     ])"_json);
 }


### PR DESCRIPTION
Modify clique base class from ethash to BaseRuleSet, So in case of Clique the compute_reward() is defined in BaseRuleSet class(return empty value) and not ethash compute_reward() that returns a real reward   