### PR TITLE
docs: Google's Style Guide updated to C++20

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -12,7 +12,6 @@ We follow the [C++ Core Guidelines][cpp-core-guidelines] as much as possible.
 
 We adhere to [Google's C++ Style Guide][cpp-google-style-guide] with the following differences:
 
-* C++20 rather than C++17.
 * `snake_case()` for function names.
 * .cpp & .hpp file extensions for C++; .c & .h are reserved for C.
 * `using namespace foo` is allowed inside .cpp files, but not inside headers.
@@ -21,7 +20,7 @@ We adhere to [Google's C++ Style Guide][cpp-google-style-guide] with the followi
 * Maximum line length is 120, indentation is 4 spaces. Use `make fmt` to reformat according to the code style.
 * Add Apache copyright banners. Use `make lint` to check the proper banner style.
 * Use `#pragma once` in the headers instead of the classic `#ifndef` guards.
-
+* `template <Concept T>` syntax is allowed.
 
 In addition to the [Boost libraries permitted in the style guide](https://google.github.io/styleguide/cppguide.html#Boost), we allow:
 * Algorithm


### PR DESCRIPTION
https://google.github.io/styleguide/cppguide.html has been recently [updated](https://github.com/google/styleguide/pull/795) to C++20