### PR TITLE
rpcdaemon: fix payloadId serialization in ForkChoiceUpdateReply

### DIFF
--- a/silkworm/silkrpc/json/fork_choice.cpp
+++ b/silkworm/silkrpc/json/fork_choice.cpp
@@ -41,8 +41,8 @@ void from_json(const nlohmann::json& json, ForkChoiceState& forkchoice_state) {
 void to_json(nlohmann::json& json, const ForkChoiceUpdatedReply& forkchoice_updated_reply) {
     nlohmann::json json_payload_status = forkchoice_updated_reply.payload_status;
     json["payloadStatus"] = json_payload_status;
-    if (forkchoice_updated_reply.payload_id != std::nullopt) {
-        json["payloadId"] = to_quantity(forkchoice_updated_reply.payload_id.value());
+    if (forkchoice_updated_reply.payload_id) {
+        json["payloadId"] = to_hex(forkchoice_updated_reply.payload_id.value());
     }
 }
 

--- a/silkworm/silkrpc/json/fork_choice_test.cpp
+++ b/silkworm/silkrpc/json/fork_choice_test.cpp
@@ -51,4 +51,16 @@ TEST_CASE("deserialize ForkChoiceStateV1", "[silkworm::json][from_json]") {
     CHECK(forkchoice_state.finalized_block_hash == 0x3559e851470f6e7bbed1db474980683e8c315bfce99b2a6ef47c057c04de7858_bytes32);
 }
 
+TEST_CASE("serialize ForkChoiceUpdatedReply", "[silkworm::json][to_json]") {
+    ForkChoiceUpdatedReply fcu_reply{
+        .payload_status = PayloadStatus::Accepted,
+        .payload_id = 0};
+
+    nlohmann::json j = fcu_reply;
+    CHECK(j == R"({
+        "payloadStatus":{"status":"ACCEPTED"},
+        "payloadId":"0x0000000000000000"
+    })"_json);
+}
+
 }  // namespace silkworm::rpc

--- a/silkworm/silkrpc/json/types.cpp
+++ b/silkworm/silkrpc/json/types.cpp
@@ -137,6 +137,12 @@ uint64_t from_quantity(const std::string& hex_quantity) {
     return std::stoul(hex_quantity, nullptr, 16);
 }
 
+std::string to_hex(uint64_t number) {
+    silkworm::Bytes number_bytes(8, '\0');
+    endian::store_big_u64(&number_bytes[0], number);
+    return silkworm::to_hex(number_bytes, /*with_prefix=*/true);
+}
+
 std::string to_hex_no_leading_zeros(uint64_t number) {
     silkworm::Bytes number_bytes(8, '\0');
     endian::store_big_u64(&number_bytes[0], number);

--- a/silkworm/silkrpc/json/types.hpp
+++ b/silkworm/silkrpc/json/types.hpp
@@ -121,6 +121,7 @@ void to_json(nlohmann::json& json, const std::set<evmc::address>& addresses);
 
 uint64_t from_quantity(const std::string& hex_quantity);
 
+std::string to_hex(uint64_t number);
 std::string to_hex_no_leading_zeros(uint64_t number);
 std::string to_hex_no_leading_zeros(silkworm::ByteView bytes);
 std::string to_quantity(uint64_t number);

--- a/silkworm/silkrpc/json/types_test.cpp
+++ b/silkworm/silkrpc/json/types_test.cpp
@@ -692,7 +692,7 @@ TEST_CASE("serialize ForkChoiceUpdatedReplyV1", "[silkworm::json][to_json]") {
             "latestValidHash":"0x0000000000000000000000000000000000000000000000000000000000000040",
             "validationError":"some error"
         },
-        "payloadId":"0x1"
+        "payloadId":"0x0000000000000001"
     })"_json);
 }
 


### PR DESCRIPTION
See [spec](https://ethereum.github.io/execution-apis/api-documentation/)