### PR TITLE
cmake: use Boost::headers for asio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ if(NOT SILKWORM_CORE_ONLY)
   set(CMAKE_POLICY_DEFAULT_CMP0048 NEW) # project() command manages VERSION variables
   set(CMAKE_POLICY_DEFAULT_CMP0063 NEW) # Honor visibility properties for all target types
 
-  find_package(Boost REQUIRED)
+  find_package(Boost REQUIRED headers)
   # Define Boost::headers target if missing because libtorrent needs it
   if(NOT TARGET Boost::headers)
     add_library(Boost::headers INTERFACE IMPORTED)

--- a/cmd/api/CMakeLists.txt
+++ b/cmd/api/CMakeLists.txt
@@ -14,7 +14,7 @@
    limitations under the License.
 ]]
 
-find_package(Boost REQUIRED)
+find_package(Boost REQUIRED headers filesystem system)
 find_package(CLI11 REQUIRED)
 
 add_executable(execute execute.cpp)

--- a/cmd/dev/CMakeLists.txt
+++ b/cmd/dev/CMakeLists.txt
@@ -15,7 +15,7 @@
 ]]
 
 find_package(absl REQUIRED)
-find_package(Boost REQUIRED)
+find_package(Boost REQUIRED headers)
 find_package(CLI11 REQUIRED)
 find_package(gRPC REQUIRED)
 find_package(magic_enum REQUIRED)

--- a/cmd/state-transition/CMakeLists.txt
+++ b/cmd/state-transition/CMakeLists.txt
@@ -23,7 +23,6 @@ else()
 endif()
 
 find_package(absl REQUIRED)
-find_package(Boost REQUIRED)
 find_package(CLI11 REQUIRED)
 find_package(nlohmann_json REQUIRED)
 

--- a/silkworm/infra/CMakeLists.txt
+++ b/silkworm/infra/CMakeLists.txt
@@ -16,7 +16,7 @@
 
 find_package(absl REQUIRED)
 find_package(asio-grpc REQUIRED)
-find_package(Boost REQUIRED container thread)
+find_package(Boost REQUIRED headers container thread)
 find_package(Catch2 REQUIRED)
 find_package(gRPC REQUIRED)
 find_package(GTest REQUIRED)

--- a/silkworm/infra/test_util/CMakeLists.txt
+++ b/silkworm/infra/test_util/CMakeLists.txt
@@ -14,7 +14,7 @@
    limitations under the License.
 ]]
 
-find_package(Boost REQUIRED thread)
+find_package(Boost REQUIRED headers)
 
 set(TARGET silkworm_infra_test_util)
 
@@ -22,4 +22,4 @@ file(GLOB_RECURSE SRC CONFIGURE_DEPENDS "*.cpp" "*.hpp")
 
 add_library(${TARGET} ${SRC})
 
-target_link_libraries(${TARGET} PUBLIC silkworm_infra Boost::thread)
+target_link_libraries(${TARGET} PUBLIC silkworm_infra Boost::headers)

--- a/silkworm/node/CMakeLists.txt
+++ b/silkworm/node/CMakeLists.txt
@@ -16,7 +16,7 @@
 
 find_package(absl REQUIRED)
 find_package(asio-grpc REQUIRED)
-find_package(Boost REQUIRED container thread)
+find_package(Boost REQUIRED headers container)
 find_package(nlohmann_json REQUIRED)
 find_package(gRPC REQUIRED)
 find_package(magic_enum REQUIRED)
