### PR TITLE
core: fix ConfigMap conversion error in MSVC

### DIFF
--- a/silkworm/core/chain/config_map.hpp
+++ b/silkworm/core/chain/config_map.hpp
@@ -81,11 +81,11 @@ class ConfigMap {
         return size_ == 0;
     }
 
-    [[nodiscard]] constexpr const ValueType* begin() const noexcept {
-        return &*data_.begin();
+    [[nodiscard]] constexpr auto begin() const noexcept {
+        return data_.begin();
     }
 
-    [[nodiscard]] constexpr const ValueType* end() const noexcept {
+    [[nodiscard]] constexpr auto end() const noexcept {
         return begin() + size_;
     }
 

--- a/silkworm/core/chain/config_map.hpp
+++ b/silkworm/core/chain/config_map.hpp
@@ -82,7 +82,7 @@ class ConfigMap {
     }
 
     [[nodiscard]] constexpr const ValueType* begin() const noexcept {
-        return data_.begin();
+        return &*data_.begin();
     }
 
     [[nodiscard]] constexpr const ValueType* end() const noexcept {


### PR DESCRIPTION
This PR fixes MSVC build broken on master after PR #1612. You can check [problem and solution in isolation](https://godbolt.org/z/oda56xWrc).