### PR TITLE
cmake: fix guess_conan_profile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,13 +32,14 @@ if(NOT SILKWORM_HAS_PARENT)
         CACHE FILEPATH "" FORCE
     )
   endif()
-
-  include(cmake/conan.cmake)
-
 endif()
 
 project(silkworm)
 set(PROJECT_VERSION 0.1.0-dev)
+
+if(NOT SILKWORM_HAS_PARENT)
+  include(cmake/conan.cmake)
+endif()
 
 include(CableBuildInfo)
 


### PR DESCRIPTION
Prior to this change `CMAKE_OSX_ARCHITECTURES` was [empty](https://stackoverflow.com/questions/51024294/cmake-system-processor-seems-to-be-empty-whats-the-best-strategy-for-os-agnost) in `guess_conan_profile` on my machine (Apple M2, macOS Sonoma 14.0, cmake 3.27.6) and so conan profile was determined incorrectly.