### PR TITLE
third_party: restore libmdbx version to 1cac65

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,7 +205,7 @@ jobs:
 
   linux-clang-address-sanitizer:
     environment:
-      BUILD_CMAKE_ARGS: -DSILKWORM_SANITIZE=address,undefined -DENABLE_UBSAN=1
+      BUILD_CMAKE_ARGS: -DSILKWORM_SANITIZE=address,undefined
       ASAN_OPTIONS: alloc_dealloc_mismatch=0 # https://github.com/llvm/llvm-project/issues/59432
       UBSAN_OPTIONS: print_stacktrace=1
     machine:

--- a/third_party/libmdbx/CMakeLists.txt
+++ b/third_party/libmdbx/CMakeLists.txt
@@ -15,10 +15,6 @@
 ]]
 
 set(MDBX_ENABLE_TESTS OFF)
-# MDBX requires ENABLE_UBSAN in UBSAN build to avoid issues
-if(SILKWORM_SANITIZE)
-  set(ENABLE_UBSAN ON)
-endif()
 add_subdirectory(libmdbx)
 target_include_directories(mdbx-static INTERFACE "libmdbx")
 target_compile_definitions(mdbx-static PUBLIC CONSTEXPR_ASSERT=assert)


### PR DESCRIPTION
Downgrade MDBX version to [1cac65](https://github.com/erigontech/libmdbx/tree/1cac65363763e7523ed3b52eed8f2c617cead973) compatible with Erigon2.

This reverts #1560 and MDBX-related changes introduced in #1563