### PR TITLE
node: revalidate canonical chain with one forward cycle at startup

### DIFF
--- a/silkworm/node/common/settings.hpp
+++ b/silkworm/node/common/settings.hpp
@@ -51,6 +51,7 @@ struct NodeSettings {
     uint32_t sync_loop_throttle_seconds{0};                // Minimum interval amongst sync cycle
     uint32_t sync_loop_log_interval_seconds{30};           // Interval for sync loop to emit logs
     std::string node_name;                                 // The node identifying name
+    bool parallel_fork_tracking_enabled{false};            // Whether to track multiple parallel forks at head
 };
 
 }  // namespace silkworm

--- a/silkworm/node/stagedsync/execution_engine.cpp
+++ b/silkworm/node/stagedsync/execution_engine.cpp
@@ -272,17 +272,17 @@ std::optional<BlockBody> ExecutionEngine::get_body(Hash header_hash) const {
 }
 
 std::optional<BlockHeader> ExecutionEngine::get_canonical_header(BlockNum bn) const {
-    auto hash = main_chain_.get_canonical_hash(bn);
+    auto hash = main_chain_.get_finalized_canonical_hash(bn);
     if (!hash) return {};
     return main_chain_.get_header(*hash);
 }
 
 std::optional<Hash> ExecutionEngine::get_canonical_hash(BlockNum bn) const {
-    return main_chain_.get_canonical_hash(bn);
+    return main_chain_.get_finalized_canonical_hash(bn);
 }
 
 std::optional<BlockBody> ExecutionEngine::get_canonical_body(BlockNum bn) const {
-    auto hash = main_chain_.get_canonical_hash(bn);
+    auto hash = main_chain_.get_finalized_canonical_hash(bn);
     if (!hash) return {};
     return main_chain_.get_body(*hash);
 }

