### PR TITLE
sentry: disc v4 ping back

### DIFF
--- a/silkworm/sentry/discovery/disc_v4/ping/message_handler.hpp
+++ b/silkworm/sentry/discovery/disc_v4/ping/message_handler.hpp
@@ -30,7 +30,7 @@ namespace silkworm::sentry::discovery::disc_v4::ping {
 
 struct MessageHandler {
     virtual ~MessageHandler() = default;
-    virtual Task<void> on_ping(PingMessage message, boost::asio::ip::udp::endpoint sender_endpoint, Bytes ping_packet_hash) = 0;
+    virtual Task<void> on_ping(PingMessage message, EccPublicKey sender_public_key, boost::asio::ip::udp::endpoint sender_endpoint, Bytes ping_packet_hash) = 0;
     virtual Task<void> on_pong(PongMessage message, EccPublicKey sender_public_key) = 0;
 };
 

--- a/silkworm/sentry/discovery/disc_v4/ping/ping_handler.cpp
+++ b/silkworm/sentry/discovery/disc_v4/ping/ping_handler.cpp
@@ -21,19 +21,23 @@
 
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/sentry/discovery/disc_v4/common/message_expiration.hpp>
+#include <silkworm/sentry/discovery/disc_v4/common/node_distance.hpp>
 
 #include "pong_message.hpp"
 
 namespace silkworm::sentry::discovery::disc_v4::ping {
 
-Task<void> PingHandler::handle(
+Task<bool> PingHandler::handle(
     PingMessage message,
+    EccPublicKey sender_public_key,
     boost::asio::ip::udp::endpoint sender_endpoint,
     Bytes ping_packet_hash,
+    EccPublicKey local_node_id,
     uint64_t local_enr_seq_num,
-    MessageSender& sender) {
+    MessageSender& sender,
+    node_db::NodeDb& db) {
     if (is_expired_message_expiration(message.expiration)) {
-        co_return;
+        co_return false;
     }
 
     auto& recipient = sender_endpoint;
@@ -52,7 +56,22 @@ Task<void> PingHandler::handle(
         log::Warning("disc_v4") << "PingHandler::handle failed to reply"
                                 << " to " << recipient
                                 << " due to exception: " << ex.what();
+        co_return false;
     }
+
+    // save a ping sender node as if it was discovered by find_neighbors()
+    auto sender_node_address = message.sender_node_address();
+    bool is_inserted = co_await db.upsert_node_address(
+        sender_public_key,
+        node_db::NodeAddress{
+            sender_node_address.endpoint.address(),
+            sender_node_address.endpoint.port(),
+            sender_node_address.port_rlpx,
+        });
+    if (is_inserted) {
+        co_await db.update_distance(sender_public_key, node_distance(sender_public_key, local_node_id));
+    }
+    co_return is_inserted;
 }
 
 }  // namespace silkworm::sentry::discovery::disc_v4::ping

--- a/silkworm/sentry/discovery/disc_v4/ping/ping_handler.hpp
+++ b/silkworm/sentry/discovery/disc_v4/ping/ping_handler.hpp
@@ -21,6 +21,8 @@
 #include <boost/asio/ip/udp.hpp>
 
 #include <silkworm/core/common/bytes.hpp>
+#include <silkworm/sentry/common/ecc_public_key.hpp>
+#include <silkworm/sentry/discovery/node_db/node_db.hpp>
 
 #include "message_sender.hpp"
 #include "ping_message.hpp"
@@ -28,12 +30,15 @@
 namespace silkworm::sentry::discovery::disc_v4::ping {
 
 struct PingHandler {
-    static Task<void> handle(
+    static Task<bool> handle(
         PingMessage message,
+        EccPublicKey sender_public_key,
         boost::asio::ip::udp::endpoint sender_endpoint,
         Bytes ping_packet_hash,
+        EccPublicKey local_node_id,
         uint64_t local_enr_seq_num,
-        MessageSender& sender);
+        MessageSender& sender,
+        node_db::NodeDb& db);
 };
 
 }  // namespace silkworm::sentry::discovery::disc_v4::ping

--- a/silkworm/sentry/discovery/disc_v4/ping/ping_message.hpp
+++ b/silkworm/sentry/discovery/disc_v4/ping/ping_message.hpp
@@ -23,6 +23,7 @@
 #include <boost/asio/ip/udp.hpp>
 
 #include <silkworm/core/common/bytes.hpp>
+#include <silkworm/sentry/discovery/common/node_address.hpp>
 
 namespace silkworm::sentry::discovery::disc_v4::ping {
 
@@ -35,6 +36,8 @@ struct PingMessage {
 
     [[nodiscard]] Bytes rlp_encode() const;
     [[nodiscard]] static PingMessage rlp_decode(ByteView data);
+
+    [[nodiscard]] NodeAddress sender_node_address() const { return {sender_endpoint, sender_port_rlpx}; };
 
     static const uint8_t kId;
 };

--- a/silkworm/sentry/discovery/disc_v4/server.cpp
+++ b/silkworm/sentry/discovery/disc_v4/server.cpp
@@ -20,11 +20,11 @@
 #include <optional>
 #include <stdexcept>
 
+#include <boost/asio/any_io_executor.hpp>
 #include <boost/asio/buffer.hpp>
 #include <boost/asio/ip/address.hpp>
 #include <boost/asio/ip/address_v4.hpp>
 #include <boost/asio/ip/udp.hpp>
-#include <boost/asio/this_coro.hpp>
 
 #include <silkworm/core/common/bytes.hpp>
 #include <silkworm/infra/common/decoding_exception.hpp>
@@ -41,20 +41,21 @@ using namespace boost::asio;
 
 class ServerImpl {
   public:
-    explicit ServerImpl(uint16_t port, std::function<EccKeyPair()> node_key, MessageHandler& handler)
+    explicit ServerImpl(
+        const any_io_executor& executor,
+        uint16_t port,
+        std::function<EccKeyPair()> node_key,
+        MessageHandler& handler)
         : ip_(ip::address{ip::address_v4::any()}),
           port_(port),
+          socket_(make_socket(executor, listen_endpoint())),
           node_key_(std::move(node_key)),
           handler_(handler) {}
 
     ServerImpl(const ServerImpl&) = delete;
     ServerImpl& operator=(const ServerImpl&) = delete;
 
-    Task<void> run() {
-        auto executor = co_await this_coro::executor;
-
-        auto endpoint = listen_endpoint();
-
+    static ip::udp::socket make_socket(const any_io_executor& executor, const ip::udp::endpoint& endpoint) {
         ip::udp::socket socket{executor, endpoint.protocol()};
         socket.set_option(ip::udp::socket::reuse_address(true));
 
@@ -66,15 +67,21 @@ class ServerImpl {
         socket.set_option(detail::socket_option::boolean<SOL_SOCKET, SO_REUSEPORT>(true));
 #endif
 
-        socket.bind(endpoint);
+        return socket;
+    }
 
+    void setup() {
+        auto endpoint = listen_endpoint();
+        socket_.bind(endpoint);
         log::Info("sentry") << "disc_v4::Server is listening at " << endpoint;
+    }
 
+    Task<void> run() {
         Bytes packet_data_buffer(1280, 0);
 
-        while (socket.is_open()) {
+        while (socket_.is_open()) {
             ip::udp::endpoint sender_endpoint;
-            size_t received_count = co_await socket.async_receive_from(buffer(packet_data_buffer), sender_endpoint, use_awaitable);
+            size_t received_count = co_await socket_.async_receive_from(buffer(packet_data_buffer), sender_endpoint, use_awaitable);
             ByteView packet_data{packet_data_buffer.data(), received_count};
 
             std::optional<MessageEnvelope> envelope;
@@ -95,6 +102,7 @@ class ServerImpl {
                     case PacketType::kPing:
                         co_await handler_.on_ping(
                             ping::PingMessage::rlp_decode(data),
+                            std::move(envelope->public_key),
                             std::move(sender_endpoint),
                             std::move(envelope->packet_hash));
                         break;
@@ -153,7 +161,7 @@ class ServerImpl {
 
     Task<void> send_message(Message message, ip::udp::endpoint recipient) {
         auto packet_data = MessageCodec::encode(
-            std::move(message),
+            message,
             node_key_().private_key());
         co_await send_packet(std::move(packet_data), recipient);
     }
@@ -162,25 +170,29 @@ class ServerImpl {
         using namespace std::chrono_literals;
         using namespace concurrency::awaitable_wait_for_one;
 
-        auto executor = co_await this_coro::executor;
-        ip::udp::socket socket{executor, recipient.protocol()};
-        socket.set_option(ip::udp::socket::reuse_address(true));
-        socket.bind(listen_endpoint());
-        co_await socket.async_connect(recipient, use_awaitable);
-        co_await (socket.async_send(buffer(data), use_awaitable) || concurrency::timeout(1s));
+        co_await (socket_.async_send_to(buffer(data), recipient, use_awaitable) || concurrency::timeout(1s));
     }
 
     boost::asio::ip::address ip_;
     uint16_t port_;
+    ip::udp::socket socket_;
     std::function<EccKeyPair()> node_key_;
     MessageHandler& handler_;
 };
 
-Server::Server(uint16_t port, std::function<EccKeyPair()> node_key, MessageHandler& handler)
-    : p_impl_(std::make_unique<ServerImpl>(port, std::move(node_key), handler)) {}
+Server::Server(
+    const any_io_executor& executor,
+    uint16_t port,
+    std::function<EccKeyPair()> node_key,
+    MessageHandler& handler)
+    : p_impl_(std::make_unique<ServerImpl>(executor, port, std::move(node_key), handler)) {}
 
 Server::~Server() {
     log::Trace("sentry") << "silkworm::sentry::discovery::disc_v4::Server::~Server";
+}
+
+void Server::setup() {
+    p_impl_->setup();
 }
 
 Task<void> Server::run() {

--- a/silkworm/sentry/discovery/disc_v4/server.hpp
+++ b/silkworm/sentry/discovery/disc_v4/server.hpp
@@ -21,6 +21,8 @@
 
 #include <silkworm/infra/concurrency/task.hpp>
 
+#include <boost/asio/any_io_executor.hpp>
+
 #include <silkworm/sentry/common/ecc_key_pair.hpp>
 
 #include "message_handler.hpp"
@@ -32,12 +34,17 @@ class ServerImpl;
 
 class Server : public MessageSender {
   public:
-    Server(uint16_t port, std::function<EccKeyPair()> node_key, MessageHandler& handler);
+    Server(
+        const boost::asio::any_io_executor& executor,
+        uint16_t port,
+        std::function<EccKeyPair()> node_key,
+        MessageHandler& handler);
     ~Server() override;
 
     Server(const Server&) = delete;
     Server& operator=(const Server&) = delete;
 
+    void setup();
     Task<void> run();
 
     Task<void> send_ping(ping::PingMessage message, boost::asio::ip::udp::endpoint recipient) override;

--- a/silkworm/sentry/discovery/node_db/node_db.hpp
+++ b/silkworm/sentry/discovery/node_db/node_db.hpp
@@ -40,7 +40,7 @@ struct NodeAddress {
 struct NodeDb {
     virtual ~NodeDb() = default;
 
-    virtual Task<void> upsert_node_address(NodeId id, NodeAddress address) = 0;
+    virtual Task<bool> upsert_node_address(NodeId id, NodeAddress address) = 0;
     virtual Task<std::optional<NodeAddress>> find_node_address_v4(NodeId id) = 0;
     virtual Task<std::optional<NodeAddress>> find_node_address_v6(NodeId id) = 0;
 

--- a/silkworm/sentry/discovery/node_db/node_db_sqlite_test.cpp
+++ b/silkworm/sentry/discovery/node_db/node_db_sqlite_test.cpp
@@ -67,13 +67,15 @@ TEST_CASE("NodeDbSqlite") {
     }
 
     SECTION("update_address") {
-        runner.run(db.upsert_node_address(test_id, test_address));
+        bool is_inserted = runner.run(db.upsert_node_address(test_id, test_address));
+        CHECK(is_inserted);
         NodeAddress test_address2{
             ip::make_address("10.0.1.17"),
             30306,
             30305,
         };
-        runner.run(db.upsert_node_address(test_id, test_address2));
+        is_inserted = runner.run(db.upsert_node_address(test_id, test_address2));
+        CHECK_FALSE(is_inserted);
         auto address = runner.run(db.find_node_address_v4(test_id));
         REQUIRE(address.has_value());
         CHECK(*address == test_address2);

--- a/silkworm/sentry/discovery/node_db/serial_node_db.cpp
+++ b/silkworm/sentry/discovery/node_db/serial_node_db.cpp
@@ -24,7 +24,7 @@ namespace silkworm::sentry::discovery::node_db {
 
 using namespace boost::asio;
 
-Task<void> SerialNodeDb::upsert_node_address(NodeId id, NodeAddress address) {
+Task<bool> SerialNodeDb::upsert_node_address(NodeId id, NodeAddress address) {
     return concurrency::co_spawn_sw(strand_, db_.upsert_node_address(std::move(id), std::move(address)), use_awaitable);
 }
 

--- a/silkworm/sentry/discovery/node_db/serial_node_db.hpp
+++ b/silkworm/sentry/discovery/node_db/serial_node_db.hpp
@@ -32,7 +32,7 @@ class SerialNodeDb : public NodeDb {
           strand_(std::move(executor)) {}
     ~SerialNodeDb() override = default;
 
-    Task<void> upsert_node_address(NodeId id, NodeAddress address) override;
+    Task<bool> upsert_node_address(NodeId id, NodeAddress address) override;
     Task<std::optional<NodeAddress>> find_node_address_v4(NodeId id) override;
     Task<std::optional<NodeAddress>> find_node_address_v6(NodeId id) override;
 


### PR DESCRIPTION
Add a new node to the ping check queue and ping immediately.
This is needed for erigon's [ensureBond()](https://github.com/ledgerwatch/erigon/blob/d62ef03cad02754795199c5e00d01fb53eeecaeb/p2p/discover/v4_udp.go#L600) to work,
otherwise ENRRequest and FindNode requests from new nodes are ignored
(even if they ping us first).
See erigon's v4_udp.go handlePing "Ping back":
https://github.com/ledgerwatch/erigon/blob/d62ef03cad02754795199c5e00d01fb53eeecaeb/p2p/discover/v4_udp.go#L701

bug fix:
Sending multiple UDP messages didn't work,
because bind() fails with "address is busy".
We have to use the same port on both client and server sockets,
so instead let's reuse the socket.