### PR TITLE
Implement transient storage (EIP-1153)

### DIFF
--- a/silkworm/core/execution/evm.cpp
+++ b/silkworm/core/execution/evm.cpp
@@ -304,7 +304,7 @@ evmc_result EVM::execute_with_baseline_interpreter(evmc_revision rev, const evmc
 
     EvmHost host{*this};
     gsl::owner<evmone::ExecutionState*> state{acquire_state()};
-    state->reset(msg, rev, host.get_interface(), host.to_context(), code);
+    state->reset(msg, rev, host.get_interface(), host.to_context(), code, {});
 
     const auto vm{static_cast<evmone::VM*>(evm1_)};
     evmc_result res{evmone::baseline::execute(*vm, msg.gas, *state, *analysis)};

--- a/silkworm/core/execution/evm.cpp
+++ b/silkworm/core/execution/evm.cpp
@@ -520,4 +520,12 @@ void EvmHost::emit_log(const evmc::address& address, const uint8_t* data, size_t
     evm_.state().add_log(log);
 }
 
+evmc::bytes32 EvmHost::get_transient_storage(const evmc::address& addr, const evmc::bytes32& key) const noexcept {
+    return evm_.state().get_transient_storage(addr, key);
+}
+
+void EvmHost::set_transient_storage(const evmc::address& addr, const evmc::bytes32& key, const evmc::bytes32& value) noexcept {
+    evm_.state().set_transient_storage(addr, key, value);
+}
+
 }  // namespace silkworm

--- a/silkworm/core/execution/evm.hpp
+++ b/silkworm/core/execution/evm.hpp
@@ -157,6 +157,10 @@ class EvmHost : public evmc::Host {
     void emit_log(const evmc::address& address, const uint8_t* data, size_t data_size, const evmc::bytes32 topics[],
                   size_t num_topics) noexcept override;
 
+    [[nodiscard]] evmc::bytes32 get_transient_storage(const evmc::address& addr, const evmc::bytes32& key) const noexcept override;
+
+    void set_transient_storage(const evmc::address& addr, const evmc::bytes32& key, const evmc::bytes32& value) noexcept override;
+
   private:
     EVM& evm_;
 };

--- a/silkworm/core/state/delta.cpp
+++ b/silkworm/core/state/delta.cpp
@@ -70,4 +70,12 @@ AccountAccessDelta::AccountAccessDelta(const evmc::address& address) noexcept : 
 
 void AccountAccessDelta::revert(IntraBlockState& state) noexcept { state.accessed_addresses_.erase(address_); }
 
+TransientStorageChangeDelta::TransientStorageChangeDelta(const evmc::address& address, const evmc::bytes32& key,
+                                                         const evmc::bytes32& previous) noexcept
+    : address_{address}, key_{key}, previous_{previous} {}
+
+void TransientStorageChangeDelta::revert(IntraBlockState& state) noexcept {
+    state.transient_storage_[address_][key_] = previous_;
+}
+
 }  // namespace silkworm::state

--- a/silkworm/core/state/delta.hpp
+++ b/silkworm/core/state/delta.hpp
@@ -157,5 +157,19 @@ namespace state {
         evmc::address address_;
     };
 
+    /// Transient storage add/modify/delete delta.
+    class TransientStorageChangeDelta : public Delta {
+      public:
+        TransientStorageChangeDelta(const evmc::address& address, const evmc::bytes32& key,
+                                    const evmc::bytes32& previous) noexcept;
+
+        void revert(IntraBlockState& state) noexcept override;
+
+      private:
+        evmc::address address_;
+        evmc::bytes32 key_;
+        evmc::bytes32 previous_;
+    };
+
 }  // namespace state
 }  // namespace silkworm

--- a/silkworm/core/state/intra_block_state.cpp
+++ b/silkworm/core/state/intra_block_state.cpp
@@ -301,6 +301,17 @@ void IntraBlockState::set_storage(const evmc::address& address, const evmc::byte
     journal_.emplace_back(new state::StorageChangeDelta{address, key, prev});
 }
 
+evmc::bytes32 IntraBlockState::get_transient_storage(const evmc::address& addr, const evmc::bytes32& key) {
+    return transient_storage_[addr][key];
+}
+
+void IntraBlockState::set_transient_storage(const evmc::address& addr, const evmc::bytes32& key, const evmc::bytes32& value) {
+    auto& v = transient_storage_[addr][key];
+    const auto prev = v;
+    v = value;
+    journal_.emplace_back(std::make_unique<state::TransientStorageChangeDelta>(addr, key, prev));
+}
+
 void IntraBlockState::write_to_db(uint64_t block_number) {
     db_.begin_block(block_number);
 
@@ -371,6 +382,8 @@ void IntraBlockState::clear_journal_and_substate() {
     // EIP-2929
     accessed_addresses_.clear();
     accessed_storage_keys_.clear();
+
+    transient_storage_.clear();
 }
 
 void IntraBlockState::add_log(const Log& log) noexcept { logs_.push_back(log); }

--- a/silkworm/core/state/intra_block_state.hpp
+++ b/silkworm/core/state/intra_block_state.hpp
@@ -112,6 +112,10 @@ class IntraBlockState {
 
     const FlatHashSet<evmc::address>& touched() const noexcept { return touched_; }
 
+    evmc::bytes32 get_transient_storage(const evmc::address& address, const evmc::bytes32& bytes32);
+
+    void set_transient_storage(const evmc::address& addr, const evmc::bytes32& key, const evmc::bytes32& value);
+
   private:
     friend class state::CreateDelta;
     friend class state::UpdateDelta;
@@ -123,6 +127,7 @@ class IntraBlockState {
     friend class state::StorageCreateDelta;
     friend class state::StorageAccessDelta;
     friend class state::AccountAccessDelta;
+    friend class state::TransientStorageChangeDelta;
 
     evmc::bytes32 get_storage(const evmc::address& address, const evmc::bytes32& key, bool original) const noexcept;
 
@@ -148,6 +153,8 @@ class IntraBlockState {
     // EIP-2929 substate
     FlatHashSet<evmc::address> accessed_addresses_;
     FlatHashMap<evmc::address, FlatHashSet<evmc::bytes32>> accessed_storage_keys_;
+
+    FlatHashMap<evmc::address, FlatHashMap<evmc::bytes32, evmc::bytes32>> transient_storage_;
 };
 
 }  // namespace silkworm


### PR DESCRIPTION
This implements the EIP-1153: "Transient storage opcodes"
https://eips.ethereum.org/EIPS/eip-1153.

- The `IntraBlockState` is extended with transient storage
  map account => (map key => value).
- The state journal is able to track transient storage changes with
  new class `TransientStorageChangeDelta`.
- evmone/EVMC are upgraded.

This has been tested with EIP-4788 disabled on:
- https://github.com/ethereum/tests/tree/develop/EIPTests/BlockchainTests/bcEIP1153-transientStorage
- https://github.com/ethereum/tests/tree/develop/EIPTests/BlockchainTests/StateTests/stEIP1153-transientStorage