### PR TITLE
sentry: disc v4 ENR

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -33,6 +33,9 @@
 [submodule "third_party/blst"]
 	path = third_party/blst
 	url = https://github.com/supranational/blst.git
+[submodule "third_party/cpp-base64"]
+	path = third_party/cpp-base64
+	url = https://github.com/ReneNyffenegger/cpp-base64.git
 [submodule "third_party/intx"]
 	path = third_party/intx
 	url = https://github.com/chfast/intx.git

--- a/silkworm/core/rlp/decode_vector.hpp
+++ b/silkworm/core/rlp/decode_vector.hpp
@@ -19,9 +19,11 @@
 #include <vector>
 
 #include <silkworm/core/rlp/decode.hpp>
+#include <silkworm/core/rlp/encode_vector.hpp>
 
 namespace silkworm::rlp {
 
+//! Decodes an RLP list of dynamic size with items of type T
 template <typename T>
 DecodingResult decode(ByteView& from, std::vector<T>& to, Leftover mode = Leftover::kProhibit) noexcept {
     const auto h{decode_header(from)};
@@ -65,7 +67,7 @@ DecodingResult decode_items(ByteView& from, Arg1& arg1, Arg2& arg2, Args&... arg
     return decode_items(from, arg2, args...);
 }
 
-// Decodes an RLP list
+//! Decodes an RLP list with a fixed number of items with various types
 template <typename Arg1, typename Arg2, typename... Args>
 DecodingResult decode(ByteView& from, Leftover mode, Arg1& arg1, Arg2& arg2, Args&... args) noexcept {
     const auto header{decode_header(from)};
@@ -87,6 +89,38 @@ DecodingResult decode(ByteView& from, Leftover mode, Arg1& arg1, Arg2& arg2, Arg
     if (from.length() != leftover) {
         return tl::unexpected{DecodingError::kUnexpectedListElements};
     }
+    return {};
+}
+
+/**
+ * Decodes an RLP list of dynamic size with items of any type.
+ * The resulting RlpByteView-s refer to RLP-encoded data of the list items.
+ * Use rlp::decode(to[i].data, ...) to fully decode them.
+ */
+template <>
+inline DecodingResult decode(ByteView& from, std::vector<RlpByteView>& to, Leftover mode) noexcept {
+    auto header = decode_header(from);
+    if (!header)
+        return tl::unexpected{header.error()};
+    if (!header->list)
+        return tl::unexpected{DecodingError::kUnexpectedString};
+
+    to.clear();
+
+    ByteView payload_view = from.substr(0, header->payload_length);
+    while (!payload_view.empty()) {
+        auto item_start = payload_view.begin();
+        auto item_header = decode_header(payload_view);
+        if (!item_header)
+            return tl::unexpected{header.error()};
+        auto item_end = payload_view.begin() + item_header->payload_length;
+        to.emplace_back(ByteView{std::span{item_start, item_end}});
+        payload_view.remove_prefix(item_header->payload_length);
+    }
+
+    from.remove_prefix(header->payload_length);
+    if ((mode != Leftover::kAllow) && !from.empty())
+        return tl::unexpected{DecodingError::kInputTooLong};
     return {};
 }
 

--- a/silkworm/core/rlp/encode_vector.hpp
+++ b/silkworm/core/rlp/encode_vector.hpp
@@ -17,37 +17,64 @@
 #pragma once
 
 #include <numeric>
+#include <span>
 #include <vector>
 
 #include <silkworm/core/rlp/encode.hpp>
 
 namespace silkworm::rlp {
 
+// std::span to RLP overloads
+
 template <typename T>
-size_t length_items(const std::vector<T>& v) {
-    return std::accumulate(v.cbegin(), v.cend(), size_t{0}, [](size_t sum, const T& x) { return sum + length(x); });
+size_t length_items(const std::span<const T>& v) {
+    return std::accumulate(v.begin(), v.end(), size_t{0}, [](size_t sum, const T& x) { return sum + length(x); });
 }
 
 template <typename T>
-size_t length(const std::vector<T>& v) {
+size_t length(const std::span<const T>& v) {
     const size_t payload_length = length_items(v);
     return length_of_length(payload_length) + payload_length;
 }
 
 template <typename T>
-void encode_items(Bytes& to, const std::vector<T>& v) {
+void encode_items(Bytes& to, const std::span<const T>& v) {
     for (const T& x : v) {
         encode(to, x);
     }
 }
 
 template <typename T>
-void encode(Bytes& to, const std::vector<T>& v) {
+void encode(Bytes& to, const std::span<const T>& v) {
     const Header h{.list = true, .payload_length = length_items(v)};
     to.reserve(to.size() + length_of_length(h.payload_length) + h.payload_length);
     encode_header(to, h);
     encode_items(to, v);
 }
+
+// std::vector to RLP overloads
+
+template <typename T>
+size_t length_items(const std::vector<T>& v) {
+    return length_items(std::span<const T>{v.data(), v.size()});
+}
+
+template <typename T>
+size_t length(const std::vector<T>& v) {
+    return length(std::span<const T>{v.data(), v.size()});
+}
+
+template <typename T>
+void encode_items(Bytes& to, const std::vector<T>& v) {
+    encode_items(to, std::span<const T>{v.data(), v.size()});
+}
+
+template <typename T>
+void encode(Bytes& to, const std::vector<T>& v) {
+    encode(to, std::span<const T>{v.data(), v.size()});
+}
+
+// variadic arguments to RLP overloads
 
 template <typename Arg1, typename Arg2>
 size_t length_items(const Arg1& arg1, const Arg2& arg2) {

--- a/silkworm/infra/common/secp256k1_context.hpp
+++ b/silkworm/infra/common/secp256k1_context.hpp
@@ -62,19 +62,19 @@ class SecP256K1Context final {
         const secp256k1_pubkey* public_key,
         const ByteView& private_key) const;
 
-    bool sign_recoverable(secp256k1_ecdsa_recoverable_signature* signature, ByteView data, ByteView private_key) {
-        if (data.size() != 32)
+    bool sign_recoverable(secp256k1_ecdsa_recoverable_signature* signature, ByteView data_hash, ByteView private_key) {
+        if (data_hash.size() != 32)
             return false;
-        return secp256k1_ecdsa_sign_recoverable(context_, signature, data.data(), private_key.data(), nullptr, nullptr);
+        return secp256k1_ecdsa_sign_recoverable(context_, signature, data_hash.data(), private_key.data(), nullptr, nullptr);
     }
 
     bool recover_signature_public_key(
         secp256k1_pubkey* public_key,
         const secp256k1_ecdsa_recoverable_signature* signature,
-        ByteView data) {
-        if (data.size() != 32)
+        ByteView data_hash) {
+        if (data_hash.size() != 32)
             return false;
-        return secp256k1_ecdsa_recover(context_, public_key, signature, data.data());
+        return secp256k1_ecdsa_recover(context_, public_key, signature, data_hash.data());
     }
 
     std::pair<Bytes, uint8_t> serialize_recoverable_signature(const secp256k1_ecdsa_recoverable_signature* signature) {
@@ -95,6 +95,30 @@ class SecP256K1Context final {
             signature,
             signature_data.data(),
             static_cast<int>(recovery_id));
+    }
+
+    bool sign(secp256k1_ecdsa_signature* signature, ByteView data_hash, ByteView private_key) {
+        if (data_hash.size() != 32)
+            return false;
+        return secp256k1_ecdsa_sign(context_, signature, data_hash.data(), private_key.data(), nullptr, nullptr);
+    }
+
+    Bytes serialize_signature(const secp256k1_ecdsa_signature* signature) {
+        Bytes data(64, 0);
+        secp256k1_ecdsa_signature_serialize_compact(context_, data.data(), signature);
+        return data;
+    }
+
+    bool parse_signature(secp256k1_ecdsa_signature* signature, ByteView signature_data) {
+        if (signature_data.size() != 64)
+            return false;
+        return secp256k1_ecdsa_signature_parse_compact(context_, signature, signature_data.data());
+    }
+
+    bool verify_signature(const secp256k1_ecdsa_signature* signature, ByteView data_hash, const secp256k1_pubkey* public_key) {
+        if (data_hash.size() != 32)
+            return false;
+        return secp256k1_ecdsa_verify(context_, signature, data_hash.data(), public_key);
     }
 
     static const size_t kPublicKeySizeCompressed;

--- a/silkworm/sentry/CMakeLists.txt
+++ b/silkworm/sentry/CMakeLists.txt
@@ -44,6 +44,9 @@ add_subdirectory(common)
 # node DB
 add_subdirectory(discovery/node_db)
 
+# discovery common
+add_subdirectory(discovery/common)
+
 # disc v4
 add_subdirectory(discovery/disc_v4)
 

--- a/silkworm/sentry/CMakeLists.txt
+++ b/silkworm/sentry/CMakeLists.txt
@@ -47,6 +47,9 @@ add_subdirectory(discovery/node_db)
 # discovery common
 add_subdirectory(discovery/common)
 
+# ENR
+add_subdirectory(discovery/enr)
+
 # disc v4
 add_subdirectory(discovery/disc_v4)
 

--- a/silkworm/sentry/CMakeLists.txt
+++ b/silkworm/sentry/CMakeLists.txt
@@ -85,6 +85,8 @@ set(LIBS_PRIVATE
     silkworm-buildinfo
     silkworm_sentry_common
     silkworm_sentry_node_db
+    silkworm_sentry_discovery_common
+    silkworm_sentry_discovery_enr
     silkworm_sentry_disc_v4
 )
 if(MSVC)

--- a/silkworm/sentry/common/crypto/ecdsa_signature.cpp
+++ b/silkworm/sentry/common/crypto/ecdsa_signature.cpp
@@ -22,12 +22,12 @@
 
 namespace silkworm::sentry::crypto::ecdsa_signature {
 
-Bytes sign(ByteView data, ByteView private_key) {
+Bytes sign_recoverable(ByteView data_hash, ByteView private_key) {
     SecP256K1Context ctx{/* allow_verify = */ false, /* allow_sign = */ true};
     secp256k1_ecdsa_recoverable_signature signature;
-    bool ok = ctx.sign_recoverable(&signature, data, private_key);
+    bool ok = ctx.sign_recoverable(&signature, data_hash, private_key);
     if (!ok) {
-        throw std::runtime_error("rlpx::auth::sign failed to sign an AuthMessage");
+        throw std::runtime_error("ecdsa_signature::sign_recoverable failed");
     }
 
     auto [signature_data, recovery_id] = ctx.serialize_recoverable_signature(&signature);
@@ -35,9 +35,20 @@ Bytes sign(ByteView data, ByteView private_key) {
     return signature_data;
 }
 
-EccPublicKey recover_and_verify(ByteView data, ByteView signature_and_recovery_id) {
+Bytes sign(ByteView data_hash, ByteView private_key) {
+    SecP256K1Context ctx{/* allow_verify = */ false, /* allow_sign = */ true};
+    secp256k1_ecdsa_signature signature;
+    bool ok = ctx.sign(&signature, data_hash, private_key);
+    if (!ok) {
+        throw std::runtime_error("ecdsa_signature::sign failed");
+    }
+
+    return ctx.serialize_signature(&signature);
+}
+
+EccPublicKey verify_and_recover(ByteView data_hash, ByteView signature_and_recovery_id) {
     if (signature_and_recovery_id.empty()) {
-        throw std::runtime_error("rlpx::auth::recover_and_verify: AuthMessage signature is empty");
+        throw std::runtime_error("ecdsa_signature::verify_and_recover: signature is empty");
     }
     uint8_t recovery_id = signature_and_recovery_id.back();
     ByteView signature_data = {signature_and_recovery_id.data(), signature_and_recovery_id.size() - 1};
@@ -46,15 +57,29 @@ EccPublicKey recover_and_verify(ByteView data, ByteView signature_and_recovery_i
     secp256k1_ecdsa_recoverable_signature signature;
     bool ok = ctx.parse_recoverable_signature(&signature, signature_data, recovery_id);
     if (!ok) {
-        throw std::runtime_error("rlpx::auth::recover_and_verify: failed to parse an AuthMessage signature");
+        throw std::runtime_error("ecdsa_signature::verify_and_recover: failed to parse a signature");
     }
 
     secp256k1_pubkey public_key;
-    ok = ctx.recover_signature_public_key(&public_key, &signature, data);
+    ok = ctx.recover_signature_public_key(&public_key, &signature, data_hash);
     if (!ok) {
-        throw std::runtime_error("rlpx::auth::recover_and_verify: failed to recover a public key from an AuthMessage signature");
+        throw std::runtime_error("ecdsa_signature::verify_and_recover: failed to recover a public key from a signature");
     }
     return EccPublicKey{Bytes{public_key.data, sizeof(public_key.data)}};
+}
+
+bool verify(ByteView data_hash, ByteView signature_data, const EccPublicKey& public_key1) {
+    SecP256K1Context ctx;
+    secp256k1_ecdsa_signature signature;
+    bool ok = ctx.parse_signature(&signature, signature_data);
+    if (!ok) {
+        throw std::runtime_error("ecdsa_signature::verify: failed to parse a signature");
+    }
+
+    secp256k1_pubkey public_key;
+    memcpy(public_key.data, public_key1.data().data(), sizeof(public_key.data));
+
+    return ctx.verify_signature(&signature, data_hash, &public_key);
 }
 
 }  // namespace silkworm::sentry::crypto::ecdsa_signature

--- a/silkworm/sentry/common/ecc_public_key.cpp
+++ b/silkworm/sentry/common/ecc_public_key.cpp
@@ -23,13 +23,13 @@
 
 namespace silkworm::sentry {
 
-Bytes EccPublicKey::serialized_std() const {
+Bytes EccPublicKey::serialized_std(bool is_compressed) const {
     auto& data = data_;
     secp256k1_pubkey public_key;
     memcpy(public_key.data, data.data(), sizeof(public_key.data));
 
     SecP256K1Context ctx;
-    return ctx.serialize_public_key(&public_key, /* is_compressed = */ false);
+    return ctx.serialize_public_key(&public_key, is_compressed);
 }
 
 Bytes EccPublicKey::serialized() const {

--- a/silkworm/sentry/common/ecc_public_key.hpp
+++ b/silkworm/sentry/common/ecc_public_key.hpp
@@ -32,7 +32,7 @@ class EccPublicKey {
     [[nodiscard]] ByteView data() const { return data_; }
     [[nodiscard]] Bytes::size_type size() const { return data_.size(); }
 
-    [[nodiscard]] Bytes serialized_std() const;
+    [[nodiscard]] Bytes serialized_std(bool is_compressed = false) const;
     [[nodiscard]] Bytes serialized() const;
     [[nodiscard]] std::string hex() const;
 

--- a/silkworm/sentry/discovery/common/CMakeLists.txt
+++ b/silkworm/sentry/discovery/common/CMakeLists.txt
@@ -17,7 +17,7 @@
 find_package(Boost REQUIRED headers)
 find_package(Catch2 REQUIRED)
 
-set(TARGET silkworm_sentry_disc_v4)
+set(TARGET silkworm_sentry_discovery_common)
 
 file(GLOB_RECURSE SRC CONFIGURE_DEPENDS "*.cpp" "*.hpp")
 list(FILTER SRC EXCLUDE REGEX "_test\\.cpp$")
@@ -26,15 +26,7 @@ add_library(${TARGET} ${SRC})
 
 target_include_directories(${TARGET} PUBLIC "${SILKWORM_MAIN_DIR}")
 
-target_link_libraries(
-  ${TARGET}
-  PUBLIC silkworm_infra silkworm_sentry_common
-  PRIVATE Boost::headers
-          stbrumme_keccak
-          silkworm_core
-          silkworm_sentry_node_db
-          silkworm_sentry_discovery_common
-)
+target_link_libraries(${TARGET} PUBLIC silkworm_core Boost::headers)
 
 # unit tests
 set(TEST_TARGET ${TARGET}_test)

--- a/silkworm/sentry/discovery/common/node_address.cpp
+++ b/silkworm/sentry/discovery/common/node_address.cpp
@@ -21,7 +21,7 @@
 #include <silkworm/core/rlp/decode_vector.hpp>
 #include <silkworm/core/rlp/encode_vector.hpp>
 
-namespace silkworm::sentry::discovery::disc_v4 {
+namespace silkworm::sentry::discovery {
 
 Bytes ip_address_to_bytes(const boost::asio::ip::address& ip) {
     if (ip.is_v4()) {
@@ -77,4 +77,4 @@ DecodingResult decode(ByteView& from, NodeAddress& to, rlp::Leftover mode) noexc
     return result;
 }
 
-}  // namespace silkworm::sentry::discovery::disc_v4
+}  // namespace silkworm::sentry::discovery

--- a/silkworm/sentry/discovery/common/node_address.hpp
+++ b/silkworm/sentry/discovery/common/node_address.hpp
@@ -23,7 +23,6 @@
 #include <boost/asio/ip/address.hpp>
 #include <boost/asio/ip/udp.hpp>
 
-#include <silkworm/core/common/base.hpp>
 #include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/rlp/decode.hpp>
 

--- a/silkworm/sentry/discovery/common/node_address.hpp
+++ b/silkworm/sentry/discovery/common/node_address.hpp
@@ -32,6 +32,16 @@ namespace silkworm::sentry::discovery {
 struct NodeAddress {
     boost::asio::ip::udp::endpoint endpoint;
     uint16_t port_rlpx{};
+
+    NodeAddress() = default;
+
+    NodeAddress(boost::asio::ip::udp::endpoint endpoint1, uint16_t port_rlpx1)
+        : endpoint(std::move(endpoint1)),
+          port_rlpx(port_rlpx1) {}
+
+    NodeAddress(const boost::asio::ip::address& ip, uint16_t port_disc, uint16_t port_rlpx1)
+        : endpoint(ip, port_disc),
+          port_rlpx(port_rlpx1) {}
 };
 
 //! RLP length

--- a/silkworm/sentry/discovery/common/node_address.hpp
+++ b/silkworm/sentry/discovery/common/node_address.hpp
@@ -27,7 +27,7 @@
 #include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/rlp/decode.hpp>
 
-namespace silkworm::sentry::discovery::disc_v4 {
+namespace silkworm::sentry::discovery {
 
 struct NodeAddress {
     boost::asio::ip::udp::endpoint endpoint;
@@ -43,4 +43,4 @@ DecodingResult decode(ByteView& from, NodeAddress& to, rlp::Leftover mode) noexc
 Bytes ip_address_to_bytes(const boost::asio::ip::address& ip);
 std::optional<boost::asio::ip::address> ip_address_from_bytes(ByteView ip_bytes) noexcept;
 
-}  // namespace silkworm::sentry::discovery::disc_v4
+}  // namespace silkworm::sentry::discovery

--- a/silkworm/sentry/discovery/disc_v4/CMakeLists.txt
+++ b/silkworm/sentry/discovery/disc_v4/CMakeLists.txt
@@ -28,12 +28,8 @@ target_include_directories(${TARGET} PUBLIC "${SILKWORM_MAIN_DIR}")
 
 target_link_libraries(
   ${TARGET}
-  PUBLIC silkworm_infra silkworm_sentry_common
-  PRIVATE Boost::headers
-          stbrumme_keccak
-          silkworm_core
-          silkworm_sentry_node_db
-          silkworm_sentry_discovery_common
+  PUBLIC silkworm_infra silkworm_sentry_common silkworm_sentry_node_db silkworm_sentry_discovery_enr
+  PRIVATE Boost::headers stbrumme_keccak silkworm_core silkworm_sentry_discovery_common
 )
 
 # unit tests

--- a/silkworm/sentry/discovery/disc_v4/discovery.hpp
+++ b/silkworm/sentry/discovery/disc_v4/discovery.hpp
@@ -25,6 +25,7 @@
 
 #include <silkworm/sentry/common/ecc_key_pair.hpp>
 #include <silkworm/sentry/common/enode_url.hpp>
+#include <silkworm/sentry/discovery/enr/enr_record.hpp>
 #include <silkworm/sentry/discovery/node_db/node_db.hpp>
 
 namespace silkworm::sentry::discovery::disc_v4 {
@@ -38,6 +39,7 @@ class Discovery {
         uint16_t server_port,
         std::function<EccKeyPair()> node_key,
         std::function<EnodeUrl()> node_url,
+        std::function<discovery::enr::EnrRecord()> node_record,
         node_db::NodeDb& node_db);
     ~Discovery();
 

--- a/silkworm/sentry/discovery/disc_v4/enr/enr_request_handler.cpp
+++ b/silkworm/sentry/discovery/disc_v4/enr/enr_request_handler.cpp
@@ -1,0 +1,68 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "enr_request_handler.hpp"
+
+#include <chrono>
+
+#include <boost/system/errc.hpp>
+#include <boost/system/system_error.hpp>
+
+#include <silkworm/infra/common/log.hpp>
+#include <silkworm/sentry/discovery/disc_v4/common/message_expiration.hpp>
+#include <silkworm/sentry/discovery/disc_v4/ping/ping_check.hpp>
+
+#include "enr_response_message.hpp"
+
+namespace silkworm::sentry::discovery::disc_v4::enr {
+
+Task<void> EnrRequestHandler::handle(
+    EnrRequestMessage message,
+    EccPublicKey sender_public_key,
+    boost::asio::ip::udp::endpoint sender_endpoint,
+    Bytes packet_hash,
+    discovery::enr::EnrRecord local_node_record,
+    MessageSender& sender,
+    node_db::NodeDb& db) {
+    if (is_expired_message_expiration(message.expiration)) {
+        co_return;
+    }
+
+    // check that the sender has a valid pong
+    auto last_pong_time = co_await db.find_last_pong_time(sender_public_key);
+    auto now = std::chrono::system_clock::system_clock::now();
+    if (!last_pong_time || (*last_pong_time < ping::min_valid_pong_time(now))) {
+        co_return;
+    }
+
+    auto& recipient = sender_endpoint;
+    EnrResponseMessage response{
+        std::move(packet_hash),
+        std::move(local_node_record),
+    };
+
+    try {
+        co_await sender.send_enr_response(std::move(response), recipient);
+    } catch (const boost::system::system_error& ex) {
+        if (ex.code() == boost::system::errc::operation_canceled)
+            throw;
+        log::Warning("disc_v4") << "EnrRequestHandler::handle failed to reply"
+                                << " to " << recipient
+                                << " due to exception: " << ex.what();
+    }
+}
+
+}  // namespace silkworm::sentry::discovery::disc_v4::enr

--- a/silkworm/sentry/discovery/disc_v4/enr/enr_request_handler.hpp
+++ b/silkworm/sentry/discovery/disc_v4/enr/enr_request_handler.hpp
@@ -20,7 +20,7 @@
 
 #include <boost/asio/ip/udp.hpp>
 
-#include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/sentry/common/ecc_public_key.hpp>
 #include <silkworm/sentry/discovery/enr/enr_record.hpp>
 #include <silkworm/sentry/discovery/node_db/node_db.hpp>

--- a/silkworm/sentry/discovery/disc_v4/enr/enr_request_handler.hpp
+++ b/silkworm/sentry/discovery/disc_v4/enr/enr_request_handler.hpp
@@ -1,0 +1,44 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <silkworm/infra/concurrency/task.hpp>
+
+#include <boost/asio/ip/udp.hpp>
+
+#include <silkworm/core/common/base.hpp>
+#include <silkworm/sentry/common/ecc_public_key.hpp>
+#include <silkworm/sentry/discovery/enr/enr_record.hpp>
+#include <silkworm/sentry/discovery/node_db/node_db.hpp>
+
+#include "enr_request_message.hpp"
+#include "message_sender.hpp"
+
+namespace silkworm::sentry::discovery::disc_v4::enr {
+
+struct EnrRequestHandler {
+    static Task<void> handle(
+        EnrRequestMessage message,
+        EccPublicKey sender_public_key,
+        boost::asio::ip::udp::endpoint sender_endpoint,
+        Bytes packet_hash,
+        discovery::enr::EnrRecord local_node_record,
+        MessageSender& sender,
+        node_db::NodeDb& db);
+};
+
+}  // namespace silkworm::sentry::discovery::disc_v4::enr

--- a/silkworm/sentry/discovery/disc_v4/enr/enr_request_message.cpp
+++ b/silkworm/sentry/discovery/disc_v4/enr/enr_request_message.cpp
@@ -1,0 +1,57 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "enr_request_message.hpp"
+
+#include <vector>
+
+#include <silkworm/core/rlp/decode_vector.hpp>
+#include <silkworm/core/rlp/encode_vector.hpp>
+#include <silkworm/infra/common/decoding_exception.hpp>
+#include <silkworm/infra/common/unix_timestamp.hpp>
+#include <silkworm/sentry/discovery/disc_v4/common/packet_type.hpp>
+
+namespace silkworm::sentry::discovery::disc_v4::enr {
+
+const uint8_t EnrRequestMessage::kId = static_cast<uint8_t>(PacketType::kEnrRequest);
+
+Bytes EnrRequestMessage::rlp_encode() const {
+    Bytes data;
+    auto expiration_ts = unix_timestamp_from_time_point(expiration);
+    rlp::encode(data, std::vector<uint64_t>{expiration_ts});
+    return data;
+}
+
+EnrRequestMessage EnrRequestMessage::rlp_decode(ByteView data) {
+    std::vector<uint64_t> expiration_ts;
+
+    auto result = rlp::decode(
+        data,
+        expiration_ts,
+        rlp::Leftover::kAllow);
+    if (!result && (result.error() != DecodingError::kUnexpectedListElements)) {
+        throw DecodingException(result.error(), "Failed to decode EnrRequestMessage RLP");
+    }
+    if (expiration_ts.empty()) {
+        throw DecodingException(DecodingError::kUnexpectedListElements, "Failed to decode EnrRequestMessage RLP: no expiration");
+    }
+
+    return EnrRequestMessage{
+        time_point_from_unix_timestamp(expiration_ts[0]),
+    };
+}
+
+}  // namespace silkworm::sentry::discovery::disc_v4::enr

--- a/silkworm/sentry/discovery/disc_v4/enr/enr_request_message.hpp
+++ b/silkworm/sentry/discovery/disc_v4/enr/enr_request_message.hpp
@@ -16,16 +16,19 @@
 
 #pragma once
 
-#include "enr/message_sender.hpp"
-#include "find/message_sender.hpp"
-#include "ping/message_sender.hpp"
+#include <chrono>
 
-namespace silkworm::sentry::discovery::disc_v4 {
+#include <silkworm/core/common/base.hpp>
 
-struct MessageSender
-    : ping::MessageSender,
-      enr::MessageSender,
-      find::MessageSender {
+namespace silkworm::sentry::discovery::disc_v4::enr {
+
+struct EnrRequestMessage {
+    std::chrono::time_point<std::chrono::system_clock> expiration;
+
+    [[nodiscard]] Bytes rlp_encode() const;
+    [[nodiscard]] static EnrRequestMessage rlp_decode(ByteView data);
+
+    static const uint8_t kId;
 };
 
-}  // namespace silkworm::sentry::discovery::disc_v4
+}  // namespace silkworm::sentry::discovery::disc_v4::enr

--- a/silkworm/sentry/discovery/disc_v4/enr/enr_request_message.hpp
+++ b/silkworm/sentry/discovery/disc_v4/enr/enr_request_message.hpp
@@ -18,7 +18,7 @@
 
 #include <chrono>
 
-#include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 
 namespace silkworm::sentry::discovery::disc_v4::enr {
 

--- a/silkworm/sentry/discovery/disc_v4/enr/enr_response_message.cpp
+++ b/silkworm/sentry/discovery/disc_v4/enr/enr_response_message.cpp
@@ -1,0 +1,72 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "enr_response_message.hpp"
+
+#include <vector>
+
+#include <silkworm/core/rlp/decode_vector.hpp>
+#include <silkworm/core/rlp/encode_vector.hpp>
+#include <silkworm/infra/common/decoding_exception.hpp>
+#include <silkworm/sentry/discovery/disc_v4/common/packet_type.hpp>
+#include <silkworm/sentry/discovery/enr/enr_codec.hpp>
+
+namespace silkworm::sentry::discovery::disc_v4::enr {
+
+const uint8_t EnrResponseMessage::kId = static_cast<uint8_t>(PacketType::kEnrResponse);
+
+Bytes EnrResponseMessage::rlp_encode(const EccKeyPair& key_pair) const {
+    Bytes request_hash_rlp_data;
+    rlp::encode(request_hash_rlp_data, request_hash);
+
+    std::vector<rlp::RlpBytes> items = {
+        rlp::RlpBytes{request_hash_rlp_data},
+        rlp::RlpBytes{discovery::enr::EnrCodec::encode(record, key_pair)},
+    };
+
+    Bytes data;
+    rlp::encode(data, items);
+    return data;
+}
+
+EnrResponseMessage EnrResponseMessage::rlp_decode(ByteView data) {
+    auto rlp_header = rlp::decode_header(data);
+    if (!rlp_header)
+        throw DecodingException(rlp_header.error(), "Failed to decode EnrResponseMessage RLP header");
+    if (!rlp_header->list)
+        throw DecodingException(DecodingError::kUnexpectedString, "Failed to decode EnrResponseMessage RLP");
+
+    Bytes request_hash;
+    auto request_hash_decode_result = rlp::decode(data, request_hash, rlp::Leftover::kAllow);
+    if (!request_hash_decode_result)
+        throw DecodingException(request_hash_decode_result.error(), "Failed to decode EnrResponseMessage RLP request_hash");
+
+    ByteView enr_data = data;
+    auto record = [&enr_data]() -> discovery::enr::EnrRecord {
+        try {
+            return discovery::enr::EnrCodec::decode(enr_data);
+        } catch (const std::runtime_error& ex) {
+            throw DecodeEnrRecordError(ex);
+        }
+    }();
+
+    return EnrResponseMessage{
+        std::move(request_hash),
+        std::move(record),
+    };
+}
+
+}  // namespace silkworm::sentry::discovery::disc_v4::enr

--- a/silkworm/sentry/discovery/disc_v4/enr/enr_response_message.hpp
+++ b/silkworm/sentry/discovery/disc_v4/enr/enr_response_message.hpp
@@ -1,0 +1,45 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+#include <silkworm/core/common/base.hpp>
+#include <silkworm/sentry/common/ecc_key_pair.hpp>
+#include <silkworm/sentry/discovery/enr/enr_record.hpp>
+
+namespace silkworm::sentry::discovery::disc_v4::enr {
+
+struct EnrResponseMessage {
+    using EnrRecord = discovery::enr::EnrRecord;
+
+    Bytes request_hash;
+    EnrRecord record;
+
+    [[nodiscard]] Bytes rlp_encode(const EccKeyPair& key_pair) const;
+    [[nodiscard]] static EnrResponseMessage rlp_decode(ByteView data);
+
+    static const uint8_t kId;
+
+    class DecodeEnrRecordError : public std::runtime_error {
+      public:
+        DecodeEnrRecordError(const std::exception& ex) : std::runtime_error(std::string("Failed to decode EnrResponseMessage.record: ") + ex.what()) {}
+    };
+};
+
+}  // namespace silkworm::sentry::discovery::disc_v4::enr

--- a/silkworm/sentry/discovery/disc_v4/enr/enr_response_message.hpp
+++ b/silkworm/sentry/discovery/disc_v4/enr/enr_response_message.hpp
@@ -19,7 +19,7 @@
 #include <stdexcept>
 #include <string>
 
-#include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/sentry/common/ecc_key_pair.hpp>
 #include <silkworm/sentry/discovery/enr/enr_record.hpp>
 

--- a/silkworm/sentry/discovery/disc_v4/enr/enr_response_message_test.cpp
+++ b/silkworm/sentry/discovery/disc_v4/enr/enr_response_message_test.cpp
@@ -1,0 +1,74 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "enr_response_message.hpp"
+
+#include <catch2/catch.hpp>
+
+#include <silkworm/core/common/util.hpp>
+#include <silkworm/core/rlp/decode_vector.hpp>
+
+namespace silkworm::sentry::discovery::disc_v4::enr {
+
+TEST_CASE("EnrResponseMessage.rlp_decode") {
+    auto message = EnrResponseMessage::rlp_decode(*from_hex("f8bda0d9291b8aeb19fc0bd30ee63ddf06a32b3d0d11f960923d7f5f2f2e4bb35ce51df89ab8405ad679e2553358ece5cd4b081032ffb64c52ea354201a354b1354240ad7df6e8571576a6628e1aaa83674e3deacd79a7cf3c459b2467abd133e338351435f0ad6a83657468cac984fc64ec0483118c30826964827634826970847f00000189736563703235366b31a103df05840e8262ca022aaab57ef93233e305181169f7ab3fdb62917756d345a8c98374637082766583756470827665"));
+    auto& record = message.record;
+    CHECK(record.public_key == EccPublicKey::deserialize_hex("df05840e8262ca022aaab57ef93233e305181169f7ab3fdb62917756d345a8c9739cf596254d5075281b7a013b6c6aff9b596830a7bfc24ae85f5d14b6efc545"));
+    CHECK(record.seq_num == 106);
+    REQUIRE(record.address_v4.has_value());
+    CHECK(record.address_v4->endpoint.address().to_string() == "127.0.0.1");
+    CHECK(record.address_v4->endpoint.port() == 30309);
+    CHECK(record.address_v4->port_rlpx == 30309);
+    CHECK_FALSE(record.address_v6.has_value());
+
+    REQUIRE(record.eth1_fork_id_data.has_value());
+    ByteView eth1_fork_id_data{*record.eth1_fork_id_data};
+    CHECK(eth1_fork_id_data.size() == 11);
+
+    // eth1_fork_id_data is RLP([[hash_u32, next_u64]]) where the outer list has a single item.
+    // It happens because in geth forkid.ID struct is contained within an enrEntry struct (each struct forms a list).
+    // This outer list has an RLP header that decode_header() cuts off.
+    auto eth1_fork_id_data_rlp_header = rlp::decode_header(eth1_fork_id_data);
+    REQUIRE(eth1_fork_id_data_rlp_header.has_value());
+    CHECK(eth1_fork_id_data_rlp_header->list);
+    CHECK(eth1_fork_id_data_rlp_header->payload_length == 10);
+
+    // now eth1_fork_id_data is just RLP([hash_u32, next_u64])
+    uint32_t eth1_fork_id_hash;
+    uint64_t eth1_fork_id_next;
+    auto eth1_fork_id_decode_result = rlp::decode(eth1_fork_id_data, rlp::Leftover::kProhibit, eth1_fork_id_hash, eth1_fork_id_next);
+    CHECK(eth1_fork_id_decode_result.has_value());
+    if (!eth1_fork_id_decode_result) {
+        FAIL("eth1_fork_id_decode_result.error = " + std::to_string(static_cast<int>(eth1_fork_id_decode_result.error())));
+    }
+    CHECK(eth1_fork_id_hash == 0xFC64EC04);
+    CHECK(eth1_fork_id_next == 1150000);
+
+    CHECK_FALSE(record.eth2_fork_id_data.has_value());
+    CHECK_FALSE(record.eth2_attestation_subnets_data.has_value());
+}
+
+TEST_CASE("EnrResponseMessage.rlp_decode.big_seq_num") {
+    auto message = EnrResponseMessage::rlp_decode(*from_hex("f8cca0db48c2d9cd569e608d40ebd8cd4dbb7d225de93dcc5366e1385d412feacf8fabf8a9b840e9201a9daeffb557a377c87f15cacd5539a7b764a16e01d610e359d13e5aa29043a7d1e81fcd3e5d62fae96dbb5c167ec3473087161eb0d73e4d5aa36c561f2286017f0e71b3c483657468c7c684dce96c2d8082696482763482697084416c4665836c6573c10189736563703235366b31a1022b252ab6a1d0f971d9722cb839a42cb81db019ba44c08754628ab4a82348707184736e6170c08374637082765f8375647082765f"));
+    auto& record = message.record;
+    CHECK(record.seq_num == 1645214806980);
+    REQUIRE(record.address_v4.has_value());
+    CHECK(record.address_v4->endpoint.address().to_string() == "65.108.70.101");
+    CHECK(record.address_v4->endpoint.port() == 30303);
+    CHECK(record.address_v4->port_rlpx == 30303);
+}
+
+}  // namespace silkworm::sentry::discovery::disc_v4::enr

--- a/silkworm/sentry/discovery/disc_v4/enr/fetch_enr_record.cpp
+++ b/silkworm/sentry/discovery/disc_v4/enr/fetch_enr_record.cpp
@@ -1,0 +1,77 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "fetch_enr_record.hpp"
+
+#include <chrono>
+#include <variant>
+
+#include <boost/asio/this_coro.hpp>
+#include <boost/system/errc.hpp>
+#include <boost/system/system_error.hpp>
+
+#include <silkworm/infra/common/log.hpp>
+#include <silkworm/infra/concurrency/awaitable_wait_for_one.hpp>
+#include <silkworm/infra/concurrency/channel.hpp>
+#include <silkworm/infra/concurrency/timeout.hpp>
+#include <silkworm/sentry/discovery/disc_v4/common/message_expiration.hpp>
+
+#include "enr_request_message.hpp"
+
+namespace silkworm::sentry::discovery::disc_v4::enr {
+
+Task<std::optional<discovery::enr::EnrRecord>> fetch_enr_record(
+    EccPublicKey node_id,
+    boost::asio::ip::udp::endpoint endpoint,
+    MessageSender& message_sender,
+    boost::signals2::signal<void(EnrResponseMessage)>& on_enr_response_signal) {
+    using namespace std::chrono_literals;
+    using namespace concurrency::awaitable_wait_for_one;
+
+    auto executor = co_await boost::asio::this_coro::executor;
+    concurrency::Channel<std::optional<discovery::enr::EnrRecord>> response_channel{executor, 1};
+    auto on_enr_response_handler = [&](EnrResponseMessage message) {
+        if (message.record.public_key == node_id) {
+            response_channel.try_send(std::move(message.record));
+        }
+    };
+
+    [[maybe_unused]] boost::signals2::scoped_connection subscription(on_enr_response_signal.connect(on_enr_response_handler));
+
+    EnrRequestMessage request_message{
+        make_message_expiration(),
+    };
+
+    try {
+        co_await message_sender.send_enr_request(std::move(request_message), endpoint);
+    } catch (const boost::system::system_error& ex) {
+        if (ex.code() == boost::system::errc::operation_canceled)
+            throw;
+        log::Debug("disc_v4") << "fetch_enr_record failed to send_enr_request"
+                              << " to " << endpoint
+                              << " due to exception: " << ex.what();
+        co_return std::nullopt;
+    }
+
+    try {
+        auto record = std::get<0>(co_await (response_channel.receive() || concurrency::timeout(500ms)));
+        co_return record;
+    } catch (const concurrency::TimeoutExpiredError&) {
+        co_return std::nullopt;
+    }
+}
+
+}  // namespace silkworm::sentry::discovery::disc_v4::enr

--- a/silkworm/sentry/discovery/disc_v4/enr/fetch_enr_record.hpp
+++ b/silkworm/sentry/discovery/disc_v4/enr/fetch_enr_record.hpp
@@ -1,0 +1,40 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <optional>
+
+#include <silkworm/infra/concurrency/task.hpp>
+
+#include <boost/asio/ip/udp.hpp>
+#include <boost/signals2.hpp>
+
+#include <silkworm/sentry/common/ecc_public_key.hpp>
+#include <silkworm/sentry/discovery/enr/enr_record.hpp>
+
+#include "enr_response_message.hpp"
+#include "message_sender.hpp"
+
+namespace silkworm::sentry::discovery::disc_v4::enr {
+
+Task<std::optional<discovery::enr::EnrRecord>> fetch_enr_record(
+    EccPublicKey node_id,
+    boost::asio::ip::udp::endpoint endpoint,
+    MessageSender& message_sender,
+    boost::signals2::signal<void(EnrResponseMessage)>& on_enr_response_signal);
+
+}  // namespace silkworm::sentry::discovery::disc_v4::enr

--- a/silkworm/sentry/discovery/disc_v4/enr/message_handler.hpp
+++ b/silkworm/sentry/discovery/disc_v4/enr/message_handler.hpp
@@ -20,7 +20,7 @@
 
 #include <boost/asio/ip/udp.hpp>
 
-#include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/sentry/common/ecc_public_key.hpp>
 
 #include "enr_request_message.hpp"

--- a/silkworm/sentry/discovery/disc_v4/enr/message_handler.hpp
+++ b/silkworm/sentry/discovery/disc_v4/enr/message_handler.hpp
@@ -1,0 +1,41 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <silkworm/infra/concurrency/task.hpp>
+
+#include <boost/asio/ip/udp.hpp>
+
+#include <silkworm/core/common/base.hpp>
+#include <silkworm/sentry/common/ecc_public_key.hpp>
+
+#include "enr_request_message.hpp"
+#include "enr_response_message.hpp"
+
+namespace silkworm::sentry::discovery::disc_v4::enr {
+
+struct MessageHandler {
+    virtual ~MessageHandler() = default;
+    virtual Task<void> on_enr_request(
+        EnrRequestMessage message,
+        EccPublicKey sender_public_key,
+        boost::asio::ip::udp::endpoint sender_endpoint,
+        Bytes packet_hash) = 0;
+    virtual Task<void> on_enr_response(EnrResponseMessage message) = 0;
+};
+
+}  // namespace silkworm::sentry::discovery::disc_v4::enr

--- a/silkworm/sentry/discovery/disc_v4/enr/message_sender.hpp
+++ b/silkworm/sentry/discovery/disc_v4/enr/message_sender.hpp
@@ -16,16 +16,19 @@
 
 #pragma once
 
-#include "enr/message_sender.hpp"
-#include "find/message_sender.hpp"
-#include "ping/message_sender.hpp"
+#include <silkworm/infra/concurrency/task.hpp>
 
-namespace silkworm::sentry::discovery::disc_v4 {
+#include <boost/asio/ip/udp.hpp>
 
-struct MessageSender
-    : ping::MessageSender,
-      enr::MessageSender,
-      find::MessageSender {
+#include "enr_request_message.hpp"
+#include "enr_response_message.hpp"
+
+namespace silkworm::sentry::discovery::disc_v4::enr {
+
+struct MessageSender {
+    virtual ~MessageSender() = default;
+    virtual Task<void> send_enr_request(EnrRequestMessage message, boost::asio::ip::udp::endpoint recipient) = 0;
+    virtual Task<void> send_enr_response(EnrResponseMessage message, boost::asio::ip::udp::endpoint recipient) = 0;
 };
 
-}  // namespace silkworm::sentry::discovery::disc_v4
+}  // namespace silkworm::sentry::discovery::disc_v4::enr

--- a/silkworm/sentry/discovery/disc_v4/find/find_neighbors.cpp
+++ b/silkworm/sentry/discovery/disc_v4/find/find_neighbors.cpp
@@ -29,9 +29,9 @@
 #include <silkworm/infra/concurrency/awaitable_wait_for_one.hpp>
 #include <silkworm/infra/concurrency/channel.hpp>
 #include <silkworm/infra/concurrency/timeout.hpp>
+#include <silkworm/sentry/discovery/common/node_address.hpp>
 #include <silkworm/sentry/discovery/disc_v4/common/ip_classify.hpp>
 #include <silkworm/sentry/discovery/disc_v4/common/message_expiration.hpp>
-#include <silkworm/sentry/discovery/disc_v4/common/node_address.hpp>
 #include <silkworm/sentry/discovery/disc_v4/common/node_distance.hpp>
 
 namespace silkworm::sentry::discovery::disc_v4::find {

--- a/silkworm/sentry/discovery/disc_v4/find/find_node_handler.cpp
+++ b/silkworm/sentry/discovery/disc_v4/find/find_node_handler.cpp
@@ -72,7 +72,8 @@ Task<void> FindNodeHandler::handle(
             address = co_await db.find_node_address_v6(node_id);
         if (address) {
             NodeAddress node_address{
-                boost::asio::ip::udp::endpoint(address->ip, address->port_disc),
+                address->ip,
+                address->port_disc,
                 address->port_rlpx,
             };
             node_addresses.insert({node_id, std::move(node_address)});

--- a/silkworm/sentry/discovery/disc_v4/find/find_node_handler.cpp
+++ b/silkworm/sentry/discovery/disc_v4/find/find_node_handler.cpp
@@ -23,8 +23,8 @@
 #include <boost/system/system_error.hpp>
 
 #include <silkworm/infra/common/log.hpp>
+#include <silkworm/sentry/discovery/common/node_address.hpp>
 #include <silkworm/sentry/discovery/disc_v4/common/message_expiration.hpp>
-#include <silkworm/sentry/discovery/disc_v4/common/node_address.hpp>
 #include <silkworm/sentry/discovery/disc_v4/common/node_distance.hpp>
 #include <silkworm/sentry/discovery/disc_v4/ping/ping_check.hpp>
 

--- a/silkworm/sentry/discovery/disc_v4/find/find_node_message.hpp
+++ b/silkworm/sentry/discovery/disc_v4/find/find_node_message.hpp
@@ -19,7 +19,6 @@
 #include <chrono>
 #include <string>
 
-#include <silkworm/core/common/base.hpp>
 #include <silkworm/core/common/bytes.hpp>
 #include <silkworm/sentry/common/ecc_public_key.hpp>
 

--- a/silkworm/sentry/discovery/disc_v4/find/neighbors_message.hpp
+++ b/silkworm/sentry/discovery/disc_v4/find/neighbors_message.hpp
@@ -19,7 +19,6 @@
 #include <chrono>
 #include <map>
 
-#include <silkworm/core/common/base.hpp>
 #include <silkworm/core/common/bytes.hpp>
 #include <silkworm/sentry/common/ecc_public_key.hpp>
 #include <silkworm/sentry/discovery/common/node_address.hpp>

--- a/silkworm/sentry/discovery/disc_v4/find/neighbors_message.hpp
+++ b/silkworm/sentry/discovery/disc_v4/find/neighbors_message.hpp
@@ -22,7 +22,7 @@
 #include <silkworm/core/common/base.hpp>
 #include <silkworm/core/common/bytes.hpp>
 #include <silkworm/sentry/common/ecc_public_key.hpp>
-#include <silkworm/sentry/discovery/disc_v4/common/node_address.hpp>
+#include <silkworm/sentry/discovery/common/node_address.hpp>
 
 namespace silkworm::sentry::discovery::disc_v4::find {
 

--- a/silkworm/sentry/discovery/disc_v4/message_codec.cpp
+++ b/silkworm/sentry/discovery/disc_v4/message_codec.cpp
@@ -48,7 +48,7 @@ Bytes MessageCodec::encode(const Message& message, ByteView private_key) {
     memcpy(packet->data, message.data.data(), message.data.size());
 
     auto type_and_data_hash = keccak256(ByteView(packet_data).substr(offsetof(Packet, type)));
-    Bytes signature = ecdsa_signature::sign(ByteView(type_and_data_hash.bytes), private_key);
+    Bytes signature = ecdsa_signature::sign_recoverable(ByteView(type_and_data_hash.bytes), private_key);
     memcpy(packet->signature, signature.data(), signature.size());
 
     auto hash = keccak256(ByteView(packet_data).substr(offsetof(Packet, signature)));
@@ -77,7 +77,7 @@ MessageEnvelope MessageCodec::decode(ByteView packet_data) {
         throw std::runtime_error("MessageCodec: invalid hash");
 
     auto type_and_data_hash = keccak256(packet_data.substr(offsetof(Packet, type)));
-    auto public_key = ecdsa_signature::recover_and_verify(
+    auto public_key = ecdsa_signature::verify_and_recover(
         ByteView(type_and_data_hash.bytes),
         ByteView(packet->signature));
 

--- a/silkworm/sentry/discovery/disc_v4/message_codec.hpp
+++ b/silkworm/sentry/discovery/disc_v4/message_codec.hpp
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <silkworm/core/common/base.hpp>
 #include <silkworm/core/common/bytes.hpp>
 #include <silkworm/sentry/common/ecc_public_key.hpp>
 #include <silkworm/sentry/common/message.hpp>

--- a/silkworm/sentry/discovery/disc_v4/message_codec_test.cpp
+++ b/silkworm/sentry/discovery/disc_v4/message_codec_test.cpp
@@ -47,6 +47,7 @@ TEST_CASE("MessageCodec.ping_encode_and_decode") {
         101,
         udp::endpoint{make_address("10.0.0.2"), 200},
         std::chrono::system_clock::now(),
+        123,
     };
 
     Message expected_message{static_cast<uint8_t>(PacketType::kPing), expected_ping_message.rlp_encode()};
@@ -64,6 +65,7 @@ TEST_CASE("MessageCodec.ping_encode_and_decode") {
     CHECK(decoded_ping_message.sender_port_rlpx == expected_ping_message.sender_port_rlpx);
     CHECK(decoded_ping_message.recipient_endpoint == expected_ping_message.recipient_endpoint);
     CHECK(std::chrono::duration_cast<std::chrono::seconds>(decoded_ping_message.expiration - expected_ping_message.expiration).count() == 0);
+    CHECK(decoded_ping_message.enr_seq_num == expected_ping_message.enr_seq_num);
 }
 
 TEST_CASE("MessageCodec.ping_decode") {

--- a/silkworm/sentry/discovery/disc_v4/message_handler.hpp
+++ b/silkworm/sentry/discovery/disc_v4/message_handler.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "enr/message_handler.hpp"
 #include "find/message_handler.hpp"
 #include "ping/message_handler.hpp"
 
@@ -23,6 +24,7 @@ namespace silkworm::sentry::discovery::disc_v4 {
 
 struct MessageHandler
     : ping::MessageHandler,
+      enr::MessageHandler,
       find::MessageHandler {
 };
 

--- a/silkworm/sentry/discovery/disc_v4/ping/message_handler.hpp
+++ b/silkworm/sentry/discovery/disc_v4/ping/message_handler.hpp
@@ -20,7 +20,6 @@
 
 #include <boost/asio/ip/udp.hpp>
 
-#include <silkworm/core/common/base.hpp>
 #include <silkworm/core/common/bytes.hpp>
 #include <silkworm/sentry/common/ecc_public_key.hpp>
 

--- a/silkworm/sentry/discovery/disc_v4/ping/ping_check.cpp
+++ b/silkworm/sentry/discovery/disc_v4/ping/ping_check.cpp
@@ -59,6 +59,7 @@ Task<bool> ping_check(
     EccPublicKey node_id,
     std::optional<boost::asio::ip::udp::endpoint> endpoint_opt,
     EnodeUrl local_node_url,
+    uint64_t local_enr_seq_num,
     MessageSender& message_sender,
     boost::signals2::signal<void(PongMessage, EccPublicKey)>& on_pong_signal,
     node_db::NodeDb& db) {
@@ -101,6 +102,7 @@ Task<bool> ping_check(
         local_node_url.port_rlpx(),
         endpoint,
         make_message_expiration(),
+        local_enr_seq_num,
     };
 
     try {

--- a/silkworm/sentry/discovery/disc_v4/ping/ping_check.hpp
+++ b/silkworm/sentry/discovery/disc_v4/ping/ping_check.hpp
@@ -37,6 +37,7 @@ Task<bool> ping_check(
     EccPublicKey node_id,
     std::optional<boost::asio::ip::udp::endpoint> endpoint_opt,
     EnodeUrl local_node_url,
+    uint64_t local_enr_seq_num,
     MessageSender& message_sender,
     boost::signals2::signal<void(PongMessage, EccPublicKey)>& on_pong_signal,
     node_db::NodeDb& db);

--- a/silkworm/sentry/discovery/disc_v4/ping/ping_handler.cpp
+++ b/silkworm/sentry/discovery/disc_v4/ping/ping_handler.cpp
@@ -30,6 +30,7 @@ Task<void> PingHandler::handle(
     PingMessage message,
     boost::asio::ip::udp::endpoint sender_endpoint,
     Bytes ping_packet_hash,
+    uint64_t local_enr_seq_num,
     MessageSender& sender) {
     if (is_expired_message_expiration(message.expiration)) {
         co_return;
@@ -40,6 +41,7 @@ Task<void> PingHandler::handle(
         recipient,
         ping_packet_hash,
         make_message_expiration(),
+        local_enr_seq_num,
     };
 
     try {

--- a/silkworm/sentry/discovery/disc_v4/ping/ping_handler.hpp
+++ b/silkworm/sentry/discovery/disc_v4/ping/ping_handler.hpp
@@ -20,7 +20,6 @@
 
 #include <boost/asio/ip/udp.hpp>
 
-#include <silkworm/core/common/base.hpp>
 #include <silkworm/core/common/bytes.hpp>
 
 #include "message_sender.hpp"

--- a/silkworm/sentry/discovery/disc_v4/ping/ping_handler.hpp
+++ b/silkworm/sentry/discovery/disc_v4/ping/ping_handler.hpp
@@ -33,6 +33,7 @@ struct PingHandler {
         PingMessage message,
         boost::asio::ip::udp::endpoint sender_endpoint,
         Bytes ping_packet_hash,
+        uint64_t local_enr_seq_num,
         MessageSender& sender);
 };
 

--- a/silkworm/sentry/discovery/disc_v4/ping/ping_message.cpp
+++ b/silkworm/sentry/discovery/disc_v4/ping/ping_message.cpp
@@ -33,7 +33,8 @@ Bytes PingMessage::rlp_encode() const {
     NodeAddress sender_address{sender_endpoint, sender_port_rlpx};
     NodeAddress recipient_address{recipient_endpoint, 0};
     auto expiration_ts = unix_timestamp_from_time_point(expiration);
-    rlp::encode(data, kDiscVersion, sender_address, recipient_address, expiration_ts);
+    auto enr_seq_num_value = enr_seq_num ? *enr_seq_num : 0;
+    rlp::encode(data, kDiscVersion, sender_address, recipient_address, expiration_ts, enr_seq_num_value);
     return data;
 }
 
@@ -42,6 +43,7 @@ PingMessage PingMessage::rlp_decode(ByteView data) {
     NodeAddress sender_address;
     NodeAddress recipient_address;
     uint64_t expiration_ts;
+    std::optional<uint64_t> enr_seq_num_opt;
 
     auto result = rlp::decode(
         data,
@@ -54,11 +56,17 @@ PingMessage PingMessage::rlp_decode(ByteView data) {
         throw DecodingException(result.error(), "Failed to decode PingMessage RLP");
     }
 
+    uint64_t enr_seq_num;
+    if (rlp::decode(data, enr_seq_num)) {
+        enr_seq_num_opt = enr_seq_num;
+    }
+
     return PingMessage{
         std::move(sender_address.endpoint),
         sender_address.port_rlpx,
         std::move(recipient_address.endpoint),
         time_point_from_unix_timestamp(expiration_ts),
+        std::move(enr_seq_num_opt),
     };
 }
 

--- a/silkworm/sentry/discovery/disc_v4/ping/ping_message.cpp
+++ b/silkworm/sentry/discovery/disc_v4/ping/ping_message.cpp
@@ -20,7 +20,7 @@
 #include <silkworm/core/rlp/encode_vector.hpp>
 #include <silkworm/infra/common/decoding_exception.hpp>
 #include <silkworm/infra/common/unix_timestamp.hpp>
-#include <silkworm/sentry/discovery/disc_v4/common/node_address.hpp>
+#include <silkworm/sentry/discovery/common/node_address.hpp>
 #include <silkworm/sentry/discovery/disc_v4/common/packet_type.hpp>
 
 namespace silkworm::sentry::discovery::disc_v4::ping {

--- a/silkworm/sentry/discovery/disc_v4/ping/ping_message.hpp
+++ b/silkworm/sentry/discovery/disc_v4/ping/ping_message.hpp
@@ -18,6 +18,7 @@
 
 #include <chrono>
 #include <cstdint>
+#include <optional>
 
 #include <boost/asio/ip/udp.hpp>
 
@@ -31,6 +32,7 @@ struct PingMessage {
     uint16_t sender_port_rlpx{};
     boost::asio::ip::udp::endpoint recipient_endpoint;
     std::chrono::time_point<std::chrono::system_clock> expiration;
+    std::optional<uint64_t> enr_seq_num;
 
     [[nodiscard]] Bytes rlp_encode() const;
     [[nodiscard]] static PingMessage rlp_decode(ByteView data);

--- a/silkworm/sentry/discovery/disc_v4/ping/ping_message.hpp
+++ b/silkworm/sentry/discovery/disc_v4/ping/ping_message.hpp
@@ -22,7 +22,6 @@
 
 #include <boost/asio/ip/udp.hpp>
 
-#include <silkworm/core/common/base.hpp>
 #include <silkworm/core/common/bytes.hpp>
 
 namespace silkworm::sentry::discovery::disc_v4::ping {

--- a/silkworm/sentry/discovery/disc_v4/ping/pong_message.cpp
+++ b/silkworm/sentry/discovery/disc_v4/ping/pong_message.cpp
@@ -31,7 +31,8 @@ Bytes PongMessage::rlp_encode() const {
     Bytes data;
     NodeAddress recipient_address{recipient_endpoint, 0};
     auto expiration_ts = unix_timestamp_from_time_point(expiration);
-    rlp::encode(data, recipient_address, ping_hash, expiration_ts);
+    auto enr_seq_num_value = enr_seq_num ? *enr_seq_num : 0;
+    rlp::encode(data, recipient_address, ping_hash, expiration_ts, enr_seq_num_value);
     return data;
 }
 
@@ -39,6 +40,7 @@ PongMessage PongMessage::rlp_decode(ByteView data) {
     NodeAddress recipient_address;
     Bytes ping_hash;
     uint64_t expiration_ts;
+    std::optional<uint64_t> enr_seq_num_opt;
 
     auto result = rlp::decode(
         data,
@@ -50,10 +52,16 @@ PongMessage PongMessage::rlp_decode(ByteView data) {
         throw DecodingException(result.error(), "Failed to decode PingMessage RLP");
     }
 
+    uint64_t enr_seq_num;
+    if (rlp::decode(data, enr_seq_num)) {
+        enr_seq_num_opt = enr_seq_num;
+    }
+
     return PongMessage{
         std::move(recipient_address.endpoint),
         std::move(ping_hash),
         time_point_from_unix_timestamp(expiration_ts),
+        std::move(enr_seq_num_opt),
     };
 }
 

--- a/silkworm/sentry/discovery/disc_v4/ping/pong_message.cpp
+++ b/silkworm/sentry/discovery/disc_v4/ping/pong_message.cpp
@@ -20,7 +20,7 @@
 #include <silkworm/core/rlp/encode_vector.hpp>
 #include <silkworm/infra/common/decoding_exception.hpp>
 #include <silkworm/infra/common/unix_timestamp.hpp>
-#include <silkworm/sentry/discovery/disc_v4/common/node_address.hpp>
+#include <silkworm/sentry/discovery/common/node_address.hpp>
 #include <silkworm/sentry/discovery/disc_v4/common/packet_type.hpp>
 
 namespace silkworm::sentry::discovery::disc_v4::ping {

--- a/silkworm/sentry/discovery/disc_v4/ping/pong_message.hpp
+++ b/silkworm/sentry/discovery/disc_v4/ping/pong_message.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <chrono>
+#include <optional>
 
 #include <boost/asio/ip/udp.hpp>
 
@@ -29,6 +30,7 @@ struct PongMessage {
     boost::asio::ip::udp::endpoint recipient_endpoint;
     Bytes ping_hash;
     std::chrono::time_point<std::chrono::system_clock> expiration;
+    std::optional<uint64_t> enr_seq_num;
 
     [[nodiscard]] Bytes rlp_encode() const;
     [[nodiscard]] static PongMessage rlp_decode(ByteView data);

--- a/silkworm/sentry/discovery/disc_v4/ping/pong_message.hpp
+++ b/silkworm/sentry/discovery/disc_v4/ping/pong_message.hpp
@@ -21,7 +21,6 @@
 
 #include <boost/asio/ip/udp.hpp>
 
-#include <silkworm/core/common/base.hpp>
 #include <silkworm/core/common/bytes.hpp>
 
 namespace silkworm::sentry::discovery::disc_v4::ping {

--- a/silkworm/sentry/discovery/disc_v4/server.cpp
+++ b/silkworm/sentry/discovery/disc_v4/server.cpp
@@ -26,7 +26,6 @@
 #include <boost/asio/ip/udp.hpp>
 #include <boost/asio/this_coro.hpp>
 
-#include <silkworm/core/common/base.hpp>
 #include <silkworm/core/common/bytes.hpp>
 #include <silkworm/infra/common/decoding_exception.hpp>
 #include <silkworm/infra/common/log.hpp>

--- a/silkworm/sentry/discovery/disc_v4/server.cpp
+++ b/silkworm/sentry/discovery/disc_v4/server.cpp
@@ -16,6 +16,7 @@
 
 #include "server.hpp"
 
+#include <concepts>
 #include <optional>
 #include <stdexcept>
 
@@ -115,11 +116,20 @@ class ServerImpl {
                             std::move(envelope->public_key));
                         break;
                     case PacketType::kEnrRequest:
+                        co_await handler_.on_enr_request(
+                            enr::EnrRequestMessage::rlp_decode(data),
+                            std::move(envelope->public_key),
+                            std::move(sender_endpoint),
+                            std::move(envelope->packet_hash));
                         break;
                     case PacketType::kEnrResponse:
+                        co_await handler_.on_enr_response(
+                            enr::EnrResponseMessage::rlp_decode(data));
                         break;
                 }
             } catch (const find::FindNodeMessage::DecodeTargetPublicKeyError& ex) {
+                log::Debug("sentry") << "disc_v4::Server received a bad message from " << sender_endpoint << " : " << ex.what();
+            } catch (const enr::EnrResponseMessage::DecodeEnrRecordError& ex) {
                 log::Debug("sentry") << "disc_v4::Server received a bad message from " << sender_endpoint << " : " << ex.what();
             } catch (const DecodingException& ex) {
                 log::Warning("sentry") << "disc_v4::Server received a bad message from " << sender_endpoint << " : " << ex.what();
@@ -129,15 +139,24 @@ class ServerImpl {
 
     template <class TMessage>
     Task<void> send_message(TMessage message, ip::udp::endpoint recipient) {
-        auto packet_data = MessageCodec::encode(
-            Message{TMessage::kId, message.rlp_encode()},
-            node_key_().private_key());
-        co_await send_packet(std::move(packet_data), recipient);
+        return send_message(Message{TMessage::kId, message.rlp_encode()}, std::move(recipient));
+    }
+
+    template <std::same_as<enr::EnrResponseMessage> TMessage>
+    Task<void> send_message(TMessage message, ip::udp::endpoint recipient) {
+        return send_message(Message{enr::EnrResponseMessage::kId, message.rlp_encode(node_key_())}, std::move(recipient));
     }
 
   private:
     [[nodiscard]] ip::udp::endpoint listen_endpoint() const {
         return ip::udp::endpoint{ip_, port_};
+    }
+
+    Task<void> send_message(Message message, ip::udp::endpoint recipient) {
+        auto packet_data = MessageCodec::encode(
+            std::move(message),
+            node_key_().private_key());
+        co_await send_packet(std::move(packet_data), recipient);
     }
 
     Task<void> send_packet(Bytes data, ip::udp::endpoint recipient) {
@@ -182,6 +201,14 @@ Task<void> Server::send_find_node(find::FindNodeMessage message, ip::udp::endpoi
 }
 
 Task<void> Server::send_neighbors(find::NeighborsMessage message, ip::udp::endpoint recipient) {
+    return p_impl_->send_message(std::move(message), std::move(recipient));
+}
+
+Task<void> Server::send_enr_request(enr::EnrRequestMessage message, ip::udp::endpoint recipient) {
+    return p_impl_->send_message(std::move(message), std::move(recipient));
+}
+
+Task<void> Server::send_enr_response(enr::EnrResponseMessage message, ip::udp::endpoint recipient) {
     return p_impl_->send_message(std::move(message), std::move(recipient));
 }
 

--- a/silkworm/sentry/discovery/disc_v4/server.hpp
+++ b/silkworm/sentry/discovery/disc_v4/server.hpp
@@ -44,6 +44,8 @@ class Server : public MessageSender {
     Task<void> send_pong(ping::PongMessage message, boost::asio::ip::udp::endpoint recipient) override;
     Task<void> send_find_node(find::FindNodeMessage message, boost::asio::ip::udp::endpoint recipient) override;
     Task<void> send_neighbors(find::NeighborsMessage message, boost::asio::ip::udp::endpoint recipient) override;
+    Task<void> send_enr_request(enr::EnrRequestMessage message, boost::asio::ip::udp::endpoint recipient) override;
+    Task<void> send_enr_response(enr::EnrResponseMessage message, boost::asio::ip::udp::endpoint recipient) override;
 
   private:
     std::unique_ptr<ServerImpl> p_impl_;

--- a/silkworm/sentry/discovery/discovery.cpp
+++ b/silkworm/sentry/discovery/discovery.cpp
@@ -40,6 +40,7 @@ class DiscoveryImpl {
         uint64_t network_id,
         std::function<EccKeyPair()> node_key,
         std::function<EnodeUrl()> node_url,
+        std::function<enr::EnrRecord()> node_record,
         std::vector<EnodeUrl> bootnodes,
         uint16_t disc_v4_port);
 
@@ -76,6 +77,7 @@ DiscoveryImpl::DiscoveryImpl(
     uint64_t network_id,
     std::function<EccKeyPair()> node_key,
     std::function<EnodeUrl()> node_url,
+    std::function<enr::EnrRecord()> node_record,
     std::vector<EnodeUrl> bootnodes,
     uint16_t disc_v4_port)
     : peer_urls_(std::move(peer_urls)),
@@ -84,7 +86,7 @@ DiscoveryImpl::DiscoveryImpl(
       network_id_(network_id),
       node_db_(executor_pool.any_executor()),
       bootnodes_(std::move(bootnodes)),
-      disc_v4_discovery_(executor_pool.any_executor(), disc_v4_port, node_key, node_url, node_db_.interface()) {
+      disc_v4_discovery_(executor_pool.any_executor(), disc_v4_port, node_key, node_url, node_record, node_db_.interface()) {
 }
 
 Task<void> DiscoveryImpl::run() {
@@ -189,6 +191,7 @@ Discovery::Discovery(
     uint64_t network_id,
     std::function<EccKeyPair()> node_key,
     std::function<EnodeUrl()> node_url,
+    std::function<enr::EnrRecord()> node_record,
     std::vector<EnodeUrl> bootnodes,
     uint16_t disc_v4_port)
     : p_impl_(std::make_unique<DiscoveryImpl>(
@@ -199,6 +202,7 @@ Discovery::Discovery(
           network_id,
           std::move(node_key),
           std::move(node_url),
+          std::move(node_record),
           std::move(bootnodes),
           disc_v4_port)) {}
 

--- a/silkworm/sentry/discovery/discovery.hpp
+++ b/silkworm/sentry/discovery/discovery.hpp
@@ -27,6 +27,7 @@
 #include <silkworm/sentry/common/ecc_key_pair.hpp>
 #include <silkworm/sentry/common/ecc_public_key.hpp>
 #include <silkworm/sentry/common/enode_url.hpp>
+#include <silkworm/sentry/discovery/enr/enr_record.hpp>
 
 namespace silkworm::sentry::discovery {
 
@@ -42,6 +43,7 @@ class Discovery {
         uint64_t network_id,
         std::function<EccKeyPair()> node_key,
         std::function<EnodeUrl()> node_url,
+        std::function<enr::EnrRecord()> node_record,
         std::vector<EnodeUrl> bootnodes,
         uint16_t disc_v4_port);
     ~Discovery();

--- a/silkworm/sentry/discovery/enr/CMakeLists.txt
+++ b/silkworm/sentry/discovery/enr/CMakeLists.txt
@@ -1,0 +1,38 @@
+#[[
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+]]
+
+find_package(Catch2 REQUIRED)
+
+set(TARGET silkworm_sentry_discovery_enr)
+
+file(GLOB_RECURSE SRC CONFIGURE_DEPENDS "*.cpp" "*.hpp")
+list(FILTER SRC EXCLUDE REGEX "_test\\.cpp$")
+
+add_library(${TARGET} ${SRC})
+
+target_include_directories(${TARGET} PUBLIC "${SILKWORM_MAIN_DIR}")
+
+target_link_libraries(
+  ${TARGET}
+  PUBLIC silkworm_sentry_common silkworm_core silkworm_sentry_discovery_common
+  PRIVATE cpp_base64 silkworm_infra
+)
+
+# unit tests
+set(TEST_TARGET ${TARGET}_test)
+file(GLOB_RECURSE TEST_SRC CONFIGURE_DEPENDS "*_test.cpp")
+add_executable(${TEST_TARGET} "${SILKWORM_MAIN_DIR}/cmd/test/unit_test.cpp" ${TEST_SRC})
+target_link_libraries(${TEST_TARGET} ${TARGET} Catch2::Catch2)

--- a/silkworm/sentry/discovery/enr/enr_codec.cpp
+++ b/silkworm/sentry/discovery/enr/enr_codec.cpp
@@ -1,0 +1,229 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "enr_codec.hpp"
+
+#include <map>
+#include <optional>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <silkworm/core/common/util.hpp>
+#include <silkworm/core/rlp/decode_vector.hpp>
+#include <silkworm/core/rlp/encode_vector.hpp>
+#include <silkworm/infra/common/decoding_exception.hpp>
+#include <silkworm/sentry/common/crypto/ecdsa_signature.hpp>
+#include <silkworm/sentry/discovery/common/node_address.hpp>
+
+namespace silkworm::sentry::discovery::enr {
+
+static Bytes decode_rlp_bytes(rlp::RlpByteView data, const char* key) {
+    ByteView from = data.data;
+    Bytes value;
+    auto result = rlp::decode(from, value);
+    if (!result)
+        throw DecodingException(result.error(), std::string("EnrCodec: failed to decode ") + key);
+    return value;
+}
+
+static rlp::RlpBytes encode_rlp_bytes(ByteView bytes) {
+    Bytes data;
+    rlp::encode(data, bytes);
+    return rlp::RlpBytes{std::move(data)};
+}
+
+template <UnsignedIntegral T>
+static T decode_rlp_num_value(rlp::RlpByteView data, const char* key) {
+    ByteView from = data.data;
+    T value;
+    auto result = rlp::decode<T>(from, value);
+    if (!result)
+        throw DecodingException(result.error(), std::string("EnrCodec: failed to decode ") + key);
+    return value;
+}
+
+template <UnsignedIntegral T>
+static rlp::RlpBytes encode_rlp_num_value(T value) {
+    Bytes data;
+    rlp::encode<T>(data, value);
+    return rlp::RlpBytes{std::move(data)};
+}
+
+static rlp::RlpBytes string_to_rlp_bytes(std::string_view s) {
+    return encode_rlp_bytes(ByteView{reinterpret_cast<const uint8_t*>(s.data()), s.size()});
+}
+
+template <class TKey, class TValue>
+static std::optional<TValue> map_get(const std::map<TKey, TValue>& entries, const TKey& key) {
+    return (entries.count(key) > 0) ? std::optional{entries.at(key)} : std::nullopt;
+}
+
+static std::optional<Bytes> copy_rlp_data(std::optional<rlp::RlpByteView> data) {
+    return data ? std::optional<Bytes>{Bytes{data->data}} : std::nullopt;
+}
+
+static std::optional<NodeAddress> try_decode_node_address(
+    const std::map<std::string, const rlp::RlpByteView>& entries_data,
+    const char* ip_key,
+    const char* port_disc_key,
+    const char* port_rlpx_key) {
+    if ((entries_data.count(ip_key) == 0) || (entries_data.count(port_disc_key) == 0))
+        return std::nullopt;
+
+    auto ip = ip_address_from_bytes(decode_rlp_bytes(entries_data.at(ip_key), ip_key));
+    if (!ip)
+        throw std::runtime_error("EnrCodec: invalid IP address");
+
+    uint16_t port_disc = decode_rlp_num_value<uint16_t>(entries_data.at(port_disc_key), port_disc_key);
+
+    uint16_t port_rlpx = 0;
+    if (entries_data.count(port_rlpx_key) > 0) {
+        port_rlpx = decode_rlp_num_value<uint16_t>(entries_data.at(port_rlpx_key), port_rlpx_key);
+    }
+
+    return NodeAddress{
+        boost::asio::ip::udp::endpoint(*ip, port_disc),
+        port_rlpx,
+    };
+}
+
+static bool is_valid_signature(const std::vector<rlp::RlpByteView>& items, const EccPublicKey& public_key) {
+    if (items.empty())
+        return false;
+    Bytes signature = decode_rlp_bytes(items[0], "signature");
+
+    std::span<const rlp::RlpByteView> content_items{items.begin() + 1, items.size() - 1};
+    Bytes content;
+    rlp::encode(content, content_items);
+
+    auto content_hash = keccak256(content);
+    return crypto::ecdsa_signature::verify(ByteView{content_hash.bytes}, signature, public_key);
+}
+
+static Bytes sign(const std::vector<rlp::RlpBytes>& items, ByteView private_key) {
+    if (items.empty())
+        return Bytes{};
+
+    std::span<const rlp::RlpBytes> content_items{items.begin() + 1, items.size() - 1};
+    Bytes content;
+    rlp::encode(content, content_items);
+
+    auto content_hash = keccak256(content);
+    return crypto::ecdsa_signature::sign(ByteView{content_hash.bytes}, private_key);
+}
+
+EnrRecord EnrCodec::decode(ByteView data) {
+    std::vector<rlp::RlpByteView> items;
+    auto decode_result = rlp::decode(data, items, rlp::Leftover::kAllow);
+    if (!decode_result)
+        throw DecodingException(decode_result.error(), "EnrCodec: failed to decode RLP");
+    if (items.size() < 6)
+        throw std::runtime_error("EnrCodec: not enough RLP list items");
+    if (items.size() % 2)
+        items.pop_back();
+
+    auto& seq_num_data = items[1];
+    uint64_t seq_num = decode_rlp_num_value<uint64_t>(seq_num_data, "seq_num");
+
+    std::map<std::string, const rlp::RlpByteView> entries_data;
+    for (size_t i = 2; i < items.size(); i += 2) {
+        auto key_data = decode_rlp_bytes(items[i], "key");
+        std::string key{reinterpret_cast<char*>(key_data.data()), key_data.size()};
+        entries_data.emplace(key, items[i + 1]);
+    }
+
+    if (entries_data.count("id") == 0)
+        throw std::runtime_error("EnrCodec: missing required 'id' key");
+    if (decode_rlp_bytes(entries_data.at("id"), "id") != Bytes{'v', '4'})
+        throw std::runtime_error("EnrCodec: unsupported ID scheme");
+
+    if (entries_data.count("secp256k1") == 0)
+        throw std::runtime_error("EnrCodec: missing required 'secp256k1' key");
+    auto public_key = EccPublicKey::deserialize_std(decode_rlp_bytes(entries_data.at("secp256k1"), "secp256k1"));
+
+    if (!is_valid_signature(items, public_key))
+        throw std::runtime_error("EnrCodec: invalid signature");
+
+    auto node_address_v4 = try_decode_node_address(entries_data, "ip", "udp", "tcp");
+    auto node_address_v6 = try_decode_node_address(entries_data, "ip6", "udp6", "tcp6");
+
+    return EnrRecord{
+        std::move(public_key),
+        seq_num,
+        std::move(node_address_v4),
+        std::move(node_address_v6),
+        copy_rlp_data(map_get(entries_data, std::string("eth"))),
+        copy_rlp_data(map_get(entries_data, std::string("eth2"))),
+        copy_rlp_data(map_get(entries_data, std::string("attnets"))),
+    };
+}
+
+Bytes EnrCodec::encode(const EnrRecord& record, const EccKeyPair& key_pair) {
+    std::map<std::string, rlp::RlpBytes> entries;
+    entries.emplace("id", string_to_rlp_bytes("v4"));
+    entries.emplace("secp256k1", encode_rlp_bytes(key_pair.public_key().serialized_std(/* is_compressed = */ true)));
+
+    if (record.address_v4) {
+        entries.emplace("ip", encode_rlp_bytes(ip_address_to_bytes(record.address_v4->endpoint.address())));
+        entries.emplace("udp", encode_rlp_num_value(record.address_v4->endpoint.port()));
+        if (record.address_v4->port_rlpx) {
+            entries.emplace("tcp", encode_rlp_num_value(record.address_v4->port_rlpx));
+        }
+    }
+
+    if (record.address_v6) {
+        entries.emplace("ip6", encode_rlp_bytes(ip_address_to_bytes(record.address_v6->endpoint.address())));
+        entries.emplace("udp6", encode_rlp_num_value(record.address_v6->endpoint.port()));
+        if (record.address_v6->port_rlpx) {
+            entries.emplace("tcp6", encode_rlp_num_value(record.address_v6->port_rlpx));
+        }
+    }
+
+    if (record.eth1_fork_id_data) {
+        entries.emplace("eth", rlp::RlpBytes{*record.eth1_fork_id_data});
+    }
+
+    if (record.eth2_fork_id_data) {
+        entries.emplace("eth2", rlp::RlpBytes{*record.eth2_fork_id_data});
+    }
+
+    if (record.eth2_attestation_subnets_data) {
+        entries.emplace("attnets", rlp::RlpBytes{*record.eth2_attestation_subnets_data});
+    }
+
+    std::vector<rlp::RlpBytes> items = {
+        rlp::RlpBytes{Bytes{rlp::kEmptyStringCode}},  // signature placeholder
+        encode_rlp_num_value(record.seq_num),
+    };
+
+    for (auto& [key, entry_data] : entries) {
+        items.push_back(string_to_rlp_bytes(key));
+        items.push_back(std::move(entry_data));
+    }
+
+    // set signature
+    Bytes signature = sign(items, key_pair.private_key());
+    items[0] = encode_rlp_bytes(std::move(signature));
+
+    Bytes data;
+    rlp::encode(data, items);
+    return data;
+}
+
+}  // namespace silkworm::sentry::discovery::enr

--- a/silkworm/sentry/discovery/enr/enr_codec.cpp
+++ b/silkworm/sentry/discovery/enr/enr_codec.cpp
@@ -98,7 +98,8 @@ static std::optional<NodeAddress> try_decode_node_address(
     }
 
     return NodeAddress{
-        boost::asio::ip::udp::endpoint(*ip, port_disc),
+        *ip,
+        port_disc,
         port_rlpx,
     };
 }

--- a/silkworm/sentry/discovery/enr/enr_codec.hpp
+++ b/silkworm/sentry/discovery/enr/enr_codec.hpp
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/sentry/common/ecc_key_pair.hpp>
 
 #include "enr_record.hpp"

--- a/silkworm/sentry/discovery/enr/enr_codec.hpp
+++ b/silkworm/sentry/discovery/enr/enr_codec.hpp
@@ -17,15 +17,15 @@
 #pragma once
 
 #include <silkworm/core/common/base.hpp>
-#include <silkworm/core/common/bytes.hpp>
-#include <silkworm/sentry/common/ecc_public_key.hpp>
+#include <silkworm/sentry/common/ecc_key_pair.hpp>
 
-namespace silkworm::sentry::crypto::ecdsa_signature {
+#include "enr_record.hpp"
 
-Bytes sign_recoverable(ByteView data_hash, ByteView private_key);
-EccPublicKey verify_and_recover(ByteView data_hash, ByteView signature_and_recovery_id);
+namespace silkworm::sentry::discovery::enr {
 
-Bytes sign(ByteView data_hash, ByteView private_key);
-bool verify(ByteView data_hash, ByteView signature_data, const EccPublicKey& public_key);
+struct EnrCodec {
+    static EnrRecord decode(ByteView data);
+    static Bytes encode(const EnrRecord& record, const EccKeyPair& key_pair);
+};
 
-}  // namespace silkworm::sentry::crypto::ecdsa_signature
+}  // namespace silkworm::sentry::discovery::enr

--- a/silkworm/sentry/discovery/enr/enr_record.hpp
+++ b/silkworm/sentry/discovery/enr/enr_record.hpp
@@ -16,16 +16,22 @@
 
 #pragma once
 
+#include <optional>
+
 #include <silkworm/core/common/base.hpp>
-#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/sentry/common/ecc_public_key.hpp>
+#include <silkworm/sentry/discovery/common/node_address.hpp>
 
-namespace silkworm::sentry::crypto::ecdsa_signature {
+namespace silkworm::sentry::discovery::enr {
 
-Bytes sign_recoverable(ByteView data_hash, ByteView private_key);
-EccPublicKey verify_and_recover(ByteView data_hash, ByteView signature_and_recovery_id);
+struct EnrRecord {
+    EccPublicKey public_key;
+    uint64_t seq_num;
+    std::optional<NodeAddress> address_v4;
+    std::optional<NodeAddress> address_v6;
+    std::optional<Bytes> eth1_fork_id_data;
+    std::optional<Bytes> eth2_fork_id_data;
+    std::optional<Bytes> eth2_attestation_subnets_data;
+};
 
-Bytes sign(ByteView data_hash, ByteView private_key);
-bool verify(ByteView data_hash, ByteView signature_data, const EccPublicKey& public_key);
-
-}  // namespace silkworm::sentry::crypto::ecdsa_signature
+}  // namespace silkworm::sentry::discovery::enr

--- a/silkworm/sentry/discovery/enr/enr_record.hpp
+++ b/silkworm/sentry/discovery/enr/enr_record.hpp
@@ -18,7 +18,7 @@
 
 #include <optional>
 
-#include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/sentry/common/ecc_public_key.hpp>
 #include <silkworm/sentry/discovery/common/node_address.hpp>
 

--- a/silkworm/sentry/discovery/enr/enr_url.cpp
+++ b/silkworm/sentry/discovery/enr/enr_url.cpp
@@ -1,0 +1,40 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "enr_url.hpp"
+
+#include <base64.h>
+
+#include <stdexcept>
+
+#include "enr_codec.hpp"
+
+namespace silkworm::sentry::discovery::enr {
+
+EnrRecord EnrUrl::parse(std::string_view url_str) {
+    if (!url_str.starts_with("enr:"))
+        throw std::invalid_argument("Invalid ENR URL format");
+    auto data_str = base64_decode(url_str.substr(4), /* remove_linebreaks = */ false);
+    ByteView data{reinterpret_cast<uint8_t*>(data_str.data()), data_str.size()};
+    return EnrCodec::decode(data);
+}
+
+std::string EnrUrl::make(const EnrRecord& record, const EccKeyPair& key_pair) {
+    Bytes data = EnrCodec::encode(record, key_pair);
+    return "enr:" + base64_encode(data.data(), data.size(), /* url = */ true);
+}
+
+}  // namespace silkworm::sentry::discovery::enr

--- a/silkworm/sentry/discovery/enr/enr_url.hpp
+++ b/silkworm/sentry/discovery/enr/enr_url.hpp
@@ -16,16 +16,18 @@
 
 #pragma once
 
-#include <silkworm/core/common/base.hpp>
-#include <silkworm/core/common/bytes.hpp>
-#include <silkworm/sentry/common/ecc_public_key.hpp>
+#include <string>
+#include <string_view>
 
-namespace silkworm::sentry::crypto::ecdsa_signature {
+#include <silkworm/sentry/common/ecc_key_pair.hpp>
 
-Bytes sign_recoverable(ByteView data_hash, ByteView private_key);
-EccPublicKey verify_and_recover(ByteView data_hash, ByteView signature_and_recovery_id);
+#include "enr_record.hpp"
 
-Bytes sign(ByteView data_hash, ByteView private_key);
-bool verify(ByteView data_hash, ByteView signature_data, const EccPublicKey& public_key);
+namespace silkworm::sentry::discovery::enr {
 
-}  // namespace silkworm::sentry::crypto::ecdsa_signature
+struct EnrUrl {
+    static EnrRecord parse(std::string_view url_str);
+    static std::string make(const EnrRecord& record, const EccKeyPair& key_pair);
+};
+
+}  // namespace silkworm::sentry::discovery::enr

--- a/silkworm/sentry/discovery/enr/enr_url_test.cpp
+++ b/silkworm/sentry/discovery/enr/enr_url_test.cpp
@@ -1,0 +1,89 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "enr_url.hpp"
+
+#include <boost/asio/ip/address.hpp>
+#include <boost/asio/ip/udp.hpp>
+#include <catch2/catch.hpp>
+
+#include <silkworm/core/common/util.hpp>
+#include <silkworm/sentry/common/ecc_key_pair.hpp>
+
+namespace silkworm::sentry::discovery::enr {
+
+static EccKeyPair test_key_pair() {
+    constexpr std::string_view kPrivateKey = "b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291";
+    return EccKeyPair{from_hex(kPrivateKey).value()};
+}
+
+using namespace boost::asio::ip;
+
+TEST_CASE("EnrUrl::parse") {
+    {
+        auto record = EnrUrl::parse("enr:-IS4QHCYrYZbAKWCBRlAy5zzaDZXJBGkcnh4MHcBFZntXNFrdvJjX04jRzjzCBOonrkTfj499SZuOh8R33Ls8RRcy5wBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQPKY0yuDUmstAHYpMa2_oxVtw0RW_QAdpzBQA8yWM0xOIN1ZHCCdl8");
+        CHECK(to_hex(record.public_key.serialized_std(/* is_compressed = */ true)) == "03ca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd3138");
+        CHECK(record.seq_num == 1);
+        REQUIRE(record.address_v4.has_value());
+        CHECK(record.address_v4->endpoint.address().to_string() == "127.0.0.1");
+        CHECK(record.address_v4->endpoint.port() == 30303);
+        CHECK(record.address_v4->port_rlpx == 0);
+        CHECK_FALSE(record.address_v6.has_value());
+    }
+
+    {
+        auto record = EnrUrl::parse("enr:-Ku4QHqVeJ8PPICcWk1vSn_XcSkjOkNiTg6Fmii5j6vUQgvzMc9L1goFnLKgXqBJspJjIsB91LTOleFmyWWrFVATGngBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpC1MD8qAAAAAP__________gmlkgnY0gmlwhAMRHkWJc2VjcDI1NmsxoQKLVXFOhp2uX6jeT0DvvDpPcU8FWMjQdR4wMuORMhpX24N1ZHCCIyg");
+        CHECK(record.seq_num == 1);
+        REQUIRE(record.address_v4.has_value());
+        CHECK(record.address_v4->endpoint.address().to_string() == "3.17.30.69");
+        CHECK(record.address_v4->endpoint.port() == 9000);
+    }
+
+    {
+        auto record = EnrUrl::parse("enr:-Ku4QImhMc1z8yCiNJ1TyUxdcfNucje3BGwEHzodEZUan8PherEo4sF7pPHPSIB1NNuSg5fZy7qFsjmUKs2ea1Whi0EBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpD1pf1CAAAAAP__________gmlkgnY0gmlwhBLf22SJc2VjcDI1NmsxoQOVphkDqal4QzPMksc5wnpuC3gvSC8AfbFOnZY_On34wIN1ZHCCIyg");
+        CHECK(record.seq_num == 1);
+        REQUIRE(record.address_v4.has_value());
+        CHECK(record.address_v4->endpoint.address().to_string() == "18.223.219.100");
+        CHECK(record.address_v4->endpoint.port() == 9000);
+    }
+}
+
+TEST_CASE("EnrUrl::encode_decode") {
+    EccKeyPair key_pair = test_key_pair();
+    EnrRecord expected_record{
+        key_pair.public_key(),
+        123,
+        NodeAddress{make_address("10.0.0.1"), 100, 101},
+        NodeAddress{make_address("fe80::40b6:ef45:4458:7fcf"), 200, 201},
+        Bytes{0x83, 'e', '1', 'f'},
+        Bytes{0x83, 'e', '2', 'f'},
+        Bytes{0x83, 'a', 't', 'n'},
+    };
+    auto actual_record = EnrUrl::parse(EnrUrl::make(expected_record, key_pair));
+    CHECK(actual_record.public_key == expected_record.public_key);
+    CHECK(actual_record.seq_num == expected_record.seq_num);
+    REQUIRE(expected_record.address_v4.has_value());
+    CHECK(actual_record.address_v4->endpoint == expected_record.address_v4->endpoint);
+    CHECK(actual_record.address_v4->port_rlpx == expected_record.address_v4->port_rlpx);
+    REQUIRE(expected_record.address_v6.has_value());
+    CHECK(actual_record.address_v6->endpoint == expected_record.address_v6->endpoint);
+    CHECK(actual_record.address_v6->port_rlpx == expected_record.address_v6->port_rlpx);
+    CHECK(actual_record.eth1_fork_id_data == expected_record.eth1_fork_id_data);
+    CHECK(actual_record.eth2_fork_id_data == expected_record.eth2_fork_id_data);
+    CHECK(actual_record.eth2_attestation_subnets_data == expected_record.eth2_attestation_subnets_data);
+}
+
+}  // namespace silkworm::sentry::discovery::enr

--- a/silkworm/sentry/eth/fork_id.cpp
+++ b/silkworm/sentry/eth/fork_id.cpp
@@ -91,6 +91,12 @@ ForkId ForkId::rlp_decode(ByteView data) {
     return value;
 }
 
+Bytes ForkId::rlp_encode_enr_entry() const {
+    Bytes data;
+    rlp::encode(data, std::vector<rlp::RlpBytes>{rlp::RlpBytes{rlp_encode()}});
+    return data;
+}
+
 bool ForkId::is_compatible_with(
     ByteView genesis_hash,
     const std::vector<BlockNum>& fork_block_numbers,

--- a/silkworm/sentry/eth/fork_id.hpp
+++ b/silkworm/sentry/eth/fork_id.hpp
@@ -47,6 +47,13 @@ class ForkId {
     [[nodiscard]] Bytes rlp_encode() const;
     [[nodiscard]] static ForkId rlp_decode(ByteView data);
 
+    /**
+     * Encode ForkId for EnrRecord.eth1_fork_id_data.
+     * It expects to be wrapped in an extra RLP list: RLP([RLP(this)]),
+     * because in geth forkid.ID struct is contained within an enrEntry struct and each struct forms a list.
+     */
+    [[nodiscard]] Bytes rlp_encode_enr_entry() const;
+
     [[nodiscard]] bool is_compatible_with(
         ByteView genesis_hash,
         const std::vector<BlockNum>& fork_block_numbers,

--- a/silkworm/sentry/rlpx/auth/auth_message.cpp
+++ b/silkworm/sentry/rlpx/auth/auth_message.cpp
@@ -66,7 +66,7 @@ AuthMessage::AuthMessage(ByteView data, const EccKeyPair& recipient_key_pair)
     // shared_secret ^= nonce_
     crypto::xor_bytes(shared_secret, nonce_);
 
-    ephemeral_public_key_ = recover_and_verify(shared_secret, signature_);
+    ephemeral_public_key_ = verify_and_recover(shared_secret, signature_);
 }
 
 Bytes AuthMessage::body_as_rlp() const {

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -112,6 +112,10 @@ target_include_directories(
   INTERFACE secp256k1/include
 )
 
+# cpp-base64
+add_library(cpp_base64 cpp-base64/base64.cpp)
+target_include_directories(cpp_base64 PUBLIC cpp-base64)
+
 # libff
 set(CURVE
     "ALT_BN128"


### PR DESCRIPTION
ENR enables filtering useless peers prior to connecting to them.
ENR support is a prerequisite for disc v5, and will be used by the eth2 p2p logic.
