### PR TITLE
Add test and fix for rare case of destruct followed by create

### DIFF
--- a/silkworm/core/state/intra_block_state.cpp
+++ b/silkworm/core/state/intra_block_state.cpp
@@ -56,6 +56,10 @@ state::Object& IntraBlockState::get_or_create_object(const evmc::address& addres
     } else if (obj->current == std::nullopt) {
         journal_.emplace_back(new state::UpdateDelta{address, *obj});
         obj->current = Account{};
+
+        if (obj->initial) {
+            obj->current->incarnation = obj->initial->incarnation;
+        }
     }
 
     return *obj;


### PR DESCRIPTION
We came across a bug that you probably did not see but could happen to you too if you're unlucky.

We run a version of your repo, but we reuse the IntraBlockState for several blocks to reduce DB access, and at a certain block we came across a validation error. There is a test case in to reproduce the errors and as you will see it is quite unlikely to happen, but if unlucky it definitely could with your code as well.

There is a case where when creating a contract, if the address selfdestructed before, the incarnation is not updated properly, which leads to the storage of the destructed contract to remain accessible by the new one.

I believe the fix for that is proper, but I am open to make it better :-)