### PR TITLE
recsplit: fix Golomb-Rice max calculation on multithreading build

### DIFF
--- a/silkworm/node/recsplit/rec_split.hpp
+++ b/silkworm/node/recsplit/rec_split.hpp
@@ -650,9 +650,13 @@ class RecSplit {
 
     static inline std::size_t skip_nodes(std::size_t m) { return (memo[m] >> 16) & 0x7FF; }
 
-    static constexpr uint64_t golomb_param(const std::size_t m, const std::array<uint32_t, kMaxBucketSize>& memo) {
-        if (m > golomb_param_max_index_) golomb_param_max_index_ = m;
+    inline uint64_t golomb_param(const std::size_t m, const std::array<uint32_t, kMaxBucketSize>& memo) const {
         return memo[m] >> 27;
+    }
+
+    inline uint64_t golomb_param_with_max_updating(const std::size_t m, const std::array<uint32_t, kMaxBucketSize>& memo) {
+        if (m > golomb_param_max_index_) golomb_param_max_index_ = m;
+        return golomb_param(m, memo);
     }
 
     // Generates the precomputed table of 32-bit values holding the Golomb-Rice code
@@ -805,7 +809,7 @@ class RecSplit {
                 }
             }
             salt -= kStartSeed[level];
-            const auto log2golomb = golomb_param(m, memo);
+            const auto log2golomb = golomb_param_with_max_updating(m, memo);
             gr_builder_.append_fixed(salt, log2golomb);
             unary.push_back(static_cast<uint32_t>(salt >> log2golomb));
         } else {
@@ -840,7 +844,7 @@ class RecSplit {
             std::copy(buffer_offsets_.data(), buffer_offsets_.data() + m, offsets.data() + start);
 
             salt -= kStartSeed[level];
-            const auto log2golomb = golomb_param(m, memo);
+            const auto log2golomb = golomb_param_with_max_updating(m, memo);
             gr_builder_.append_fixed(salt, log2golomb);
             unary.push_back(static_cast<uint32_t>(salt >> log2golomb));
 
@@ -907,7 +911,7 @@ class RecSplit {
     static const std::size_t kUpperAggregationBound;
 
     //! The max index used in Golomb parameter array
-    static inline uint16_t golomb_param_max_index_{0};
+    uint16_t golomb_param_max_index_{0};
 
     //! For each bucket size, the Golomb-Rice parameter (upper 8 bits) and the number of bits to
     //! skip in the fixed part of the tree (lower 24 bits).

--- a/silkworm/node/snapshot/index.cpp
+++ b/silkworm/node/snapshot/index.cpp
@@ -132,7 +132,7 @@ void TransactionIndex::build() {
         .base_data_id = first_tx_id,
         .double_enum_index = true,
         .etl_optimal_size = etl::kOptimalBufferSize / 2};
-    RecSplit8 tx_hash_rs{tx_hash_rs_settings, 1};
+    RecSplit8 tx_hash_rs{tx_hash_rs_settings};
 
     const SnapshotPath tx2block_idx_file = segment_path_.index_file_for_type(SnapshotType::transactions_to_block);
     SILK_TRACE << "TransactionIndex::build tx2block_idx_file path: " << tx2block_idx_file.path().string();
@@ -143,7 +143,7 @@ void TransactionIndex::build() {
         .base_data_id = first_block_num,
         .double_enum_index = false,
         .etl_optimal_size = etl::kOptimalBufferSize / 2};
-    RecSplit8 tx_hash_to_block_rs{tx_hash_to_block_rs_settings, 1};
+    RecSplit8 tx_hash_to_block_rs{tx_hash_to_block_rs_settings};
 
     huffman::Decompressor bodies_decoder{bodies_segment_path.path()};
     bodies_decoder.open();


### PR DESCRIPTION
When indexes are built using multiple threads we need a Recsplit without shared mutable members