### PR TITLE
rpcdaemon: improve debug_traceBlockByNumber performance

### DIFF
--- a/silkworm/silkrpc/commands/debug_api.cpp
+++ b/silkworm/silkrpc/commands/debug_api.cpp
@@ -394,7 +394,7 @@ Task<void> DebugRpcApi::handle_debug_trace_transaction(const nlohmann::json& req
     SILK_DEBUG << "transaction_hash: " << silkworm::to_hex(transaction_hash) << " config: {" << config << "}";
 
     stream.open_object();
-    stream.write_field("id", request["id"]);
+    stream.write_json_field("id", request["id"]);
     stream.write_field("jsonrpc", "2.0");
 
     auto tx = co_await database_->begin();
@@ -407,11 +407,11 @@ Task<void> DebugRpcApi::handle_debug_trace_transaction(const nlohmann::json& req
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
         const Error error{100, e.what()};
-        stream.write_field("error", error);
+        stream.write_json_field("error", error);
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
         const Error error{100, "unexpected exception"};
-        stream.write_field("error", error);
+        stream.write_json_field("error", error);
     }
 
     stream.close_object();
@@ -441,7 +441,7 @@ Task<void> DebugRpcApi::handle_debug_trace_call(const nlohmann::json& request, j
     SILK_DEBUG << "call: " << call << " block_number_or_hash: " << block_number_or_hash << " config: {" << config << "}";
 
     stream.open_object();
-    stream.write_field("id", request["id"]);
+    stream.write_json_field("id", request["id"]);
     stream.write_field("jsonrpc", "2.0");
 
     auto tx = co_await database_->begin();
@@ -462,11 +462,11 @@ Task<void> DebugRpcApi::handle_debug_trace_call(const nlohmann::json& request, j
         std::ostringstream oss;
         oss << "block " << block_number_or_hash.number() << "(" << silkworm::to_hex(block_number_or_hash.hash()) << ") not found";
         const Error error{-32000, oss.str()};
-        stream.write_field("error", error);
+        stream.write_json_field("error", error);
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
         const Error error{100, "unexpected exception"};
-        stream.write_field("error", error);
+        stream.write_json_field("error", error);
     }
 
     stream.close_object();
@@ -516,7 +516,7 @@ Task<void> DebugRpcApi::handle_debug_trace_call_many(const nlohmann::json& reque
     SILK_DEBUG << "bundles: " << bundles << " simulation_context: " << simulation_context << " config: {" << config << "}";
 
     stream.open_object();
-    stream.write_field("id", request["id"]);
+    stream.write_json_field("id", request["id"]);
     stream.write_field("jsonrpc", "2.0");
 
     auto tx = co_await database_->begin();
@@ -529,7 +529,7 @@ Task<void> DebugRpcApi::handle_debug_trace_call_many(const nlohmann::json& reque
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
         const Error error{100, "unexpected exception"};
-        stream.write_field("error", error);
+        stream.write_json_field("error", error);
     }
 
     stream.close_object();
@@ -558,7 +558,7 @@ Task<void> DebugRpcApi::handle_debug_trace_block_by_number(const nlohmann::json&
     SILK_DEBUG << "block_number: " << block_number << " config: {" << config << "}";
 
     stream.open_object();
-    stream.write_field("id", request["id"]);
+    stream.write_json_field("id", request["id"]);
     stream.write_field("jsonrpc", "2.0");
 
     auto tx = co_await database_->begin();
@@ -574,15 +574,15 @@ Task<void> DebugRpcApi::handle_debug_trace_block_by_number(const nlohmann::json&
         std::ostringstream oss;
         oss << "block_number " << block_number << " not found";
         const Error error{-32000, oss.str()};
-        stream.write_field("error", error);
+        stream.write_json_field("error", error);
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
         const Error error{100, e.what()};
-        stream.write_field("error", error);
+        stream.write_json_field("error", error);
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
         const Error error{100, "unexpected exception"};
-        stream.write_field("error", error);
+        stream.write_json_field("error", error);
     }
 
     stream.close_object();
@@ -611,7 +611,7 @@ Task<void> DebugRpcApi::handle_debug_trace_block_by_hash(const nlohmann::json& r
     SILK_DEBUG << "block_hash: " << silkworm::to_hex(block_hash) << " config: {" << config << "}";
 
     stream.open_object();
-    stream.write_field("id", request["id"]);
+    stream.write_json_field("id", request["id"]);
     stream.write_field("jsonrpc", "2.0");
 
     auto tx = co_await database_->begin();
@@ -627,15 +627,15 @@ Task<void> DebugRpcApi::handle_debug_trace_block_by_hash(const nlohmann::json& r
         std::ostringstream oss;
         oss << "block_hash " << silkworm::to_hex(block_hash) << " not found";
         const Error error{-32000, oss.str()};
-        stream.write_field("error", error);
+        stream.write_json_field("error", error);
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
         const Error error{100, e.what()};
-        stream.write_field("error", error);
+        stream.write_json_field("error", error);
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
         const Error error{100, "unexpected exception"};
-        stream.write_field("error", error);
+        stream.write_json_field("error", error);
     }
 
     stream.close_object();

--- a/silkworm/silkrpc/commands/trace_api.cpp
+++ b/silkworm/silkrpc/commands/trace_api.cpp
@@ -369,7 +369,7 @@ Task<void> TraceRpcApi::handle_trace_filter(const nlohmann::json& request, json:
     SILK_TRACE << "trace_filter: " << trace_filter;
 
     stream.open_object();
-    stream.write_field("id", request["id"]);
+    stream.write_json_field("id", request["id"]);
     stream.write_field("jsonrpc", "2.0");
 
     auto tx = co_await database_->begin();
@@ -385,12 +385,12 @@ Task<void> TraceRpcApi::handle_trace_filter(const nlohmann::json& request, json:
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
 
         const Error error{100, e.what()};
-        stream.write_field("error", error);
+        stream.write_json_field("error", error);
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
 
         const Error error{100, "unexpected exception"};
-        stream.write_field("error", error);
+        stream.write_json_field("error", error);
     }
 
     stream.close_object();

--- a/silkworm/silkrpc/core/evm_debug.cpp
+++ b/silkworm/silkrpc/core/evm_debug.cpp
@@ -90,7 +90,7 @@ static std::string EMPTY_MEMORY(64, '0');
 void output_stack(std::vector<std::string>& vect, const evmone::uint256* stack, uint32_t stack_size) {
     vect.reserve(stack_size);
     for (int i = int(stack_size - 1); i >= 0; --i) {
-        vect.push_back(std::move(uint256_to_hex(stack[-i])));
+        vect.push_back(uint256_to_hex(stack[-i]));
     }
 }
 
@@ -100,7 +100,7 @@ void output_memory(std::vector<std::string>& vect, const evmone::Memory& memory)
 
     const auto data = memory.data();
     for (std::size_t start = 0; start < memory.size(); start += len) {
-        vect.push_back(std::move(silkworm::to_hex({data + start, len})));
+        vect.push_back(silkworm::to_hex({data + start, len}));
     }
 }
 

--- a/silkworm/silkrpc/core/evm_debug.hpp
+++ b/silkworm/silkrpc/core/evm_debug.hpp
@@ -25,6 +25,7 @@
 
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/thread_pool.hpp>
+#include <evmc/hex.hpp>
 #include <gsl/narrow>
 #include <nlohmann/json.hpp>
 
@@ -50,17 +51,20 @@ struct DebugConfig {
     bool disableStack{false};
 };
 
+std::string uint256_to_hex(const evmone::uint256& x);
+std::string bytes_to_hex(evmc::bytes_view bv);
+
 void from_json(const nlohmann::json& json, DebugConfig& tc);
 std::ostream& operator<<(std::ostream& out, const DebugConfig& tc);
 
 using Storage = std::map<std::string, std::string>;
 
 struct DebugLog {
-    uint32_t pc;
+    std::uint32_t pc;
     std::string op;
-    int64_t gas;
-    int64_t gas_cost;
-    int32_t depth;
+    std::int64_t gas;
+    std::int64_t gas_cost;
+    std::int32_t depth;
     bool error{false};
     std::vector<std::string> memory;
     std::vector<std::string> stack;

--- a/silkworm/silkrpc/core/evm_debug_test.cpp
+++ b/silkworm/silkrpc/core/evm_debug_test.cpp
@@ -1309,6 +1309,26 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugConfig") {
         CHECK(os.str() == "disableStorage: true disableMemory: false disableStack: true");
     }
 }
+
+TEST_CASE("uint256_to_hex", "evmone::uint256") {
+    SECTION("test 1") {
+        evmone::uint256 v{0xB0A0};
+        const std::string intx_hex{"0x" + intx::to_string(v, 16)};
+
+        std::string hex{uint256_to_hex(v)};
+
+        CHECK(intx_hex == hex);
+    }
+    SECTION("test 2") {
+        evmone::uint256 v{0xCB0A0};
+        const std::string intx_hex{"0x" + intx::to_string(v, 16)};
+
+        std::string hex{uint256_to_hex(v)};
+
+        CHECK(intx_hex == hex);
+    }
+}
+
 #endif  // SILKWORM_SANITIZE
 
 }  // namespace silkworm::rpc::debug

--- a/silkworm/silkrpc/core/evm_trace.cpp
+++ b/silkworm/silkrpc/core/evm_trace.cpp
@@ -1602,19 +1602,19 @@ Task<void> TraceCallExecutor::trace_filter(const TraceFilter& trace_filter, cons
     const auto from_block_with_hash = co_await core::read_block_by_number_or_hash(block_cache_, storage, database_reader_, trace_filter.from_block);
     if (!from_block_with_hash) {
         const Error error{-32000, "invalid parameters: fromBlock not found"};
-        stream->write_field("error", error);
+        stream->write_json_field("error", error);
         co_return;
     }
     const auto to_block_with_hash = co_await core::read_block_by_number_or_hash(block_cache_, storage, database_reader_, trace_filter.to_block);
     if (!to_block_with_hash) {
         const Error error{-32000, "invalid parameters: toBlock not found"};
-        stream->write_field("error", error);
+        stream->write_json_field("error", error);
         co_return;
     }
 
     if (from_block_with_hash->block.header.number > to_block_with_hash->block.header.number) {
         const Error error{-32000, "invalid parameters: fromBlock cannot be greater than toBlock"};
-        stream->write_field("error", error);
+        stream->write_json_field("error", error);
         co_return;
     }
 

--- a/silkworm/silkrpc/http/request_handler.cpp
+++ b/silkworm/silkrpc/http/request_handler.cpp
@@ -215,7 +215,7 @@ Task<void> RequestHandler::handle_request(uint32_t request_id, commands::RpcApiT
 Task<void> RequestHandler::handle_request(commands::RpcApiTable::HandleStream handler, const nlohmann::json& request_json) {
     try {
         SocketWriter socket_writer(socket_);
-        ChunksWriter chunks_writer(socket_writer);
+        ChunksWriter chunks_writer(socket_writer, 0x1FFF);
         json::Stream stream(chunks_writer);
 
         co_await write_headers();

--- a/silkworm/silkrpc/json/stream.hpp
+++ b/silkworm/silkrpc/json/stream.hpp
@@ -18,6 +18,7 @@
 
 #include <stack>
 #include <string>
+#include <string_view>
 
 #include <nlohmann/json.hpp>
 
@@ -43,12 +44,22 @@ class Stream {
     void close_array();
 
     void write_json(const nlohmann::json& json);
+    void write_json_field(std::string_view name, const nlohmann::json& value);
 
-    void write_field(const std::string& name);
-    void write_field(const std::string& name, const nlohmann::json& value);
+    void write_field(std::string_view name);
+    void write_entry(std::string_view value);
+    void write_field(std::string_view name, std::string_view value);
+    void write_field(std::string_view name, bool value);
+    void write_field(std::string_view name, const char* value);
+    void write_field(std::string_view name, std::int32_t value);
+    void write_field(std::string_view name, std::uint32_t value);
+    void write_field(std::string_view name, std::int64_t value);
+    void write_field(std::string_view name, std::uint64_t value);
+    void write_field(std::string_view name, std::float_t value);
+    void write_field(std::string_view name, std::double_t value);
 
   private:
-    void write_string(const std::string& str);
+    void write_string(std::string_view str);
     void ensure_separator();
 
     Writer& writer_;

--- a/silkworm/silkrpc/json/stream_test.cpp
+++ b/silkworm/silkrpc/json/stream_test.cpp
@@ -112,7 +112,7 @@ TEST_CASE("JsonStream calls") {
     }
     SECTION("simple object 1") {
         stream.open_object();
-        stream.write_field("null", JSON_NULL);
+        stream.write_json_field("null", JSON_NULL);
         stream.close_object();
         stream.close();
 
@@ -120,7 +120,7 @@ TEST_CASE("JsonStream calls") {
     }
     SECTION("simple object 2") {
         stream.open_object();
-        stream.write_field("array", EMPTY_ARRAY);
+        stream.write_json_field("array", EMPTY_ARRAY);
         stream.close_object();
         stream.close();
 
@@ -150,7 +150,7 @@ TEST_CASE("JsonStream calls") {
 
         stream.open_object();
         stream.write_field("name1", "value1");
-        stream.write_field("name2", json);
+        stream.write_json_field("name2", json);
         stream.close_object();
         stream.close();
 
@@ -163,7 +163,7 @@ TEST_CASE("JsonStream calls") {
 
         stream.open_object();
         stream.write_field("name1", "value1");
-        stream.write_field("name2", json);
+        stream.write_json_field("name2", json);
         stream.close_object();
         stream.close();
 
@@ -194,8 +194,8 @@ TEST_CASE("JsonStream calls") {
         ])"_json;
 
         stream.open_object();
-        stream.write_field("name1", json_obj);
-        stream.write_field("name2", json_array);
+        stream.write_json_field("name1", json_obj);
+        stream.write_json_field("name2", json_array);
         stream.close_object();
         stream.close();
 
@@ -211,8 +211,8 @@ TEST_CASE("JsonStream calls") {
         ])"_json;
 
         stream.open_object();
-        stream.write_field("name1", json_obj);
-        stream.write_field("name2", json_array);
+        stream.write_json_field("name1", json_obj);
+        stream.write_json_field("name2", json_array);
         stream.close_object();
         stream.close();
 

--- a/silkworm/silkrpc/types/writer.cpp
+++ b/silkworm/silkrpc/types/writer.cpp
@@ -17,6 +17,8 @@
 #include "writer.hpp"
 
 #include <algorithm>
+#include <charconv>
+#include <iostream>
 #include <utility>
 
 #include <boost/asio/detached.hpp>
@@ -30,26 +32,26 @@ const std::string kChunkSep{'\r', '\n'};                     // NOLINT(runtime/s
 const std::string kFinalChunk{'0', '\r', '\n', '\r', '\n'};  // NOLINT(runtime/string)
 
 ChunksWriter::ChunksWriter(Writer& writer, std::size_t chunck_size)
-    : writer_(writer), chunk_size_(chunck_size), available_(chunck_size), buffer_{new char[chunk_size_]} {
+    : writer_(writer), chunk_size_(chunck_size), available_(chunk_size_), buffer_{new char[chunk_size_]} {
     std::memset(buffer_.get(), 0, chunk_size_);
 }
 
-void ChunksWriter::write(const std::string& content) {
-    auto c_str = content.c_str();
+void ChunksWriter::write(std::string_view content) {
+    auto c_str = content.data();
     auto size = content.size();
 
     SILK_DEBUG << "ChunksWriter::write available_: " << available_ << " size: " << size;
 
     char* buffer_start = buffer_.get() + (chunk_size_ - available_);
     if (available_ > size) {
-        std::strncpy(buffer_start, c_str, size);
+        std::memcpy(buffer_start, c_str, size);
         available_ -= size;
         return;
     }
 
     while (size > 0) {
         const auto count = std::min(available_, size);
-        std::strncpy(buffer_start, c_str, count);
+        std::memcpy(buffer_start, c_str, count);
         size -= count;
         c_str += count;
         available_ -= count;
@@ -73,16 +75,75 @@ void ChunksWriter::flush() {
     SILK_DEBUG << "ChunksWriter::flush available_: " << available_ << " size: " << size;
 
     if (size > 0) {
-        std::stringstream stream;
-        stream << std::hex << size << "\r\n";
+        std::array<char, 19> str;
+        if (auto [ptr, ec] = std::to_chars(str.data(), str.data() + str.size(), size, 16); ec == std::errc()) {
+            writer_.write(std::string_view(str.data(), ptr));
+            writer_.write(kChunkSep);
+        } else {
+            writer_.write("Invalid value");
+        }
 
-        writer_.write(stream.str());
-        std::string str{buffer_.get(), size};
-        writer_.write(str);
+        writer_.write(std::string_view(buffer_.get(), size));
         writer_.write(kChunkSep);
     }
     available_ = chunk_size_;
-    std::memset(buffer_.get(), 0, chunk_size_);
+}
+
+JsonChunksWriter::JsonChunksWriter(Writer& writer, std::size_t chunck_size)
+    : writer_(writer), chunk_size_(chunck_size), room_left_in_chunck_(chunk_size_), written_(0) {
+    str_chunk_size_ << std::hex << chunk_size_ << kChunkSep;
+}
+
+void JsonChunksWriter::write(std::string_view content) {
+    auto size = content.size();
+
+    SILK_DEBUG << "JsonChunksWriter::write written_: " << written_ << " size: " << size;
+
+    if (!chunk_open_) {
+        writer_.write(str_chunk_size_.str());
+        chunk_open_ = true;
+    }
+
+    size_t remaining_in_view = size;
+    size_t start = 0;
+    while (start < size) {
+        const auto length = std::min(room_left_in_chunck_, remaining_in_view);
+        std::string_view sub_view(content.data() + start, length);
+        writer_.write(sub_view);
+
+        written_ += length;
+        start += length;
+        remaining_in_view -= length;
+        room_left_in_chunck_ -= length;
+
+        if ((room_left_in_chunck_ % chunk_size_) == 0) {
+            if (chunk_open_) {
+                writer_.write(kChunkSep);
+                room_left_in_chunck_ = chunk_size_;
+                chunk_open_ = false;
+            }
+            if (remaining_in_view > 0) {
+                writer_.write(str_chunk_size_.str());
+                chunk_open_ = true;
+            }
+        }
+    }
+}
+
+void JsonChunksWriter::close() {
+    if (chunk_open_) {
+        if (room_left_in_chunck_ > 0) {
+            std::unique_ptr<char[]> buffer{new char[room_left_in_chunck_]};
+            std::memset(buffer.get(), ' ', room_left_in_chunck_);
+            writer_.write(std::string_view(buffer.get(), room_left_in_chunck_));
+        }
+        writer_.write(kChunkSep);
+        chunk_open_ = false;
+        room_left_in_chunck_ = chunk_size_;
+    }
+
+    writer_.write(kFinalChunk);
+    writer_.close();
 }
 
 }  // namespace silkworm::rpc

--- a/silkworm/silkrpc/types/writer_test.cpp
+++ b/silkworm/silkrpc/types/writer_test.cpp
@@ -19,6 +19,7 @@
 #include <iostream>
 
 #include <catch2/catch.hpp>
+#include <nlohmann/json.hpp>
 
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/test_util/log.hpp>
@@ -100,6 +101,71 @@ TEST_CASE("ChunksWriter", "[silkrpc]") {
         writer.close();
 
         CHECK(s_writer.get_content() == "0\r\n\r\n");
+    }
+}
+
+TEST_CASE("JsonChunksWriter", "[silkrpc]") {
+    silkworm::test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
+
+    SECTION("write&close under chunk size") {
+        StringWriter s_writer;
+        JsonChunksWriter writer(s_writer, 16);
+
+        writer.write("1234");
+        writer.close();
+
+        CHECK(s_writer.get_content() == "10\r\n1234            \r\n0\r\n\r\n");
+    }
+    SECTION("write&close over chunk size 4") {
+        StringWriter s_writer;
+        JsonChunksWriter writer(s_writer, 4);
+
+        writer.write("1234567890");
+        writer.close();
+
+        CHECK(s_writer.get_content() == "4\r\n1234\r\n4\r\n5678\r\n4\r\n90  \r\n0\r\n\r\n");
+    }
+    SECTION("write&close over chunk size 5") {
+        StringWriter s_writer;
+        JsonChunksWriter writer(s_writer, 5);
+
+        writer.write("1234567890");
+        writer.close();
+
+        CHECK(s_writer.get_content() == "5\r\n12345\r\n5\r\n67890\r\n0\r\n\r\n");
+    }
+    SECTION("write&close over chunk size 5") {
+        StringWriter s_writer;
+        JsonChunksWriter writer(s_writer, 5);
+
+        writer.write("123456789012");
+        writer.close();
+
+        CHECK(s_writer.get_content() == "5\r\n12345\r\n5\r\n67890\r\n5\r\n12   \r\n0\r\n\r\n");
+    }
+    SECTION("close") {
+        StringWriter s_writer;
+        JsonChunksWriter writer(s_writer);
+
+        writer.close();
+
+        CHECK(s_writer.get_content() == "0\r\n\r\n");
+    }
+    SECTION("write json") {
+        StringWriter s_writer;
+        JsonChunksWriter writer(s_writer, 48);
+
+        nlohmann::json json = R"({
+            "accounts": {},
+            "next": "next",
+            "root": "root"
+        })"_json;
+
+        const auto content = json.dump(/*indent=*/-1, /*indent_char=*/' ', /*ensure_ascii=*/false, nlohmann::json::error_handler_t::replace);
+        writer.write(content);
+        writer.close();
+
+        CHECK(s_writer.get_content() == "30\r\n{\"accounts\":{},\"next\":\"next\",\"root\":\"root\"}     \r\n0\r\n\r\n");
     }
 }
 }  // namespace silkworm::rpc


### PR DESCRIPTION
This PR contains the following improvements for debug_traceBlockByNumber API:

- use less memory allocations by replacing `nlohmann::json` with custom JSON objects
- replace `intx::to_string` with custom function