### PR TITLE
core: fix gcc13 compilation

### DIFF
--- a/silkworm/core/common/bytes.hpp
+++ b/silkworm/core/common/bytes.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <span>
 #include <string>
 #include <string_view>


### PR DESCRIPTION
Otherwise I'm getting
```
/home/andrew/silkworm/silkworm/core/common/bytes.hpp:26:33: error: ‘uint8_t’ was not declared in this scope
   26 | using Bytes = std::basic_string<uint8_t>;
      |                                 ^~~~~~~

```