### PR TITLE
node: insert call traces in state buffer

### DIFF
--- a/silkworm/core/state/in_memory_state.cpp
+++ b/silkworm/core/state/in_memory_state.cpp
@@ -138,6 +138,8 @@ void InMemoryState::decanonize_block(uint64_t block_number) { (void)canonical_ha
 
 void InMemoryState::insert_receipts(uint64_t, const std::vector<Receipt>&) {}
 
+void InMemoryState::insert_call_traces(BlockNum /*block_number*/, const CallTraces& /*traces*/) {}
+
 void InMemoryState::begin_block(uint64_t block_number) {
     block_number_ = block_number;
     account_changes_.erase(block_number);

--- a/silkworm/core/state/in_memory_state.hpp
+++ b/silkworm/core/state/in_memory_state.hpp
@@ -68,6 +68,8 @@ class InMemoryState : public State {
 
     void insert_receipts(uint64_t block_number, const std::vector<Receipt>& receipts) override;
 
+    void insert_call_traces(BlockNum block_number, const CallTraces& traces) override;
+
     void begin_block(uint64_t block_number) override;
 
     void update_account(const evmc::address& address, std::optional<Account> initial,

--- a/silkworm/core/state/state.hpp
+++ b/silkworm/core/state/state.hpp
@@ -18,6 +18,7 @@
 
 #include <silkworm/core/state/block_state.hpp>
 #include <silkworm/core/types/account.hpp>
+#include <silkworm/core/types/call_traces.hpp>
 #include <silkworm/core/types/receipt.hpp>
 
 namespace silkworm {
@@ -60,6 +61,8 @@ class State : public BlockState {
     virtual void decanonize_block(uint64_t block_number) = 0;
 
     virtual void insert_receipts(uint64_t block_number, const std::vector<Receipt>& receipts) = 0;
+
+    virtual void insert_call_traces(BlockNum block_number, const CallTraces& traces) = 0;
 
     /** @name State changes
      *  Change sets are backward changes of the state, i.e. account/storage values <em>at the beginning of a block</em>.

--- a/silkworm/core/types/call_traces.hpp
+++ b/silkworm/core/types/call_traces.hpp
@@ -16,14 +16,15 @@
 
 #pragma once
 
-#include <absl/container/btree_set.h>
+#include <set>
+
 #include <evmc/evmc.h>
 
 namespace silkworm {
 
 struct CallTraces {
-    absl::btree_set<evmc::address> senders;
-    absl::btree_set<evmc::address> recipients;
+    std::set<evmc::address> senders;
+    std::set<evmc::address> recipients;
 };
 
 }  // namespace silkworm

--- a/silkworm/node/db/buffer.hpp
+++ b/silkworm/node/db/buffer.hpp
@@ -79,6 +79,8 @@ class Buffer : public State {
 
     void insert_receipts(uint64_t block_number, const std::vector<Receipt>& receipts) override;
 
+    void insert_call_traces(BlockNum block_number, const CallTraces& traces) override;
+
     /** @name State changes
      *  Change sets are backward changes of the state, i.e. account/storage values <em>at the beginning of a block</em>.
      */
@@ -120,10 +122,12 @@ class Buffer : public State {
 
     //! \brief Persists *all* accrued contents into db
     //! \remarks write_history_to_db is implicitly called
-    void write_to_db();
+    //! @param write_change_sets flag indicating if state changes should be written or not (default: true)
+    void write_to_db(bool write_change_sets = true);
 
-    //! \brief Persists *history* accrued contents into db
-    void write_history_to_db();
+    //! \brief Persist *history* accrued contents into db
+    //! @param write_change_sets flag indicating if state changes should be written or not (default: true)
+    void write_history_to_db(bool write_change_sets = true);
 
   private:
     //! \brief Persists *state* accrued contents into db
@@ -153,10 +157,11 @@ class Buffer : public State {
 
     // History and changesets
 
-    absl::btree_map<uint64_t, AccountChanges> block_account_changes_;  // per block
-    absl::btree_map<uint64_t, StorageChanges> block_storage_changes_;  // per block
+    absl::btree_map<BlockNum, AccountChanges> block_account_changes_;  // per block
+    absl::btree_map<BlockNum, StorageChanges> block_storage_changes_;  // per block
     absl::btree_map<Bytes, Bytes> receipts_;
     absl::btree_map<Bytes, Bytes> logs_;
+    absl::btree_map<BlockNum, absl::btree_set<Bytes>> call_traces_;
 
     mutable size_t batch_state_size_{0};    // Accounts in memory data for state
     mutable size_t batch_history_size_{0};  // Accounts in memory data for history

--- a/silkworm/node/db/buffer.hpp
+++ b/silkworm/node/db/buffer.hpp
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include <absl/container/btree_map.h>
+#include <absl/container/btree_set.h>
 #include <absl/container/flat_hash_map.h>
 #include <absl/container/flat_hash_set.h>
 

--- a/silkworm/silkrpc/core/local_state.hpp
+++ b/silkworm/silkrpc/core/local_state.hpp
@@ -66,6 +66,8 @@ class LocalState : public silkworm::State {
 
     void insert_receipts(BlockNum /*block_number*/, const std::vector<silkworm::Receipt>& /*receipts*/) override {}
 
+    void insert_call_traces(BlockNum /*block_number*/, const CallTraces& /*traces*/) override {}
+
     void begin_block(BlockNum /*block_number*/) override {}
 
     void update_account(

--- a/silkworm/silkrpc/core/override_state.hpp
+++ b/silkworm/silkrpc/core/override_state.hpp
@@ -71,6 +71,10 @@ class OverrideState : public silkworm::State {
         return inner_state_.insert_receipts(block_number, receipts);
     }
 
+    void insert_call_traces(BlockNum block_number, const CallTraces& traces) override {
+        return inner_state_.insert_call_traces(block_number, traces);
+    }
+
     void begin_block(BlockNum block_number) override {
         return inner_state_.begin_block(block_number);
     }

--- a/silkworm/silkrpc/core/remote_state.hpp
+++ b/silkworm/silkrpc/core/remote_state.hpp
@@ -100,6 +100,8 @@ class RemoteState : public silkworm::State {
 
     void insert_receipts(BlockNum /*block_number*/, const std::vector<silkworm::Receipt>& /*receipts*/) override {}
 
+    void insert_call_traces(BlockNum /*block_number*/, const CallTraces& /*traces*/) override {}
+
     void begin_block(BlockNum /*block_number*/) override {}
 
     void update_account(


### PR DESCRIPTION
core: do not use Abseil containers in call traces