--- a/silkworm/node/stagedsync/execution_pipeline.cpp
+++ b/silkworm/node/stagedsync/execution_pipeline.cpp
@@ -151,7 +151,7 @@ void ExecutionPipeline::load_stages() {
                                     db::stages::kTxLookupKey,
                                     db::stages::kLogIndexKey,
                                     db::stages::kHistoryIndexKey,
-                                    db::stages::kHashStateKey,           // Needs to happen before unwinding Execution
+                                    db::stages::kHashStateKey,
                                     db::stages::kIntermediateHashesKey,  // Needs to happen after unwinding HashState
                                     db::stages::kExecutionKey,
                                     db::stages::kSendersKey,

--- a/silkworm/node/stagedsync/execution_pipeline.hpp
+++ b/silkworm/node/stagedsync/execution_pipeline.hpp
@@ -45,12 +45,13 @@ class ExecutionPipeline : public Stoppable {
     silkworm::NodeSettings* node_settings_;
     std::unique_ptr<SyncContext> sync_context_;  // context shared across stages
 
-    using Stage_Container = std::map<const char*, std::unique_ptr<stagedsync::Stage>>;
-    Stage_Container stages_;
+    using StageContainer = std::map<const char*, std::unique_ptr<stagedsync::Stage>>;
+    StageContainer stages_;
+    StageContainer::iterator current_stage_;
 
-    Stage_Container::iterator current_stage_;
-    std::vector<const char*> stages_forward_order_;
-    std::vector<const char*> stages_unwind_order_;
+    using StageNames = std::vector<const char*>;
+    StageNames stages_forward_order_;
+    StageNames stages_unwind_order_;
     std::atomic<size_t> current_stages_count_{0};
     std::atomic<size_t> current_stage_number_{0};
 

--- a/silkworm/node/stagedsync/forks/main_chain.cpp
+++ b/silkworm/node/stagedsync/forks/main_chain.cpp
@@ -66,7 +66,7 @@ void MainChain::open() {
     // - if last cycle completed successfully, this will simply do nothing (no hurt)
     // - if last cycle was executed partially (i.e. not all stages are at the same height), this will do a cleanup cycle
     const auto& canonical_head{canonical_chain_.current_head()};
-    SILK_INFO << "Revalidate chain up to the canonical current head number=" << canonical_head.number << " hash=" << to_hex(canonical_head.hash);
+    SILK_INFO << "Revalidate canonical chain up to number=" << canonical_head.number << " hash=" << to_hex(canonical_head.hash);
 
     forward(canonical_head.number, canonical_head.hash);
 

--- a/silkworm/node/stagedsync/forks/main_chain.hpp
+++ b/silkworm/node/stagedsync/forks/main_chain.hpp
@@ -70,7 +70,7 @@ class MainChain {
     // header/body retrieval
     BlockNum get_block_progress() const;
     std::optional<BlockHeader> get_header(BlockNum, Hash) const;
-    std::optional<Hash> get_canonical_hash(BlockNum) const;
+    std::optional<Hash> get_finalized_canonical_hash(BlockNum) const;
     std::optional<TotalDifficulty> get_header_td(BlockNum, Hash) const;
     std::vector<BlockHeader> get_last_headers(uint64_t limit) const;
     bool extends_last_fork_choice(BlockNum, Hash) const;

--- a/silkworm/node/stagedsync/forks/main_chain.hpp
+++ b/silkworm/node/stagedsync/forks/main_chain.hpp
@@ -54,17 +54,19 @@ class MainChain {
     void reintegrate_fork(ExtendingFork&);                       // reintegrate fork into the main chain
     std::optional<BlockId> find_forking_point(const BlockHeader& header, const Hash& header_hash) const;
     std::optional<BlockId> find_forking_point(const Hash& header_hash) const;
-    bool is_canonical(BlockId block) const;
+    bool is_finalized_canonical(BlockId block) const;
 
     // verification
     // verify chain up to head_block_hash
     VerificationResult verify_chain(Hash head_block_hash);
     // accept the current chain up to head_block_hash
     bool notify_fork_choice_update(Hash head_block_hash, std::optional<Hash> finalized_block_hash = std::nullopt);
+    bool notify_fork_choice_update2(Hash head_block_hash, std::optional<Hash> finalized_block_hash = std::nullopt);
 
     // state
     BlockId last_chosen_head() const;  // set by notify_fork_choice_update(), is always valid
     BlockId last_finalized_head() const;
+    BlockId current_head() const;
 
     // header/body retrieval
     BlockNum get_block_progress() const;
@@ -75,7 +77,7 @@ class MainChain {
     bool extends_last_fork_choice(BlockNum, Hash) const;
     bool extends(BlockId block, BlockId supposed_parent) const;
     bool is_ancestor(BlockId supposed_parent, BlockId block) const;
-    bool is_canonical(Hash) const;
+    bool is_finalized_canonical(Hash) const;
     // Warning: this getters use kHeaderNumbers so will return only header processed by the pipeline
     std::optional<BlockHeader> get_header(Hash) const;
     std::optional<TotalDifficulty> get_header_td(Hash) const;
@@ -88,8 +90,11 @@ class MainChain {
   protected:
     Hash insert_header(const BlockHeader&);
     void insert_body(const Block&, const Hash& block_hash);
+    void forward(BlockNum head_height, const Hash& head_hash);
+    void unwind(BlockNum unwind_point);
 
-    BlockId current_head() const;  // private state, it is implementation dependent, this head can be invalid
+    bool is_canonical(BlockNum block_height, const Hash& block_hash) const;
+    bool is_canonical_head_ancestor(const Hash& block_hash) const;
 
     std::set<Hash> collect_bad_headers(db::RWTxn& tx, InvalidChain& invalid_chain);
 

--- a/silkworm/node/stagedsync/forks/main_chain.hpp
+++ b/silkworm/node/stagedsync/forks/main_chain.hpp
@@ -61,7 +61,6 @@ class MainChain {
     VerificationResult verify_chain(Hash head_block_hash);
     // accept the current chain up to head_block_hash
     bool notify_fork_choice_update(Hash head_block_hash, std::optional<Hash> finalized_block_hash = std::nullopt);
-    bool notify_fork_choice_update2(Hash head_block_hash, std::optional<Hash> finalized_block_hash = std::nullopt);
 
     // state
     BlockId last_chosen_head() const;  // set by notify_fork_choice_update(), is always valid

--- a/silkworm/node/stagedsync/local_client.cpp
+++ b/silkworm/node/stagedsync/local_client.cpp
@@ -13,6 +13,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
+
 #include "local_client.hpp"
 
 #include <silkworm/node/stagedsync/server.hpp>

--- a/silkworm/node/stagedsync/server.cpp
+++ b/silkworm/node/stagedsync/server.cpp
@@ -34,12 +34,14 @@ bool Server::stop() {
 }
 
 void Server::execution_loop() {
+    SILK_TRACE << "execution::Server::execution_loop enter";
     exec_engine_.open();
 
     asio::executor_work_guard<decltype(io_context_.get_executor())> work{io_context_.get_executor()};
     io_context_.run();
 
     exec_engine_.close();
+    SILK_TRACE << "execution::Server::execution_loop exit";
 }
 
 void Server::handle_exception(const std::exception_ptr& e) {

--- a/silkworm/node/stagedsync/stages/stage.hpp
+++ b/silkworm/node/stagedsync/stages/stage.hpp
@@ -54,23 +54,20 @@ struct SyncContext {
 class Stage : public Stoppable {
   public:
     enum class [[nodiscard]] Result{
-        kSuccess,                 //
+        kSuccess,                 // valid chain
         kUnknownChainId,          //
         kUnknownProtocolRuleSet,  //
-        kBadBlockHash,            //
         kBadChainSequence,        //
-        kInvalidRange,            //
         kInvalidProgress,         //
-        kInvalidBlock,            //
+        kInvalidBlock,            // invalid chain
         kInvalidTransaction,      //
         kDecodingError,           //
-        kWrongFork,               // The persisted canonical chain must be changed
-        kWrongStateRoot,          //
+        kWrongFork,               // invalid chain: the persisted canonical chain must be changed
+        kWrongStateRoot,          // invalid chain
         kUnexpectedError,         //
-        kUnknownError,            //
         kDbError,                 //
         kAborted,                 //
-        kStoppedByEnv,            // Encountered "STOP_BEFORE_STAGE" env var
+        kStoppedByEnv,            // valid chain: encountered "STOP_BEFORE_STAGE" env var
         kUnspecified,
     };
 

--- a/silkworm/node/stagedsync/stages/stage_execution.cpp
+++ b/silkworm/node/stagedsync/stages/stage_execution.cpp
@@ -105,9 +105,7 @@ Stage::Result Execution::forward(db::RWTxn& txn) {
                                                       prune_receipts)};
 
             // If we return with success we must persist data
-            // Though counterintuitive we also must persist on KInvalidBlock to allow subsequent unwind
-            if (execution_result != Stage::Result::kSuccess &&
-                execution_result != Stage::Result::kInvalidBlock) {
+            if (execution_result != Stage::Result::kSuccess) {
                 throw StageError(execution_result);
             }
 
@@ -122,11 +120,6 @@ Stage::Result Execution::forward(db::RWTxn& txn) {
             auto [_, duration]{commit_stopwatch.stop()};
             log::Info(log_prefix_ + " commit", {"batch time", StopWatch::format(duration)});
 
-            // If an invalid block returned now can throw
-            if (execution_result == Stage::Result::kInvalidBlock) {
-                ret = execution_result;
-                break;
-            }
             block_num_++;
         }
 


### PR DESCRIPTION
node: handle already existing canonical block in main chain verification
node: avoid committing changes for invalid block in Execution stage