@@ -93,7 +93,7 @@ set(SILKWORM_NODE_PUBLIC_LIBS
     absl::flat_hash_set
     asio-grpc::asio-grpc
     Boost::container
-    Boost::thread
+    Boost::headers
     gRPC::grpc++
     mdbx-static
     nlohmann_json::nlohmann_json

--- a/silkworm/sentry/CMakeLists.txt
+++ b/silkworm/sentry/CMakeLists.txt
@@ -17,7 +17,7 @@
 set(TARGET silkworm_sentry)
 
 find_package(absl REQUIRED)
-find_package(Boost REQUIRED thread)
+find_package(Boost REQUIRED headers)
 find_package(Catch2 REQUIRED)
 find_package(gRPC REQUIRED)
 find_package(Microsoft.GSL REQUIRED)
@@ -93,7 +93,7 @@ endif(MSVC)
 
 # cmake-format: off
 set(LIBS_PUBLIC
-    Boost::thread
+    Boost::headers
     Microsoft.GSL::GSL
     silkworm_infra
 )

--- a/silkworm/sentry/common/CMakeLists.txt
+++ b/silkworm/sentry/common/CMakeLists.txt
@@ -14,7 +14,7 @@
    limitations under the License.
 ]]
 
-find_package(Boost REQUIRED thread)
+find_package(Boost REQUIRED headers)
 find_package(Catch2 REQUIRED)
 
 set(TARGET silkworm_sentry_common)
@@ -26,11 +26,7 @@ add_library(${TARGET} ${SRC})
 
 target_include_directories(${TARGET} PUBLIC "${SILKWORM_MAIN_DIR}")
 
-target_link_libraries(
-  ${TARGET}
-  PUBLIC Boost::thread silkworm_core silkworm_infra
-  PRIVATE Boost::headers
-)
+target_link_libraries(${TARGET} PUBLIC Boost::headers silkworm_core silkworm_infra)
 
 # unit tests
 set(TEST_TARGET ${TARGET}_test)

--- a/silkworm/sentry/discovery/disc_v4/CMakeLists.txt
+++ b/silkworm/sentry/discovery/disc_v4/CMakeLists.txt
@@ -14,7 +14,7 @@
    limitations under the License.
 ]]
 
-find_package(Boost REQUIRED headers thread)
+find_package(Boost REQUIRED headers)
 find_package(Catch2 REQUIRED)
 
 set(TARGET silkworm_sentry_disc_v4)
@@ -29,7 +29,7 @@ target_include_directories(${TARGET} PUBLIC "${SILKWORM_MAIN_DIR}")
 target_link_libraries(
   ${TARGET}
   PUBLIC silkworm_infra silkworm_sentry_common
-  PRIVATE Boost::headers Boost::thread stbrumme_keccak silkworm_core silkworm_sentry_node_db
+  PRIVATE Boost::headers stbrumme_keccak silkworm_core silkworm_sentry_node_db
 )
 
 # unit tests

--- a/silkworm/sentry/discovery/node_db/CMakeLists.txt
+++ b/silkworm/sentry/discovery/node_db/CMakeLists.txt
@@ -14,7 +14,7 @@
    limitations under the License.
 ]]
 
-find_package(Boost REQUIRED thread)
+find_package(Boost REQUIRED headers)
 find_package(Catch2 REQUIRED)
 find_package(SQLiteCpp REQUIRED)
 
@@ -30,7 +30,7 @@ target_include_directories(${TARGET} PUBLIC "${SILKWORM_MAIN_DIR}")
 target_link_libraries(
   ${TARGET}
   PUBLIC silkworm_infra silkworm_sentry_common
-  PRIVATE Boost::thread SQLiteCpp::SQLiteCpp
+  PRIVATE Boost::headers SQLiteCpp::SQLiteCpp
 )
 
 # unit tests

--- a/silkworm/silkrpc/CMakeLists.txt
+++ b/silkworm/silkrpc/CMakeLists.txt
@@ -16,7 +16,7 @@
 
 find_package(absl REQUIRED)
 find_package(asio-grpc REQUIRED)
-find_package(Boost REQUIRED container thread)
+find_package(Boost REQUIRED headers container)
 find_package(gRPC REQUIRED)
 find_package(jwt-cpp REQUIRED)
 find_package(nlohmann_json REQUIRED)
@@ -55,7 +55,7 @@ set(SILKRPC_PUBLIC_LIBRARIES
     absl::flat_hash_set
     absl::btree
     Boost::container
-    Boost::thread
+    Boost::headers
     protobuf::libprotobuf
     intx::intx
     pico_http_parser


### PR DESCRIPTION
Previously some files referred to Boost::thread by mistake.