### PR TITLE
third_party: fix MDBX issues in UBSAN build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,7 +205,7 @@ jobs:
 
   linux-clang-address-sanitizer:
     environment:
-      BUILD_CMAKE_ARGS: -DSILKWORM_SANITIZE=address,undefined
+      BUILD_CMAKE_ARGS: -DSILKWORM_SANITIZE=address,undefined -DENABLE_UBSAN=1
       ASAN_OPTIONS: alloc_dealloc_mismatch=0 # https://github.com/llvm/llvm-project/issues/59432
       UBSAN_OPTIONS: print_stacktrace=1
     machine:

--- a/silkworm/node/stagedsync/stages/stage_history_index_test.cpp
+++ b/silkworm/node/stagedsync/stages/stage_history_index_test.cpp
@@ -33,16 +33,11 @@ using namespace evmc::literals;
 namespace silkworm {
 
 TEST_CASE("Stage History Index") {
-    // Temporarily override std::cout and std::cerr with null stream to avoid terminal output
-    test_util::StreamSwap cout_swap{std::cout, test_util::null_stream()};
-    test_util::StreamSwap cerr_swap{std::cerr, test_util::null_stream()};
+    test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
 
     test::Context context;
     db::RWTxn& txn{context.rw_txn()};
     txn.disable_commit();
-    log::Settings log_settings;
-    log_settings.log_std_out = true;
-    log::init(log_settings);
 
     SECTION("Check bitmaps values") {
         // ---------------------------------------

--- a/silkworm/node/stagedsync/stages/stage_tx_lookup_test.cpp
+++ b/silkworm/node/stagedsync/stages/stage_tx_lookup_test.cpp
@@ -35,9 +35,6 @@ TEST_CASE("Stage Transaction Lookups") {
     test::Context context;
     db::RWTxn& txn{context.rw_txn()};
     txn.disable_commit();
-    log::Settings log_settings;
-    log_settings.log_std_out = true;
-    log::init(log_settings);
 
     db::PooledCursor canonicals(txn, db::table::kCanonicalHashes);
     db::PooledCursor bodies_table(txn, db::table::kBlockBodies);

--- a/third_party/libmdbx/CMakeLists.txt
+++ b/third_party/libmdbx/CMakeLists.txt
@@ -15,6 +15,10 @@
 ]]
 
 set(MDBX_ENABLE_TESTS OFF)
+# MDBX requires ENABLE_UBSAN in UBSAN build to avoid issues
+if(SILKWORM_SANITIZE)
+    set(ENABLE_UBSAN ON)
+endif()
 add_subdirectory(libmdbx)
 target_include_directories(mdbx-static INTERFACE "libmdbx")
 target_compile_definitions(mdbx-static PUBLIC CONSTEXPR_ASSERT=assert)

--- a/third_party/libmdbx/CMakeLists.txt
+++ b/third_party/libmdbx/CMakeLists.txt
@@ -17,7 +17,7 @@
 set(MDBX_ENABLE_TESTS OFF)
 # MDBX requires ENABLE_UBSAN in UBSAN build to avoid issues
 if(SILKWORM_SANITIZE)
-    set(ENABLE_UBSAN ON)
+  set(ENABLE_UBSAN ON)
 endif()
 add_subdirectory(libmdbx)
 target_include_directories(mdbx-static INTERFACE "libmdbx")


### PR DESCRIPTION
node: avoid spurious output during unit test execution