### PR TITLE
sentry: refactor string to Bytes conversions

### DIFF
--- a/cmd/dev/check_log_indices.cpp
+++ b/cmd/dev/check_log_indices.cpp
@@ -26,7 +26,7 @@
 #include <roaring/roaring.hh>
 
 #include <silkworm/buildinfo.h>
-#include <silkworm/core/common/cast.hpp>
+#include <silkworm/core/common/bytes_to_string.hpp>
 #include <silkworm/core/execution/address.hpp>
 #include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/infra/common/directories.hpp>

--- a/cmd/dev/toolbox.cpp
+++ b/cmd/dev/toolbox.cpp
@@ -31,7 +31,7 @@
 #include <silkworm/core/chain/genesis.hpp>
 #include <silkworm/core/common/as_range.hpp>
 #include <silkworm/core/common/assert.hpp>
-#include <silkworm/core/common/cast.hpp>
+#include <silkworm/core/common/bytes_to_string.hpp>
 #include <silkworm/core/common/endian.hpp>
 #include <silkworm/core/execution/address.hpp>
 #include <silkworm/core/trie/hash_builder.hpp>

--- a/cmd/state-transition/state_transition.hpp
+++ b/cmd/state-transition/state_transition.hpp
@@ -21,7 +21,7 @@
 #include <nlohmann/json.hpp>
 
 #include "cmd/state-transition/expected_state.hpp"
-#include "silkworm/core/common/cast.hpp"
+#include "silkworm/core/common/bytes_to_string.hpp"
 #include "silkworm/core/execution/execution.hpp"
 #include "silkworm/core/protocol/rule_set.hpp"
 #include "silkworm/core/rlp/encode_vector.hpp"

--- a/silkworm/core/chain/genesis.cpp
+++ b/silkworm/core/chain/genesis.cpp
@@ -21,7 +21,7 @@
 
 #include <silkworm/core/chain/config.hpp>
 #include <silkworm/core/common/assert.hpp>
-#include <silkworm/core/common/cast.hpp>
+#include <silkworm/core/common/bytes_to_string.hpp>
 #include <silkworm/core/protocol/param.hpp>
 
 extern const char* genesis_mainnet_data();

--- a/silkworm/core/common/bytes_to_string.hpp
+++ b/silkworm/core/common/bytes_to_string.hpp
@@ -33,6 +33,11 @@ inline const uint8_t* byte_ptr_cast(const char* ptr) { return reinterpret_cast<c
 
 inline ByteView string_view_to_byte_view(std::string_view v) { return {byte_ptr_cast(v.data()), v.length()}; }
 
+template <std::size_t Size>
+ByteView array_to_byte_view(const std::array<unsigned char, Size>& array) {
+    return ByteView{reinterpret_cast<const uint8_t*>(array.data()), Size};
+}
+
 inline std::string_view byte_view_to_string_view(ByteView v) { return {byte_ptr_cast(v.data()), v.length()}; }
 
 }  // namespace silkworm

--- a/silkworm/core/protocol/clique_rule_set_test.cpp
+++ b/silkworm/core/protocol/clique_rule_set_test.cpp
@@ -18,7 +18,7 @@
 
 #include <catch2/catch.hpp>
 
