### PR TITLE
core: refactor Bytes/ByteView

### DIFF
--- a/cmd/dev/backend_kv_server.cpp
+++ b/cmd/dev/backend_kv_server.cpp
@@ -29,6 +29,7 @@
 
 #include <silkworm/buildinfo.h>
 #include <silkworm/core/execution/address.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/infra/common/directories.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/concurrency/awaitable_wait_for_one.hpp>

--- a/cmd/dev/backend_kv_server.cpp
+++ b/cmd/dev/backend_kv_server.cpp
@@ -28,6 +28,7 @@
 #include <grpcpp/grpcpp.h>
 
 #include <silkworm/buildinfo.h>
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/infra/common/directories.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/concurrency/awaitable_wait_for_one.hpp>

--- a/cmd/dev/check_changes.cpp
+++ b/cmd/dev/check_changes.cpp
@@ -21,6 +21,7 @@
 
 #include <silkworm/core/execution/address.hpp>
 #include <silkworm/core/execution/processor.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/infra/common/directories.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/node/db/access_layer.hpp>

--- a/cmd/dev/check_changes.cpp
+++ b/cmd/dev/check_changes.cpp
@@ -19,6 +19,7 @@
 #include <CLI/CLI.hpp>
 #include <absl/container/flat_hash_set.h>
 
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/core/execution/processor.hpp>
 #include <silkworm/infra/common/directories.hpp>
 #include <silkworm/infra/common/log.hpp>
