### PR TITLE
Fix gcc 11 compilation

### DIFF
--- a/silkworm/core/chain/config.cpp
+++ b/silkworm/core/chain/config.cpp
@@ -261,7 +261,7 @@ std::map<std::string, uint64_t> get_known_chains_map() noexcept {
     return ret;
 }
 
-constinit const ChainConfig kMainnetConfig{
+SILKWORM_CONSTINIT const ChainConfig kMainnetConfig{
     .chain_id = 1,
     .homestead_block = 1'150'000,
     .dao_block = 1'920'000,
@@ -281,7 +281,7 @@ constinit const ChainConfig kMainnetConfig{
     .rule_set_config = protocol::EthashConfig{},
 };
 
-constinit const ChainConfig kGoerliConfig{
+SILKWORM_CONSTINIT const ChainConfig kGoerliConfig{
     .chain_id = 5,
     .homestead_block = 0,
     .tangerine_whistle_block = 0,
@@ -297,7 +297,7 @@ constinit const ChainConfig kGoerliConfig{
     .rule_set_config = protocol::CliqueConfig{},
 };
 
-constinit const ChainConfig kSepoliaConfig{
+SILKWORM_CONSTINIT const ChainConfig kSepoliaConfig{
     .chain_id = 11155111,
     .homestead_block = 0,
     .tangerine_whistle_block = 0,

--- a/silkworm/core/chain/config.hpp
+++ b/silkworm/core/chain/config.hpp
@@ -26,6 +26,7 @@
 #include <intx/intx.hpp>
 #include <nlohmann/json.hpp>
 
+#include <silkworm/core/common/base.hpp>
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/core/protocol/bor_config.hpp>
 
@@ -127,13 +128,13 @@ struct ChainConfig {
 std::ostream& operator<<(std::ostream& out, const ChainConfig& obj);
 
 inline constexpr evmc::bytes32 kMainnetGenesisHash{0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3_bytes32};
-constinit extern const ChainConfig kMainnetConfig;
+SILKWORM_CONSTINIT extern const ChainConfig kMainnetConfig;
 
 inline constexpr evmc::bytes32 kGoerliGenesisHash{0xbf7e331f7f7c1dd2e05159666b3bf8bc7a8a3a9eb1d518969eab529dd9b88c1a_bytes32};
-constinit extern const ChainConfig kGoerliConfig;
+SILKWORM_CONSTINIT extern const ChainConfig kGoerliConfig;
 
 inline constexpr evmc::bytes32 kSepoliaGenesisHash{0x25a5cc106eea7138acab33231d7160d69cb777ee0c2c553fcddf5138993e6dd9_bytes32};
-constinit extern const ChainConfig kSepoliaConfig;
+SILKWORM_CONSTINIT extern const ChainConfig kSepoliaConfig;
 
 inline constexpr evmc::bytes32 kPolygonGenesisHash{0xa9c28ce2141b56c474f1dc504bee9b01eb1bd7d1a507580d5519d4437a97de1b_bytes32};
 extern const ChainConfig kPolygonConfig;

--- a/silkworm/core/common/base.hpp
+++ b/silkworm/core/common/base.hpp
@@ -26,6 +26,12 @@
 #include <evmc/evmc.hpp>
 #include <intx/intx.hpp>
 
+#if defined(_MSC_VER)
+#define SILKWORM_CONSTINIT
+#else
+#define SILKWORM_CONSTINIT constinit
+#endif
+
 #if defined(__wasm__)
 #define SILKWORM_THREAD_LOCAL static
 #else

--- a/silkworm/core/common/test_util.cpp
+++ b/silkworm/core/common/test_util.cpp
@@ -21,11 +21,11 @@
 
 namespace silkworm::test {
 
-constinit const ChainConfig kFrontierConfig{
+const ChainConfig kFrontierConfig{
     .chain_id = 1,
 };
 
-constinit const ChainConfig kLondonConfig{
+const ChainConfig kLondonConfig{
     .chain_id = 1,
     .homestead_block = 0,
     .tangerine_whistle_block = 0,
@@ -38,7 +38,7 @@ constinit const ChainConfig kLondonConfig{
     .london_block = 0,
 };
 
-constinit const ChainConfig kShanghaiConfig{
+const ChainConfig kShanghaiConfig{
     .chain_id = 1,
     .homestead_block = 0,
     .tangerine_whistle_block = 0,

--- a/silkworm/core/common/test_util.hpp
+++ b/silkworm/core/common/test_util.hpp
@@ -24,13 +24,13 @@
 namespace silkworm::test {
 
 //! Always Frontier rules.
-constinit extern const ChainConfig kFrontierConfig;
+extern const ChainConfig kFrontierConfig;
 
 //! Enables London from genesis.
-constinit extern const ChainConfig kLondonConfig;
+extern const ChainConfig kLondonConfig;
 
 //! Enables Shanghai from genesis.
-constinit extern const ChainConfig kShanghaiConfig;
+extern const ChainConfig kShanghaiConfig;
 
 static const std::map<std::string, ChainConfig> kNetworkConfig{
     {"Frontier", test::kFrontierConfig},


### PR DESCRIPTION
For some reason gcc 11 doesn't like `constinit` in test_util, introduced by PR #1571 