### PR TITLE
ci: conan version 1.60 for macOS and Windows

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Install Prerequisites
       run: |
         brew install gmp
-        pip3 install --user conan==1.58.0 chardet
+        pip3 install --user conan==1.60.0 chardet
         echo "$HOME/Library/Python/$(ls $HOME/Library/Python)/bin" >> "$GITHUB_PATH"
 
     - name: Create Build Environment

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -47,7 +47,7 @@ jobs:
       id: conan
       uses: turtlebrowser/get-conan@main
       with:
-        version: 1.59.0
+        version: 1.60.0
 
     - name: Create Build Environment
       # Some projects don't allow in-source building, so create a separate build directory


### PR DESCRIPTION
This PR fixes the recent CI failures happening on master branch on [macOS](https://github.com/erigontech/silkworm/actions/runs/6610070383/job/17951288191) and [Windows](https://github.com/erigontech/silkworm/actions/runs/6610070379/job/17951288185) builds.