@@ -38,7 +39,7 @@ static const absl::flat_hash_set<evmc::address> kPhantomAccounts{
 
 static void print_storage_changes(const db::StorageChanges& s) {
     for (const auto& [address, x] : s) {
-        std::cout << to_hex(address) << "\n";
+        std::cout << address << "\n";
         for (const auto& [incarnation, changes] : x) {
             std::cout << "  " << incarnation << "\n";
             for (const auto& [location, value] : changes) {
@@ -111,11 +112,11 @@ int main(int argc, char* argv[]) {
                 for (const auto& e : db_account_changes) {
                     if (!calculated_account_changes.contains(e.first)) {
                         if (!kPhantomAccounts.contains(e.first)) {
-                            log::Error() << to_hex(e.first) << " is missing";
+                            log::Error() << e.first << " is missing";
                             mismatch = true;
                         }
                     } else if (Bytes val{calculated_account_changes.at(e.first)}; val != e.second) {
-                        log::Error() << "Value mismatch for " << to_hex(e.first) << ":\n"
+                        log::Error() << "Value mismatch for " << e.first << ":\n"
                                      << to_hex(val) << "\n"
                                      << "vs DB\n"
                                      << to_hex(e.second);
@@ -124,7 +125,7 @@ int main(int argc, char* argv[]) {
                 }
                 for (const auto& e : calculated_account_changes) {
                     if (!db_account_changes.contains(e.first)) {
-                        log::Error() << to_hex(e.first) << " is not in DB";
+                        log::Error() << e.first << " is not in DB";
                         mismatch = true;
                     }
                 }

--- a/cmd/dev/check_log_indices.cpp
+++ b/cmd/dev/check_log_indices.cpp
@@ -27,6 +27,7 @@
 
 #include <silkworm/buildinfo.h>
 #include <silkworm/core/common/cast.hpp>
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/infra/common/directories.hpp>
 #include <silkworm/infra/common/ensure.hpp>
 #include <silkworm/infra/common/log.hpp>
@@ -130,7 +131,7 @@ std::string block_range(const Settings& settings) {
 }
 
 void trace(const Log& log) {
-    log::Trace() << "address: " << to_hex(log.address) << " topics: " << log.topics.size();
+    log::Trace() << "address: " << log.address << " topics: " << log.topics.size();
     int i{0};
     for (const auto& t : log.topics) {
         log::Trace() << "topic[" << i << "]: " << to_hex(t);
@@ -234,7 +235,7 @@ int main(int argc, char* argv[]) {
 
                 if (settings.index != TargetIndex::kLogTopic) {
                     if (log.address == settings.address) {
-                        log::Info() << "block " << block_number << " tx " << tx_id << " generated log for " << to_hex(log.address);
+                        log::Info() << "block " << block_number << " tx " << tx_id << " generated log for " << log.address;
                     }
                     check_address_index(block_number, log.address, log_address_cursor.get());
                     processed_addresses_count++;

--- a/cmd/dev/check_log_indices.cpp
+++ b/cmd/dev/check_log_indices.cpp
@@ -28,6 +28,7 @@
 #include <silkworm/buildinfo.h>
 #include <silkworm/core/common/cast.hpp>
 #include <silkworm/core/execution/address.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/infra/common/directories.hpp>
 #include <silkworm/infra/common/ensure.hpp>
 #include <silkworm/infra/common/log.hpp>

--- a/cmd/dev/check_pow.cpp
+++ b/cmd/dev/check_pow.cpp
@@ -23,6 +23,7 @@
 
 #include <silkworm/core/chain/config.hpp>
 #include <silkworm/core/common/endian.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/infra/common/directories.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/common/stopwatch.hpp>

--- a/cmd/dev/check_senders.cpp
+++ b/cmd/dev/check_senders.cpp
@@ -19,6 +19,7 @@
 #include <silkworm/buildinfo.h>
 #include <silkworm/core/common/assert.hpp>
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/common/endian.hpp>
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/infra/common/decoding_exception.hpp>

--- a/cmd/dev/check_senders.cpp
+++ b/cmd/dev/check_senders.cpp
@@ -23,6 +23,7 @@
 #include <silkworm/core/common/endian.hpp>
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/core/execution/address.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/infra/common/decoding_exception.hpp>
 #include <silkworm/infra/common/directories.hpp>
 #include <silkworm/infra/common/log.hpp>

--- a/cmd/dev/check_senders.cpp
+++ b/cmd/dev/check_senders.cpp
@@ -22,6 +22,7 @@
 #include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/common/endian.hpp>
 #include <silkworm/core/common/util.hpp>
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/infra/common/decoding_exception.hpp>
 #include <silkworm/infra/common/directories.hpp>
 #include <silkworm/infra/common/log.hpp>
@@ -156,8 +157,8 @@ int main(int argc, char* argv[]) {
 
                     // The most important check: i-th stored sender MUST be equal to i-th transaction recomputed sender
                     if (senders[i] != *tx.from) {
-                        log::Error() << "Block " << block_number << " tx " << i << " recovered sender " << to_hex(senders[i])
-                                     << " does not match computed sender " << to_hex(*tx.from);
+                        log::Error() << "Block " << block_number << " tx " << i << " recovered sender " << senders[i]
+                                     << " does not match computed sender " << *tx.from;
                     }
                     processed_senders_count++;
 

--- a/cmd/dev/grpc_toolbox.cpp
+++ b/cmd/dev/grpc_toolbox.cpp
@@ -29,6 +29,7 @@
 #include <grpcpp/grpcpp.h>
 
 #include <silkworm/core/common/util.hpp>
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/grpc/client/client_context_pool.hpp>
 #include <silkworm/interfaces/remote/ethbackend.grpc.pb.h>

--- a/cmd/dev/snapshots.cpp
+++ b/cmd/dev/snapshots.cpp
@@ -28,6 +28,7 @@
 
 #include <silkworm/buildinfo.h>
 #include <silkworm/core/chain/config.hpp>
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/infra/common/ensure.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/node/bittorrent/client.hpp>
@@ -335,13 +336,13 @@ static void print_header(const BlockHeader& header, const std::string& snapshot_
               << "hash=" << to_hex(header.hash()) << "\n"
               << "parent_hash=" << to_hex(header.parent_hash) << "\n"
               << "number=" << header.number << "\n"
-              << "beneficiary=" << to_hex(header.beneficiary) << "\n"
+              << "beneficiary=" << header.beneficiary << "\n"
               << "ommers_hash=" << to_hex(header.ommers_hash) << "\n"
               << "state_root=" << to_hex(header.state_root) << "\n"
               << "transactions_root=" << to_hex(header.transactions_root) << "\n"
               << "receipts_root=" << to_hex(header.receipts_root) << "\n"
               << "withdrawals_root=" << (header.withdrawals_root ? to_hex(*header.withdrawals_root) : "") << "\n"
-              << "beneficiary=" << to_hex(header.beneficiary) << "\n"
+              << "beneficiary=" << header.beneficiary << "\n"
               << "timestamp=" << header.timestamp << "\n"
               << "nonce=" << to_hex(header.nonce) << "\n"
               << "prev_randao=" << to_hex(header.prev_randao) << "\n"
@@ -487,8 +488,8 @@ static void print_txn(const Transaction& txn, const std::string& snapshot_filena
     std::cout << "Transaction found in: " << snapshot_filename << "\n"
               << "hash=" << to_hex(txn.hash()) << "\n"
               << "type=" << magic_enum::enum_name(txn.type) << "\n"
-              << "from=" << (txn.from ? to_hex(*txn.from) : "") << "\n"
-              << "to=" << (txn.to ? to_hex(*txn.to) : "") << "\n"
+              << "from=" << (txn.from ? address_to_string(*txn.from) : "") << "\n"
+              << "to=" << (txn.to ? address_to_string(*txn.to) : "") << "\n"
               << "chain_id=" << (txn.chain_id ? intx::to_string(*txn.chain_id) : "") << "\n"
               << "nonce=" << txn.nonce << "\n"
               << "value=" << intx::to_string(txn.value) << "\n"
@@ -505,7 +506,7 @@ static void print_txn(const Transaction& txn, const std::string& snapshot_filena
                      std::string rep{"["};
                      for (size_t i{0}; i < txn.access_list.size(); ++i) {
                          const auto& access_entry{txn.access_list[i]};
-                         rep.append(to_hex(access_entry.account));
+                         rep.append(address_to_string(access_entry.account));
                          rep.append(" : [");
                          for (size_t j{0}; j < access_entry.storage_keys.size(); ++j) {
                              rep.append(to_hex(access_entry.storage_keys[j].bytes));

--- a/cmd/dev/snapshots.cpp
+++ b/cmd/dev/snapshots.cpp
@@ -29,6 +29,7 @@
 #include <silkworm/buildinfo.h>
 #include <silkworm/core/chain/config.hpp>
 #include <silkworm/core/execution/address.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/infra/common/ensure.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/node/bittorrent/client.hpp>

--- a/cmd/dev/toolbox.cpp
+++ b/cmd/dev/toolbox.cpp
@@ -33,6 +33,7 @@
 #include <silkworm/core/common/assert.hpp>
 #include <silkworm/core/common/cast.hpp>
 #include <silkworm/core/common/endian.hpp>
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/core/trie/hash_builder.hpp>
 #include <silkworm/core/trie/nibbles.hpp>
 #include <silkworm/core/trie/prefix_set.hpp>
@@ -157,13 +158,13 @@ static void print_header(const BlockHeader& header) {
     std::cout << "Header:\nhash=" << to_hex(header.hash()) << "\n"
               << "parent_hash=" << to_hex(header.parent_hash) << "\n"
               << "number=" << header.number << "\n"
-              << "beneficiary=" << to_hex(header.beneficiary) << "\n"
+              << "beneficiary=" << header.beneficiary << "\n"
               << "ommers_hash=" << to_hex(header.ommers_hash) << "\n"
               << "state_root=" << to_hex(header.state_root) << "\n"
               << "transactions_root=" << to_hex(header.transactions_root) << "\n"
               << "receipts_root=" << to_hex(header.receipts_root) << "\n"
               << "withdrawals_root=" << (header.withdrawals_root ? to_hex(*header.withdrawals_root) : "") << "\n"
-              << "beneficiary=" << to_hex(header.beneficiary) << "\n"
+              << "beneficiary=" << header.beneficiary << "\n"
               << "timestamp=" << header.timestamp << "\n"
               << "nonce=" << to_hex(header.nonce) << "\n"
               << "prev_randao=" << to_hex(header.prev_randao) << "\n"

--- a/cmd/dev/toolbox.cpp
+++ b/cmd/dev/toolbox.cpp
@@ -37,6 +37,7 @@
 #include <silkworm/core/trie/hash_builder.hpp>
 #include <silkworm/core/trie/nibbles.hpp>
 #include <silkworm/core/trie/prefix_set.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/infra/common/directories.hpp>
 #include <silkworm/infra/common/ensure.hpp>
 #include <silkworm/infra/common/log.hpp>
@@ -1644,7 +1645,7 @@ void do_trie_root(db::EnvConfig& config) {
     for (auto trie_data{trie_cursor.to_prefix({})}; trie_data.key.has_value(); trie_data = trie_cursor.to_next()) {
         SILKWORM_ASSERT(!trie_data.first_uncovered.has_value());  // Means skip state
         log::Info("Trie", {"key", to_hex(trie_data.key.value(), true), "hash", to_hex(trie_data.hash.value(), true)});
-        auto hash{to_bytes32(trie_data.hash.value())};
+        auto& hash = trie_data.hash.value();
         hash_builder.add_branch_node(trie_data.key.value(), hash, false);
         if (SignalHandler::signalled()) {
             throw std::runtime_error("Interrupted");

--- a/cmd/state-transition/expected_state.cpp
+++ b/cmd/state-transition/expected_state.cpp
@@ -20,6 +20,8 @@
 
 #include <nlohmann/json.hpp>
 
+#include <silkworm/core/types/evmc_bytes32.hpp>
+
 #include "silkworm/core/chain/config.hpp"
 #include "silkworm/core/common/test_util.hpp"
 

--- a/cmd/state-transition/state_transition.cpp
+++ b/cmd/state-transition/state_transition.cpp
@@ -26,6 +26,7 @@
 #include <nlohmann/json.hpp>
 
 #include <silkworm/core/common/util.hpp>
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/core/execution/execution.hpp>
 #include <silkworm/core/protocol/param.hpp>
 #include <silkworm/core/protocol/rule_set.hpp>

--- a/cmd/state-transition/state_transition.cpp
+++ b/cmd/state-transition/state_transition.cpp
@@ -32,6 +32,7 @@
 #include <silkworm/core/protocol/rule_set.hpp>
 #include <silkworm/core/rlp/encode_vector.hpp>
 #include <silkworm/core/state/in_memory_state.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/sentry/common/ecc_key_pair.hpp>
 
 #include "expected_state.hpp"

--- a/cmd/test/backend_kv_test.cpp
+++ b/cmd/test/backend_kv_test.cpp
@@ -32,6 +32,7 @@
 
 #include <silkworm/core/common/assert.hpp>
 #include <silkworm/core/common/util.hpp>
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/grpc/common/conversion.hpp>
 #include <silkworm/infra/grpc/common/util.hpp>
@@ -479,7 +480,7 @@ class AsyncEtherbaseCall : public AsyncUnaryCall<
         if (ok && status_.ok()) {
             if (reply_.has_address()) {
                 const auto h160_address = reply_.address();
-                const auto address = silkworm::to_hex(silkworm::rpc::address_from_H160(h160_address));
+                const auto address = silkworm::rpc::address_from_H160(h160_address);
                 SILK_INFO << "Etherbase reply: " << address << " [latency=" << latency() / 1ns << " ns]";
             } else {
                 SILK_INFO << "Etherbase reply: no address";

--- a/cmd/test/ethereum.cpp
+++ b/cmd/test/ethereum.cpp
@@ -37,6 +37,7 @@
 #include <silkworm/core/protocol/ethash_rule_set.hpp>
 #include <silkworm/core/protocol/intrinsic_gas.hpp>
 #include <silkworm/core/state/in_memory_state.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/infra/common/stopwatch.hpp>
 #include <silkworm/infra/common/terminal.hpp>
 #include <silkworm/infra/concurrency/thread_pool.hpp>

--- a/cmd/test/ethereum.cpp
+++ b/cmd/test/ethereum.cpp
@@ -31,6 +31,7 @@
 #include <silkworm/core/chain/config.hpp>
 #include <silkworm/core/common/as_range.hpp>
 #include <silkworm/core/common/test_util.hpp>
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/core/execution/evm.hpp>
 #include <silkworm/core/protocol/blockchain.hpp>
 #include <silkworm/core/protocol/ethash_rule_set.hpp>
@@ -416,7 +417,7 @@ RunResults transaction_test(const nlohmann::json& j, bool) {
         const std::string expected_sender{test["sender"].get<std::string>()};
         if (txn.from != to_evmc_address(*from_hex(expected_sender))) {
             std::cout << "Sender mismatch for " << entry.key() << ":\n"
-                      << to_hex(*txn.from) << " != " << expected_sender << std::endl;
+                      << *txn.from << " != " << expected_sender << std::endl;
             return Status::kFailed;
         }
 

--- a/silkworm/core/chain/config.cpp
+++ b/silkworm/core/chain/config.cpp
@@ -21,6 +21,7 @@
 #include <set>
 
 #include <silkworm/core/common/as_range.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 
 namespace silkworm {
 

--- a/silkworm/core/chain/genesis_test.cpp
+++ b/silkworm/core/chain/genesis_test.cpp
@@ -22,6 +22,7 @@
 #include <silkworm/core/execution/address.hpp>
 #include <silkworm/core/common/endian.hpp>
 #include <silkworm/core/common/util.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/core/state/in_memory_state.hpp>
 
 namespace silkworm {

--- a/silkworm/core/chain/genesis_test.cpp
+++ b/silkworm/core/chain/genesis_test.cpp
@@ -19,6 +19,7 @@
 
 #include <silkworm/core/chain/config.hpp>
 #include <silkworm/core/chain/genesis.hpp>
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/core/common/endian.hpp>
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/core/state/in_memory_state.hpp>

--- a/silkworm/core/common/base.hpp
+++ b/silkworm/core/common/base.hpp
@@ -21,9 +21,6 @@
 #include <concepts>
 #include <cstddef>
 #include <cstdint>
-#include <span>
-#include <string>
-#include <string_view>
 #include <tuple>
 
 #include <evmc/evmc.hpp>
@@ -42,38 +39,6 @@ using namespace evmc::literals;
 template <class T>
 concept UnsignedIntegral = std::unsigned_integral<T> || std::same_as<T, intx::uint128> ||
     std::same_as<T, intx::uint256> || std::same_as<T, intx::uint512>;
-
-using Bytes = std::basic_string<uint8_t>;
-
-class ByteView : public std::basic_string_view<uint8_t> {
-  public:
-    constexpr ByteView() noexcept = default;
-
-    constexpr ByteView(const std::basic_string_view<uint8_t>& other) noexcept
-        : std::basic_string_view<uint8_t>{other.data(), other.length()} {}
-
-    ByteView(const Bytes& str) noexcept : std::basic_string_view<uint8_t>{str.data(), str.length()} {}
-
-    constexpr ByteView(const uint8_t* data, size_type length) noexcept
-        : std::basic_string_view<uint8_t>{data, length} {}
-
-    template <std::size_t N>
-    constexpr ByteView(const uint8_t (&array)[N]) noexcept : std::basic_string_view<uint8_t>{array, N} {}
-
-    template <std::size_t N>
-    constexpr ByteView(const std::array<uint8_t, N>& array) noexcept
-        : std::basic_string_view<uint8_t>{array.data(), N} {}
-
-    constexpr ByteView(const evmc::address& address) noexcept : ByteView{address.bytes} {}
-
-    constexpr ByteView(const evmc::bytes32& hash) noexcept : ByteView{hash.bytes} {}
-
-    template <std::size_t Extent>
-    constexpr ByteView(std::span<const uint8_t, Extent> span) noexcept
-        : std::basic_string_view<uint8_t>{span.data(), span.size()} {}
-
-    [[nodiscard]] bool is_null() const noexcept { return data() == nullptr; }
-};
 
 using BlockNum = uint64_t;
 using BlockNumRange = std::pair<BlockNum, BlockNum>;

--- a/silkworm/core/common/bytes.hpp
+++ b/silkworm/core/common/bytes.hpp
@@ -45,8 +45,6 @@ class ByteView : public std::basic_string_view<uint8_t> {
     constexpr ByteView(const std::array<uint8_t, N>& array) noexcept
         : std::basic_string_view<uint8_t>{array.data(), N} {}
 
-    constexpr ByteView(const evmc::address& address) noexcept : ByteView{address.bytes} {}
-
     constexpr ByteView(const evmc::bytes32& hash) noexcept : ByteView{hash.bytes} {}
 
     template <std::size_t Extent>

--- a/silkworm/core/common/bytes.hpp
+++ b/silkworm/core/common/bytes.hpp
@@ -20,8 +20,6 @@
 #include <string>
 #include <string_view>
 
-#include <evmc/evmc.hpp>
-
 namespace silkworm {
 
 using Bytes = std::basic_string<uint8_t>;
@@ -44,8 +42,6 @@ class ByteView : public std::basic_string_view<uint8_t> {
     template <std::size_t N>
     constexpr ByteView(const std::array<uint8_t, N>& array) noexcept
         : std::basic_string_view<uint8_t>{array.data(), N} {}
-
-    constexpr ByteView(const evmc::bytes32& hash) noexcept : ByteView{hash.bytes} {}
 
     template <std::size_t Extent>
     constexpr ByteView(std::span<const uint8_t, Extent> span) noexcept

--- a/silkworm/core/common/bytes.hpp
+++ b/silkworm/core/common/bytes.hpp
@@ -1,0 +1,59 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <span>
+#include <string>
+#include <string_view>
+
+#include <evmc/evmc.hpp>
+
+namespace silkworm {
+
+using Bytes = std::basic_string<uint8_t>;
+
+class ByteView : public std::basic_string_view<uint8_t> {
+  public:
+    constexpr ByteView() noexcept = default;
+
+    constexpr ByteView(const std::basic_string_view<uint8_t>& other) noexcept
+        : std::basic_string_view<uint8_t>{other.data(), other.length()} {}
+
+    ByteView(const Bytes& str) noexcept : std::basic_string_view<uint8_t>{str.data(), str.length()} {}
+
+    constexpr ByteView(const uint8_t* data, size_type length) noexcept
+        : std::basic_string_view<uint8_t>{data, length} {}
+
+    template <std::size_t N>
+    constexpr ByteView(const uint8_t (&array)[N]) noexcept : std::basic_string_view<uint8_t>{array, N} {}
+
+    template <std::size_t N>
+    constexpr ByteView(const std::array<uint8_t, N>& array) noexcept
+        : std::basic_string_view<uint8_t>{array.data(), N} {}
+
+    constexpr ByteView(const evmc::address& address) noexcept : ByteView{address.bytes} {}
+
+    constexpr ByteView(const evmc::bytes32& hash) noexcept : ByteView{hash.bytes} {}
+
+    template <std::size_t Extent>
+    constexpr ByteView(std::span<const uint8_t, Extent> span) noexcept
+        : std::basic_string_view<uint8_t>{span.data(), span.size()} {}
+
+    [[nodiscard]] bool is_null() const noexcept { return data() == nullptr; }
+};
+
+}  // namespace silkworm

--- a/silkworm/core/common/cast.hpp
+++ b/silkworm/core/common/cast.hpp
@@ -21,6 +21,7 @@
 #include <string_view>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 
 namespace silkworm {
 

--- a/silkworm/core/common/endian.hpp
+++ b/silkworm/core/common/endian.hpp
@@ -27,6 +27,7 @@ See https://en.wikipedia.org/wiki/Endianness
 #include <intx/intx.hpp>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/common/decoding_result.hpp>
 
 namespace silkworm::endian {

--- a/silkworm/core/common/test_util.cpp
+++ b/silkworm/core/common/test_util.cpp
@@ -16,6 +16,7 @@
 
 #include "test_util.hpp"
 
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/core/types/log.hpp>
 
 namespace silkworm::test {

--- a/silkworm/core/common/util.cpp
+++ b/silkworm/core/common/util.cpp
@@ -57,15 +57,6 @@ static constexpr uint8_t kUnhexTable4[256] = {
     0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
     0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
 
-evmc::address to_evmc_address(ByteView bytes) {
-    evmc::address out;
-    if (!bytes.empty()) {
-        size_t n{std::min(bytes.length(), kAddressLength)};
-        std::memcpy(out.bytes + kAddressLength - n, bytes.data(), n);
-    }
-    return out;
-}
-
 evmc::bytes32 to_bytes32(ByteView bytes) {
     evmc::bytes32 out;
     if (!bytes.empty()) {

--- a/silkworm/core/common/util.cpp
+++ b/silkworm/core/common/util.cpp
@@ -57,15 +57,6 @@ static constexpr uint8_t kUnhexTable4[256] = {
     0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
     0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
 
-evmc::bytes32 to_bytes32(ByteView bytes) {
-    evmc::bytes32 out;
-    if (!bytes.empty()) {
-        size_t n{std::min(bytes.length(), kHashLength)};
-        std::memcpy(out.bytes + kHashLength - n, bytes.data(), n);
-    }
-    return out;
-}
-
 ByteView zeroless_view(ByteView data) {
     const auto is_zero_byte = [](const auto& b) { return b == 0x0; };
     const auto first_nonzero_byte_it{as_range::find_if_not(data, is_zero_byte)};

--- a/silkworm/core/common/util.hpp
+++ b/silkworm/core/common/util.hpp
@@ -31,10 +31,6 @@
 
 namespace silkworm {
 
-// Converts bytes to evmc::bytes32; input is cropped if necessary.
-// Short inputs are left-padded with 0s.
-evmc::bytes32 to_bytes32(ByteView bytes);
-
 //! \brief Strips leftmost zeroed bytes from byte sequence
 //! \param [in] data : The view to process
 //! \return A new view of the sequence

--- a/silkworm/core/common/util.hpp
+++ b/silkworm/core/common/util.hpp
@@ -27,6 +27,7 @@
 #include <intx/intx.hpp>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 
 namespace silkworm {
 

--- a/silkworm/core/common/util.hpp
+++ b/silkworm/core/common/util.hpp
@@ -31,10 +31,6 @@
 
 namespace silkworm {
 
-// Converts bytes to evmc::address; input is cropped if necessary.
-// Short inputs are left-padded with 0s.
-evmc::address to_evmc_address(ByteView bytes);
-
 // Converts bytes to evmc::bytes32; input is cropped if necessary.
 // Short inputs are left-padded with 0s.
 evmc::bytes32 to_bytes32(ByteView bytes);

--- a/silkworm/core/common/util_test.cpp
+++ b/silkworm/core/common/util_test.cpp
@@ -18,6 +18,8 @@
 
 #include <catch2/catch.hpp>
 
+#include <silkworm/core/types/evmc_bytes32.hpp>
+
 namespace silkworm {
 
 TEST_CASE("Hex") {
@@ -92,10 +94,10 @@ TEST_CASE("Integrals to hex") {
 
 TEST_CASE("Zeroless view") {
     SECTION("from bytes32") {
-        CHECK(to_hex(zeroless_view(0x0000000000000000000000000000000000000000000000000000000000000000_bytes32)).empty());
-        CHECK(to_hex(zeroless_view(0x000000000000000000000000000000000000000000000000000000000004bc00_bytes32)) ==
+        CHECK(to_hex(zeroless_view((0x0000000000000000000000000000000000000000000000000000000000000000_bytes32).bytes)).empty());
+        CHECK(to_hex(zeroless_view((0x000000000000000000000000000000000000000000000000000000000004bc00_bytes32).bytes)) ==
               "04bc00");
-        CHECK(to_hex(zeroless_view(0x100000000000000000000000000000000000000000000000000000000004bc00_bytes32)) ==
+        CHECK(to_hex(zeroless_view((0x100000000000000000000000000000000000000000000000000000000004bc00_bytes32).bytes)) ==
               "100000000000000000000000000000000000000000000000000000000004bc00");
     }
     SECTION("from Bytes") {

--- a/silkworm/core/execution/address.cpp
+++ b/silkworm/core/execution/address.cpp
@@ -68,6 +68,15 @@ evmc::address create2_address(const evmc::address& caller, const evmc::bytes32& 
     return address;
 }
 
+evmc::address to_evmc_address(ByteView bytes) {
+    evmc::address out;
+    if (!bytes.empty()) {
+        size_t n{std::min(bytes.length(), kAddressLength)};
+        std::memcpy(out.bytes + kAddressLength - n, bytes.data(), n);
+    }
+    return out;
+}
+
 std::string address_to_string(const evmc::address& address) {
     return to_hex(ByteView{address.bytes}, true);
 }

--- a/silkworm/core/execution/address.cpp
+++ b/silkworm/core/execution/address.cpp
@@ -23,6 +23,18 @@
 
 namespace silkworm {
 
+namespace rlp {
+
+    void encode(Bytes& to, const evmc::address& address) {
+        encode(to, ByteView{address.bytes});
+    }
+
+    size_t length(const evmc::address& address) noexcept {
+        return length(ByteView{address.bytes});
+    }
+
+}  // namespace rlp
+
 evmc::address create_address(const evmc::address& caller, uint64_t nonce) noexcept {
     rlp::Header h{true, 1 + kAddressLength};
     h.payload_length += rlp::length(nonce);
@@ -55,4 +67,17 @@ evmc::address create2_address(const evmc::address& caller, const evmc::bytes32& 
     std::memcpy(address.bytes, hash.bytes + 12, kAddressLength);
     return address;
 }
+
+std::string address_to_string(const evmc::address& address) {
+    return to_hex(ByteView{address.bytes}, true);
+}
+
 }  // namespace silkworm
+
+namespace evmc {
+
+std::ostream& operator<<(std::ostream& out, const evmc::address& address) {
+    return out << silkworm::address_to_string(address);
+}
+
+}  // namespace evmc

--- a/silkworm/core/execution/address.hpp
+++ b/silkworm/core/execution/address.hpp
@@ -19,7 +19,8 @@
 #include <ostream>
 #include <string>
 
-#include <silkworm/core/common/base.hpp>
+#include <evmc/evmc.hpp>
+
 #include <silkworm/core/common/bytes.hpp>
 
 namespace silkworm {

--- a/silkworm/core/execution/address.hpp
+++ b/silkworm/core/execution/address.hpp
@@ -16,13 +16,32 @@
 
 #pragma once
 
+#include <ostream>
+#include <string>
+
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 
 namespace silkworm {
+
 // Yellow Paper, Section 7
 evmc::address create_address(const evmc::address& caller, uint64_t nonce) noexcept;
 
 // https://eips.ethereum.org/EIPS/eip-1014
 evmc::address create2_address(const evmc::address& caller, const evmc::bytes32& salt,
                               uint8_t (&code_hash)[32]) noexcept;
+
+std::string address_to_string(const evmc::address& address);
+
+namespace rlp {
+    void encode(Bytes& to, const evmc::address& address);
+    size_t length(const evmc::address& address) noexcept;
+}  // namespace rlp
+
 }  // namespace silkworm
+
+namespace evmc {
+
+std::ostream& operator<<(std::ostream& out, const evmc::address& address);
+
+}  // namespace evmc

--- a/silkworm/core/execution/address.hpp
+++ b/silkworm/core/execution/address.hpp
@@ -31,6 +31,10 @@ evmc::address create_address(const evmc::address& caller, uint64_t nonce) noexce
 evmc::address create2_address(const evmc::address& caller, const evmc::bytes32& salt,
                               uint8_t (&code_hash)[32]) noexcept;
 
+// Converts bytes to evmc::address; input is cropped if necessary.
+// Short inputs are left-padded with 0s.
+evmc::address to_evmc_address(ByteView bytes);
+
 std::string address_to_string(const evmc::address& address);
 
 namespace rlp {

--- a/silkworm/core/execution/evm_test.cpp
+++ b/silkworm/core/execution/evm_test.cpp
@@ -25,6 +25,7 @@
 #include <silkworm/core/common/test_util.hpp>
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/core/state/in_memory_state.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 
 #include "address.hpp"
 
@@ -114,7 +115,7 @@ TEST_CASE("Smart contract with storage") {
 
     evmc::address contract_address{create_address(caller, /*nonce=*/1)};
     evmc::bytes32 key0{};
-    CHECK(to_hex(zeroless_view(state.get_current_storage(contract_address, key0))) == "2a");
+    CHECK(to_hex(zeroless_view(state.get_current_storage(contract_address, key0).bytes)) == "2a");
 
     evmc::bytes32 new_val{to_bytes32(*from_hex("f5"))};
     txn.to = contract_address;
@@ -240,7 +241,7 @@ TEST_CASE("DELEGATECALL") {
     CHECK(res.data.empty());
 
     evmc::bytes32 key0{};
-    CHECK(to_hex(zeroless_view(state.get_current_storage(caller_address, key0)), true) == address_to_string(caller_address));
+    CHECK(to_hex(zeroless_view(state.get_current_storage(caller_address, key0).bytes), true) == address_to_string(caller_address));
 }
 
 // https://eips.ethereum.org/EIPS/eip-211#specification
@@ -539,7 +540,7 @@ TEST_CASE("Tracing smart contract with storage") {
     evm.add_tracer(tracer3);
     CHECK(evm.tracers().size() == 3);
 
-    CHECK(to_hex(zeroless_view(state.get_current_storage(contract_address, key0))) == "2a");
+    CHECK(to_hex(zeroless_view(state.get_current_storage(contract_address, key0).bytes)) == "2a");
     evmc::bytes32 new_val{to_bytes32(*from_hex("f5"))};
     txn.to = contract_address;
     txn.data = ByteView{new_val};

--- a/silkworm/core/execution/evm_test.cpp
+++ b/silkworm/core/execution/evm_test.cpp
@@ -232,7 +232,7 @@ TEST_CASE("DELEGATECALL") {
     Transaction txn{};
     txn.from = caller_address;
     txn.to = caller_address;
-    txn.data = ByteView{to_bytes32(callee_address)};
+    txn.data = ByteView{to_bytes32(callee_address.bytes)};
 
     uint64_t gas{1'000'000};
     CallResult res{evm.execute(txn, gas)};
@@ -240,7 +240,7 @@ TEST_CASE("DELEGATECALL") {
     CHECK(res.data.empty());
 
     evmc::bytes32 key0{};
-    CHECK(to_hex(zeroless_view(state.get_current_storage(caller_address, key0))) == to_hex(caller_address));
+    CHECK(to_hex(zeroless_view(state.get_current_storage(caller_address, key0)), true) == address_to_string(caller_address));
 }
 
 // https://eips.ethereum.org/EIPS/eip-211#specification

--- a/silkworm/core/execution/execution_test.cpp
+++ b/silkworm/core/execution/execution_test.cpp
@@ -26,6 +26,7 @@
 #include <silkworm/core/trie/vector_root.hpp>
 #include <silkworm/core/types/account.hpp>
 #include <silkworm/core/types/block.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 
 namespace silkworm {
 

--- a/silkworm/core/execution/precompile.hpp
+++ b/silkworm/core/execution/precompile.hpp
@@ -21,6 +21,7 @@
 #include <evmc/evmc.h>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 
 // See Yellow Paper, Appendix E "Precompiled Contracts"
 namespace silkworm::precompile {

--- a/silkworm/core/execution/processor_test.cpp
+++ b/silkworm/core/execution/processor_test.cpp
@@ -21,6 +21,7 @@
 
 #include <silkworm/core/protocol/param.hpp>
 #include <silkworm/core/state/in_memory_state.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 
 #include "address.hpp"
 

--- a/silkworm/core/execution/processor_test.cpp
+++ b/silkworm/core/execution/processor_test.cpp
@@ -198,7 +198,7 @@ TEST_CASE("Self-destruct") {
         originator,  // from
     };
 
-    evmc::bytes32 address_as_hash{to_bytes32(suicidal_address)};
+    evmc::bytes32 address_as_hash{to_bytes32(suicidal_address.bytes)};
     txn.data = ByteView{address_as_hash};
 
     Receipt receipt1;

--- a/silkworm/core/protocol/param.hpp
+++ b/silkworm/core/protocol/param.hpp
@@ -19,6 +19,7 @@
 #include <cstdint>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 
 namespace silkworm::protocol {
 

--- a/silkworm/core/rlp/decode.cpp
+++ b/silkworm/core/rlp/decode.cpp
@@ -87,10 +87,6 @@ tl::expected<Header, DecodingError> decode_header(ByteView& from) noexcept {
     return h;
 }
 
-DecodingResult decode(ByteView& from, evmc::bytes32& to, Leftover mode) noexcept {
-    return decode(from, to.bytes, mode);
-}
-
 DecodingResult decode(ByteView& from, Bytes& to, Leftover mode) noexcept {
     const auto h{decode_header(from)};
     if (!h) {

--- a/silkworm/core/rlp/decode.hpp
+++ b/silkworm/core/rlp/decode.hpp
@@ -43,8 +43,6 @@ enum class Leftover {
 // in which case the byte is put back.
 [[nodiscard]] tl::expected<Header, DecodingError> decode_header(ByteView& from) noexcept;
 
-DecodingResult decode(ByteView& from, evmc::bytes32& to, Leftover mode = Leftover::kProhibit) noexcept;
-
 DecodingResult decode(ByteView& from, Bytes& to, Leftover mode = Leftover::kProhibit) noexcept;
 
 template <UnsignedIntegral T>

--- a/silkworm/core/rlp/decode.hpp
+++ b/silkworm/core/rlp/decode.hpp
@@ -26,6 +26,7 @@
 #include <intx/intx.hpp>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/common/decoding_result.hpp>
 #include <silkworm/core/rlp/encode.hpp>
 

--- a/silkworm/core/rlp/encode.hpp
+++ b/silkworm/core/rlp/encode.hpp
@@ -22,6 +22,7 @@
 #include <intx/intx.hpp>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/common/endian.hpp>
 
 namespace silkworm::rlp {

--- a/silkworm/core/state/in_memory_state.cpp
+++ b/silkworm/core/state/in_memory_state.cpp
@@ -24,6 +24,7 @@
 #include <silkworm/core/rlp/encode.hpp>
 #include <silkworm/core/trie/hash_builder.hpp>
 #include <silkworm/core/trie/nibbles.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 
 namespace silkworm {
 
@@ -226,15 +227,15 @@ evmc::bytes32 InMemoryState::account_storage_root(const evmc::address& address, 
     std::map<evmc::bytes32, Bytes> storage_rlp;
     Bytes buffer;
     for (const auto& [location, value] : storage) {
-        ethash::hash256 hash{keccak256(location)};
+        ethash::hash256 hash{keccak256(location.bytes)};
         buffer.clear();
-        rlp::encode(buffer, zeroless_view(value));
+        rlp::encode(buffer, zeroless_view(value.bytes));
         storage_rlp[to_bytes32(hash.bytes)] = buffer;
     }
 
     trie::HashBuilder hb;
     for (const auto& [hash, rlp] : storage_rlp) {
-        hb.add_leaf(trie::unpack_nibbles(hash), rlp);
+        hb.add_leaf(trie::unpack_nibbles(hash.bytes), rlp);
     }
 
     return hb.root_hash();
@@ -254,7 +255,7 @@ evmc::bytes32 InMemoryState::state_root_hash() const {
 
     trie::HashBuilder hb;
     for (const auto& [hash, rlp] : account_rlp) {
-        hb.add_leaf(trie::unpack_nibbles(hash), rlp);
+        hb.add_leaf(trie::unpack_nibbles(hash.bytes), rlp);
     }
 
     return hb.root_hash();

--- a/silkworm/core/state/in_memory_state.cpp
+++ b/silkworm/core/state/in_memory_state.cpp
@@ -247,7 +247,7 @@ evmc::bytes32 InMemoryState::state_root_hash() const {
 
     std::map<evmc::bytes32, Bytes> account_rlp;
     for (const auto& [address, account] : accounts_) {
-        ethash::hash256 hash{keccak256(address)};
+        ethash::hash256 hash{keccak256(address.bytes)};
         evmc::bytes32 storage_root{account_storage_root(address, account.incarnation)};
         account_rlp[to_bytes32(hash.bytes)] = account.rlp(storage_root);
     }

--- a/silkworm/core/state/intra_block_state.hpp
+++ b/silkworm/core/state/intra_block_state.hpp
@@ -22,6 +22,7 @@
 #include <intx/intx.hpp>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/common/hash_maps.hpp>
 #include <silkworm/core/state/delta.hpp>
 #include <silkworm/core/state/object.hpp>

--- a/silkworm/core/trie/hash_builder.hpp
+++ b/silkworm/core/trie/hash_builder.hpp
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/trie/node.hpp>
 
 namespace silkworm::trie {

--- a/silkworm/core/trie/hash_builder_test.cpp
+++ b/silkworm/core/trie/hash_builder_test.cpp
@@ -23,6 +23,7 @@
 #include <silkworm/core/rlp/encode.hpp>
 #include <silkworm/core/trie/hash_builder.hpp>
 #include <silkworm/core/trie/nibbles.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 
 namespace silkworm::trie {
 
@@ -39,8 +40,8 @@ TEST_CASE("HashBuilder1") {
     const auto val2{*from_hex("02")};
 
     HashBuilder hb;
-    hb.add_leaf(unpack_nibbles(key1), val1);
-    hb.add_leaf(unpack_nibbles(key2), val2);
+    hb.add_leaf(unpack_nibbles(key1.bytes), val1);
+    hb.add_leaf(unpack_nibbles(key2.bytes), val2);
 
     // even terminating
     const Bytes encoded_empty_terminating_path{*from_hex("20")};

--- a/silkworm/core/trie/nibbles.hpp
+++ b/silkworm/core/trie/nibbles.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 
 namespace silkworm::trie {
 

--- a/silkworm/core/trie/node.hpp
+++ b/silkworm/core/trie/node.hpp
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/common/decoding_result.hpp>
 
 namespace silkworm::trie {

--- a/silkworm/core/trie/prefix_set.hpp
+++ b/silkworm/core/trie/prefix_set.hpp
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 
 namespace silkworm::trie {
 

--- a/silkworm/core/trie/vector_root_test.cpp
+++ b/silkworm/core/trie/vector_root_test.cpp
@@ -19,6 +19,7 @@
 #include <catch2/catch.hpp>
 
 #include <silkworm/core/common/util.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/core/types/receipt.hpp>
 #include <silkworm/core/types/transaction.hpp>
 

--- a/silkworm/core/types/account.cpp
+++ b/silkworm/core/types/account.cpp
@@ -18,6 +18,7 @@
 
 #include <silkworm/core/common/endian.hpp>
 #include <silkworm/core/rlp/encode.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 
 namespace silkworm {
 

--- a/silkworm/core/types/account.hpp
+++ b/silkworm/core/types/account.hpp
@@ -19,6 +19,7 @@
 #include <intx/intx.hpp>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/common/decoding_result.hpp>
 
 namespace silkworm {

--- a/silkworm/core/types/block.cpp
+++ b/silkworm/core/types/block.cpp
@@ -22,6 +22,7 @@
 #include <silkworm/core/protocol/param.hpp>
 #include <silkworm/core/rlp/decode_vector.hpp>
 #include <silkworm/core/rlp/encode_vector.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 
 namespace silkworm {
 

--- a/silkworm/core/types/block.cpp
+++ b/silkworm/core/types/block.cpp
@@ -18,6 +18,7 @@
 
 #include <bit>
 
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/core/protocol/param.hpp>
 #include <silkworm/core/rlp/decode_vector.hpp>
 #include <silkworm/core/rlp/encode_vector.hpp>

--- a/silkworm/core/types/bloom.cpp
+++ b/silkworm/core/types/bloom.cpp
@@ -35,7 +35,7 @@ Bloom logs_bloom(const std::vector<Log>& logs) {
     for (const Log& log : logs) {
         m3_2048(bloom, log.address.bytes);
         for (const auto& topic : log.topics) {
-            m3_2048(bloom, topic);
+            m3_2048(bloom, topic.bytes);
         }
     }
     return bloom;

--- a/silkworm/core/types/bloom.cpp
+++ b/silkworm/core/types/bloom.cpp
@@ -33,7 +33,7 @@ void m3_2048(Bloom& bloom, ByteView x) {
 Bloom logs_bloom(const std::vector<Log>& logs) {
     Bloom bloom{};  // zero initialization
     for (const Log& log : logs) {
-        m3_2048(bloom, log.address);
+        m3_2048(bloom, log.address.bytes);
         for (const auto& topic : log.topics) {
             m3_2048(bloom, topic);
         }

--- a/silkworm/core/types/evmc_bytes32.cpp
+++ b/silkworm/core/types/evmc_bytes32.cpp
@@ -1,0 +1,56 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "evmc_bytes32.hpp"
+
+#include <algorithm>
+#include <cstring>
+
+#include <silkworm/core/common/util.hpp>
+#include <silkworm/core/rlp/encode.hpp>
+
+namespace silkworm {
+
+evmc::bytes32 to_bytes32(ByteView bytes) {
+    evmc::bytes32 out;
+    if (!bytes.empty()) {
+        size_t n{std::min(bytes.length(), kHashLength)};
+        std::memcpy(out.bytes + kHashLength - n, bytes.data(), n);
+    }
+    return out;
+}
+
+std::string to_hex(const evmc::bytes32& value, bool with_prefix) {
+    return silkworm::to_hex(ByteView{value.bytes}, with_prefix);
+}
+
+}  // namespace silkworm
+
+namespace silkworm::rlp {
+
+void encode(Bytes& to, const evmc::bytes32& value) {
+    return silkworm::rlp::encode(to, ByteView{value.bytes});
+}
+
+size_t length(const evmc::bytes32& value) noexcept {
+    return silkworm::rlp::length(ByteView{value.bytes});
+}
+
+DecodingResult decode(ByteView& from, evmc::bytes32& to, Leftover mode) noexcept {
+    return silkworm::rlp::decode(from, to.bytes, mode);
+}
+
+}  // namespace silkworm::rlp

--- a/silkworm/core/types/evmc_bytes32.hpp
+++ b/silkworm/core/types/evmc_bytes32.hpp
@@ -1,0 +1,48 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <string>
+
+#include <evmc/evmc.hpp>
+
+#include <silkworm/core/common/bytes.hpp>
+#include <silkworm/core/rlp/decode.hpp>
+
+namespace silkworm {
+
+// Converts bytes to evmc::bytes32; input is cropped if necessary.
+// Short inputs are left-padded with 0s.
+evmc::bytes32 to_bytes32(ByteView bytes);
+
+std::string to_hex(const evmc::bytes32& value, bool with_prefix = false);
+
+}  // namespace silkworm
+
+namespace silkworm::rlp {
+
+void encode(Bytes& to, const evmc::bytes32& value);
+size_t length(const evmc::bytes32& value) noexcept;
+
+DecodingResult decode(ByteView& from, evmc::bytes32& to, Leftover mode = Leftover::kProhibit) noexcept;
+
+}  // namespace silkworm::rlp
+
+namespace evmc {
+using silkworm::rlp::encode;
+using silkworm::rlp::length;
+}  // namespace evmc

--- a/silkworm/core/types/hash.hpp
+++ b/silkworm/core/types/hash.hpp
@@ -24,6 +24,7 @@
 
 #include <silkworm/core/common/assert.hpp>
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/core/rlp/decode.hpp>
 

--- a/silkworm/core/types/hash.hpp
+++ b/silkworm/core/types/hash.hpp
@@ -45,8 +45,8 @@ class Hash : public evmc::bytes32 {
     [[nodiscard]] std::string to_hex() const { return silkworm::to_hex(*this); }
     static std::optional<Hash> from_hex(const std::string& hex) { return evmc::from_hex<Hash>(hex); }
 
-    // conversion to ByteView is handled in ByteView class,
-    // conversion operator Byte() { return {bytes, length()}; } is handled elsewhere
+    // conversion to ByteView
+    operator ByteView() const { return ByteView{bytes}; }
 
     static_assert(sizeof(evmc::bytes32) == 32);
 };

--- a/silkworm/core/types/log.cpp
+++ b/silkworm/core/types/log.cpp
@@ -16,6 +16,7 @@
 
 #include "log.hpp"
 
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/core/rlp/encode_vector.hpp>
 
 namespace silkworm ::rlp {

--- a/silkworm/core/types/log.cpp
+++ b/silkworm/core/types/log.cpp
@@ -18,8 +18,9 @@
 
 #include <silkworm/core/execution/address.hpp>
 #include <silkworm/core/rlp/encode_vector.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 
-namespace silkworm ::rlp {
+namespace silkworm::rlp {
 
 static Header header(const Log& l) {
     Header h;

--- a/silkworm/core/types/log.hpp
+++ b/silkworm/core/types/log.hpp
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 
 namespace silkworm {
 

--- a/silkworm/core/types/log_test.cpp
+++ b/silkworm/core/types/log_test.cpp
@@ -21,6 +21,7 @@
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/core/execution/address.hpp>
 #include <silkworm/core/rlp/encode_vector.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 
 namespace silkworm {
 

--- a/silkworm/core/types/log_test.cpp
+++ b/silkworm/core/types/log_test.cpp
@@ -19,6 +19,7 @@
 #include <catch2/catch.hpp>
 
 #include <silkworm/core/common/util.hpp>
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/core/rlp/encode_vector.hpp>
 
 namespace silkworm {

--- a/silkworm/core/types/transaction.cpp
+++ b/silkworm/core/types/transaction.cpp
@@ -22,6 +22,7 @@
 
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/core/crypto/ecdsa.h>
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/core/protocol/param.hpp>
 #include <silkworm/core/rlp/decode_vector.hpp>
 #include <silkworm/core/rlp/encode_vector.hpp>

--- a/silkworm/core/types/transaction.cpp
+++ b/silkworm/core/types/transaction.cpp
@@ -26,6 +26,7 @@
 #include <silkworm/core/protocol/param.hpp>
 #include <silkworm/core/rlp/decode_vector.hpp>
 #include <silkworm/core/rlp/encode_vector.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 
 #include "y_parity_and_chain_id.hpp"
 

--- a/silkworm/core/types/transaction.hpp
+++ b/silkworm/core/types/transaction.hpp
@@ -22,6 +22,7 @@
 #include <intx/intx.hpp>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/rlp/decode.hpp>
 #include <silkworm/core/types/hash.hpp>
 

--- a/silkworm/core/types/withdrawal.cpp
+++ b/silkworm/core/types/withdrawal.cpp
@@ -16,6 +16,7 @@
 
 #include "withdrawal.hpp"
 
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/core/rlp/decode_vector.hpp>
 #include <silkworm/core/rlp/encode.hpp>
 

--- a/silkworm/core/types/withdrawal.hpp
+++ b/silkworm/core/types/withdrawal.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/rlp/decode.hpp>
 
 namespace silkworm {

--- a/silkworm/core/types/withdrawal_test.cpp
+++ b/silkworm/core/types/withdrawal_test.cpp
@@ -20,6 +20,7 @@
 
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/core/trie/vector_root.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 
 namespace silkworm {
 

--- a/silkworm/infra/common/secp256k1_context.hpp
+++ b/silkworm/infra/common/secp256k1_context.hpp
@@ -24,6 +24,7 @@
 #include <secp256k1_recovery.h>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 
 namespace silkworm {
 

--- a/silkworm/infra/grpc/common/conversion.hpp
+++ b/silkworm/infra/grpc/common/conversion.hpp
@@ -24,6 +24,7 @@
 #include <intx/intx.hpp>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/common/endian.hpp>
 #include <silkworm/interfaces/types/types.pb.h>
 

--- a/silkworm/node/backend/remote/backend_kv_server_test.cpp
+++ b/silkworm/node/backend/remote/backend_kv_server_test.cpp
@@ -30,6 +30,7 @@
 #include <catch2/catch.hpp>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/infra/common/directories.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/common/os.hpp>

--- a/silkworm/node/backend/remote/grpc/backend_calls.cpp
+++ b/silkworm/node/backend/remote/grpc/backend_calls.cpp
@@ -16,6 +16,7 @@
 
 #include "backend_calls.hpp"
 
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/grpc/client/call.hpp>
 #include <silkworm/infra/grpc/common/conversion.hpp>
@@ -39,7 +40,7 @@ Task<void> EtherbaseCall::operator()(const EthereumBackEnd& /*backend*/) {
     SILK_TRACE << "EtherbaseCall START";
     if (response_.has_address()) {
         co_await agrpc::finish(responder_, response_, grpc::Status::OK);
-        SILK_TRACE << "EtherbaseCall END etherbase: " << to_hex(address_from_H160(response_.address()));
+        SILK_TRACE << "EtherbaseCall END etherbase: " << address_from_H160(response_.address());
     } else {
         const grpc::Status error{grpc::StatusCode::INTERNAL, "etherbase must be explicitly specified"};
         co_await agrpc::finish_with_error(responder_, error);

--- a/silkworm/node/backend/state_change_collection.cpp
+++ b/silkworm/node/backend/state_change_collection.cpp
@@ -19,6 +19,7 @@
 #include <silkworm/core/common/assert.hpp>
 #include <silkworm/core/common/base.hpp>
 #include <silkworm/core/common/bytes.hpp>
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/grpc/common/conversion.hpp>
 
@@ -87,7 +88,7 @@ void StateChangeCollection::change_account(const evmc::address& address, uint64_
             account_change->set_action(remote::Action::UPSERT_CODE);
             break;
         case remote::Action::REMOVE:
-            SILK_CRIT << "cannot change deleted account: " << to_hex(address) << " incarnation: " << incarnation;
+            SILK_CRIT << "cannot change deleted account: " << address << " incarnation: " << incarnation;
             SILKWORM_ASSERT(false);
             break;
         default:
@@ -121,7 +122,7 @@ void StateChangeCollection::change_code(const evmc::address& address, uint64_t i
             account_change->set_action(remote::Action::UPSERT_CODE);
             break;
         case remote::Action::REMOVE:
-            SILK_CRIT << "cannot change code for deleted account: " << to_hex(address)
+            SILK_CRIT << "cannot change code for deleted account: " << address
                       << " incarnation: " << incarnation;
             SILKWORM_ASSERT(false);
             break;
@@ -151,7 +152,7 @@ void StateChangeCollection::change_storage(const evmc::address& address, uint64_
     remote::AccountChange* account_change = latest_change_->mutable_changes(static_cast<int>(ac_index.value()));
     switch (account_change->action()) {
         case remote::Action::REMOVE:
-            SILK_CRIT << "cannot change storage for deleted account: " << to_hex(address)
+            SILK_CRIT << "cannot change storage for deleted account: " << address
                       << " incarnation: " << incarnation;
             SILKWORM_ASSERT(false);
             break;

--- a/silkworm/node/backend/state_change_collection.cpp
+++ b/silkworm/node/backend/state_change_collection.cpp
@@ -18,6 +18,7 @@
 
 #include <silkworm/core/common/assert.hpp>
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/grpc/common/conversion.hpp>
 

--- a/silkworm/node/backend/state_change_collection_test.cpp
+++ b/silkworm/node/backend/state_change_collection_test.cpp
@@ -22,6 +22,7 @@
 #include <evmc/evmc.hpp>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/common/test_util.hpp>
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/core/types/transaction.hpp>

--- a/silkworm/node/db/access_layer.cpp
+++ b/silkworm/node/db/access_layer.cpp
@@ -629,7 +629,7 @@ static std::optional<ByteView> historical_account(ROTxn& txn, const evmc::addres
 
     cursor->bind(txn, table::kAccountChangeSet);
     const Bytes change_set_key{block_key(*change_block)};
-    return find_value_suffix(*cursor, change_set_key, address);
+    return find_value_suffix(*cursor, change_set_key, address.bytes);
 }
 
 // Erigon FindByHistory for storage

--- a/silkworm/node/db/access_layer_test.cpp
+++ b/silkworm/node/db/access_layer_test.cpp
@@ -659,9 +659,9 @@ TEST_CASE("Storage", "[silkworm][node][db][access_layer]") {
     const auto val2{0x000000000000000000000000000000000000000000005666856076ebaf477f07_bytes32};
     const auto val3{0x4400000000000000000000000000000000000000000000000000000000000000_bytes32};
 
-    upsert_storage_value(table, key, loc1, val1);
-    upsert_storage_value(table, key, loc2, val2);
-    upsert_storage_value(table, key, loc3, val3);
+    upsert_storage_value(table, key, loc1.bytes, val1.bytes);
+    upsert_storage_value(table, key, loc2.bytes, val2.bytes);
+    upsert_storage_value(table, key, loc3.bytes, val3.bytes);
 
     CHECK(db::read_storage(txn, addr, kDefaultIncarnation, loc1) == val1);
     CHECK(db::read_storage(txn, addr, kDefaultIncarnation, loc2) == val2);

--- a/silkworm/node/db/bitmap.hpp
+++ b/silkworm/node/db/bitmap.hpp
@@ -36,6 +36,7 @@
 #pragma GCC diagnostic pop
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/node/db/mdbx.hpp>
 #include <silkworm/node/etl/collector.hpp>
 

--- a/silkworm/node/db/buffer.cpp
+++ b/silkworm/node/db/buffer.cpp
@@ -101,7 +101,7 @@ void Buffer::update_storage(const evmc::address& address, uint64_t incarnation, 
     }
     if (block_number_ >= prune_history_threshold_) {
         changed_storage_.insert(address);
-        ByteView initial_val{zeroless_view(initial)};
+        ByteView initial_val{zeroless_view(initial.bytes)};
         if (block_storage_changes_[block_number_][address][incarnation]
                 .insert_or_assign(location, initial_val)
                 .second) {
@@ -314,7 +314,7 @@ void Buffer::write_state_to_db() {
             for (const auto& [incarnation, contract_storage] : it->second) {
                 Bytes prefix{storage_prefix(address, incarnation)};
                 for (const auto& [location, value] : contract_storage) {
-                    upsert_storage_value(*state_table, prefix, location, value);
+                    upsert_storage_value(*state_table, prefix, location.bytes, value.bytes);
                     written_size += prefix.length() + kLocationLength + kHashLength;
                 }
             }

--- a/silkworm/node/db/buffer_test.cpp
+++ b/silkworm/node/db/buffer_test.cpp
@@ -18,6 +18,7 @@
 
 #include <silkworm/core/common/endian.hpp>
 #include <silkworm/core/execution/address.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/infra/test_util/log.hpp>
 #include <silkworm/node/db/buffer.hpp>
 #include <silkworm/node/db/tables.hpp>
@@ -42,8 +43,8 @@ TEST_CASE("Storage update") {
 
     auto state = txn.rw_cursor_dup_sort(table::kPlainState);
 
-    upsert_storage_value(*state, key, location_a, value_a1);
-    upsert_storage_value(*state, key, location_b, value_b);
+    upsert_storage_value(*state, key, location_a.bytes, value_a1.bytes);
+    upsert_storage_value(*state, key, location_b.bytes, value_b.bytes);
 
     Buffer buffer{txn, 0};
 
@@ -59,14 +60,14 @@ TEST_CASE("Storage update") {
     buffer.write_to_db();
 
     // Location A should have the new value
-    const std::optional<ByteView> db_value_a{find_value_suffix(*state, key, location_a)};
+    const std::optional<ByteView> db_value_a{find_value_suffix(*state, key, location_a.bytes)};
     REQUIRE(db_value_a.has_value());
-    CHECK(db_value_a == zeroless_view(value_a2));
+    CHECK(db_value_a == zeroless_view(value_a2.bytes));
 
     // Location B should not change
-    const std::optional<ByteView> db_value_b{find_value_suffix(*state, key, location_b)};
+    const std::optional<ByteView> db_value_b{find_value_suffix(*state, key, location_b.bytes)};
     REQUIRE(db_value_b.has_value());
-    CHECK(db_value_b == zeroless_view(value_b));
+    CHECK(db_value_b == zeroless_view(value_b.bytes));
 }
 
 TEST_CASE("Account update") {

--- a/silkworm/node/db/buffer_test.cpp
+++ b/silkworm/node/db/buffer_test.cpp
@@ -17,6 +17,7 @@
 #include <catch2/catch.hpp>
 
 #include <silkworm/core/common/endian.hpp>
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/infra/test_util/log.hpp>
 #include <silkworm/node/db/buffer.hpp>
 #include <silkworm/node/db/tables.hpp>

--- a/silkworm/node/db/genesis.cpp
+++ b/silkworm/node/db/genesis.cpp
@@ -23,6 +23,7 @@
 #include <silkworm/core/state/in_memory_state.hpp>
 #include <silkworm/core/trie/hash_builder.hpp>
 #include <silkworm/core/trie/nibbles.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 
 #include "tables.hpp"
 
@@ -147,7 +148,7 @@ evmc::bytes32 initialize_genesis_allocations(RWTxn& txn, const nlohmann::json& g
 
         trie::HashBuilder hb;
         for (const auto& [hash, rlp] : account_rlp) {
-            hb.add_leaf(trie::unpack_nibbles(hash), rlp);
+            hb.add_leaf(trie::unpack_nibbles(hash.bytes), rlp);
         }
         state_root_hash = hb.root_hash();
     }
@@ -206,7 +207,7 @@ bool initialize_genesis(RWTxn& txn, const nlohmann::json& genesis_json, bool all
         // Write Chain Settings
         auto config_data{genesis_json["config"].dump()};
         db::open_cursor(txn, db::table::kConfig)
-            .upsert(db::to_slice(block_hash.bytes), mdbx::slice{config_data.data()});
+            .upsert(db::to_slice(block_hash), mdbx::slice{config_data.data()});
 
         return true;
 

--- a/silkworm/node/db/genesis.cpp
+++ b/silkworm/node/db/genesis.cpp
@@ -19,6 +19,7 @@
 #include <stdexcept>
 
 #include <silkworm/core/chain/genesis.hpp>
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/core/state/in_memory_state.hpp>
 #include <silkworm/core/trie/hash_builder.hpp>
 #include <silkworm/core/trie/nibbles.hpp>

--- a/silkworm/node/db/genesis.cpp
+++ b/silkworm/node/db/genesis.cpp
@@ -140,7 +140,7 @@ evmc::bytes32 initialize_genesis_allocations(RWTxn& txn, const nlohmann::json& g
             state_table.upsert(db::to_slice(address), db::to_slice(encoded));
 
             // First pass for state_root_hash
-            ethash::hash256 hash{keccak256(address)};
+            ethash::hash256 hash{keccak256(address.bytes)};
             account_rlp[to_bytes32(hash.bytes)] = account.rlp(kEmptyRoot);
         }
 

--- a/silkworm/node/db/mdbx.hpp
+++ b/silkworm/node/db/mdbx.hpp
@@ -32,6 +32,7 @@
 #include <absl/functional/function_ref.h>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/common/object_pool.hpp>
 #include <silkworm/core/common/util.hpp>
 

--- a/silkworm/node/db/util.cpp
+++ b/silkworm/node/db/util.cpp
@@ -35,6 +35,10 @@ Bytes storage_prefix(ByteView address, uint64_t incarnation) {
     return res;
 }
 
+Bytes storage_prefix(const evmc::address& address, uint64_t incarnation) {
+    return storage_prefix(ByteView{address.bytes}, incarnation);
+}
+
 Bytes block_key(BlockNum block_number) {
     Bytes key(sizeof(BlockNum), '\0');
     endian::store_big_u64(&key[0], block_number);

--- a/silkworm/node/db/util.hpp
+++ b/silkworm/node/db/util.hpp
@@ -74,6 +74,8 @@ using StorageChanges = absl::btree_map<evmc::address, absl::btree_map<uint64_t, 
 // address can be either plain account address (20 bytes) or hash thereof (32 bytes)
 Bytes storage_prefix(ByteView address, uint64_t incarnation);
 
+Bytes storage_prefix(const evmc::address& address, uint64_t incarnation);
+
 // Erigon EncodeBlockNumber
 Bytes block_key(BlockNum block_number);
 
@@ -120,6 +122,10 @@ std::tuple<ByteView, uint32_t> split_log_topic_key(const mdbx::slice& key);
 std::pair<Bytes, Bytes> changeset_to_plainstate_format(ByteView key, ByteView value);
 
 inline mdbx::slice to_slice(ByteView value) { return {value.data(), value.length()}; }
+
+inline mdbx::slice to_slice(const evmc::address& address) {
+    return to_slice(ByteView{address.bytes});
+}
 
 inline ByteView from_slice(const mdbx::slice slice) {
     return {static_cast<const uint8_t*>(slice.data()), slice.length()};

--- a/silkworm/node/db/util.hpp
+++ b/silkworm/node/db/util.hpp
@@ -29,6 +29,7 @@ see its package dbutils.
 #include <absl/strings/str_cat.h>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/types/block.hpp>
 #include <silkworm/node/db/mdbx.hpp>
 

--- a/silkworm/node/db/util.hpp
+++ b/silkworm/node/db/util.hpp
@@ -123,6 +123,10 @@ std::pair<Bytes, Bytes> changeset_to_plainstate_format(ByteView key, ByteView va
 
 inline mdbx::slice to_slice(ByteView value) { return {value.data(), value.length()}; }
 
+inline mdbx::slice to_slice(const evmc::bytes32& value) {
+    return to_slice(ByteView{value.bytes});
+}
+
 inline mdbx::slice to_slice(const evmc::address& address) {
     return to_slice(ByteView{address.bytes});
 }

--- a/silkworm/node/etl/util.hpp
+++ b/silkworm/node/etl/util.hpp
@@ -19,6 +19,7 @@
 #include <stdexcept>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 
 namespace silkworm::etl {
 

--- a/silkworm/node/huffman/decompressor.hpp
+++ b/silkworm/node/huffman/decompressor.hpp
@@ -28,6 +28,7 @@
 #include <absl/functional/function_ref.h>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/common/memory_mapped_file.hpp>
 

--- a/silkworm/node/recsplit/encoding/elias_fano.hpp
+++ b/silkworm/node/recsplit/encoding/elias_fano.hpp
@@ -55,6 +55,7 @@
 
 #include <silkworm/core/common/assert.hpp>
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/common/endian.hpp>
 #include <silkworm/infra/common/ensure.hpp>
 #include <silkworm/infra/common/log.hpp>

--- a/silkworm/node/recsplit/encoding/elias_fano_test.cpp
+++ b/silkworm/node/recsplit/encoding/elias_fano_test.cpp
@@ -21,6 +21,7 @@
 #include <catch2/catch.hpp>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/common/endian.hpp>
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/infra/test_util/log.hpp>

--- a/silkworm/node/recsplit/encoding/sequence.hpp
+++ b/silkworm/node/recsplit/encoding/sequence.hpp
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/common/endian.hpp>
 
 namespace silkworm::succinct {

--- a/silkworm/node/snapshot/snapshot.cpp
+++ b/silkworm/node/snapshot/snapshot.cpp
@@ -19,6 +19,7 @@
 #include <magic_enum.hpp>
 
 #include <silkworm/core/common/util.hpp>
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/core/types/transaction.hpp>
 #include <silkworm/infra/common/decoding_exception.hpp>
 #include <silkworm/infra/common/ensure.hpp>

--- a/silkworm/node/snapshot/snapshot.hpp
+++ b/silkworm/node/snapshot/snapshot.hpp
@@ -25,6 +25,7 @@
 #include <utility>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/types/block.hpp>
 #include <silkworm/infra/common/os.hpp>
 #include <silkworm/node/db/util.hpp>

--- a/silkworm/node/snapshot/sync.cpp
+++ b/silkworm/node/snapshot/sync.cpp
@@ -243,7 +243,7 @@ void SnapshotSync::update_block_headers(db::RWTxn& txn, BlockNum max_block_avail
     intx::uint256 total_difficulty{0};
     uint64_t block_count{0};
     repository_->for_each_header([&](const BlockHeader* header) -> bool {
-        SILK_TRACE << "SnapshotSync: header number=" << header->number << " hash=" << to_hex(header->hash());
+        SILK_TRACE << "SnapshotSync: header number=" << header->number << " hash=" << Hash{header->hash()}.to_hex();
         const auto block_number = header->number;
         if (block_number > max_block_available) return true;
 

--- a/silkworm/node/stagedsync/remote_client.cpp
+++ b/silkworm/node/stagedsync/remote_client.cpp
@@ -17,6 +17,7 @@
 #include "remote_client.hpp"
 
 #include <silkworm/core/types/bloom.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/core/types/transaction.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/grpc/client/call.hpp>

--- a/silkworm/node/stagedsync/stages/_test.cpp
+++ b/silkworm/node/stagedsync/stages/_test.cpp
@@ -23,6 +23,7 @@
 #include <silkworm/core/execution/address.hpp>
 #include <silkworm/core/execution/execution.hpp>
 #include <silkworm/core/trie/vector_root.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/infra/test_util/log.hpp>
 #include <silkworm/node/db/access_layer.hpp>
 #include <silkworm/node/db/buffer.hpp>
@@ -460,15 +461,15 @@ TEST_CASE("Sync Stages") {
             REQUIRE(hashed_storage_table.count_multivalue() == 2);
 
             // location 0
-            auto hashed_loc0{keccak256(0x0000000000000000000000000000000000000000000000000000000000000000_bytes32)};
+            auto hashed_loc0{keccak256((0x0000000000000000000000000000000000000000000000000000000000000000_bytes32).bytes)};
             hashed_storage_table.to_current_first_multi();
             mdbx::slice db_val{hashed_storage_table.current().value};
             REQUIRE(db_val.starts_with(db::to_slice(hashed_loc0.bytes)));
             ByteView value{db::from_slice(db_val).substr(kHashLength)};
-            REQUIRE(to_hex(value) == to_hex(zeroless_view(new_val)));
+            REQUIRE(to_hex(value) == to_hex(zeroless_view(new_val.bytes)));
 
             // location 1
-            auto hashed_loc1{keccak256(0x0000000000000000000000000000000000000000000000000000000000000001_bytes32)};
+            auto hashed_loc1{keccak256((0x0000000000000000000000000000000000000000000000000000000000000001_bytes32).bytes)};
             hashed_storage_table.to_current_next_multi();
             db_val = hashed_storage_table.current().value;
             CHECK(db_val.starts_with(db::to_slice(hashed_loc1.bytes)));

--- a/silkworm/node/stagedsync/stages/_test.cpp
+++ b/silkworm/node/stagedsync/stages/_test.cpp
@@ -35,6 +35,10 @@
 using namespace silkworm;
 using namespace evmc::literals;
 
+static ethash::hash256 keccak256(const evmc::address& address) {
+    return silkworm::keccak256(address.bytes);
+}
+
 TEST_CASE("Sync Stages") {
     TemporaryDirectory temp_dir{};
     NodeSettings node_settings{};

--- a/silkworm/node/stagedsync/stages/stage_hashstate.cpp
+++ b/silkworm/node/stagedsync/stages/stage_hashstate.cpp
@@ -22,6 +22,7 @@
 
 #include <silkworm/core/common/cast.hpp>
 #include <silkworm/core/common/endian.hpp>
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/infra/common/decoding_exception.hpp>
 #include <silkworm/node/db/access_layer.hpp>
 
@@ -804,7 +805,7 @@ Stage::Result HashState::write_changes_from_changed_addresses(db::RWTxn& txn, co
             throw_if_stopping();
             last_address = address;
             log_lck.lock();
-            current_key_ = to_hex(address, true);
+            current_key_ = address_to_string(address);
             log_lck.unlock();
         }
 
@@ -857,7 +858,7 @@ Stage::Result HashState::write_changes_from_changed_storage(
             std::memcpy(&hashed_storage_prefix[0], hashed_addresses.at(last_address).bytes, kHashLength);
 
             log_lck.lock();
-            current_key_ = to_hex(address, true);
+            current_key_ = address_to_string(address);
             log_lck.unlock();
         }
 

--- a/silkworm/node/stagedsync/stages/stage_interhashes.cpp
+++ b/silkworm/node/stagedsync/stages/stage_interhashes.cpp
@@ -24,6 +24,7 @@
 
 #include <silkworm/core/common/endian.hpp>
 #include <silkworm/core/common/lru_cache.hpp>
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/core/trie/nibbles.hpp>
 #include <silkworm/infra/common/decoding_exception.hpp>
 #include <silkworm/infra/common/stopwatch.hpp>

--- a/silkworm/node/stagedsync/stages/stage_interhashes.cpp
+++ b/silkworm/node/stagedsync/stages/stage_interhashes.cpp
@@ -26,6 +26,7 @@
 #include <silkworm/core/common/lru_cache.hpp>
 #include <silkworm/core/execution/address.hpp>
 #include <silkworm/core/trie/nibbles.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/infra/common/decoding_exception.hpp>
 #include <silkworm/infra/common/stopwatch.hpp>
 #include <silkworm/node/db/access_layer.hpp>
@@ -263,7 +264,7 @@ trie::PrefixSet InterHashes::collect_account_changes(db::RWTxn& txn, BlockNum fr
             if (auto item{plainstate_accounts.get(address)}; item != nullptr) {
                 plainstate_account = *item;
             } else {
-                auto ps_data{plain_state->find(db::to_slice(address.bytes), false)};
+                auto ps_data{plain_state->find(db::to_slice(address), false)};
                 if (ps_data && ps_data.value.length()) {
                     const auto account{Account::from_encoded_storage(db::from_slice(ps_data.value))};
                     success_or_throw(account);

--- a/silkworm/node/stagedsync/stages/stage_interhashes.cpp
+++ b/silkworm/node/stagedsync/stages/stage_interhashes.cpp
@@ -252,7 +252,7 @@ trie::PrefixSet InterHashes::collect_account_changes(db::RWTxn& txn, BlockNum fr
             changeset_value_view.remove_prefix(kAddressLength);
             auto hashed_addresses_it{hashed_addresses.find(address)};
             if (hashed_addresses_it == hashed_addresses.end()) {
-                const auto hashed_address{keccak256(address)};
+                const auto hashed_address{keccak256(address.bytes)};
                 hashed_addresses_it = hashed_addresses.insert_or_assign(address, hashed_address).first;
             }
 

--- a/silkworm/node/stagedsync/stages/stage_interhashes/_test.cpp
+++ b/silkworm/node/stagedsync/stages/stage_interhashes/_test.cpp
@@ -16,6 +16,7 @@
 
 #include <catch2/catch.hpp>
 
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/core/trie/hash_builder.hpp>
 #include <silkworm/core/trie/nibbles.hpp>
 #include <silkworm/core/types/account.hpp>

--- a/silkworm/node/stagedsync/stages/stage_interhashes/_test.cpp
+++ b/silkworm/node/stagedsync/stages/stage_interhashes/_test.cpp
@@ -27,6 +27,10 @@
 
 namespace silkworm::trie {
 
+static ethash::hash256 keccak256(const evmc::address& address) {
+    return silkworm::keccak256(address.bytes);
+}
+
 TEST_CASE("Trie Cursor") {
     test::Context db_context{};
     auto txn{db_context.txn()};
@@ -786,8 +790,8 @@ TEST_CASE("Trie Storage : incremental vs regeneration") {
         const evmc::bytes32 plain_loc1{int_to_bytes32(2 * i)};
         const evmc::bytes32 plain_loc2{int_to_bytes32(2 * i + 1)};
 
-        const auto hashed_loc1{keccak256(plain_loc1)};
-        const auto hashed_loc2{keccak256(plain_loc2)};
+        const auto hashed_loc1{silkworm::keccak256(plain_loc1)};
+        const auto hashed_loc2{silkworm::keccak256(plain_loc2)};
 
         const auto nibbled_hashed_loc1{unpack_nibbles(hashed_loc1.bytes)};
         const auto nibbled_hashed_loc2{unpack_nibbles(hashed_loc2.bytes)};

--- a/silkworm/node/stagedsync/stages/stage_senders.hpp
+++ b/silkworm/node/stagedsync/stages/stage_senders.hpp
@@ -26,6 +26,7 @@
 #include <evmc/evmc.h>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/infra/concurrency/thread_pool.hpp>
 #include <silkworm/node/etl/collector.hpp>
 #include <silkworm/node/stagedsync/stages/stage.hpp>

--- a/silkworm/node/test/files.hpp
+++ b/silkworm/node/test/files.hpp
@@ -21,6 +21,7 @@
 #include <string>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/infra/common/directories.hpp>
 
 namespace silkworm::test {

--- a/silkworm/node/types/log_cbor.hpp
+++ b/silkworm/node/types/log_cbor.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/types/hash.hpp>
 #include <silkworm/core/types/log.hpp>
 

--- a/silkworm/sentry/common/crypto/ecdsa_signature.hpp
+++ b/silkworm/sentry/common/crypto/ecdsa_signature.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/sentry/common/ecc_public_key.hpp>
 
 namespace silkworm::sentry::crypto::ecdsa_signature {

--- a/silkworm/sentry/common/crypto/xor.hpp
+++ b/silkworm/sentry/common/crypto/xor.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 
 namespace silkworm::sentry::crypto {
 

--- a/silkworm/sentry/common/ecc_key_pair.hpp
+++ b/silkworm/sentry/common/ecc_key_pair.hpp
@@ -19,6 +19,7 @@
 #include <string>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 
 #include "ecc_public_key.hpp"
 

--- a/silkworm/sentry/common/ecc_public_key.hpp
+++ b/silkworm/sentry/common/ecc_public_key.hpp
@@ -21,6 +21,7 @@
 #include <string_view>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 
 namespace silkworm::sentry {
 

--- a/silkworm/sentry/common/message.hpp
+++ b/silkworm/sentry/common/message.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 
 namespace silkworm::sentry {
 

--- a/silkworm/sentry/common/random.hpp
+++ b/silkworm/sentry/common/random.hpp
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 
 namespace silkworm::sentry {
 

--- a/silkworm/sentry/common/socket_stream.hpp
+++ b/silkworm/sentry/common/socket_stream.hpp
@@ -22,6 +22,7 @@
 #include <boost/asio/ip/tcp.hpp>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 
 namespace silkworm::sentry {
 

--- a/silkworm/sentry/discovery/disc_v4/common/node_address.hpp
+++ b/silkworm/sentry/discovery/disc_v4/common/node_address.hpp
@@ -24,6 +24,7 @@
 #include <boost/asio/ip/udp.hpp>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/rlp/decode.hpp>
 
 namespace silkworm::sentry::discovery::disc_v4 {

--- a/silkworm/sentry/discovery/disc_v4/find/find_node_message.hpp
+++ b/silkworm/sentry/discovery/disc_v4/find/find_node_message.hpp
@@ -20,6 +20,7 @@
 #include <string>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/sentry/common/ecc_public_key.hpp>
 
 namespace silkworm::sentry::discovery::disc_v4::find {

--- a/silkworm/sentry/discovery/disc_v4/find/neighbors_message.hpp
+++ b/silkworm/sentry/discovery/disc_v4/find/neighbors_message.hpp
@@ -20,6 +20,7 @@
 #include <map>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/sentry/common/ecc_public_key.hpp>
 #include <silkworm/sentry/discovery/disc_v4/common/node_address.hpp>
 

--- a/silkworm/sentry/discovery/disc_v4/message_codec.hpp
+++ b/silkworm/sentry/discovery/disc_v4/message_codec.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/sentry/common/ecc_public_key.hpp>
 #include <silkworm/sentry/common/message.hpp>
 

--- a/silkworm/sentry/discovery/disc_v4/ping/message_handler.hpp
+++ b/silkworm/sentry/discovery/disc_v4/ping/message_handler.hpp
@@ -21,6 +21,7 @@
 #include <boost/asio/ip/udp.hpp>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/sentry/common/ecc_public_key.hpp>
 
 #include "ping_message.hpp"

--- a/silkworm/sentry/discovery/disc_v4/ping/ping_handler.hpp
+++ b/silkworm/sentry/discovery/disc_v4/ping/ping_handler.hpp
@@ -21,6 +21,7 @@
 #include <boost/asio/ip/udp.hpp>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 
 #include "message_sender.hpp"
 #include "ping_message.hpp"

--- a/silkworm/sentry/discovery/disc_v4/ping/ping_message.hpp
+++ b/silkworm/sentry/discovery/disc_v4/ping/ping_message.hpp
@@ -22,6 +22,7 @@
 #include <boost/asio/ip/udp.hpp>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 
 namespace silkworm::sentry::discovery::disc_v4::ping {
 

--- a/silkworm/sentry/discovery/disc_v4/ping/pong_message.hpp
+++ b/silkworm/sentry/discovery/disc_v4/ping/pong_message.hpp
@@ -21,6 +21,7 @@
 #include <boost/asio/ip/udp.hpp>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 
 namespace silkworm::sentry::discovery::disc_v4::ping {
 

--- a/silkworm/sentry/discovery/disc_v4/server.cpp
+++ b/silkworm/sentry/discovery/disc_v4/server.cpp
@@ -26,6 +26,7 @@
 #include <boost/asio/this_coro.hpp>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/infra/common/decoding_exception.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/concurrency/awaitable_wait_for_one.hpp>

--- a/silkworm/sentry/eth/fork_id.hpp
+++ b/silkworm/sentry/eth/fork_id.hpp
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/rlp/decode.hpp>
 
 namespace silkworm::sentry::eth {

--- a/silkworm/sentry/eth/status_message.hpp
+++ b/silkworm/sentry/eth/status_message.hpp
@@ -19,6 +19,7 @@
 #include <intx/intx.hpp>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/sentry/common/message.hpp>
 
 #include "fork_id.hpp"

--- a/silkworm/sentry/grpc/interfaces/status_data.cpp
+++ b/silkworm/sentry/grpc/interfaces/status_data.cpp
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/infra/grpc/common/conversion.hpp>
 #include <silkworm/sentry/eth/fork_id.hpp>
 

--- a/silkworm/sentry/nat/stun_ip_resolver.cpp
+++ b/silkworm/sentry/nat/stun_ip_resolver.cpp
@@ -27,6 +27,7 @@
 #include <boost/asio/this_coro.hpp>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/infra/concurrency/awaitable_wait_for_one.hpp>
 #include <silkworm/infra/concurrency/timeout.hpp>
 #include <silkworm/sentry/common/random.hpp>

--- a/silkworm/sentry/node_key_config.hpp
+++ b/silkworm/sentry/node_key_config.hpp
@@ -21,6 +21,7 @@
 #include <variant>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/infra/common/directories.hpp>
 #include <silkworm/sentry/common/ecc_key_pair.hpp>
 

--- a/silkworm/sentry/rlpx/auth/auth_ack_message.hpp
+++ b/silkworm/sentry/rlpx/auth/auth_ack_message.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/sentry/common/ecc_key_pair.hpp>
 #include <silkworm/sentry/common/ecc_public_key.hpp>
 

--- a/silkworm/sentry/rlpx/auth/auth_initiator.cpp
+++ b/silkworm/sentry/rlpx/auth/auth_initiator.cpp
@@ -17,6 +17,7 @@
 #include "auth_initiator.hpp"
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/infra/concurrency/awaitable_wait_for_one.hpp>
 #include <silkworm/infra/concurrency/timeout.hpp>
 

--- a/silkworm/sentry/rlpx/auth/auth_message.hpp
+++ b/silkworm/sentry/rlpx/auth/auth_message.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/sentry/common/ecc_key_pair.hpp>
 #include <silkworm/sentry/common/ecc_public_key.hpp>
 

--- a/silkworm/sentry/rlpx/auth/auth_recipient.cpp
+++ b/silkworm/sentry/rlpx/auth/auth_recipient.cpp
@@ -17,6 +17,7 @@
 #include "auth_recipient.hpp"
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/infra/concurrency/awaitable_wait_for_one.hpp>
 #include <silkworm/infra/concurrency/timeout.hpp>
 

--- a/silkworm/sentry/rlpx/auth/ecies_cipher.hpp
+++ b/silkworm/sentry/rlpx/auth/ecies_cipher.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/sentry/common/ecc_public_key.hpp>
 
 namespace silkworm::sentry::rlpx::auth {

--- a/silkworm/sentry/rlpx/auth/hello_message.hpp
+++ b/silkworm/sentry/rlpx/auth/hello_message.hpp
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/sentry/common/ecc_public_key.hpp>
 #include <silkworm/sentry/common/message.hpp>
 

--- a/silkworm/sentry/rlpx/common/disconnect_message.hpp
+++ b/silkworm/sentry/rlpx/common/disconnect_message.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/sentry/common/message.hpp>
 
 #include "disconnect_reason.hpp"

--- a/silkworm/sentry/rlpx/crypto/aes.hpp
+++ b/silkworm/sentry/rlpx/crypto/aes.hpp
@@ -21,6 +21,7 @@
 #include <gsl/pointers>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 
 typedef struct evp_cipher_ctx_st EVP_CIPHER_CTX;
 

--- a/silkworm/sentry/rlpx/crypto/hmac.hpp
+++ b/silkworm/sentry/rlpx/crypto/hmac.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 
 namespace silkworm::sentry::rlpx::crypto {
 

--- a/silkworm/sentry/rlpx/crypto/sha256.hpp
+++ b/silkworm/sentry/rlpx/crypto/sha256.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 
 namespace silkworm::sentry::rlpx::crypto {
 

--- a/silkworm/sentry/rlpx/crypto/sha3_hasher.hpp
+++ b/silkworm/sentry/rlpx/crypto/sha3_hasher.hpp
@@ -19,6 +19,7 @@
 #include <memory>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 
 class Keccak;
 

--- a/silkworm/sentry/rlpx/framing/framing_cipher.hpp
+++ b/silkworm/sentry/rlpx/framing/framing_cipher.hpp
@@ -19,6 +19,7 @@
 #include <memory>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 
 namespace silkworm::sentry::rlpx::framing {
 

--- a/silkworm/sentry/rlpx/ping_message.hpp
+++ b/silkworm/sentry/rlpx/ping_message.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/sentry/common/message.hpp>
 
 namespace silkworm::sentry::rlpx {

--- a/silkworm/sentry/settings.hpp
+++ b/silkworm/sentry/settings.hpp
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/concurrency/context_pool_settings.hpp>
 #include <silkworm/sentry/common/enode_url.hpp>

--- a/silkworm/silkrpc/commands/debug_api.cpp
+++ b/silkworm/silkrpc/commands/debug_api.cpp
@@ -31,6 +31,7 @@
 #include <silkworm/core/common/endian.hpp>
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/core/execution/address.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/node/db/tables.hpp>
 #include <silkworm/node/db/util.hpp>
@@ -162,7 +163,7 @@ Task<void> DebugRpcApi::handle_debug_get_modified_accounts_by_hash(const nlohman
     if (params.size() == 2) {
         end_hash = params[1].get<evmc::bytes32>();
     }
-    SILK_DEBUG << "start_hash: " << start_hash << " end_hash: " << end_hash;
+    SILK_DEBUG << "start_hash: " << silkworm::to_hex(start_hash) << " end_hash: " << silkworm::to_hex(end_hash);
 
     auto tx = co_await database_->begin();
 
@@ -388,7 +389,7 @@ Task<void> DebugRpcApi::handle_debug_trace_transaction(const nlohmann::json& req
         config = params[1].get<debug::DebugConfig>();
     }
 
-    SILK_DEBUG << "transaction_hash: " << transaction_hash << " config: {" << config << "}";
+    SILK_DEBUG << "transaction_hash: " << silkworm::to_hex(transaction_hash) << " config: {" << config << "}";
 
     stream.open_object();
     stream.write_field("id", request["id"]);
@@ -457,7 +458,7 @@ Task<void> DebugRpcApi::handle_debug_trace_call(const nlohmann::json& request, j
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
         std::ostringstream oss;
-        oss << "block " << block_number_or_hash.number() << "(" << block_number_or_hash.hash() << ") not found";
+        oss << "block " << block_number_or_hash.number() << "(" << silkworm::to_hex(block_number_or_hash.hash()) << ") not found";
         const Error error{-32000, oss.str()};
         stream.write_field("error", error);
     } catch (...) {
@@ -605,7 +606,7 @@ Task<void> DebugRpcApi::handle_debug_trace_block_by_hash(const nlohmann::json& r
         config = params[1].get<debug::DebugConfig>();
     }
 
-    SILK_DEBUG << "block_hash: " << block_hash << " config: {" << config << "}";
+    SILK_DEBUG << "block_hash: " << silkworm::to_hex(block_hash) << " config: {" << config << "}";
 
     stream.open_object();
     stream.write_field("id", request["id"]);
@@ -622,7 +623,7 @@ Task<void> DebugRpcApi::handle_debug_trace_block_by_hash(const nlohmann::json& r
     } catch (const std::invalid_argument& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
         std::ostringstream oss;
-        oss << "block_hash " << block_hash << " not found";
+        oss << "block_hash " << silkworm::to_hex(block_hash) << " not found";
         const Error error{-32000, oss.str()};
         stream.write_field("error", error);
     } catch (const std::exception& e) {
@@ -761,7 +762,7 @@ Task<void> DebugRpcApi::handle_debug_get_raw_transaction(const nlohmann::json& r
         co_return;
     }
     auto transaction_hash = params[0].get<evmc::bytes32>();
-    SILK_DEBUG << "transaction_hash: " << transaction_hash;
+    SILK_DEBUG << "transaction_hash: " << silkworm::to_hex(transaction_hash);
 
     auto tx = co_await database_->begin();
 

--- a/silkworm/silkrpc/commands/debug_api.cpp
+++ b/silkworm/silkrpc/commands/debug_api.cpp
@@ -30,6 +30,7 @@
 
 #include <silkworm/core/common/endian.hpp>
 #include <silkworm/core/common/util.hpp>
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/node/db/tables.hpp>
 #include <silkworm/node/db/util.hpp>
@@ -77,7 +78,7 @@ Task<void> DebugRpcApi::handle_debug_account_range(const nlohmann::json& request
     }
 
     SILK_TRACE << "block_number_or_hash: " << block_number_or_hash
-               << " start_address: 0x" << silkworm::to_hex(start_address)
+               << " start_address: " << start_address
                << " max_result: " << max_result
                << " exclude_code: " << exclude_code
                << " exclude_storage: " << exclude_storage;
@@ -205,7 +206,7 @@ Task<void> DebugRpcApi::handle_debug_storage_range_at(const nlohmann::json& requ
 
     SILK_DEBUG << "block_hash: 0x" << silkworm::to_hex(block_hash)
                << " tx_index: " << tx_index
-               << " address: 0x" << silkworm::to_hex(address)
+               << " address: " << address
                << " start_key: 0x" << silkworm::to_hex(start_key)
                << " max_result: " << max_result;
 
@@ -285,7 +286,7 @@ Task<void> DebugRpcApi::handle_debug_account_at(const nlohmann::json& request, n
 
     SILK_DEBUG << "block_hash: 0x" << silkworm::to_hex(block_hash)
                << " tx_index: " << tx_index
-               << " address: 0x" << silkworm::to_hex(address);
+               << " address: " << address;
 
     auto tx = co_await database_->begin();
 
@@ -656,7 +657,7 @@ Task<std::set<evmc::address>> get_modified_accounts(ethdb::TransactionDatabase& 
             if (block_number <= end_block_number) {
                 auto address = silkworm::to_evmc_address(value.substr(0, silkworm::kAddressLength));
 
-                SILK_TRACE << "Walker: processing block " << block_number << " address 0x" << silkworm::to_hex(address);
+                SILK_TRACE << "Walker: processing block " << block_number << " address " << address;
                 addresses.insert(address);
             }
             return block_number <= end_block_number;

--- a/silkworm/silkrpc/commands/engine_api.cpp
+++ b/silkworm/silkrpc/commands/engine_api.cpp
@@ -21,6 +21,7 @@
 
 #include <evmc/evmc.hpp>
 
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/infra/common/ensure.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/silkrpc/core/rawdb/chain.hpp>
@@ -447,7 +448,7 @@ Task<void> EngineRpcApi::handle_engine_exchange_transition_configuration_v1(cons
         }
         if (cl_configuration.terminal_block_hash != kZeroHash) {
             SILK_ERROR << "execution layer has the incorrect terminal block hash, expected: "
-                       << cl_configuration.terminal_block_hash << " got: " << kZeroHash;
+                       << silkworm::to_hex(cl_configuration.terminal_block_hash) << " got: " << silkworm::to_hex(kZeroHash);
             reply = make_json_error(request.at("id"), kInvalidParams, "consensus layer terminal block hash is not zero");
             co_await tx->close();
             co_return;

--- a/silkworm/silkrpc/commands/engine_api_test.cpp
+++ b/silkworm/silkrpc/commands/engine_api_test.cpp
@@ -28,6 +28,7 @@
 #include <nlohmann/json.hpp>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/grpc/client/client_context_pool.hpp>
 #include <silkworm/infra/test_util/log.hpp>

--- a/silkworm/silkrpc/commands/erigon_api.cpp
+++ b/silkworm/silkrpc/commands/erigon_api.cpp
@@ -25,6 +25,7 @@
 
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/core/protocol/ethash_rule_set.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/silkrpc/common/binary_search.hpp>
 #include <silkworm/silkrpc/common/util.hpp>
@@ -194,7 +195,7 @@ Task<void> ErigonRpcApi::handle_erigon_get_block_receipts_by_block_hash(const nl
         co_return;
     }
     const auto block_hash = params[0].get<evmc::bytes32>();
-    SILK_DEBUG << "block_hash: " << block_hash;
+    SILK_DEBUG << "block_hash: " << silkworm::to_hex(block_hash);
 
     auto tx = co_await database_->begin();
 
@@ -244,7 +245,7 @@ Task<void> ErigonRpcApi::handle_erigon_get_header_by_hash(const nlohmann::json& 
         co_return;
     }
     const auto block_hash = params[0].get<evmc::bytes32>();
-    SILK_DEBUG << "block_hash: " << block_hash;
+    SILK_DEBUG << "block_hash: " << silkworm::to_hex(block_hash);
 
     auto tx = co_await database_->begin();
 
@@ -406,7 +407,7 @@ Task<void> ErigonRpcApi::handle_erigon_get_logs_by_hash(const nlohmann::json& re
         co_return;
     }
     const auto block_hash = params[0].get<evmc::bytes32>();
-    SILK_DEBUG << "block_hash: " << block_hash;
+    SILK_DEBUG << "block_hash: " << silkworm::to_hex(block_hash);
 
     auto tx = co_await database_->begin();
 

--- a/silkworm/silkrpc/commands/eth_api.cpp
+++ b/silkworm/silkrpc/commands/eth_api.cpp
@@ -976,7 +976,7 @@ Task<void> EthereumRpcApi::handle_eth_get_balance(const nlohmann::json& request,
     }
     const auto address = params[0].get<evmc::address>();
     const auto block_id = params[1].get<std::string>();
-    SILK_DEBUG << "address: " << silkworm::to_hex(address) << " block_id: " << block_id;
+    SILK_DEBUG << "address: " << address << " block_id: " << block_id;
 
     auto tx = co_await database_->begin();
 
@@ -1016,7 +1016,7 @@ Task<void> EthereumRpcApi::handle_eth_get_code(const nlohmann::json& request, nl
     }
     const auto address = params[0].get<evmc::address>();
     const auto block_id = params[1].get<std::string>();
-    SILK_DEBUG << "address: " << silkworm::to_hex(address) << " block_id: " << block_id;
+    SILK_DEBUG << "address: " << address << " block_id: " << block_id;
 
     auto tx = co_await database_->begin();
 
@@ -1058,7 +1058,7 @@ Task<void> EthereumRpcApi::handle_eth_get_transaction_count(const nlohmann::json
     }
     const auto address = params[0].get<evmc::address>();
     const auto block_id = params[1].get<std::string>();
-    SILK_DEBUG << "address: " << silkworm::to_hex(address) << " block_id: " << block_id;
+    SILK_DEBUG << "address: " << address << " block_id: " << block_id;
 
     auto tx = co_await database_->begin();
 
@@ -1100,7 +1100,7 @@ Task<void> EthereumRpcApi::handle_eth_get_storage_at(const nlohmann::json& reque
     const auto address = params[0].get<evmc::address>();
     const auto location = params[1].get<evmc::bytes32>();
     const auto block_id = params[2].get<std::string>();
-    SILK_DEBUG << "address: " << silkworm::to_hex(address) << " block_id: " << block_id;
+    SILK_DEBUG << "address: " << address << " block_id: " << block_id;
 
     auto tx = co_await database_->begin();
 

--- a/silkworm/silkrpc/commands/eth_api.cpp
+++ b/silkworm/silkrpc/commands/eth_api.cpp
@@ -31,6 +31,7 @@
 #include <silkworm/core/common/endian.hpp>
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/core/execution/address.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/core/types/transaction.hpp>
 #include <silkworm/infra/common/ensure.hpp>
 #include <silkworm/infra/common/log.hpp>
@@ -194,7 +195,7 @@ Task<void> EthereumRpcApi::handle_eth_get_block_by_hash(const nlohmann::json& re
     }
     auto block_hash = params[0].get<evmc::bytes32>();
     auto full_tx = params[1].get<bool>();
-    SILK_DEBUG << "block_hash: " << block_hash << " full_tx: " << std::boolalpha << full_tx;
+    SILK_DEBUG << "block_hash: " << silkworm::to_hex(block_hash) << " full_tx: " << std::boolalpha << full_tx;
 
     auto tx = co_await database_->begin();
 
@@ -279,7 +280,7 @@ Task<void> EthereumRpcApi::handle_eth_get_block_transaction_count_by_hash(const 
         co_return;
     }
     auto block_hash = params[0].get<evmc::bytes32>();
-    SILK_DEBUG << "block_hash: " << block_hash;
+    SILK_DEBUG << "block_hash: " << silkworm::to_hex(block_hash);
 
     auto tx = co_await database_->begin();
 
@@ -358,7 +359,7 @@ Task<void> EthereumRpcApi::handle_eth_get_uncle_by_block_hash_and_index(const nl
     }
     const auto block_hash = params[0].get<evmc::bytes32>();
     const auto index = params[1].get<std::string>();
-    SILK_DEBUG << "block_hash: " << block_hash << " index: " << index;
+    SILK_DEBUG << "block_hash: " << silkworm::to_hex(block_hash) << " index: " << index;
 
     auto tx = co_await database_->begin();
 
@@ -465,7 +466,7 @@ Task<void> EthereumRpcApi::handle_eth_get_uncle_count_by_block_hash(const nlohma
         co_return;
     }
     auto block_hash = params[0].get<evmc::bytes32>();
-    SILK_DEBUG << "block_hash: " << block_hash;
+    SILK_DEBUG << "block_hash: " << silkworm::to_hex(block_hash);
 
     auto tx = co_await database_->begin();
 
@@ -539,7 +540,7 @@ Task<void> EthereumRpcApi::handle_eth_get_transaction_by_hash(const nlohmann::js
         co_return;
     }
     auto transaction_hash = params[0].get<evmc::bytes32>();
-    SILK_DEBUG << "transaction_hash: " << transaction_hash;
+    SILK_DEBUG << "transaction_hash: " << silkworm::to_hex(transaction_hash);
 
     auto tx = co_await database_->begin();
 
@@ -595,7 +596,7 @@ Task<void> EthereumRpcApi::handle_eth_get_raw_transaction_by_hash(const nlohmann
         co_return;
     }
     const auto transaction_hash = params[0].get<evmc::bytes32>();
-    SILK_DEBUG << "transaction_hash: " << transaction_hash;
+    SILK_DEBUG << "transaction_hash: " << silkworm::to_hex(transaction_hash);
 
     auto tx = co_await database_->begin();
 
@@ -644,7 +645,7 @@ Task<void> EthereumRpcApi::handle_eth_get_transaction_by_block_hash_and_index(co
     }
     const auto block_hash = params[0].get<evmc::bytes32>();
     const auto index = params[1].get<std::string>();
-    SILK_DEBUG << "block_hash: " << block_hash << " index: " << index;
+    SILK_DEBUG << "block_hash: " << silkworm::to_hex(block_hash) << " index: " << index;
 
     auto tx = co_await database_->begin();
 
@@ -693,7 +694,7 @@ Task<void> EthereumRpcApi::handle_eth_get_raw_transaction_by_block_hash_and_inde
     }
     const auto block_hash = params[0].get<evmc::bytes32>();
     const auto index = params[1].get<std::string>();
-    SILK_DEBUG << "block_hash: " << block_hash << " index: " << index;
+    SILK_DEBUG << "block_hash: " << silkworm::to_hex(block_hash) << " index: " << index;
 
     auto tx = co_await database_->begin();
 
@@ -848,7 +849,7 @@ Task<void> EthereumRpcApi::handle_eth_get_transaction_receipt(const nlohmann::js
         co_return;
     }
     auto transaction_hash = params[0].get<evmc::bytes32>();
-    SILK_DEBUG << "transaction_hash: " << transaction_hash;
+    SILK_DEBUG << "transaction_hash: " << silkworm::to_hex(transaction_hash);
     auto tx = co_await database_->begin();
 
     try {
@@ -871,7 +872,7 @@ Task<void> EthereumRpcApi::handle_eth_get_transaction_receipt(const nlohmann::js
         for (size_t idx{0}; idx < transactions.size(); idx++) {
             auto ethash_hash{hash_of_transaction(transactions[idx])};
 
-            SILK_TRACE << "tx " << idx << ") hash: " << silkworm::to_bytes32({ethash_hash.bytes, silkworm::kHashLength});
+            SILK_TRACE << "tx " << idx << ") hash: " << silkworm::to_hex(silkworm::to_bytes32({ethash_hash.bytes, silkworm::kHashLength}));
             if (std::memcmp(transaction_hash.bytes, ethash_hash.bytes, silkworm::kHashLength) == 0) {
                 tx_index = idx;
                 const intx::uint256 base_fee_per_gas{block_with_hash->block.header.base_fee_per_gas.value_or(0)};
@@ -1838,9 +1839,9 @@ Task<void> EthereumRpcApi::handle_eth_send_raw_transaction(const nlohmann::json&
     const auto hash = silkworm::to_bytes32({ethash_hash.bytes, silkworm::kHashLength});
     if (!txn.to.has_value()) {
         const auto contract_address = silkworm::create_address(*txn.from, txn.nonce);
-        SILK_DEBUG << "submitted contract creation hash: " << hash << " from: " << *txn.from << " nonce: " << txn.nonce << " contract: " << contract_address << " value: " << txn.value;
+        SILK_DEBUG << "submitted contract creation hash: " << silkworm::to_hex(hash) << " from: " << *txn.from << " nonce: " << txn.nonce << " contract: " << contract_address << " value: " << txn.value;
     } else {
-        SILK_DEBUG << "submitted transaction hash: " << hash << " from: " << *txn.from << " nonce: " << txn.nonce << " recipient: " << *txn.to << " value: " << txn.value;
+        SILK_DEBUG << "submitted transaction hash: " << silkworm::to_hex(hash) << " from: " << *txn.from << " nonce: " << txn.nonce << " recipient: " << *txn.to << " value: " << txn.value;
     }
 
     reply = make_json_content(request["id"], hash);

--- a/silkworm/silkrpc/commands/eth_api.cpp
+++ b/silkworm/silkrpc/commands/eth_api.cpp
@@ -27,6 +27,7 @@
 
 #include <silkworm/core/chain/config.hpp>
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/common/endian.hpp>
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/core/execution/address.hpp>

--- a/silkworm/silkrpc/commands/ots_api.cpp
+++ b/silkworm/silkrpc/commands/ots_api.cpp
@@ -19,6 +19,7 @@
 #include <numeric>
 #include <string>
 
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/core/protocol/ethash_rule_set.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/node/db/access_layer.hpp>
@@ -54,7 +55,7 @@ Task<void> OtsRpcApi::handle_ots_has_code(const nlohmann::json& request, nlohman
     const auto address = params[0].get<evmc::address>();
     const auto block_id = params[1].get<std::string>();
 
-    SILK_DEBUG << "address: " << silkworm::to_hex(address) << " block_id: " << block_id;
+    SILK_DEBUG << "address: " << address << " block_id: " << block_id;
 
     auto tx = co_await database_->begin();
 
@@ -663,7 +664,7 @@ Task<void> OtsRpcApi::handle_ots_search_transactions_before(const nlohmann::json
     auto block_number = params[1].get<BlockNum>();
     const auto page_size = params[2].get<uint64_t>();
 
-    SILK_DEBUG << "address: " << silkworm::to_hex(address) << " block_number: " << block_number << " page_size: " << page_size;
+    SILK_DEBUG << "address: " << address << " block_number: " << block_number << " page_size: " << page_size;
     auto tx = co_await database_->begin();
 
     try {
@@ -747,7 +748,7 @@ Task<void> OtsRpcApi::handle_ots_search_transactions_after(const nlohmann::json&
     auto block_number = params[1].get<BlockNum>();
     const auto page_size = params[2].get<uint64_t>();
 
-    SILK_DEBUG << "address: " << silkworm::to_hex(address) << " block_number: " << block_number << " page_size: " << page_size;
+    SILK_DEBUG << "address: " << address << " block_number: " << block_number << " page_size: " << page_size;
     auto tx = co_await database_->begin();
 
     try {

--- a/silkworm/silkrpc/commands/ots_api.cpp
+++ b/silkworm/silkrpc/commands/ots_api.cpp
@@ -21,6 +21,7 @@
 
 #include <silkworm/core/execution/address.hpp>
 #include <silkworm/core/protocol/ethash_rule_set.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/node/db/access_layer.hpp>
 #include <silkworm/node/db/bitmap.hpp>
@@ -148,7 +149,7 @@ Task<void> OtsRpcApi::handle_ots_get_block_details_by_hash(const nlohmann::json&
     }
     auto block_hash = params[0].get<evmc::bytes32>();
 
-    SILK_DEBUG << "block_hash: " << block_hash;
+    SILK_DEBUG << "block_hash: " << silkworm::to_hex(block_hash);
 
     auto tx = co_await database_->begin();
 
@@ -521,7 +522,7 @@ Task<void> OtsRpcApi::handle_ots_trace_transaction(const nlohmann::json& request
 
     const auto transaction_hash = params[0].get<evmc::bytes32>();
 
-    SILK_DEBUG << "transaction_hash: " << transaction_hash;
+    SILK_DEBUG << "transaction_hash: " << silkworm::to_hex(transaction_hash);
 
     auto tx = co_await database_->begin();
 
@@ -568,7 +569,7 @@ Task<void> OtsRpcApi::handle_ots_get_transaction_error(const nlohmann::json& req
 
     const auto transaction_hash = params[0].get<evmc::bytes32>();
 
-    SILK_DEBUG << "transaction_hash: " << transaction_hash;
+    SILK_DEBUG << "transaction_hash: " << silkworm::to_hex(transaction_hash);
 
     auto tx = co_await database_->begin();
 
@@ -615,7 +616,7 @@ Task<void> OtsRpcApi::handle_ots_get_internal_operations(const nlohmann::json& r
 
     const auto transaction_hash = params[0].get<evmc::bytes32>();
 
-    SILK_DEBUG << "transaction_hash: " << transaction_hash;
+    SILK_DEBUG << "transaction_hash: " << silkworm::to_hex(transaction_hash);
 
     auto tx = co_await database_->begin();
 

--- a/silkworm/silkrpc/commands/ots_api.hpp
+++ b/silkworm/silkrpc/commands/ots_api.hpp
@@ -23,6 +23,7 @@
 
 #include <silkworm/core/common/base.hpp>
 #include <silkworm/core/common/block_cache.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/infra/concurrency/private_service.hpp>
 #include <silkworm/infra/concurrency/shared_service.hpp>
 #include <silkworm/node/db/bitmap.hpp>

--- a/silkworm/silkrpc/commands/parity_api.cpp
+++ b/silkworm/silkrpc/commands/parity_api.cpp
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include <silkworm/core/common/util.hpp>
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/node/db/tables.hpp>
 #include <silkworm/silkrpc/common/util.hpp>
@@ -100,9 +101,9 @@ Task<void> ParityRpcApi::handle_parity_list_storage_keys(const nlohmann::json& r
         block_id = params[3].get<std::string>();
     }
 
-    SILK_DEBUG << "address: 0x" << silkworm::to_hex(address)
+    SILK_DEBUG << "address: " << address
                << " quantity: " << quantity
-               << " offset: 0x" << (offset ? silkworm::to_hex(offset.value()) : silkworm::to_hex(silkworm::Bytes{}));
+               << " offset: " << (offset ? silkworm::to_hex(offset.value(), true) : "null");
 
     auto tx = co_await database_->begin();
 
@@ -111,7 +112,7 @@ Task<void> ParityRpcApi::handle_parity_list_storage_keys(const nlohmann::json& r
         StateReader state_reader{tx_database};
 
         const auto block_number = co_await core::get_block_number(block_id, tx_database);
-        SILK_DEBUG << "read account with address: " << silkworm::to_hex(address) << " block number: " << block_number;
+        SILK_DEBUG << "read account with address: " << address << " block number: " << block_number;
         std::optional<silkworm::Account> account = co_await state_reader.read_account(address, block_number);
         if (!account) throw std::domain_error{"account not found"};
 

--- a/silkworm/silkrpc/commands/rpc_api_test.cpp
+++ b/silkworm/silkrpc/commands/rpc_api_test.cpp
@@ -158,7 +158,7 @@ std::unique_ptr<InMemoryState> populate_genesis(db::RWTxn& txn, const std::files
     // Write Chain Settings
     auto config_data{genesis_json["config"].dump()};
     db::open_cursor(txn, db::table::kConfig)
-        .upsert(db::to_slice(block_hash.bytes), mdbx::slice{config_data.data()});
+        .upsert(db::to_slice(block_hash), mdbx::slice{config_data.data()});
 
     return state_buffer;
 }

--- a/silkworm/silkrpc/commands/rpc_api_test.cpp
+++ b/silkworm/silkrpc/commands/rpc_api_test.cpp
@@ -29,6 +29,7 @@
 #include <nlohmann/json.hpp>
 
 #include <silkworm/core/chain/genesis.hpp>
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/core/execution/execution.hpp>
 #include <silkworm/core/state/in_memory_state.hpp>
 #include <silkworm/core/types/block.hpp>

--- a/silkworm/silkrpc/commands/trace_api.cpp
+++ b/silkworm/silkrpc/commands/trace_api.cpp
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include <silkworm/core/common/util.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/silkrpc/common/util.hpp>
 #include <silkworm/silkrpc/core/blocks.hpp>
@@ -277,7 +278,7 @@ Task<void> TraceRpcApi::handle_trace_replay_transaction(const nlohmann::json& re
     const auto transaction_hash = params[0].get<evmc::bytes32>();
     const auto config = params[1].get<trace::TraceConfig>();
 
-    SILK_TRACE << "transaction_hash: " << transaction_hash << " config: " << config;
+    SILK_TRACE << "transaction_hash: " << silkworm::to_hex(transaction_hash) << " config: " << config;
 
     auto tx = co_await database_->begin();
 
@@ -287,7 +288,7 @@ Task<void> TraceRpcApi::handle_trace_replay_transaction(const nlohmann::json& re
         const auto tx_with_block = co_await core::read_transaction_by_hash(*block_cache_, *chain_storage, transaction_hash);
         if (!tx_with_block) {
             std::ostringstream oss;
-            oss << "transaction 0x" << transaction_hash << " not found";
+            oss << "transaction " << silkworm::to_hex(transaction_hash, true) << " not found";
             reply = make_json_error(request["id"], -32000, oss.str());
         } else {
             trace::TraceCallExecutor executor{*block_cache_, tx_database, *chain_storage, workers_, *tx};
@@ -413,7 +414,7 @@ Task<void> TraceRpcApi::handle_trace_get(const nlohmann::json& request, nlohmann
     std::vector<uint16_t> indices;
     std::transform(str_indices.begin(), str_indices.end(), std::back_inserter(indices),
                    [](const std::string& str) { return std::stoi(str, nullptr, 16); });
-    SILK_TRACE << "transaction_hash: " << transaction_hash << ", #indices: " << indices.size();
+    SILK_TRACE << "transaction_hash: " << silkworm::to_hex(transaction_hash) << ", #indices: " << indices.size();
 
     // Erigon RpcDaemon compatibility
     // Parity fails if it gets more than a single index. It returns nothing in this case. Must we?
@@ -464,7 +465,7 @@ Task<void> TraceRpcApi::handle_trace_transaction(const nlohmann::json& request, 
     }
     const auto transaction_hash = params[0].get<evmc::bytes32>();
 
-    SILK_TRACE << "transaction_hash: " << transaction_hash;
+    SILK_TRACE << "transaction_hash: " << silkworm::to_hex(transaction_hash);
 
     auto tx = co_await database_->begin();
 

--- a/silkworm/silkrpc/commands/txpool_api.cpp
+++ b/silkworm/silkrpc/commands/txpool_api.cpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <utility>
 
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/silkrpc/json/types.hpp>
 
@@ -54,7 +55,7 @@ Task<void> TxPoolRpcApi::handle_txpool_content(const nlohmann::json& request, nl
         bool error = false;
         for (std::size_t i{0}; i < txpool_transactions.size(); i++) {
             silkworm::ByteView from{txpool_transactions[i].rlp};
-            std::string sender = silkworm::to_hex(txpool_transactions[i].sender, true);
+            std::string sender = silkworm::address_to_string(txpool_transactions[i].sender);
             Transaction txn{};
             const auto result = silkworm::rlp::decode_transaction(from, txn, rlp::Eip2718Wrapping::kBoth);
             if (!result) {

--- a/silkworm/silkrpc/common/util.cpp
+++ b/silkworm/silkrpc/common/util.cpp
@@ -16,12 +16,14 @@
 
 #include "util.hpp"
 
+#include <silkworm/core/types/evmc_bytes32.hpp>
+
 namespace silkworm {
 
 std::ostream& operator<<(std::ostream& out, const Account& account) {
     out << "nonce: " << account.nonce;
     out << " balance: " << account.balance;
-    out << " code_hash: 0x" << account.code_hash;
+    out << " code_hash: 0x" << to_hex(account.code_hash);
     out << " incarnation: " << account.incarnation;
     return out;
 }

--- a/silkworm/silkrpc/common/util.hpp
+++ b/silkworm/silkrpc/common/util.hpp
@@ -115,11 +115,6 @@ inline auto hash_of_transaction(const silkworm::Transaction& txn) {
 
 namespace evmc {
 
-inline std::ostream& operator<<(std::ostream& out, const address& addr) {
-    out << silkworm::to_hex(addr);
-    return out;
-}
-
 inline std::ostream& operator<<(std::ostream& out, const bytes32& b32) {
     out << silkworm::to_hex(b32);
     return out;

--- a/silkworm/silkrpc/common/util.hpp
+++ b/silkworm/silkrpc/common/util.hpp
@@ -27,6 +27,7 @@
 
 #include <silkworm/core/chain/config.hpp>
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/core/types/account.hpp>
 #include <silkworm/core/types/bloom.hpp>

--- a/silkworm/silkrpc/common/util.hpp
+++ b/silkworm/silkrpc/common/util.hpp
@@ -31,6 +31,7 @@
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/core/types/account.hpp>
 #include <silkworm/core/types/bloom.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/core/types/transaction.hpp>
 
 namespace silkworm {
@@ -112,15 +113,6 @@ inline auto hash_of_transaction(const silkworm::Transaction& txn) {
     silkworm::rlp::encode(txn_rlp, txn, /*wrap_eip2718_into_string=*/false);
     return ethash::keccak256(txn_rlp.data(), txn_rlp.length());
 }
-
-namespace evmc {
-
-inline std::ostream& operator<<(std::ostream& out, const bytes32& b32) {
-    out << silkworm::to_hex(b32);
-    return out;
-}
-
-}  // namespace evmc
 
 namespace intx {
 template <unsigned N>

--- a/silkworm/silkrpc/common/util_test.cpp
+++ b/silkworm/silkrpc/common/util_test.cpp
@@ -22,6 +22,7 @@
 #include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/core/execution/address.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/infra/test_util/log.hpp>
 
 namespace silkworm {
@@ -74,9 +75,9 @@ TEST_CASE("print empty address", "[silkrpc][common][util]") {
 
 TEST_CASE("print bytes32", "[silkrpc][common][util]") {
     evmc::bytes32 b32_1{};
-    CHECK_NOTHROW(test_util::null_stream() << b32_1);
+    CHECK_NOTHROW(test_util::null_stream() << to_hex(b32_1));
     evmc::bytes32 b32_2{0x3763e4f6e4198413383534c763f3f5dac5c5e939f0a81724e3beb96d6e2ad0d5_bytes32};
-    CHECK_NOTHROW(test_util::null_stream() << b32_2);
+    CHECK_NOTHROW(test_util::null_stream() << to_hex(b32_2));
 }
 
 TEST_CASE("print empty const_buffer", "[silkrpc][common][util]") {

--- a/silkworm/silkrpc/common/util_test.cpp
+++ b/silkworm/silkrpc/common/util_test.cpp
@@ -19,6 +19,7 @@
 #include <catch2/catch.hpp>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/infra/test_util/log.hpp>
 

--- a/silkworm/silkrpc/common/util_test.cpp
+++ b/silkworm/silkrpc/common/util_test.cpp
@@ -21,6 +21,7 @@
 #include <silkworm/core/common/base.hpp>
 #include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/common/util.hpp>
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/infra/test_util/log.hpp>
 
 namespace silkworm {

--- a/silkworm/silkrpc/core/account_dumper.cpp
+++ b/silkworm/silkrpc/core/account_dumper.cpp
@@ -19,6 +19,7 @@
 #include <utility>
 
 #include <silkworm/core/common/decoding_result.hpp>
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/core/trie/hash_builder.hpp>
 #include <silkworm/core/trie/nibbles.hpp>
 #include <silkworm/infra/common/decoding_exception.hpp>

--- a/silkworm/silkrpc/core/block_reader.cpp
+++ b/silkworm/silkrpc/core/block_reader.cpp
@@ -20,6 +20,7 @@
 
 #include <silkworm/core/common/endian.hpp>
 #include <silkworm/core/common/util.hpp>
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/core/types/account.hpp>
 #include <silkworm/infra/common/decoding_exception.hpp>
 #include <silkworm/infra/common/log.hpp>
@@ -37,7 +38,7 @@ namespace silkworm::rpc {
 
 void to_json(nlohmann::json& json, const BalanceChanges& balance_changes) {
     for (const auto& entry : balance_changes) {
-        json["0x" + silkworm::to_hex(entry.first)] = to_quantity(entry.second);
+        json[silkworm::address_to_string(entry.first)] = to_quantity(entry.second);
     }
 }
 
@@ -64,7 +65,7 @@ Task<void> BlockReader::read_balance_changes(BlockCache& cache, const BlockNumbe
                 it = balance_changes.erase(it);
             } else {
                 SILK_DEBUG << "Address "
-                           << "0x" + silkworm::to_hex(it->first) << ": balance changed from " << to_quantity(it->second) << " to " << to_quantity(balance);
+                           << it->first << ": balance changed from " << to_quantity(it->second) << " to " << to_quantity(balance);
                 it->second = balance;
                 it++;
             }

--- a/silkworm/silkrpc/core/blocks_test.cpp
+++ b/silkworm/silkrpc/core/blocks_test.cpp
@@ -25,6 +25,7 @@
 #include <gmock/gmock.h>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/node/db/tables.hpp>
 // #include <silkworm/infra/test_util/log.hpp>

--- a/silkworm/silkrpc/core/cached_chain_test.cpp
+++ b/silkworm/silkrpc/core/cached_chain_test.cpp
@@ -28,6 +28,7 @@
 #include <gmock/gmock.h>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/infra/test_util/log.hpp>
 #include <silkworm/node/db/tables.hpp>

--- a/silkworm/silkrpc/core/estimate_gas_oracle.cpp
+++ b/silkworm/silkrpc/core/estimate_gas_oracle.cpp
@@ -22,6 +22,7 @@
 #include <boost/asio/post.hpp>
 #include <boost/asio/use_awaitable.hpp>
 
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/silkrpc/core/blocks.hpp>
 
@@ -55,7 +56,7 @@ Task<intx::uint256> EstimateGasOracle::estimate_gas(const Call& call, const silk
         std::optional<silkworm::Account> account{co_await account_reader_(from, block_number + 1)};
 
         intx::uint256 balance = account->balance;
-        SILK_DEBUG << "balance for address 0x" << from << ": 0x" << intx::hex(balance);
+        SILK_DEBUG << "balance for address " << from << ": 0x" << intx::hex(balance);
         if (call.value.value_or(0) > balance) {
             // TODO(sixtysixter) what is the right error code?
             throw EstimateGasException{-1, "insufficient funds for transfer"};

--- a/silkworm/silkrpc/core/evm_access_list_tracer.cpp
+++ b/silkworm/silkrpc/core/evm_access_list_tracer.cpp
@@ -24,6 +24,7 @@
 #include <evmone/instructions.hpp>
 #include <intx/intx.hpp>
 
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/silkrpc/common/util.hpp>
 

--- a/silkworm/silkrpc/core/evm_access_list_tracer.cpp
+++ b/silkworm/silkrpc/core/evm_access_list_tracer.cpp
@@ -25,6 +25,7 @@
 #include <intx/intx.hpp>
 
 #include <silkworm/core/execution/address.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/silkrpc/common/util.hpp>
 
@@ -113,7 +114,7 @@ inline bool AccessListTracer::exclude(const evmc::address& address) {
 }
 
 void AccessListTracer::add_storage(const evmc::address& address, const evmc::bytes32& storage) {
-    SILK_TRACE << "add_storage:" << address << " storage: " << storage;
+    SILK_TRACE << "add_storage:" << address << " storage: " << to_hex(storage);
     for (std::size_t i{0}; i < access_list_.size(); i++) {
         if (access_list_[i].account == address) {
             for (const auto& storage_key : access_list_[i].storage_keys) {
@@ -148,7 +149,7 @@ void AccessListTracer::dump(const std::string& user_string, const AccessList& ac
     for (std::size_t i{0}; i < acl.size(); i++) {
         std::cout << "Address: " << acl[i].account << "\n";
         for (std::size_t z{0}; z < acl[i].storage_keys.size(); z++) {
-            std::cout << "-> StorageKeys: " << acl[i].storage_keys[z] << "\n";
+            std::cout << "-> StorageKeys: " << to_hex(acl[i].storage_keys[z]) << "\n";
         }
     }
 }

--- a/silkworm/silkrpc/core/evm_debug.cpp
+++ b/silkworm/silkrpc/core/evm_debug.cpp
@@ -28,6 +28,7 @@
 #include <evmone/instructions.hpp>
 #include <intx/intx.hpp>
 
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/silkrpc/common/util.hpp>
 #include <silkworm/silkrpc/core/cached_chain.hpp>

--- a/silkworm/silkrpc/core/evm_debug.cpp
+++ b/silkworm/silkrpc/core/evm_debug.cpp
@@ -29,6 +29,7 @@
 #include <intx/intx.hpp>
 
 #include <silkworm/core/execution/address.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/silkrpc/common/util.hpp>
 #include <silkworm/silkrpc/core/cached_chain.hpp>
@@ -322,7 +323,7 @@ Task<void> DebugExecutor::trace_transaction(json::Stream& stream, const ChainSto
 
     if (!tx_with_block) {
         std::ostringstream oss;
-        oss << "transaction 0x" << tx_hash << " not found";
+        oss << "transaction " << silkworm::to_hex(tx_hash, true) << " not found";
         const Error error{-32000, oss.str()};
         stream.write_field("error", error);
     } else {

--- a/silkworm/silkrpc/core/evm_executor.cpp
+++ b/silkworm/silkrpc/core/evm_executor.cpp
@@ -27,6 +27,7 @@
 #include <intx/intx.hpp>
 
 #include <silkworm/core/common/util.hpp>
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/core/protocol/intrinsic_gas.hpp>
 #include <silkworm/core/protocol/param.hpp>
 #include <silkworm/infra/common/log.hpp>
@@ -189,23 +190,23 @@ std::optional<std::string> EVMExecutor::pre_check(const EVM& evm, const silkworm
     if (rev >= EVMC_LONDON) {
         if (txn.max_fee_per_gas > 0 || txn.max_priority_fee_per_gas > 0) {
             if (txn.max_fee_per_gas < base_fee_per_gas) {
-                const std::string from = to_hex(*txn.from);
-                const std::string error = "fee cap less than block base fee: address 0x" + from + ", gasFeeCap: " +
+                const std::string from = address_to_string(*txn.from);
+                const std::string error = "fee cap less than block base fee: address " + from + ", gasFeeCap: " +
                                           intx::to_string(txn.max_fee_per_gas) + " baseFee: " + intx::to_string(base_fee_per_gas);
                 return error;
             }
 
             if (txn.max_fee_per_gas < txn.max_priority_fee_per_gas) {
-                std::string from = to_hex(*txn.from);
-                std::string error = "tip higher than fee cap: address 0x" + from + ", tip: " + intx::to_string(txn.max_priority_fee_per_gas) + " gasFeeCap: " +
+                std::string from = address_to_string(*txn.from);
+                std::string error = "tip higher than fee cap: address " + from + ", tip: " + intx::to_string(txn.max_priority_fee_per_gas) + " gasFeeCap: " +
                                     intx::to_string(txn.max_fee_per_gas);
                 return error;
             }
         }
     }
     if (txn.gas_limit < g0) {
-        std::string from = to_hex(*txn.from);
-        std::string error = "intrinsic gas too low: have " + std::to_string(txn.gas_limit) + ", want " + intx::to_string(g0);
+        std::string from = address_to_string(*txn.from);
+        std::string error = "intrinsic gas too low: address " + from + ", have " + std::to_string(txn.gas_limit) + ", want " + intx::to_string(g0);
         return error;
     }
     return std::nullopt;
@@ -256,8 +257,8 @@ ExecutionResult EVMExecutor::call(
     if (have < want + txn.value) {
         if (!gas_bailout) {
             Bytes data{};
-            std::string from = to_hex(*txn.from);
-            std::string msg = "insufficient funds for gas * price + value: address 0x" + from + " have " + intx::to_string(have) + " want " + intx::to_string(want + txn.value);
+            std::string from = address_to_string(*txn.from);
+            std::string msg = "insufficient funds for gas * price + value: address " + from + ", have " + intx::to_string(have) + ", want " + intx::to_string(want + txn.value);
             return {std::nullopt, txn.gas_limit, data, msg};
         }
     } else {

--- a/silkworm/silkrpc/core/evm_executor_test.cpp
+++ b/silkworm/silkrpc/core/evm_executor_test.cpp
@@ -90,7 +90,7 @@ TEST_CASE("EVMExecutor") {
         my_pool.stop();
         my_pool.join();
         CHECK(result.error_code == std::nullopt);
-        CHECK(result.pre_check_error.value() == "intrinsic gas too low: have 0, want 53000");
+        CHECK(result.pre_check_error.value() == "intrinsic gas too low: address 0xa872626373628737383927236382161739290870, have 0, want 53000");
     }
 
     SECTION("failed if base_fee_per_gas > max_fee_per_gas ") {
@@ -185,7 +185,7 @@ TEST_CASE("EVMExecutor") {
         my_pool.stop();
         my_pool.join();
         CHECK(result.error_code == std::nullopt);
-        CHECK(result.pre_check_error.value() == "insufficient funds for gas * price + value: address 0xa872626373628737383927236382161739290870 have 0 want 60000");
+        CHECK(result.pre_check_error.value() == "insufficient funds for gas * price + value: address 0xa872626373628737383927236382161739290870, have 0, want 60000");
     }
 
     SECTION("doesn't fail if transaction cost greater user amount && gasBailout == true") {

--- a/silkworm/silkrpc/core/evm_trace.cpp
+++ b/silkworm/silkrpc/core/evm_trace.cpp
@@ -35,6 +35,7 @@
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/core/execution/address.hpp>
 #include <silkworm/core/protocol/ethash_rule_set.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/silkrpc/common/util.hpp>
 #include <silkworm/silkrpc/core/cached_chain.hpp>
@@ -1054,8 +1055,8 @@ void StateDiffTracer::on_reward_granted(const silkworm::CallResult& result, cons
                     if (initial_storage != final_storage) {
                         all_equals = false;
                         entry.storage[key] = DiffValue{
-                            "0x" + silkworm::to_hex(intra_block_state.get_original_storage(address, key_b32)),
-                            "0x" + silkworm::to_hex(intra_block_state.get_current_storage(address, key_b32))};
+                            silkworm::to_hex(intra_block_state.get_original_storage(address, key_b32), true),
+                            silkworm::to_hex(intra_block_state.get_current_storage(address, key_b32), true)};
                     }
                 }
                 if (all_equals) {
@@ -1071,7 +1072,7 @@ void StateDiffTracer::on_reward_granted(const silkworm::CallResult& result, cons
                 for (auto& key : diff_storage) {
                     auto key_b32 = silkworm::bytes32_from_hex(key);
                     entry.storage[key] = DiffValue{
-                        "0x" + silkworm::to_hex(intra_block_state.get_original_storage(address, key_b32))};
+                        silkworm::to_hex(intra_block_state.get_original_storage(address, key_b32), true)};
                 }
             }
         } else if (exists) {
@@ -1094,7 +1095,7 @@ void StateDiffTracer::on_reward_granted(const silkworm::CallResult& result, cons
                 if (intra_block_state.get_current_storage(address, key_b32) != evmc::bytes32{}) {
                     entry.storage[key] = DiffValue{
                         {},
-                        "0x" + silkworm::to_hex(intra_block_state.get_current_storage(address, key_b32))};
+                        silkworm::to_hex(intra_block_state.get_current_storage(address, key_b32), true)};
                 }
                 to_be_removed = false;
             }

--- a/silkworm/silkrpc/core/evm_trace.cpp
+++ b/silkworm/silkrpc/core/evm_trace.cpp
@@ -33,6 +33,7 @@
 
 #include <silkworm/core/common/endian.hpp>
 #include <silkworm/core/common/util.hpp>
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/core/protocol/ethash_rule_set.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/silkrpc/common/util.hpp>
@@ -1015,7 +1016,7 @@ void StateDiffTracer::on_reward_granted(const silkworm::CallResult& result, cons
         auto exists = intra_block_state.exists(address);
         auto& diff_storage = diff_storage_[address];
 
-        auto address_key = "0x" + silkworm::to_hex(address);
+        auto address_key = silkworm::address_to_string(address);
         auto& entry = state_diff_[address_key];
         if (initial_exists) {
             auto initial_balance = state_addresses_.get_balance(address);

--- a/silkworm/silkrpc/core/evm_trace_test.cpp
+++ b/silkworm/silkrpc/core/evm_trace_test.cpp
@@ -307,7 +307,7 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_call 1") {
         const auto result = spawn_and_wait(executor.trace_call(block, call, config));
 
         CHECK(result.pre_check_error.has_value() == true);
-        CHECK(result.pre_check_error.value() == "intrinsic gas too low: have 50000, want 53072");
+        CHECK(result.pre_check_error.value() == "intrinsic gas too low: address 0xe0a2bd4258d2768837baa26a28fe71dc079f84c7, have 50000, want 53072");
     }
 
     SECTION("Call: full output") {
@@ -1655,7 +1655,7 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_calls") {
         const auto result = spawn_and_wait(executor.trace_calls(block, calls));
 
         CHECK(result.pre_check_error.has_value() == true);
-        CHECK(result.pre_check_error.value() == "first run for txIndex 0 error: intrinsic gas too low: have 50000, want 53072");
+        CHECK(result.pre_check_error.value() == "first run for txIndex 0 error: intrinsic gas too low: address 0xe0a2bd4258d2768837baa26a28fe71dc079f84c7, have 50000, want 53072");
     }
 
     SECTION("Call: full output") {
@@ -6488,8 +6488,8 @@ TEST_CASE("TraceFilter") {
         os << config;
 
         CHECK(os.str() ==
-              "from_block: 0x0, to_block: latest, from_addresses: [0a6bb546b9208cfab9e8fa2b9b2c042b18df7030, ], "
-              "to_addresses: [0a6bb546b9208cfab9e8fa2b9b2c042b18df7031, ], mode: union, after: 0, count: 4294967295");
+              "from_block: 0x0, to_block: latest, from_addresses: [0x0a6bb546b9208cfab9e8fa2b9b2c042b18df7030, ], "
+              "to_addresses: [0x0a6bb546b9208cfab9e8fa2b9b2c042b18df7031, ], mode: union, after: 0, count: 4294967295");
     }
     SECTION("json deserialization: simple") {
         nlohmann::json json = R"({

--- a/silkworm/silkrpc/core/gas_price_oracle.cpp
+++ b/silkworm/silkrpc/core/gas_price_oracle.cpp
@@ -21,6 +21,7 @@
 #include <boost/asio/post.hpp>
 #include <boost/asio/use_awaitable.hpp>
 
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/silkrpc/core/blocks.hpp>
 
@@ -73,7 +74,7 @@ Task<void> GasPriceOracle::load_block_prices(BlockNum block_number, uint64_t lim
 
     SILK_TRACE << "GasPriceOracle::load_block_prices # transactions in block: " << block_with_hash->block.transactions.size();
     SILK_TRACE << "GasPriceOracle::load_block_prices # block base_fee: 0x" << intx::hex(base_fee);
-    SILK_TRACE << "GasPriceOracle::load_block_prices # block beneficiary: 0x" << coinbase;
+    SILK_TRACE << "GasPriceOracle::load_block_prices # block beneficiary: " << coinbase;
 
     std::vector<intx::uint256> block_prices;
     int idx = 0;

--- a/silkworm/silkrpc/core/logs_walker.cpp
+++ b/silkworm/silkrpc/core/logs_walker.cpp
@@ -21,6 +21,7 @@
 #include <boost/endian/conversion.hpp>
 
 #include <silkworm/core/execution/address.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/node/db/tables.hpp>
 #include <silkworm/silkrpc/core/blocks.hpp>
@@ -193,12 +194,12 @@ void LogsWalker::filter_logs(const std::vector<Log>&& logs, const FilterAddresse
                 continue;
             }
             for (size_t i{0}; i < topics.size(); i++) {
-                SILK_DEBUG << "log.topics[i]: " << log.topics[i];
+                SILK_DEBUG << "log.topics[i]: " << to_hex(log.topics[i]);
                 auto subtopics = topics[i];
                 auto matches_subtopics = subtopics.empty();  // empty rule set == wildcard
                 SILK_DEBUG << "matches_subtopics: " << std::boolalpha << matches_subtopics;
                 for (auto& topic : subtopics) {
-                    SILK_DEBUG << "topic: " << topic;
+                    SILK_DEBUG << "topic: " << to_hex(topic);
                     if (log.topics[i] == topic) {
                         matches_subtopics = true;
                         SILK_DEBUG << "matches_subtopics: " << std::boolalpha << matches_subtopics;

--- a/silkworm/silkrpc/core/logs_walker.cpp
+++ b/silkworm/silkrpc/core/logs_walker.cpp
@@ -20,6 +20,7 @@
 
 #include <boost/endian/conversion.hpp>
 
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/node/db/tables.hpp>
 #include <silkworm/silkrpc/core/blocks.hpp>
@@ -182,7 +183,7 @@ void LogsWalker::filter_logs(const std::vector<Log>&& logs, const FilterAddresse
     for (auto& log : logs) {
         SILK_DEBUG << "log: " << log;
         if (!addresses.empty() && std::find(addresses.begin(), addresses.end(), log.address) == addresses.end()) {
-            SILK_DEBUG << "skipped log for address: 0x" << silkworm::to_hex(log.address);
+            SILK_DEBUG << "skipped log for address: " << log.address;
             continue;
         }
         auto matches = true;

--- a/silkworm/silkrpc/core/override_state.cpp
+++ b/silkworm/silkrpc/core/override_state.cpp
@@ -26,6 +26,7 @@
 #include <ethash/keccak.hpp>
 
 #include <silkworm/core/common/util.hpp>
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/silkrpc/core/rawdb/chain.hpp>
 

--- a/silkworm/silkrpc/core/override_state.cpp
+++ b/silkworm/silkrpc/core/override_state.cpp
@@ -27,6 +27,7 @@
 
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/core/execution/address.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/silkrpc/core/rawdb/chain.hpp>
 
@@ -69,36 +70,36 @@ std::optional<silkworm::Account> OverrideState::read_account(const evmc::address
 }
 
 silkworm::ByteView OverrideState::read_code(const evmc::bytes32& code_hash) const noexcept {
-    SILK_DEBUG << "OverrideState::read_code code_hash=" << code_hash << " start";
+    SILK_DEBUG << "OverrideState::read_code code_hash=" << to_hex(code_hash) << " start";
     auto it = code_hash_.find(code_hash);
     if (it != code_hash_.end()) {
-        SILK_DEBUG << "OverrideState::read_code code_hash=" << code_hash << " code: " << it->second;
+        SILK_DEBUG << "OverrideState::read_code code_hash=" << to_hex(code_hash) << " code: " << it->second;
         return it->second;
     }
     return inner_state_.read_code(code_hash);
 }
 
 evmc::bytes32 OverrideState::read_storage(const evmc::address& address, uint64_t incarnation, const evmc::bytes32& location) const noexcept {
-    SILK_DEBUG << "OverrideState::read_storage address=" << address << " incarnation=" << incarnation << " location=" << location << " start";
+    SILK_DEBUG << "OverrideState::read_storage address=" << address << " incarnation=" << incarnation << " location=" << to_hex(location) << " start";
     auto storage_value = inner_state_.read_storage(address, incarnation, location);
-    SILK_DEBUG << "OverrideState::read_storage storage_value=" << storage_value;
+    SILK_DEBUG << "OverrideState::read_storage storage_value=" << to_hex(storage_value);
     return storage_value;
 }
 
 std::optional<silkworm::BlockHeader> OverrideState::read_header(BlockNum block_number, const evmc::bytes32& block_hash) const noexcept {
-    SILK_DEBUG << "OverrideState::read_header block_number=" << block_number << " block_hash=" << block_hash;
+    SILK_DEBUG << "OverrideState::read_header block_number=" << block_number << " block_hash=" << to_hex(block_hash);
     auto optional_header = inner_state_.read_header(block_number, block_hash);
     return optional_header;
 }
 
 bool OverrideState::read_body(BlockNum block_number, const evmc::bytes32& block_hash, silkworm::BlockBody& filled_body) const noexcept {
-    SILK_DEBUG << "OverrideState::read_body block_number=" << block_number << " block_hash=" << block_hash;
+    SILK_DEBUG << "OverrideState::read_body block_number=" << block_number << " block_hash=" << to_hex(block_hash);
     auto result = inner_state_.read_body(block_number, block_hash, filled_body);
     return result;
 }
 
 std::optional<intx::uint256> OverrideState::total_difficulty(BlockNum block_number, const evmc::bytes32& block_hash) const noexcept {
-    SILK_DEBUG << "OverrideState::total_difficulty block_number=" << block_number << " block_hash=" << block_hash;
+    SILK_DEBUG << "OverrideState::total_difficulty block_number=" << block_number << " block_hash=" << to_hex(block_hash);
     auto optional_total_difficulty = inner_state_.total_difficulty(block_number, block_hash);
     SILK_DEBUG << "OverrideState::total_difficulty optional_total_difficulty=" << optional_total_difficulty.value_or(intx::uint256{});
     return optional_total_difficulty;
@@ -107,7 +108,7 @@ std::optional<intx::uint256> OverrideState::total_difficulty(BlockNum block_numb
 std::optional<evmc::bytes32> OverrideState::canonical_hash(BlockNum block_number) const {
     SILK_DEBUG << "OverrideState::canonical_hash block_number=" << block_number;
     auto optional_canonical_hash = inner_state_.canonical_hash(block_number);
-    SILK_DEBUG << "OverrideState::canonical_hash optional_canonical_hash=" << optional_canonical_hash.value_or(evmc::bytes32{});
+    SILK_DEBUG << "OverrideState::canonical_hash optional_canonical_hash=" << to_hex(optional_canonical_hash.value_or(evmc::bytes32{}));
     return optional_canonical_hash;
 }
 

--- a/silkworm/silkrpc/core/rawdb/chain.cpp
+++ b/silkworm/silkrpc/core/rawdb/chain.cpp
@@ -23,6 +23,7 @@
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/core/execution/address.hpp>
 #include <silkworm/core/rlp/decode.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/infra/common/decoding_exception.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/node/db/tables.hpp>
@@ -52,7 +53,7 @@ Task<uint64_t> read_header_number(const DatabaseReader& reader, const evmc::byte
 
 Task<ChainConfig> read_chain_config(const DatabaseReader& reader) {
     const auto genesis_block_hash{co_await read_canonical_block_hash(reader, kEarliestBlockNumber)};
-    SILK_DEBUG << "rawdb::read_chain_config genesis_block_hash: " << genesis_block_hash;
+    SILK_DEBUG << "rawdb::read_chain_config genesis_block_hash: " << silkworm::to_hex(genesis_block_hash);
     const silkworm::ByteView genesis_block_hash_bytes{genesis_block_hash.bytes, silkworm::kHashLength};
     const auto data{co_await reader.get_one(db::table::kConfigName, genesis_block_hash_bytes)};
     if (data.empty()) {
@@ -80,7 +81,7 @@ Task<evmc::bytes32> read_canonical_block_hash(const DatabaseReader& reader, uint
         throw std::invalid_argument{"empty block hash value in read_canonical_block_hash"};
     }
     const auto canonical_block_hash{silkworm::to_bytes32(value)};
-    SILK_DEBUG << "rawdb::read_canonical_block_hash canonical block hash: " << canonical_block_hash;
+    SILK_DEBUG << "rawdb::read_canonical_block_hash canonical block hash: " << silkworm::to_hex(canonical_block_hash);
     co_return canonical_block_hash;
 }
 
@@ -133,7 +134,7 @@ Task<evmc::bytes32> read_head_header_hash(const DatabaseReader& reader) {
         throw std::invalid_argument{"empty head header hash value in read_head_header_hash"};
     }
     const auto head_header_hash{silkworm::to_bytes32(value)};
-    SILK_DEBUG << "head header hash: " << head_header_hash;
+    SILK_DEBUG << "head header hash: " << silkworm::to_hex(head_header_hash);
     co_return head_header_hash;
 }
 

--- a/silkworm/silkrpc/core/rawdb/util.cpp
+++ b/silkworm/silkrpc/core/rawdb/util.cpp
@@ -20,6 +20,7 @@
 #include <cstring>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/common/endian.hpp>
 #include <silkworm/node/db/util.hpp>
 

--- a/silkworm/silkrpc/core/remote_state.cpp
+++ b/silkworm/silkrpc/core/remote_state.cpp
@@ -26,6 +26,7 @@
 #include <boost/asio/use_future.hpp>
 
 #include <silkworm/core/common/util.hpp>
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/silkrpc/core/rawdb/chain.hpp>
 

--- a/silkworm/silkrpc/core/remote_state.cpp
+++ b/silkworm/silkrpc/core/remote_state.cpp
@@ -27,6 +27,7 @@
 
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/core/execution/address.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/silkrpc/core/rawdb/chain.hpp>
 
@@ -95,7 +96,7 @@ std::optional<silkworm::Account> RemoteState::read_account(const evmc::address& 
 }
 
 silkworm::ByteView RemoteState::read_code(const evmc::bytes32& code_hash) const noexcept {
-    SILK_DEBUG << "RemoteState::read_code code_hash=" << code_hash << " start";
+    SILK_DEBUG << "RemoteState::read_code code_hash=" << to_hex(code_hash) << " start";
     try {
         std::future<silkworm::ByteView> result{boost::asio::co_spawn(executor_, async_state_.read_code(code_hash), boost::asio::use_future)};
         const auto code{result.get()};
@@ -107,11 +108,11 @@ silkworm::ByteView RemoteState::read_code(const evmc::bytes32& code_hash) const 
 }
 
 evmc::bytes32 RemoteState::read_storage(const evmc::address& address, uint64_t incarnation, const evmc::bytes32& location) const noexcept {
-    SILK_DEBUG << "RemoteState::read_storage address=" << address << " incarnation=" << incarnation << " location=" << location << " start";
+    SILK_DEBUG << "RemoteState::read_storage address=" << address << " incarnation=" << incarnation << " location=" << to_hex(location) << " start";
     try {
         std::future<evmc::bytes32> result{boost::asio::co_spawn(executor_, async_state_.read_storage(address, incarnation, location), boost::asio::use_future)};
         const auto storage_value{result.get()};
-        SILK_DEBUG << "RemoteState::read_storage storage_value=" << storage_value << " end\n";
+        SILK_DEBUG << "RemoteState::read_storage storage_value=" << to_hex(storage_value) << " end\n";
         return storage_value;
     } catch (const std::exception& e) {
         SILK_ERROR << "RemoteState::read_storage exception: " << e.what();
@@ -125,11 +126,11 @@ uint64_t RemoteState::previous_incarnation(const evmc::address& address) const n
 }
 
 std::optional<silkworm::BlockHeader> RemoteState::read_header(BlockNum block_number, const evmc::bytes32& block_hash) const noexcept {
-    SILK_DEBUG << "RemoteState::read_header block_number=" << block_number << " block_hash=" << block_hash;
+    SILK_DEBUG << "RemoteState::read_header block_number=" << block_number << " block_hash=" << to_hex(block_hash);
     try {
         std::future<std::optional<silkworm::BlockHeader>> result{boost::asio::co_spawn(executor_, async_state_.read_header(block_number, block_hash), boost::asio::use_future)};
         auto optional_header{result.get()};
-        SILK_DEBUG << "RemoteState::read_header block_number=" << block_number << " block_hash=" << block_hash;
+        SILK_DEBUG << "RemoteState::read_header block_number=" << block_number << " block_hash=" << to_hex(block_hash);
         return optional_header;
     } catch (const std::exception& e) {
         SILK_ERROR << "RemoteState::read_header exception: " << e.what();
@@ -138,10 +139,10 @@ std::optional<silkworm::BlockHeader> RemoteState::read_header(BlockNum block_num
 }
 
 bool RemoteState::read_body(BlockNum block_number, const evmc::bytes32& block_hash, silkworm::BlockBody& filled_body) const noexcept {
-    SILK_DEBUG << "RemoteState::read_body block_number=" << block_number << " block_hash=" << block_hash;
+    SILK_DEBUG << "RemoteState::read_body block_number=" << block_number << " block_hash=" << to_hex(block_hash);
     try {
         auto result{boost::asio::co_spawn(executor_, async_state_.read_body(block_number, block_hash, filled_body), boost::asio::use_future)};
-        SILK_DEBUG << "RemoteState::read_body block_number=" << block_number << " block_hash=" << block_hash;
+        SILK_DEBUG << "RemoteState::read_body block_number=" << block_number << " block_hash=" << to_hex(block_hash);
         return result.get();
     } catch (const std::exception& e) {
         SILK_ERROR << "RemoteState::read_body exception: " << e.what();
@@ -150,11 +151,11 @@ bool RemoteState::read_body(BlockNum block_number, const evmc::bytes32& block_ha
 }
 
 std::optional<intx::uint256> RemoteState::total_difficulty(BlockNum block_number, const evmc::bytes32& block_hash) const noexcept {
-    SILK_DEBUG << "RemoteState::total_difficulty block_number=" << block_number << " block_hash=" << block_hash;
+    SILK_DEBUG << "RemoteState::total_difficulty block_number=" << block_number << " block_hash=" << to_hex(block_hash);
     try {
         std::future<std::optional<intx::uint256>> result{boost::asio::co_spawn(executor_, async_state_.total_difficulty(block_number, block_hash), boost::asio::use_future)};
         const auto optional_total_difficulty{result.get()};
-        SILK_DEBUG << "RemoteState::total_difficulty block_number=" << block_number << " block_hash=" << block_hash;
+        SILK_DEBUG << "RemoteState::total_difficulty block_number=" << block_number << " block_hash=" << to_hex(block_hash);
         return optional_total_difficulty;
     } catch (const std::exception& e) {
         SILK_ERROR << "RemoteState::total_difficulty exception: " << e.what();

--- a/silkworm/silkrpc/core/remote_state_test.cpp
+++ b/silkworm/silkrpc/core/remote_state_test.cpp
@@ -25,6 +25,7 @@
 #include <gmock/gmock.h>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/silkrpc/core/rawdb/accessors.hpp>
 #include <silkworm/silkrpc/storage/remote_chain_storage.hpp>

--- a/silkworm/silkrpc/core/state_reader.cpp
+++ b/silkworm/silkrpc/core/state_reader.cpp
@@ -62,7 +62,7 @@ Task<evmc::bytes32> StateReader::read_storage(
     if (!value) {
         auto composite_key{silkworm::composite_storage_key_without_hash_lookup(address, incarnation)};
         SILK_DEBUG << "StateReader::read_storage composite_key: " << composite_key;
-        value = co_await db_reader_.get_both_range(db::table::kPlainStateName, composite_key, location_hash);
+        value = co_await db_reader_.get_both_range(db::table::kPlainStateName, composite_key, location_hash.bytes);
         SILK_DEBUG << "StateReader::read_storage value: " << (value ? *value : silkworm::Bytes{});
     }
     if (!value) {

--- a/silkworm/silkrpc/core/storage_walker.cpp
+++ b/silkworm/silkrpc/core/storage_walker.cpp
@@ -20,6 +20,7 @@
 #include <sstream>
 
 #include <silkworm/core/common/endian.hpp>
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/infra/common/decoding_exception.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/node/db/bitmap.hpp>

--- a/silkworm/silkrpc/core/storage_walker.cpp
+++ b/silkworm/silkrpc/core/storage_walker.cpp
@@ -99,7 +99,7 @@ Task<void> StorageWalker::walk_of_storages(
     auto ps_key{make_key(address, incarnation)};
     ethdb::SplitCursorDupSort ps_split_cursor{*ps_cursor,
                                               ps_key,
-                                              location_hash,            /* subkey */
+                                              location_hash.bytes,      /* subkey */
                                               8 * (kAddressLength + 8), /* match_bits */
                                               kAddressLength,           /* part1_end */
                                               kHashLength};             /* value_offset */

--- a/silkworm/silkrpc/core/storage_walker_test.cpp
+++ b/silkworm/silkrpc/core/storage_walker_test.cpp
@@ -25,6 +25,7 @@
 #include <catch2/catch.hpp>
 
 #include <silkworm/core/common/util.hpp>
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/core/rlp/encode.hpp>
 #include <silkworm/silkrpc/ethdb/cursor.hpp>
 #include <silkworm/silkrpc/ethdb/database.hpp>
@@ -246,7 +247,7 @@ TEST_CASE("StorageWalker::walk_of_storages") {
 
     nlohmann::json storage({});
     StorageWalker::AccountCollector collector = [&](const evmc::address& address, const silkworm::ByteView loc, const silkworm::ByteView data) {
-        auto key = "0x" + silkworm::to_hex(address);
+        auto key = silkworm::address_to_string(address);
         storage[key].push_back({{"loc", "0x" + silkworm::to_hex(loc)}, {"data", "0x" + silkworm::to_hex(data)}});
 
         return true;

--- a/silkworm/silkrpc/ethbackend/remote_backend.cpp
+++ b/silkworm/silkrpc/ethbackend/remote_backend.cpp
@@ -22,6 +22,7 @@
 #include <boost/endian/conversion.hpp>
 #include <grpcpp/grpcpp.h>
 
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/infra/common/decoding_exception.hpp>
 #include <silkworm/infra/common/ensure.hpp>
 #include <silkworm/infra/common/log.hpp>

--- a/silkworm/silkrpc/ethdb/bitmap.cpp
+++ b/silkworm/silkrpc/ethdb/bitmap.cpp
@@ -23,6 +23,7 @@
 
 #include <gsl/narrow>
 
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/infra/common/log.hpp>
 
 namespace silkworm::rpc::ethdb::bitmap {
@@ -90,7 +91,7 @@ Task<Roaring> from_topics(
         roaring::Roaring subtopic_bitmap;
         for (auto& topic : subtopics) {
             silkworm::Bytes topic_key{std::begin(topic.bytes), std::end(topic.bytes)};
-            SILK_TRACE << "topic: " << topic << " topic_key: " << silkworm::to_hex(topic);
+            SILK_TRACE << "topic: " << silkworm::to_hex(topic) << " topic_key: " << silkworm::to_hex(topic_key);
             auto bitmap = co_await ethdb::bitmap::get(db_reader, table, topic_key, gsl::narrow<uint32_t>(start), gsl::narrow<uint32_t>(end));
             SILK_TRACE << "bitmap: " << bitmap.toString();
             subtopic_bitmap |= bitmap;

--- a/silkworm/silkrpc/ethdb/cursor_test.cpp
+++ b/silkworm/silkrpc/ethdb/cursor_test.cpp
@@ -42,7 +42,7 @@ static const silkworm::Bytes wrong_key_last_byte{*silkworm::from_hex("0x79a4d35b
 static const silkworm::Bytes wrong_key_first_byte{*silkworm::from_hex("0x59a4d35bd00b1843ec5292217e71dace5e5a7430")};
 static const silkworm::Bytes key{(0x79a4d35bd00b1843ec5292217e71dace5e5a7439_address).bytes};
 static const silkworm::Bytes correct_key{*silkworm::from_hex("0x79a4d35bd00b1843ec5292217e71dace5e5a7439")};
-static const evmc::bytes32 location = 0x0000000000000000000000000000000000000000000000000000000000000001_bytes32;
+static const silkworm::Bytes location{(0x0000000000000000000000000000000000000000000000000000000000000001_bytes32).bytes};
 
 TEST_CASE("split cursor dup sort") {
     boost::asio::thread_pool pool{1};

--- a/silkworm/silkrpc/ethdb/cursor_test.cpp
+++ b/silkworm/silkrpc/ethdb/cursor_test.cpp
@@ -40,9 +40,9 @@ static const silkworm::Bytes empty_key{};
 static const silkworm::Bytes short_key{*silkworm::from_hex("0x79a4d35bd00b1843ec5292217e71dace5e5")};
 static const silkworm::Bytes wrong_key_last_byte{*silkworm::from_hex("0x79a4d35bd00b1843ec5292217e71dace5e5a7430")};
 static const silkworm::Bytes wrong_key_first_byte{*silkworm::from_hex("0x59a4d35bd00b1843ec5292217e71dace5e5a7430")};
-static const silkworm::Bytes key{(0x79a4d35bd00b1843ec5292217e71dace5e5a7439_address).bytes};
+static const silkworm::Bytes key{(0x79a4d35bd00b1843ec5292217e71dace5e5a7439_address).bytes, kAddressLength};
 static const silkworm::Bytes correct_key{*silkworm::from_hex("0x79a4d35bd00b1843ec5292217e71dace5e5a7439")};
-static const silkworm::Bytes location{(0x0000000000000000000000000000000000000000000000000000000000000001_bytes32).bytes};
+static const silkworm::Bytes location{(0x0000000000000000000000000000000000000000000000000000000000000001_bytes32).bytes, kHashLength};
 
 TEST_CASE("split cursor dup sort") {
     boost::asio::thread_pool pool{1};

--- a/silkworm/silkrpc/ethdb/cursor_test.cpp
+++ b/silkworm/silkrpc/ethdb/cursor_test.cpp
@@ -24,6 +24,7 @@
 #include <catch2/catch.hpp>
 #include <gmock/gmock.h>
 
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/silkrpc/test/mock_cursor.hpp>
 
 namespace silkworm::rpc::ethdb {
@@ -39,7 +40,7 @@ static const silkworm::Bytes empty_key{};
 static const silkworm::Bytes short_key{*silkworm::from_hex("0x79a4d35bd00b1843ec5292217e71dace5e5")};
 static const silkworm::Bytes wrong_key_last_byte{*silkworm::from_hex("0x79a4d35bd00b1843ec5292217e71dace5e5a7430")};
 static const silkworm::Bytes wrong_key_first_byte{*silkworm::from_hex("0x59a4d35bd00b1843ec5292217e71dace5e5a7430")};
-static const evmc::address key = 0x79a4d35bd00b1843ec5292217e71dace5e5a7439_address;
+static const silkworm::Bytes key{(0x79a4d35bd00b1843ec5292217e71dace5e5a7439_address).bytes};
 static const silkworm::Bytes correct_key{*silkworm::from_hex("0x79a4d35bd00b1843ec5292217e71dace5e5a7439")};
 static const evmc::bytes32 location = 0x0000000000000000000000000000000000000000000000000000000000000001_bytes32;
 

--- a/silkworm/silkrpc/ethdb/kv/state_cache.cpp
+++ b/silkworm/silkrpc/ethdb/kv/state_cache.cpp
@@ -22,6 +22,7 @@
 
 #include <silkworm/core/common/assert.hpp>
 #include <silkworm/core/common/util.hpp>
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/grpc/common/conversion.hpp>
 #include <silkworm/node/db/tables.hpp>

--- a/silkworm/silkrpc/ethdb/kv/state_cache.hpp
+++ b/silkworm/silkrpc/ethdb/kv/state_cache.hpp
@@ -28,6 +28,7 @@
 #include <absl/container/btree_set.h>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/interfaces/remote/kv.pb.h>
 #include <silkworm/silkrpc/common/util.hpp>
 #include <silkworm/silkrpc/ethdb/transaction.hpp>

--- a/silkworm/silkrpc/ethdb/kv/state_cache_test.cpp
+++ b/silkworm/silkrpc/ethdb/kv/state_cache_test.cpp
@@ -30,6 +30,7 @@
 
 #include <silkworm/core/common/assert.hpp>
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/grpc/common/conversion.hpp>

--- a/silkworm/silkrpc/json/call.cpp
+++ b/silkworm/silkrpc/json/call.cpp
@@ -20,6 +20,7 @@
 #include <utility>
 
 #include <silkworm/core/common/util.hpp>
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/silkrpc/common/util.hpp>
 #include <silkworm/silkrpc/json/types.hpp>
 

--- a/silkworm/silkrpc/json/log.cpp
+++ b/silkworm/silkrpc/json/log.cpp
@@ -22,6 +22,7 @@
 
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/core/execution/address.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/silkrpc/common/util.hpp>
 
 #include "types.hpp"
@@ -128,8 +129,8 @@ void make_glaze_json_content(std::string& reply, uint32_t id, const Logs& logs) 
     for (const auto& l : logs) {
         GlazeJsonLogItem item{};
         to_hex(std::span(item.address), l.address.bytes);
-        to_hex(std::span(item.tx_hash), l.tx_hash);
-        to_hex(std::span(item.block_hash), l.block_hash);
+        to_hex(std::span(item.tx_hash), l.tx_hash.bytes);
+        to_hex(std::span(item.block_hash), l.block_hash.bytes);
         to_quantity(std::span(item.block_number), l.block_number);
         to_quantity(std::span(item.tx_index), l.tx_index);
         to_quantity(std::span(item.index), l.index);
@@ -139,7 +140,7 @@ void make_glaze_json_content(std::string& reply, uint32_t id, const Logs& logs) 
             item.timestamp = to_quantity(*(l.timestamp));
         }
         for (const auto& t : l.topics) {
-            item.topics.push_back("0x" + silkworm::to_hex(t));
+            item.topics.push_back(silkworm::to_hex(t, true));
         }
         log_json_data.log_json_list.push_back(item);
     }

--- a/silkworm/silkrpc/json/log.cpp
+++ b/silkworm/silkrpc/json/log.cpp
@@ -126,7 +126,7 @@ void make_glaze_json_content(std::string& reply, uint32_t id, const Logs& logs) 
 
     for (const auto& l : logs) {
         GlazeJsonLogItem item{};
-        to_hex(std::span(item.address), l.address);
+        to_hex(std::span(item.address), l.address.bytes);
         to_hex(std::span(item.tx_hash), l.tx_hash);
         to_hex(std::span(item.block_hash), l.block_hash);
         to_quantity(std::span(item.block_number), l.block_number);

--- a/silkworm/silkrpc/json/log.cpp
+++ b/silkworm/silkrpc/json/log.cpp
@@ -21,6 +21,7 @@
 #include <utility>
 
 #include <silkworm/core/common/util.hpp>
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/silkrpc/common/util.hpp>
 
 #include "types.hpp"

--- a/silkworm/silkrpc/json/types.cpp
+++ b/silkworm/silkrpc/json/types.cpp
@@ -24,6 +24,7 @@
 
 #include <silkworm/core/common/endian.hpp>
 #include <silkworm/core/common/util.hpp>
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/silkrpc/common/util.hpp>
 
@@ -169,7 +170,7 @@ std::string to_quantity(intx::uint256 number) {
 namespace evmc {
 
 void to_json(nlohmann::json& json, const address& addr) {
-    json = "0x" + silkworm::to_hex(addr);
+    json = silkworm::address_to_string(addr);
 }
 
 void from_json(const nlohmann::json& json, address& addr) {
@@ -454,7 +455,7 @@ void to_json(nlohmann::json& json, const RevertError& error) {
 void to_json(nlohmann::json& json, const std::set<evmc::address>& addresses) {
     json = nlohmann::json::array();
     for (const auto& address : addresses) {
-        json.push_back("0x" + silkworm::to_hex(address));
+        json.push_back(silkworm::address_to_string(address));
     }
 }
 

--- a/silkworm/silkrpc/json/types.cpp
+++ b/silkworm/silkrpc/json/types.cpp
@@ -25,6 +25,7 @@
 #include <silkworm/core/common/endian.hpp>
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/core/execution/address.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/silkrpc/common/util.hpp>
 
@@ -154,6 +155,10 @@ std::string to_quantity(silkworm::ByteView bytes) {
     return "0x" + to_hex_no_leading_zeros(bytes);
 }
 
+std::string to_quantity(const evmc::bytes32& bytes) {
+    return to_quantity(silkworm::ByteView{bytes.bytes});
+}
+
 std::string to_quantity(uint64_t number) {
     return "0x" + to_hex_no_leading_zeros(number);
 }
@@ -179,7 +184,7 @@ void from_json(const nlohmann::json& json, address& addr) {
 }
 
 void to_json(nlohmann::json& json, const bytes32& b32) {
-    json = "0x" + silkworm::to_hex(b32);
+    json = silkworm::to_hex(b32, true);
 }
 
 void from_json(const nlohmann::json& json, bytes32& b32) {

--- a/silkworm/silkrpc/json/types_test.cpp
+++ b/silkworm/silkrpc/json/types_test.cpp
@@ -64,14 +64,14 @@ TEST_CASE("convert positive uint256 to quantity(buff)", "[silkrpc][to_quantity]"
 TEST_CASE("serialize empty address using to_hex(char *)", "[silkrpc][to_json]") {
     evmc::address address{};
     char address_zero[64];
-    to_hex(address_zero, address);
+    to_hex(address_zero, address.bytes);
     CHECK(strcmp(address_zero, "0x0000000000000000000000000000000000000000") == 0);
 }
 
 TEST_CASE("serialize empty address using to_hex(char *) small buffer", "[silkrpc][to_json]") {
     evmc::address address{};
     char address_zero[10];
-    CHECK_THROWS(to_hex(address_zero, address));
+    CHECK_THROWS(to_hex(address_zero, address.bytes));
 }
 
 TEST_CASE("serialize empty address", "[silkrpc][to_json]") {

--- a/silkworm/silkrpc/stagedsync/stages.hpp
+++ b/silkworm/silkrpc/stagedsync/stages.hpp
@@ -19,6 +19,7 @@
 #include <silkworm/infra/concurrency/task.hpp>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/node/db/stages.hpp>
 #include <silkworm/silkrpc/core/rawdb/accessors.hpp>
 

--- a/silkworm/silkrpc/storage/chain_storage.hpp
+++ b/silkworm/silkrpc/storage/chain_storage.hpp
@@ -21,6 +21,7 @@
 #include <silkworm/infra/concurrency/task.hpp>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/types/block.hpp>
 
 namespace silkworm::rpc {

--- a/silkworm/silkrpc/test/mock_chain_storage.hpp
+++ b/silkworm/silkrpc/test/mock_chain_storage.hpp
@@ -23,6 +23,7 @@
 #include <gmock/gmock.h>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/infra/test_util/log.hpp>
 #include <silkworm/silkrpc/common/util.hpp>
 #include <silkworm/silkrpc/storage/chain_storage.hpp>

--- a/silkworm/silkrpc/test/mock_cursor.hpp
+++ b/silkworm/silkrpc/test/mock_cursor.hpp
@@ -23,6 +23,7 @@
 #include <gmock/gmock.h>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/silkrpc/common/util.hpp>
 #include <silkworm/silkrpc/ethdb/cursor.hpp>
 

--- a/silkworm/silkrpc/test/mock_database_reader.hpp
+++ b/silkworm/silkrpc/test/mock_database_reader.hpp
@@ -24,6 +24,7 @@
 #include <gmock/gmock.h>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/silkrpc/common/util.hpp>
 #include <silkworm/silkrpc/core/rawdb/accessors.hpp>
 

--- a/silkworm/silkrpc/txpool/miner.cpp
+++ b/silkworm/silkrpc/txpool/miner.cpp
@@ -16,6 +16,7 @@
 
 #include "miner.hpp"
 
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/silkrpc/common/clock_time.hpp>
 #include <silkworm/silkrpc/grpc/unary_rpc.hpp>
@@ -40,11 +41,11 @@ Task<WorkResult> Miner::get_work() {
     UnaryRpc<&::txpool::Mining::StubInterface::AsyncGetWork> get_work_rpc{*stub_, grpc_context_};
     const auto reply = co_await get_work_rpc.finish_on(executor_, ::txpool::GetWorkRequest{});
     const auto header_hash = silkworm::bytes32_from_hex(reply.header_hash());
-    SILK_DEBUG << "Miner::get_work header_hash=" << header_hash;
+    SILK_DEBUG << "Miner::get_work header_hash=" << silkworm::to_hex(header_hash);
     const auto seed_hash = silkworm::bytes32_from_hex(reply.seed_hash());
-    SILK_DEBUG << "Miner::get_work seed_hash=" << seed_hash;
+    SILK_DEBUG << "Miner::get_work seed_hash=" << silkworm::to_hex(seed_hash);
     const auto target = silkworm::bytes32_from_hex(reply.target());
-    SILK_DEBUG << "Miner::get_work target=" << target;
+    SILK_DEBUG << "Miner::get_work target=" << silkworm::to_hex(target);
     const auto block_number = silkworm::from_hex(reply.block_number()).value_or(silkworm::Bytes{});
     SILK_DEBUG << "Miner::get_work block_number=" << block_number;
     WorkResult result{header_hash, seed_hash, target, block_number};
@@ -54,7 +55,7 @@ Task<WorkResult> Miner::get_work() {
 
 Task<bool> Miner::submit_work(const silkworm::Bytes& block_nonce, const evmc::bytes32& pow_hash, const evmc::bytes32& digest) {
     const auto start_time = clock_time::now();
-    SILK_DEBUG << "Miner::submit_work block_nonce=" << block_nonce << " pow_hash=" << pow_hash << " digest=" << digest;
+    SILK_DEBUG << "Miner::submit_work block_nonce=" << block_nonce << " pow_hash=" << silkworm::to_hex(pow_hash) << " digest=" << silkworm::to_hex(digest);
     ::txpool::SubmitWorkRequest submit_work_request;
     submit_work_request.set_block_nonce(block_nonce.data(), block_nonce.size());
     submit_work_request.set_pow_hash(pow_hash.bytes, silkworm::kHashLength);
@@ -68,7 +69,7 @@ Task<bool> Miner::submit_work(const silkworm::Bytes& block_nonce, const evmc::by
 
 Task<bool> Miner::submit_hash_rate(const intx::uint256& rate, const evmc::bytes32& id) {
     const auto start_time = clock_time::now();
-    SILK_DEBUG << "Miner::submit_hash_rate rate=" << rate << " id=" << id;
+    SILK_DEBUG << "Miner::submit_hash_rate rate=" << rate << " id=" << silkworm::to_hex(id);
     ::txpool::SubmitHashRateRequest submit_hash_rate_request;
     submit_hash_rate_request.set_rate(uint64_t(rate));
     submit_hash_rate_request.set_id(id.bytes, silkworm::kHashLength);

--- a/silkworm/silkrpc/txpool/miner.hpp
+++ b/silkworm/silkrpc/txpool/miner.hpp
@@ -29,6 +29,7 @@
 #include <intx/intx.hpp>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/interfaces/txpool/mining.grpc.pb.h>
 #include <silkworm/interfaces/types/types.pb.h>
 #include <silkworm/silkrpc/common/util.hpp>

--- a/silkworm/silkrpc/txpool/miner_test.cpp
+++ b/silkworm/silkrpc/txpool/miner_test.cpp
@@ -25,6 +25,7 @@
 #include <gmock/gmock.h>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/interfaces/txpool/mining.grpc.pb.h>
 #include <silkworm/silkrpc/test/api_test_base.hpp>
 #include <silkworm/silkrpc/test/grpc_actions.hpp>

--- a/silkworm/silkrpc/txpool/transaction_pool.cpp
+++ b/silkworm/silkrpc/txpool/transaction_pool.cpp
@@ -17,6 +17,7 @@
 #include "transaction_pool.hpp"
 
 #include <silkworm/core/execution/address.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/grpc/common/conversion.hpp>
 #include <silkworm/silkrpc/common/clock_time.hpp>
@@ -77,7 +78,7 @@ Task<OperationResult> TransactionPool::add_transaction(const silkworm::ByteView&
 
 Task<std::optional<silkworm::Bytes>> TransactionPool::get_transaction(const evmc::bytes32& tx_hash) {
     const auto start_time = clock_time::now();
-    SILK_DEBUG << "TransactionPool::get_transaction tx_hash=" << tx_hash;
+    SILK_DEBUG << "TransactionPool::get_transaction tx_hash=" << silkworm::to_hex(tx_hash);
     auto hi = new ::types::H128{};
     auto lo = new ::types::H128{};
     hi->set_hi(evmc::load64be(tx_hash.bytes + 0));

--- a/silkworm/silkrpc/txpool/transaction_pool.cpp
+++ b/silkworm/silkrpc/txpool/transaction_pool.cpp
@@ -16,6 +16,7 @@
 
 #include "transaction_pool.hpp"
 
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/grpc/common/conversion.hpp>
 #include <silkworm/silkrpc/common/clock_time.hpp>

--- a/silkworm/silkrpc/txpool/transaction_pool.hpp
+++ b/silkworm/silkrpc/txpool/transaction_pool.hpp
@@ -31,6 +31,7 @@
 #include <grpcpp/grpcpp.h>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/interfaces/txpool/txpool.grpc.pb.h>
 #include <silkworm/interfaces/types/types.pb.h>
 #include <silkworm/silkrpc/common/clock_time.hpp>

--- a/silkworm/silkrpc/txpool/transaction_pool_test.cpp
+++ b/silkworm/silkrpc/txpool/transaction_pool_test.cpp
@@ -26,6 +26,7 @@
 #include <grpcpp/grpcpp.h>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/interfaces/txpool/txpool.grpc.pb.h>
 #include <silkworm/silkrpc/test/api_test_base.hpp>
 #include <silkworm/silkrpc/test/grpc_actions.hpp>

--- a/silkworm/silkrpc/types/block.cpp
+++ b/silkworm/silkrpc/types/block.cpp
@@ -21,22 +21,23 @@
 #include <silkworm/core/common/assert.hpp>
 #include <silkworm/core/common/endian.hpp>
 #include <silkworm/core/rlp/encode_vector.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/silkrpc/common/util.hpp>
 #include <silkworm/silkrpc/core/blocks.hpp>
 
 namespace silkworm::rpc {
 
 std::ostream& operator<<(std::ostream& out, const Block& b) {
-    out << "parent_hash: " << b.block.header.parent_hash;
-    out << " ommers_hash: " << b.block.header.ommers_hash;
+    out << "parent_hash: " << to_hex(b.block.header.parent_hash);
+    out << " ommers_hash: " << to_hex(b.block.header.ommers_hash);
     out << " beneficiary: ";
     for (const auto& byte : b.block.header.beneficiary.bytes) {
         out << std::hex << std::setw(2) << std::setfill('0') << int(byte);
     }
     out << std::dec;
-    out << " state_root: " << b.block.header.state_root;
-    out << " transactions_root: " << b.block.header.transactions_root;
-    out << " receipts_root: " << b.block.header.receipts_root;
+    out << " state_root: " << to_hex(b.block.header.state_root);
+    out << " transactions_root: " << to_hex(b.block.header.transactions_root);
+    out << " receipts_root: " << to_hex(b.block.header.receipts_root);
     out << " logs_bloom: " << silkworm::to_hex(full_view(b.block.header.logs_bloom));
     out << " difficulty: " << silkworm::to_hex(silkworm::endian::to_big_compact(b.block.header.difficulty));
     out << " number: " << b.block.header.number;
@@ -44,11 +45,11 @@ std::ostream& operator<<(std::ostream& out, const Block& b) {
     out << " gas_used: " << b.block.header.gas_used;
     out << " timestamp: " << b.block.header.timestamp;
     out << " extra_data: " << silkworm::to_hex(b.block.header.extra_data);
-    out << " prev_randao: " << b.block.header.prev_randao;
+    out << " prev_randao: " << to_hex(b.block.header.prev_randao);
     out << " nonce: " << silkworm::to_hex({b.block.header.nonce.data(), b.block.header.nonce.size()});
     out << " #transactions: " << b.block.transactions.size();
     out << " #ommers: " << b.block.ommers.size();
-    out << " hash: " << b.hash;
+    out << " hash: " << to_hex(b.hash);
     out << " total_difficulty: " << silkworm::to_hex(silkworm::endian::to_big_compact(b.total_difficulty));
     out << " full_tx: " << b.full_tx;
     return out;
@@ -70,7 +71,7 @@ std::ostream& operator<<(std::ostream& out, const BlockNumberOrHash& bnoh) {
     if (bnoh.is_number()) {
         out << "0x" << std::hex << bnoh.number() << std::dec;
     } else if (bnoh.is_hash()) {
-        out << "0x" << bnoh.hash();
+        out << to_hex(bnoh.hash(), true);
     } else {
         SILKWORM_ASSERT(bnoh.is_tag());
         out << bnoh.tag();

--- a/silkworm/silkrpc/types/block_test.cpp
+++ b/silkworm/silkrpc/types/block_test.cpp
@@ -21,6 +21,7 @@
 #include <catch2/catch.hpp>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/infra/test_util/log.hpp>
 
 namespace silkworm::rpc {

--- a/silkworm/silkrpc/types/call.cpp
+++ b/silkworm/silkrpc/types/call.cpp
@@ -20,6 +20,7 @@
 
 #include <silkworm/core/common/endian.hpp>
 #include <silkworm/core/common/util.hpp>
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/silkrpc/common/util.hpp>
 
 namespace silkworm::rpc {

--- a/silkworm/silkrpc/types/chain_config.cpp
+++ b/silkworm/silkrpc/types/chain_config.cpp
@@ -16,12 +16,13 @@
 
 #include "chain_config.hpp"
 
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/silkrpc/common/util.hpp>
 
 namespace silkworm::rpc {
 
 std::ostream& operator<<(std::ostream& out, const ChainConfig& chain_config) {
-    out << "genesis: " << chain_config.genesis_hash << " "
+    out << "genesis: " << to_hex(chain_config.genesis_hash) << " "
         << "config: " << chain_config.config.dump();
     return out;
 }

--- a/silkworm/silkrpc/types/dump_account.cpp
+++ b/silkworm/silkrpc/types/dump_account.cpp
@@ -17,6 +17,7 @@
 #include "dump_account.hpp"
 
 #include <silkworm/core/common/util.hpp>
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/silkrpc/common/util.hpp>
 #include <silkworm/silkrpc/json/types.hpp>
 
@@ -35,7 +36,7 @@ void to_json(nlohmann::json& json, const DumpAccounts& dump) {
     for (const auto& entry : dump.accounts) {
         nlohmann::json item;
         to_json(item, entry.second);
-        accounts.push_back(nlohmann::json::object_t::value_type("0x" + silkworm::to_hex(entry.first), item));
+        accounts.push_back(nlohmann::json::object_t::value_type(silkworm::address_to_string(entry.first), item));
     }
     auto encoded = base64_encode({dump.next.bytes, kAddressLength}, false);
     json = {

--- a/silkworm/silkrpc/types/dump_account.cpp
+++ b/silkworm/silkrpc/types/dump_account.cpp
@@ -18,13 +18,14 @@
 
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/core/execution/address.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/silkrpc/common/util.hpp>
 #include <silkworm/silkrpc/json/types.hpp>
 
 namespace silkworm::rpc {
 
 std::ostream& operator<<(std::ostream& out, const DumpAccounts& dump) {
-    out << "root: 0x" << dump.root
+    out << "root: 0x" << silkworm::to_hex(dump.root)
         << " next: " << dump.next
         << " accounts: " << dump.accounts.size();
     return out;

--- a/silkworm/silkrpc/types/dump_account.hpp
+++ b/silkworm/silkrpc/types/dump_account.hpp
@@ -27,6 +27,7 @@
 #include <nlohmann/json.hpp>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 
 namespace silkworm::rpc {
 

--- a/silkworm/silkrpc/types/error.hpp
+++ b/silkworm/silkrpc/types/error.hpp
@@ -22,6 +22,7 @@
 #include <evmc/evmc.hpp>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 
 namespace silkworm::rpc {
 

--- a/silkworm/silkrpc/types/execution_payload.cpp
+++ b/silkworm/silkrpc/types/execution_payload.cpp
@@ -16,6 +16,7 @@
 
 #include "execution_payload.hpp"
 
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/silkrpc/common/util.hpp>
 
 namespace silkworm::rpc {

--- a/silkworm/silkrpc/types/execution_payload.cpp
+++ b/silkworm/silkrpc/types/execution_payload.cpp
@@ -17,6 +17,7 @@
 #include "execution_payload.hpp"
 
 #include <silkworm/core/execution/address.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/silkrpc/common/util.hpp>
 
 namespace silkworm::rpc {
@@ -25,15 +26,15 @@ std::ostream& operator<<(std::ostream& out, const ExecutionPayload& payload) {
     auto bloom_bytes{silkworm::ByteView(&payload.logs_bloom[0], 256)};
     out << "version: " << payload.version
         << " number: " << payload.number
-        << " block_hash: " << payload.block_hash
-        << " parent_hash: " << payload.parent_hash
+        << " block_hash: " << to_hex(payload.block_hash)
+        << " parent_hash: " << to_hex(payload.parent_hash)
         << " timestamp: " << payload.timestamp
         << " gas_limit: " << payload.gas_limit
         << " gas_used: " << payload.gas_used
         << " suggested_fee_recipient: " << payload.suggested_fee_recipient
-        << " state_root: " << payload.state_root
-        << " receipts_root: " << payload.receipts_root
-        << " prev_randao: " << payload.prev_randao
+        << " state_root: " << to_hex(payload.state_root)
+        << " receipts_root: " << to_hex(payload.receipts_root)
+        << " prev_randao: " << to_hex(payload.prev_randao)
         << " logs_bloom: " << silkworm::to_hex(bloom_bytes)
         << " extra_data: " << silkworm::to_hex(payload.extra_data)
         << " #transactions: " << payload.transactions.size();
@@ -46,7 +47,7 @@ std::ostream& operator<<(std::ostream& out, const ExecutionPayload& payload) {
 std::ostream& operator<<(std::ostream& out, const PayloadStatus& payload_status) {
     out << "status: " << payload_status.status;
     if (payload_status.latest_valid_hash) {
-        out << " latest_valid_hash: " << *payload_status.latest_valid_hash;
+        out << " latest_valid_hash: " << to_hex(*payload_status.latest_valid_hash);
     }
     if (payload_status.validation_error) {
         out << " validation_error: " << *payload_status.validation_error;
@@ -55,16 +56,16 @@ std::ostream& operator<<(std::ostream& out, const PayloadStatus& payload_status)
 }
 
 std::ostream& operator<<(std::ostream& out, const ForkChoiceState& fork_choice_state) {
-    out << "head_block_hash: " << fork_choice_state.head_block_hash
-        << " safe_block_hash: " << fork_choice_state.safe_block_hash
-        << " finalized_block_hash: " << fork_choice_state.finalized_block_hash;
+    out << "head_block_hash: " << to_hex(fork_choice_state.head_block_hash)
+        << " safe_block_hash: " << to_hex(fork_choice_state.safe_block_hash)
+        << " finalized_block_hash: " << to_hex(fork_choice_state.finalized_block_hash);
     return out;
 }
 
 std::ostream& operator<<(std::ostream& out, const PayloadAttributes& attributes) {
     out << "version: " << attributes.version
         << " timestamp: " << attributes.timestamp
-        << " prev_randao: " << attributes.prev_randao
+        << " prev_randao: " << to_hex(attributes.prev_randao)
         << " suggested_fee_recipient: " << attributes.suggested_fee_recipient;
     if (attributes.withdrawals) {
         out << " #withdrawals: " << attributes.withdrawals->size();
@@ -90,7 +91,7 @@ std::ostream& operator<<(std::ostream& out, const ForkChoiceUpdatedReply& fcu_re
 
 std::ostream& operator<<(std::ostream& out, const TransitionConfiguration& transition_configuration) {
     out << "terminal_total_difficulty: " << transition_configuration.terminal_total_difficulty
-        << " terminal_block_hash: " << transition_configuration.terminal_block_hash
+        << " terminal_block_hash: " << to_hex(transition_configuration.terminal_block_hash)
         << " terminal_block_number: " << transition_configuration.terminal_block_number;
     return out;
 }

--- a/silkworm/silkrpc/types/execution_payload.hpp
+++ b/silkworm/silkrpc/types/execution_payload.hpp
@@ -24,6 +24,7 @@
 #include <intx/intx.hpp>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/types/bloom.hpp>
 #include <silkworm/core/types/withdrawal.hpp>
 

--- a/silkworm/silkrpc/types/filter.cpp
+++ b/silkworm/silkrpc/types/filter.cpp
@@ -17,6 +17,7 @@
 #include "filter.hpp"
 
 #include <silkworm/core/execution/address.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/silkrpc/common/util.hpp>
 
 std::ostream& operator<<(std::ostream& out, const std::optional<silkworm::rpc::FilterAddresses>& addresses) {
@@ -39,7 +40,7 @@ std::ostream& operator<<(std::ostream& out, const std::optional<silkworm::rpc::F
 std::ostream& operator<<(std::ostream& out, const silkworm::rpc::FilterSubTopics& subtopics) {
     out << "[";
     for (std::size_t i{0}; i < subtopics.size(); i++) {
-        out << "0x" << subtopics[i];
+        out << silkworm::to_hex(subtopics[i], true);
         if (i != subtopics.size() - 1) {
             out << " ";
         }

--- a/silkworm/silkrpc/types/filter.cpp
+++ b/silkworm/silkrpc/types/filter.cpp
@@ -16,6 +16,7 @@
 
 #include "filter.hpp"
 
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/silkrpc/common/util.hpp>
 
 std::ostream& operator<<(std::ostream& out, const std::optional<silkworm::rpc::FilterAddresses>& addresses) {
@@ -23,7 +24,7 @@ std::ostream& operator<<(std::ostream& out, const std::optional<silkworm::rpc::F
         auto address_vector = addresses.value();
         out << "[";
         for (std::size_t i{0}; i < address_vector.size(); i++) {
-            out << "0x" << address_vector[i];
+            out << address_vector[i];
             if (i != address_vector.size() - 1) {
                 out << " ";
             }

--- a/silkworm/silkrpc/types/log.cpp
+++ b/silkworm/silkrpc/types/log.cpp
@@ -18,6 +18,7 @@
 
 #include <iomanip>
 
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/silkrpc/common/util.hpp>
 
 namespace silkworm::rpc {
@@ -26,9 +27,9 @@ std::ostream& operator<<(std::ostream& out, const Log& log) {
     out << "#topics: " << log.topics.size();
     out << " #data: " << log.data.size();
     out << " block_number: " << uint32_t(log.block_number);
-    out << " tx_hash: " << log.tx_hash;
+    out << " tx_hash: " << to_hex(log.tx_hash);
     out << " tx_index: " << log.tx_index;
-    out << " block_hash: " << log.block_hash;
+    out << " block_hash: " << to_hex(log.block_hash);
     out << " index: " << log.index;
     out << " removed: " << log.removed;
     out << " address: ";

--- a/silkworm/silkrpc/types/log.hpp
+++ b/silkworm/silkrpc/types/log.hpp
@@ -26,6 +26,7 @@
 #include <glaze/glaze.hpp>
 #pragma GCC diagnostic pop
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 
 namespace silkworm::rpc {
 

--- a/silkworm/silkrpc/types/receipt.cpp
+++ b/silkworm/silkrpc/types/receipt.cpp
@@ -18,6 +18,7 @@
 
 #include <iomanip>
 
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/core/types/bloom.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/silkrpc/common/util.hpp>
@@ -30,7 +31,7 @@ std::ostream& operator<<(std::ostream& out, const Receipt& r) {
     out << " contract_address: " << r.contract_address;
     out << " cumulative_gas_used: " << r.cumulative_gas_used;
     if (r.from) {
-        out << " from: " << silkworm::to_hex(*r.from);
+        out << " from: " << *r.from;
     } else {
         out << " from: null";
     }
@@ -40,7 +41,7 @@ std::ostream& operator<<(std::ostream& out, const Receipt& r) {
     out << " bloom: " << silkworm::to_hex(bloom_view);
     out << " success: " << r.success;
     if (r.to) {
-        out << " to: " << silkworm::to_hex(*r.to);
+        out << " to: " << *r.to;
     } else {
         out << " to: null";
     }

--- a/silkworm/silkrpc/types/receipt.cpp
+++ b/silkworm/silkrpc/types/receipt.cpp
@@ -20,13 +20,14 @@
 
 #include <silkworm/core/execution/address.hpp>
 #include <silkworm/core/types/bloom.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/silkrpc/common/util.hpp>
 
 namespace silkworm::rpc {
 
 std::ostream& operator<<(std::ostream& out, const Receipt& r) {
-    out << " block_hash: " << r.block_hash;
+    out << " block_hash: " << to_hex(r.block_hash);
     out << " block_number: " << r.block_number;
     out << " contract_address: " << r.contract_address;
     out << " cumulative_gas_used: " << r.cumulative_gas_used;
@@ -45,7 +46,7 @@ std::ostream& operator<<(std::ostream& out, const Receipt& r) {
     } else {
         out << " to: null";
     }
-    out << " tx_hash: " << r.tx_hash;
+    out << " tx_hash: " << to_hex(r.tx_hash);
     out << " tx_index: " << r.tx_index;
     if (r.type) {
         out << " type: 0x" << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(*r.type) << std::dec;

--- a/silkworm/silkrpc/types/transaction.cpp
+++ b/silkworm/silkrpc/types/transaction.cpp
@@ -20,6 +20,7 @@
 
 #include <silkworm/core/common/endian.hpp>
 #include <silkworm/core/execution/address.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/silkrpc/common/util.hpp>
 
 namespace silkworm::rpc {
@@ -30,7 +31,7 @@ intx::uint256 Transaction::effective_gas_price() const {
 
 std::ostream& operator<<(std::ostream& out, const Transaction& t) {
     out << " #access_list: " << t.access_list.size();
-    out << " block_hash: " << t.block_hash;
+    out << " block_hash: " << to_hex(t.block_hash);
     out << " block_number: " << t.block_number;
     out << " block_base_fee_per_gas: " << silkworm::to_hex(silkworm::endian::to_big_compact(t.block_base_fee_per_gas.value_or(0)));
     if (t.chain_id) {

--- a/silkworm/silkrpc/types/transaction.cpp
+++ b/silkworm/silkrpc/types/transaction.cpp
@@ -19,6 +19,7 @@
 #include <iomanip>
 
 #include <silkworm/core/common/endian.hpp>
+#include <silkworm/core/execution/address.hpp>
 #include <silkworm/silkrpc/common/util.hpp>
 
 namespace silkworm::rpc {
@@ -39,7 +40,7 @@ std::ostream& operator<<(std::ostream& out, const Transaction& t) {
     }
     out << " data: " << silkworm::to_hex(t.data);
     if (t.from) {
-        out << " from: " << silkworm::to_hex(*t.from);
+        out << " from: " << *t.from;
     } else {
         out << " from: null";
     }
@@ -54,7 +55,7 @@ std::ostream& operator<<(std::ostream& out, const Transaction& t) {
     out << " s: " << silkworm::to_hex(silkworm::endian::to_big_compact(t.s));
 
     if (t.to) {
-        out << " to: " << silkworm::to_hex(*t.to);
+        out << " to: " << *t.to;
     } else {
         out << " to: null";
     }
@@ -74,7 +75,7 @@ std::ostream& operator<<(std::ostream& out, const silkworm::Transaction& t) {
     }
     out << " data: " << silkworm::to_hex(t.data);
     if (t.from) {
-        out << " from: " << silkworm::to_hex(*t.from);
+        out << " from: " << *t.from;
     } else {
         out << " from: null";
     }
@@ -88,7 +89,7 @@ std::ostream& operator<<(std::ostream& out, const silkworm::Transaction& t) {
     out << " s: " << silkworm::to_hex(silkworm::endian::to_big_compact(t.s));
 
     if (t.to) {
-        out << " to: " << silkworm::to_hex(*t.to);
+        out << " to: " << *t.to;
     } else {
         out << " to: null";
     }

--- a/silkworm/silkrpc/types/transaction.hpp
+++ b/silkworm/silkrpc/types/transaction.hpp
@@ -26,6 +26,7 @@
 #include <intx/intx.hpp>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/types/block.hpp>
 #include <silkworm/core/types/transaction.hpp>
 

--- a/silkworm/sync/internals/chain_fork_view.cpp
+++ b/silkworm/sync/internals/chain_fork_view.cpp
@@ -18,6 +18,7 @@
 
 #include <silkworm/core/chain/genesis.hpp>
 #include <silkworm/core/types/block.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/infra/common/log.hpp>
 
 namespace silkworm::chainsync {

--- a/silkworm/sync/internals/header_chain.cpp
+++ b/silkworm/sync/internals/header_chain.cpp
@@ -21,6 +21,8 @@
 #include <silkworm/core/common/as_range.hpp>
 #include <silkworm/core/common/random_number.hpp>
 #include <silkworm/core/common/singleton.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
+#include <silkworm/core/types/hash.hpp>
 #include <silkworm/infra/common/environment.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/node/db/db_utils.hpp>
@@ -268,7 +270,7 @@ void HeaderChain::reduce_persisted_links_to(size_t limit) {
  * Add a ready header to the chain, if it becomes a new anchor then try to extend it if there are no other anchors
  */
 std::shared_ptr<OutboundMessage> HeaderChain::add_header(const BlockHeader& anchor, time_point_t tp) {
-    SILK_TRACE << "HeaderChain: adding header " << anchor.number << " " << anchor.hash();
+    SILK_TRACE << "HeaderChain: adding header " << anchor.number << " " << Hash{anchor.hash()};
 
     statistics_.received_items += 1;
 
@@ -679,7 +681,7 @@ HeaderChain::RequestMoreHeaders HeaderChain::process_segment(const Segment& segm
 
     if (end == 0) {
         SILK_TRACE << "HeaderChain: segment cut&paste error, duplicated segment, bn=" << segment[start]->number
-                   << ", hash=" << segment[start]->hash() << " parent-hash=" << segment[start]->parent_hash
+                   << ", hash=" << Hash{segment[start]->hash()} << " parent-hash=" << Hash{segment[start]->parent_hash}
                    << (anchor.has_value() ? ", removing corresponding anchor" : ", corresponding anchor not found");
         // If duplicate segment is extending from the anchor, the anchor needs to be deleted,
         // otherwise it will keep producing requests that will be found duplicate
@@ -731,7 +733,7 @@ HeaderChain::RequestMoreHeaders HeaderChain::process_segment(const Segment& segm
         //            << ") down=" << endNum << " (" << segment[end - 1]->hash() << ") (more=" << requestMore << ")";
     } catch (segment_cut_and_paste_error& e) {
         log::Trace() << "[WARNING] HeaderChain, segment cut&paste error, " << op << " up=" << startNum << " ("
-                     << segment[start]->hash() << ") down=" << endNum << " (" << segment[end - 1]->hash()
+                     << Hash{segment[start]->hash()} << ") down=" << endNum << " (" << Hash{segment[end - 1]->hash()}
                      << ") failed, reason: " << e.what();
         return false;
     }

--- a/silkworm/sync/internals/types.hpp
+++ b/silkworm/sync/internals/types.hpp
@@ -31,10 +31,6 @@ namespace silkworm {
 
 using BigInt = intx::uint256;  // use intx::to_string, from_string, ...
 
-// using Bytes = std::basic_string<uint8_t>; already defined elsewhere
-// using std::string to_hex(ByteView bytes);
-// using std::optional<Bytes> from_hex(std::string_view hex) noexcept;
-
 using time_point_t = std::chrono::time_point<std::chrono::system_clock>;
 using duration_t = std::chrono::system_clock::duration;
 using seconds_t = std::chrono::seconds;
@@ -45,16 +41,6 @@ inline std::ostream& operator<<(std::ostream& out, const silkworm::ByteView& byt
     out << silkworm::to_hex(bytes);
     return out;
 }
-
-inline std::ostream& operator<<(std::ostream& out, const evmc::address& addr) {
-    out << silkworm::to_hex(addr);
-    return out;
-}
-
-/*inline std::ostream& operator<<(std::ostream& out, const evmc::bytes32& b32) {
-    out << silkworm::to_hex(b32);
-    return out;
-}*/
 
 // Peers
 using PeerId = Bytes;

--- a/silkworm/sync/messages/outbound_message.hpp
+++ b/silkworm/sync/messages/outbound_message.hpp
@@ -18,6 +18,7 @@
 #include <ostream>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/sentry/eth/message_id.hpp>
 
 #include "message.hpp"

--- a/silkworm/sync/packets/hash_or_number.hpp
+++ b/silkworm/sync/packets/hash_or_number.hpp
@@ -20,6 +20,7 @@
 
 #include <silkworm/core/rlp/decode.hpp>
 #include <silkworm/core/rlp/encode.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/sync/internals/types.hpp>
 
 namespace silkworm {
@@ -78,7 +79,7 @@ namespace rlp {
 
 inline std::ostream& operator<<(std::ostream& os, const HashOrNumber& packet) {
     if (std::holds_alternative<Hash>(packet))
-        os << std::get<Hash>(packet);
+        os << std::get<Hash>(packet).to_hex();
     else
         os << std::get<BlockNum>(packet);
     return os;

--- a/silkworm/wasm/silkworm_wasm_api.hpp
+++ b/silkworm/wasm/silkworm_wasm_api.hpp
@@ -27,6 +27,7 @@
 #include <intx/intx.hpp>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/protocol/blockchain.hpp>
 #include <silkworm/core/state/in_memory_state.hpp>
 #include <silkworm/core/types/account.hpp>


### PR DESCRIPTION
* move Bytes/ByteView to a separate file
* make ByteView and util.hpp independent of evmc types:
  * move code related to evmc::address to core/execution/address.hpp
  * move code related to evmc::bytes32 to core/types/evmc_bytes32.hpp
* adjust writing evmc types to streams:
  * when evmc::address is written to streams it always produces a '0x'-prefixed hex representation
  * when evmc::bytes32 is written to streams, call to_hex() explicitly to control if it needs to be '0x'-prefixed or not depending on the context