-#include <silkworm/core/common/cast.hpp>
+#include <silkworm/core/common/bytes_to_string.hpp>
 #include <silkworm/core/state/in_memory_state.hpp>
 
 namespace silkworm::protocol {

--- a/silkworm/core/trie/prefix_set_test.cpp
+++ b/silkworm/core/trie/prefix_set_test.cpp
@@ -18,7 +18,7 @@
 
 #include <catch2/catch.hpp>
 
-#include <silkworm/core/common/cast.hpp>
+#include <silkworm/core/common/bytes_to_string.hpp>
 #include <silkworm/core/common/util.hpp>
 
 namespace silkworm::trie {

--- a/silkworm/core/types/block_test.cpp
+++ b/silkworm/core/types/block_test.cpp
@@ -18,7 +18,7 @@
 
 #include <catch2/catch.hpp>
 
-#include <silkworm/core/common/cast.hpp>
+#include <silkworm/core/common/bytes_to_string.hpp>
 
 namespace silkworm {
 

--- a/silkworm/node/db/access_layer_test.cpp
+++ b/silkworm/node/db/access_layer_test.cpp
@@ -21,7 +21,7 @@
 #include <catch2/catch.hpp>
 
 #include <silkworm/core/chain/genesis.hpp>
-#include <silkworm/core/common/cast.hpp>
+#include <silkworm/core/common/bytes_to_string.hpp>
 #include <silkworm/core/common/test_util.hpp>
 #include <silkworm/core/execution/execution.hpp>
 #include <silkworm/core/protocol/param.hpp>

--- a/silkworm/node/db/bitmap.cpp
+++ b/silkworm/node/db/bitmap.cpp
@@ -18,7 +18,7 @@
 
 #include <stdexcept>
 
-#include <silkworm/core/common/cast.hpp>
+#include <silkworm/core/common/bytes_to_string.hpp>
 #include <silkworm/infra/common/binary_search.hpp>
 #include <silkworm/infra/common/ensure.hpp>
 #include <silkworm/infra/concurrency/signal_handler.hpp>

--- a/silkworm/node/db/mdbx_test.cpp
+++ b/silkworm/node/db/mdbx_test.cpp
@@ -20,7 +20,7 @@
 
 #include <catch2/catch.hpp>
 
-#include <silkworm/core/common/cast.hpp>
+#include <silkworm/core/common/bytes_to_string.hpp>
 #include <silkworm/node/test/context.hpp>
 
 static const std::map<std::string, std::string> kGeneticCode{

--- a/silkworm/node/etl/file_provider.cpp
+++ b/silkworm/node/etl/file_provider.cpp
@@ -18,7 +18,7 @@
 
 #include <filesystem>
 
-#include <silkworm/core/common/cast.hpp>
+#include <silkworm/core/common/bytes_to_string.hpp>
 
 namespace silkworm::etl {
 

--- a/silkworm/node/stagedsync/execution_engine_test.cpp
+++ b/silkworm/node/stagedsync/execution_engine_test.cpp
@@ -21,7 +21,7 @@
 #include <boost/asio/io_context.hpp>
 #include <catch2/catch.hpp>
 
-#include <silkworm/core/common/cast.hpp>
+#include <silkworm/core/common/bytes_to_string.hpp>
 #include <silkworm/core/types/block.hpp>
 #include <silkworm/infra/common/environment.hpp>
 #include <silkworm/infra/test_util/log.hpp>

--- a/silkworm/node/stagedsync/forks/fork_test.cpp
+++ b/silkworm/node/stagedsync/forks/fork_test.cpp
@@ -21,7 +21,7 @@
 #include <boost/asio/io_context.hpp>
 #include <catch2/catch.hpp>
 
-#include <silkworm/core/common/cast.hpp>
+#include <silkworm/core/common/bytes_to_string.hpp>
 #include <silkworm/infra/common/environment.hpp>
 #include <silkworm/infra/test_util/log.hpp>
 #include <silkworm/node/common/preverified_hashes.hpp>

--- a/silkworm/node/stagedsync/forks/main_chain_test.cpp
+++ b/silkworm/node/stagedsync/forks/main_chain_test.cpp
@@ -21,7 +21,7 @@
 #include <boost/asio/io_context.hpp>
 #include <catch2/catch.hpp>
 
-#include <silkworm/core/common/cast.hpp>
+#include <silkworm/core/common/bytes_to_string.hpp>
 #include <silkworm/core/types/block.hpp>
 #include <silkworm/infra/common/environment.hpp>
 #include <silkworm/infra/test_util/log.hpp>

--- a/silkworm/node/stagedsync/stages/stage_bodies_test.cpp
+++ b/silkworm/node/stagedsync/stages/stage_bodies_test.cpp
@@ -20,7 +20,7 @@
 
 #include <catch2/catch.hpp>
 
-#include <silkworm/core/common/cast.hpp>
+#include <silkworm/core/common/bytes_to_string.hpp>
 #include <silkworm/core/types/block.hpp>
 #include <silkworm/node/db/genesis.hpp>
 #include <silkworm/node/db/stages.hpp>

--- a/silkworm/node/stagedsync/stages/stage_finish.cpp
+++ b/silkworm/node/stagedsync/stages/stage_finish.cpp
@@ -18,7 +18,7 @@
 
 #include <magic_enum.hpp>
 
-#include <silkworm/core/common/cast.hpp>
+#include <silkworm/core/common/bytes_to_string.hpp>
 #include <silkworm/node/db/access_layer.hpp>
 
 namespace silkworm::stagedsync {

--- a/silkworm/node/stagedsync/stages/stage_hashstate.cpp
+++ b/silkworm/node/stagedsync/stages/stage_hashstate.cpp
@@ -20,7 +20,7 @@
 
 #include <magic_enum.hpp>
 
-#include <silkworm/core/common/cast.hpp>
+#include <silkworm/core/common/bytes_to_string.hpp>
 #include <silkworm/core/common/endian.hpp>
 #include <silkworm/core/execution/address.hpp>
 #include <silkworm/core/types/evmc_bytes32.hpp>

--- a/silkworm/node/stagedsync/stages/stage_headers_test.cpp
+++ b/silkworm/node/stagedsync/stages/stage_headers_test.cpp
@@ -19,7 +19,7 @@
 #include <catch2/catch.hpp>
 
 #include <silkworm/core/chain/genesis.hpp>
-#include <silkworm/core/common/cast.hpp>
+#include <silkworm/core/common/bytes_to_string.hpp>
 #include <silkworm/node/db/genesis.hpp>
 #include <silkworm/node/test/context.hpp>
 

--- a/silkworm/node/stagedsync/stages/stage_history_index.cpp
+++ b/silkworm/node/stagedsync/stages/stage_history_index.cpp
@@ -18,7 +18,7 @@
 
 #include <magic_enum.hpp>
 
-#include <silkworm/core/common/cast.hpp>
+#include <silkworm/core/common/bytes_to_string.hpp>
 #include <silkworm/core/common/endian.hpp>
 
 namespace silkworm::stagedsync {

--- a/silkworm/sentry/common/ecc_public_key.hpp
+++ b/silkworm/sentry/common/ecc_public_key.hpp
@@ -22,6 +22,7 @@
 
 #include <silkworm/core/common/base.hpp>
 #include <silkworm/core/common/bytes.hpp>
+#include <silkworm/core/common/bytes_to_string.hpp>
 
 namespace silkworm::sentry {
 
@@ -57,8 +58,7 @@ namespace std {
 template <>
 struct hash<silkworm::sentry::EccPublicKey> {
     size_t operator()(const silkworm::sentry::EccPublicKey& public_key) const noexcept {
-        silkworm::ByteView data = public_key.data();
-        std::string_view data_str{reinterpret_cast<const char*>(data.data()), data.size()};
+        auto data_str = silkworm::byte_view_to_string_view(public_key.data());
         return std::hash<std::string_view>{}(data_str);
     }
 };

--- a/silkworm/sentry/discovery/common/node_address.cpp
+++ b/silkworm/sentry/discovery/common/node_address.cpp
@@ -18,6 +18,7 @@
 
 #include <cstring>
 
+#include <silkworm/core/common/bytes_to_string.hpp>
 #include <silkworm/core/rlp/decode_vector.hpp>
 #include <silkworm/core/rlp/encode_vector.hpp>
 
@@ -26,11 +27,11 @@ namespace silkworm::sentry::discovery {
 Bytes ip_address_to_bytes(const boost::asio::ip::address& ip) {
     if (ip.is_v4()) {
         auto ip_bytes = ip.to_v4().to_bytes();
-        return Bytes{reinterpret_cast<uint8_t*>(ip_bytes.data()), ip_bytes.size()};
+        return Bytes{array_to_byte_view(ip_bytes)};
     }
     if (ip.is_v6()) {
         auto ip_bytes = ip.to_v6().to_bytes();
-        return Bytes{reinterpret_cast<uint8_t*>(ip_bytes.data()), ip_bytes.size()};
+        return Bytes{array_to_byte_view(ip_bytes)};
     }
     return {};
 }

--- a/silkworm/sentry/discovery/disc_v4/common/node_distance.cpp
+++ b/silkworm/sentry/discovery/disc_v4/common/node_distance.cpp
@@ -18,6 +18,7 @@
 
 #include <bit>
 
+#include <silkworm/core/common/bytes_to_string.hpp>
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/sentry/common/crypto/xor.hpp>
 
@@ -27,8 +28,8 @@ size_t node_distance(const EccPublicKey& id1, const EccPublicKey& id2) {
     auto id1_hash = keccak256(id1.serialized());
     auto id2_hash = keccak256(id2.serialized());
 
-    Bytes diff{reinterpret_cast<uint8_t*>(id1_hash.str), sizeof(id1_hash.str)};
-    ByteView id2_hash_bytes{reinterpret_cast<uint8_t*>(id2_hash.str), sizeof(id2_hash.str)};
+    Bytes diff{ByteView{id1_hash.bytes}};
+    ByteView id2_hash_bytes{id2_hash.bytes};
 
     crypto::xor_bytes(diff, id2_hash_bytes);
 

--- a/silkworm/sentry/grpc/interfaces/message.cpp
+++ b/silkworm/sentry/grpc/interfaces/message.cpp
@@ -19,6 +19,7 @@
 #include <cassert>
 #include <optional>
 
+#include <silkworm/core/common/bytes_to_string.hpp>
 #include <silkworm/sentry/eth/message_id.hpp>
 #include <silkworm/sentry/eth/status_message.hpp>
 
@@ -115,14 +116,10 @@ proto::MessageId proto_message_id_from_message_id(uint8_t message_id) {
     return proto_message_id_from_eth_id(eth::eth_message_id_from_common_id(message_id));
 }
 
-static Bytes bytes_from_string(const std::string& s) {
-    return Bytes{reinterpret_cast<const uint8_t*>(s.data()), s.size()};
-}
-
 sentry::Message message_from_outbound_data(const proto::OutboundMessageData& message_data) {
     return {
         message_id_from_proto_message_id(message_data.id()),
-        bytes_from_string(message_data.data()),
+        Bytes{string_view_to_byte_view(message_data.data())},
     };
 }
 
@@ -136,7 +133,7 @@ proto::OutboundMessageData outbound_data_from_message(const sentry::Message& mes
 sentry::Message message_from_inbound_message(const ::sentry::InboundMessage& message_data) {
     return {
         message_id_from_proto_message_id(message_data.id()),
-        bytes_from_string(message_data.data()),
+        Bytes{string_view_to_byte_view(message_data.data())},
     };
 }
 

--- a/silkworm/sentry/rlpx/auth/hello_message.hpp
+++ b/silkworm/sentry/rlpx/auth/hello_message.hpp
@@ -23,6 +23,7 @@
 
 #include <silkworm/core/common/base.hpp>
 #include <silkworm/core/common/bytes.hpp>
+#include <silkworm/core/common/bytes_to_string.hpp>
 #include <silkworm/sentry/common/ecc_public_key.hpp>
 #include <silkworm/sentry/common/message.hpp>
 
@@ -36,14 +37,14 @@ class HelloMessage {
         Capability(
             std::string_view name,
             uint8_t version1)
-            : name_bytes(reinterpret_cast<const uint8_t*>(name.data()), name.size()),
+            : name_bytes(string_view_to_byte_view(name)),
               version(version1) {}
 
         explicit Capability(const std::pair<std::string, uint8_t>& info)
             : Capability(info.first, info.second) {}
 
         [[nodiscard]] std::string_view name() const {
-            return {reinterpret_cast<const char*>(name_bytes.data()), name_bytes.size()};
+            return byte_view_to_string_view(name_bytes);
         }
 
         [[nodiscard]] std::string to_string() const;
@@ -59,13 +60,13 @@ class HelloMessage {
         std::vector<Capability> capabilities,
         uint16_t listen_port,
         const EccPublicKey& node_id)
-        : client_id_bytes_(reinterpret_cast<const uint8_t*>(client_id.data()), client_id.size()),
+        : client_id_bytes_(string_view_to_byte_view(client_id)),
           capabilities_(std::move(capabilities)),
           listen_port_(listen_port),
           node_id_bytes_(node_id.serialized()) {}
 
     [[nodiscard]] std::string_view client_id() const {
-        return {reinterpret_cast<const char*>(client_id_bytes_.data()), client_id_bytes_.size()};
+        return byte_view_to_string_view(client_id_bytes_);
     }
 
     [[nodiscard]] const std::vector<Capability>& capabilities() const { return capabilities_; }

--- a/silkworm/sync/internals/body_sequence_test.cpp
+++ b/silkworm/sync/internals/body_sequence_test.cpp
@@ -21,7 +21,7 @@
 #include <catch2/catch.hpp>
 
 #include <silkworm/core/chain/genesis.hpp>
-#include <silkworm/core/common/cast.hpp>
+#include <silkworm/core/common/bytes_to_string.hpp>
 #include <silkworm/infra/test_util/log.hpp>
 #include <silkworm/node/db/genesis.hpp>
 #include <silkworm/node/test/context.hpp>

--- a/silkworm/sync/internals/chain_elements_test.cpp
+++ b/silkworm/sync/internals/chain_elements_test.cpp
@@ -21,7 +21,7 @@
 #include <catch2/catch.hpp>
 #include <evmc/evmc.hpp>
 
-#include <silkworm/core/common/cast.hpp>
+#include <silkworm/core/common/bytes_to_string.hpp>
 
 namespace silkworm {
 

--- a/silkworm/sync/internals/header_chain_plus_exec_test.cpp
+++ b/silkworm/sync/internals/header_chain_plus_exec_test.cpp
@@ -20,7 +20,7 @@
 #include <catch2/catch.hpp>
 
 #include <silkworm/core/common/as_range.hpp>
-#include <silkworm/core/common/cast.hpp>
+#include <silkworm/core/common/bytes_to_string.hpp>
 #include <silkworm/core/protocol/rule_set.hpp>
 #include <silkworm/core/types/block.hpp>
 #include <silkworm/infra/common/environment.hpp>

--- a/silkworm/sync/internals/header_chain_test.cpp
+++ b/silkworm/sync/internals/header_chain_test.cpp
@@ -20,7 +20,7 @@
 
 #include <catch2/catch.hpp>
 
-#include <silkworm/core/common/cast.hpp>
+#include <silkworm/core/common/bytes_to_string.hpp>
 #include <silkworm/infra/test_util/log.hpp>
 
 namespace silkworm {

--- a/silkworm/sync/internals/priority_queue_test.cpp
+++ b/silkworm/sync/internals/priority_queue_test.cpp
@@ -18,7 +18,7 @@
 
 #include <catch2/catch.hpp>
 
-#include <silkworm/core/common/cast.hpp>
+#include <silkworm/core/common/bytes_to_string.hpp>
 
 #include "header_chain.hpp"
 

--- a/silkworm/sync/internals/types.hpp
+++ b/silkworm/sync/internals/types.hpp
@@ -19,7 +19,7 @@
 #include <chrono>
 
 #include <silkworm/core/common/assert.hpp>
-#include <silkworm/core/common/cast.hpp>
+#include <silkworm/core/common/bytes_to_string.hpp>
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/core/rlp/decode.hpp>
 #include <silkworm/core/rlp/encode.hpp>


### PR DESCRIPTION
Group `char*` to ByteView conversions.