### PR TITLE
snapshot: increase index bucket size

### DIFF
--- a/silkworm/node/snapshot/index.hpp
+++ b/silkworm/node/snapshot/index.hpp
@@ -28,7 +28,7 @@ namespace silkworm::snapshot {
 class Index {
   public:
     static constexpr uint64_t kPageSize{4096};
-    static constexpr std::size_t kBucketSize{2'000};
+    static constexpr std::size_t kBucketSize{2'048};
 
     explicit Index(SnapshotPath segment_path, std::optional<MemoryMappedRegion> segment_region = {})
         : segment_path_(std::move(segment_path)), segment_region_{std::move(segment_region)} {}


### PR DESCRIPTION
Bucket size in snapshot indexes needs to be slightly larger than 2000 bytes.
Setting this size to 2000 bytes is not a bug but may cause a performance penalty