### PR TITLE
core: revert fix for create-after-destruct

### DIFF
--- a/silkworm/core/execution/evm_test.cpp
+++ b/silkworm/core/execution/evm_test.cpp
@@ -80,27 +80,34 @@ TEST_CASE("Destruct and create") {
         state.clear_journal_and_substate();
         state.create_contract(to);
         state.set_storage(to, {}, evmc::bytes32{1});
-        CHECK(state.get_current_storage(to, {}) == evmc::bytes32{1});
+        REQUIRE(state.get_current_storage(to, {}) == evmc::bytes32{1});
         state.finalize_transaction(EVMC_SHANGHAI);
         state.write_to_db(1);
+        REQUIRE(db.state_root_hash() == 0xc2d663880f143c9bdd3c7bd2c282dc8d24e2bccf81bc779c058d18685a4a7386_bytes32);
     }
 
-    // Then destruct it in another "transaction" and "block"
-    IntraBlockState state{db};
-    state.clear_journal_and_substate();
-    CHECK(state.record_suicide(to));
-    state.destruct_suicides();
-    state.finalize_transaction(EVMC_SHANGHAI);
+    {
+        IntraBlockState state{db};
 
-    // Add some balance to it
-    state.clear_journal_and_substate();
-    state.add_to_balance(to, 1);
-    state.finalize_transaction(EVMC_SHANGHAI);
+        // Then destruct it in another "transaction" and "block"
+        state.clear_journal_and_substate();
+        CHECK(state.record_suicide(to));
+        state.destruct_suicides();
+        state.finalize_transaction(EVMC_SHANGHAI);
 
-    // Recreate it
-    state.clear_journal_and_substate();
-    state.create_contract(to);
-    CHECK(state.get_current_storage(to, {}) == evmc::bytes32{});
+        // Add some balance to it
+        state.clear_journal_and_substate();
+        state.add_to_balance(to, 1);
+        state.finalize_transaction(EVMC_SHANGHAI);
+
+        // Recreate it
+        state.clear_journal_and_substate();
+        state.create_contract(to);
+        // The following check does not pass, so skipping for now (fix in PR #1553 breaks state root trie)
+        // CHECK(state.get_current_storage(to, {}) == evmc::bytes32{});
+        state.write_to_db(2);
+        CHECK(db.state_root_hash() == 0x73ea1e235dec8e2f576eadd4173322b5ff7a442a1d09ff8da4941d18e03ff071_bytes32);
+    }
 }
 
 TEST_CASE("Smart contract with storage") {

--- a/silkworm/core/state/intra_block_state.cpp
+++ b/silkworm/core/state/intra_block_state.cpp
@@ -18,8 +18,6 @@
 
 #include <bit>
 
-#include <ethash/keccak.hpp>
-
 #include <silkworm/core/common/util.hpp>
 
 namespace silkworm {
@@ -56,10 +54,6 @@ state::Object& IntraBlockState::get_or_create_object(const evmc::address& addres
     } else if (obj->current == std::nullopt) {
         journal_.emplace_back(new state::UpdateDelta{address, *obj});
         obj->current = Account{};
-
-        if (obj->initial) {
-            obj->current->incarnation = obj->initial->incarnation;
-        }
     }
 
     return *obj;


### PR DESCRIPTION
This reverts the change from PR #1553 because it breaks the state trie root at block [116525](https://etherscan.io/block/116525)