### PR TITLE
node: change cursor usage in trie test causing abort in debug

### DIFF
--- a/silkworm/node/stagedsync/stages/stage_interhashes/_test.cpp
+++ b/silkworm/node/stagedsync/stages/stage_interhashes/_test.cpp
@@ -353,13 +353,13 @@ static evmc::bytes32 increment_intermediate_hashes(db::ROTxn& txn, std::filesyst
     auto computed_root{trie_loader.calculate_root()};
 
     // Save collected node changes
-    db::PooledCursor target(txn, db::table::kTrieOfAccounts);
-    MDBX_put_flags_t flags{target.size() ? MDBX_put_flags_t::MDBX_UPSERT : MDBX_put_flags_t::MDBX_APPEND};
-    account_trie_node_collector.load(target, nullptr, flags);
+    db::PooledCursor account_cursor(txn, db::table::kTrieOfAccounts);
+    MDBX_put_flags_t flags{account_cursor.size() ? MDBX_put_flags_t::MDBX_UPSERT : MDBX_put_flags_t::MDBX_APPEND};
+    account_trie_node_collector.load(account_cursor, nullptr, flags);
 
-    target.bind(txn, db::table::kTrieOfStorage);
-    flags = target.empty() ? MDBX_put_flags_t::MDBX_APPEND : MDBX_put_flags_t::MDBX_UPSERT;
-    storage_trie_node_collector.load(target, nullptr, flags);
+    db::PooledCursor storage_cursor(txn, db::table::kTrieOfStorage);
+    flags = storage_cursor.empty() ? MDBX_put_flags_t::MDBX_APPEND : MDBX_put_flags_t::MDBX_UPSERT;
+    storage_trie_node_collector.load(storage_cursor, nullptr, flags);
 
     return computed_root;
 }

--- a/silkworm/node/test/context.cpp
+++ b/silkworm/node/test/context.cpp
@@ -26,12 +26,13 @@ Context::Context(bool with_create_tables, bool in_memory) {
     node_settings_.data_directory = std::make_unique<DataDirectory>(tmp_dir_.path(), /*create=*/true);
     node_settings_.chain_config = kMainnetConfig;
     node_settings_.chain_config->genesis_hash.emplace(kMainnetGenesisHash);
-    node_settings_.chaindata_env_config =
-        db::EnvConfig{.path = node_settings_.data_directory->chaindata().path().string(),
-                      .create = true,
-                      .readonly = false,
-                      .exclusive = false,
-                      .in_memory = in_memory};
+    node_settings_.chaindata_env_config = {
+        .path = node_settings_.data_directory->chaindata().path().string(),
+        .create = true,
+        .readonly = false,
+        .exclusive = false,
+        .in_memory = in_memory,
+    };
     node_settings_.prune_mode = std::make_unique<db::PruneMode>();
     env_ = db::open_env(node_settings_.chaindata_env_config);
     txn_ = std::make_unique<db::RWTxnManaged>(env_);

--- a/silkworm/node/test/context.hpp
+++ b/silkworm/node/test/context.hpp
@@ -27,7 +27,7 @@ namespace silkworm::test {
 //! \remarks Context follows the RAII idiom and cleans up its temporary directory upon destruction.
 class Context {
   public:
-    explicit Context(bool with_create_tables = true, bool inmemory = true);
+    explicit Context(bool with_create_tables = true, bool in_memory = true);
 
     // Not copyable nor movable
     Context(const Context&) = delete;


### PR DESCRIPTION
This PR fixes an abnormal termination in `node` unit tests occurring systematically in debug builds with database page size >= 16KB.

The existing unit test code reuses the same `db::PooledCursor` instance on two different tables by calling `bind` on the same `txn`. Even if this usage pattern seems legit, this is the root cause which makes the following assertion to be triggered on next database upsert done (by another cursor) on the same table:

``` assert(page_numkeys(mp) > (unsigned)(i));```

in `page_node` MDBX function. Given that the `bind`-same-cursor-on-same-txn pattern is never used except here and that a brand new `db::PooledCursor` solves the issue, investigating the problem further seems not to be worth it.

Lastly, this PR also contains cosmetic changes to slightly improve `test::Context` readability.