### PR TITLE
capi: block execution commits after state batch has been flushed

### DIFF
--- a/silkworm/capi/silkworm.cpp
+++ b/silkworm/capi/silkworm.cpp
@@ -86,8 +86,7 @@ static log::Args log_args_for_exec_flush(const db::Buffer& state_buffer, uint64_
         "history",
         human_size(state_buffer.current_batch_history_size()),
         "block",
-        std::to_string(current_block)
-    };
+        std::to_string(current_block)};
 }
 
 static std::filesystem::path make_path(const char data_dir_path[SILKWORM_PATH_SIZE]) {

--- a/silkworm/capi/silkworm.cpp
+++ b/silkworm/capi/silkworm.cpp
@@ -50,7 +50,7 @@ static MemoryMappedRegion make_region(const SilkwormMemoryMappedFile& mmf) {
 static log::Settings kLogSettingsLikeErigon{
     .log_utc = false,       // display local time
     .log_timezone = false,  // no timezone ID
-    .log_nocolor = true,    // use colors
+    .log_nocolor = true,    // do not use colors
     .log_trim = true,       // compact rendering (i.e. no whitespaces)
 };
 

--- a/silkworm/capi/silkworm.cpp
+++ b/silkworm/capi/silkworm.cpp
@@ -381,9 +381,9 @@ int silkworm_execute_blocks(SilkwormHandle handle, MDBX_txn* mdbx_txn, uint64_t 
         AnalysisCache analysis_cache{kCacheSize};
         ObjectPool<evmone::ExecutionState> state_pool;
 
-        // Transform batch size limit into gas units (Ggas = Giga gas)
-        const size_t gas_max_batch_size{batch_size * 1_Kibi * 2};          // batch size 256MB -> 512Ggas roughly
-        const size_t gas_max_history_batch_size{batch_size * 1_Kibi * 2};  // batch size 256MB -> 512Ggas roughly
+        // Transform batch size limit into gas units (Ggas = Giga gas, Tgas = Tera gas)
+        const size_t gas_max_history_batch_size{batch_size * 1_Kibi / 2};  // 512MB -> 256Ggas roughly
+        const size_t gas_max_batch_size{gas_max_history_batch_size * 20};  // 256Ggas -> 5Tgas roughly
 
         // Preload requested blocks in batches from storage, i.e. from MDBX database or snapshots
         static constexpr size_t kMaxPrefetchedBlocks{10240};
@@ -447,21 +447,14 @@ int silkworm_execute_blocks(SilkwormHandle handle, MDBX_txn* mdbx_txn, uint64_t 
 
             prefetched_blocks.pop_front();
 
-            // Flush current state and state history if we've reached the target batch size, otherwise just state history
-            if (state_buffer.current_batch_state_size() >= batch_size) {
-                log::Info{"[4/12 Execution] Flushing state + history",  // NOLINT(*-unused-raii)
-                          log::Args{"state", human_size(state_buffer.current_batch_state_size()),
-                                    "history", human_size(state_buffer.current_batch_history_size()),
-                                    "block", std::to_string(block.header.number)}};
+            // Flush whole state buffer or just history if we've reached the target batch sizes in gas units
+            if (gas_batch_size >= gas_max_batch_size) {
+                SILK_TRACE << log::Args{"buffer", "state", "size", human_size(state_buffer.current_batch_state_size())};
                 state_buffer.write_to_db(write_change_sets);
                 gas_batch_size = 0;
                 gas_history_size = 0;
-            }
-            if (state_buffer.current_batch_history_size() >= batch_size) {
-                log::Info{"[4/12 Execution] Flushing history",  // NOLINT(*-unused-raii)
-                          log::Args{"state", human_size(state_buffer.current_batch_state_size()),
-                                    "history", human_size(state_buffer.current_batch_history_size()),
-                                    "block", std::to_string(block.header.number)}};
+            } else if (gas_history_size >= gas_max_history_batch_size) {
+                SILK_TRACE << log::Args{"buffer", "history", "size", human_size(state_buffer.current_batch_history_size())};
                 state_buffer.write_history_to_db(write_change_sets);
                 gas_history_size = 0;
             }

--- a/silkworm/capi/silkworm.cpp
+++ b/silkworm/capi/silkworm.cpp
@@ -74,8 +74,7 @@ static log::Args log_args_for_version() {
         "git_tag",
         std::string(build_info->project_version),
         "git_commit",
-        std::string(build_info->git_commit_hash),
-    };
+        std::string(build_info->git_commit_hash)};
 }
 
 //! Generate log arguments for execution flush at specified block
@@ -130,8 +129,7 @@ static log::Args log_args_for_exec_progress(ExecutionProgress& progress, uint64_
         "gasState",
         float_to_string(progress.gas_state_perc),
         "gasHistory",
-        float_to_string(progress.gas_history_perc),
-    };
+        float_to_string(progress.gas_history_perc)};
 }
 
 //! A signal handler guard using RAII pattern to acquire/release signal handling

--- a/silkworm/core/common/util.cpp
+++ b/silkworm/core/common/util.cpp
@@ -200,8 +200,8 @@ std::optional<uint64_t> parse_size(const std::string& sizestr) {
     return number;
 }
 
-std::string human_size(uint64_t bytes) {
-    static const char* suffix[]{"B", "KB", "MB", "GB", "TB"};
+std::string human_size(uint64_t bytes, const char* unit) {
+    static const char* suffix[]{"", "K", "M", "G", "T"};
     static const uint32_t items{sizeof(suffix) / sizeof(suffix[0])};
     uint32_t index{0};
     double value{static_cast<double>(bytes)};
@@ -213,7 +213,7 @@ std::string human_size(uint64_t bytes) {
     }
     static constexpr size_t kBufferSize{64};
     SILKWORM_THREAD_LOCAL char output[kBufferSize];
-    SILKWORM_ASSERT(std::snprintf(output, kBufferSize, "%.02lf %s", value, suffix[index]) > 0);
+    SILKWORM_ASSERT(std::snprintf(output, kBufferSize, "%.02lf %s%s", value, suffix[index], unit) > 0);
     return output;
 }
 

--- a/silkworm/core/common/util.hpp
+++ b/silkworm/core/common/util.hpp
@@ -86,7 +86,7 @@ std::optional<Bytes> from_hex(std::string_view hex) noexcept;
 std::optional<uint64_t> parse_size(const std::string& sizestr);
 
 // Converts a number of bytes in a human-readable format
-std::string human_size(uint64_t bytes);
+std::string human_size(uint64_t bytes, const char* unit = "B");
 
 // Compares two strings for equality with case insensitivity
 bool iequals(std::string_view a, std::string_view b);

--- a/silkworm/core/state/in_memory_state.cpp
+++ b/silkworm/core/state/in_memory_state.cpp
@@ -150,6 +150,10 @@ void InMemoryState::begin_block(BlockNum block_number) {
 
 void InMemoryState::update_account(const evmc::address& address, std::optional<Account> initial,
                                    std::optional<Account> current) {
+    // Skip update if both initial and final state are non-existent (i.e. contract creation+destruction within the same block)
+    if (!initial && !current) {
+        return;
+    }
     account_changes_[block_number_][address] = initial;
 
     if (current.has_value()) {

--- a/silkworm/core/state/intra_block_state.cpp
+++ b/silkworm/core/state/intra_block_state.cpp
@@ -341,10 +341,6 @@ void IntraBlockState::write_to_db(uint64_t block_number) {
     }
 
     for (const auto& [address, obj] : objects_) {
-        // Skip update if both initial and final state are empty (i.e. contract creation+destruction within the same block)
-        if (!obj.initial && !obj.current) {
-            continue;
-        }
         db_.update_account(address, obj.initial, obj.current);
         if (!obj.current) {
             continue;

--- a/silkworm/node/db/buffer.hpp
+++ b/silkworm/node/db/buffer.hpp
@@ -130,10 +130,10 @@ class Buffer : public State {
     //! @param write_change_sets flag indicating if state changes should be written or not (default: true)
     void write_history_to_db(bool write_change_sets = true);
 
-  private:
     //! \brief Persists *state* accrued contents into db
     void write_state_to_db();
 
+  private:
     RWTxn& txn_;
     db::DataModel access_layer_;
     uint64_t prune_history_threshold_;
@@ -148,9 +148,9 @@ class Buffer : public State {
     mutable absl::flat_hash_map<evmc::address, std::optional<Account>> accounts_;
 
     // address -> incarnation -> location -> value
-    mutable absl::flat_hash_map<evmc::address,
-                                absl::btree_map<uint64_t, absl::flat_hash_map<evmc::bytes32, evmc::bytes32>>>
-        storage_;
+    using Storage = absl::flat_hash_map<evmc::bytes32, evmc::bytes32>;
+    using StorageByIncarnation = absl::btree_map<uint64_t, Storage>;
+    mutable absl::flat_hash_map<evmc::address, StorageByIncarnation> storage_;
 
     absl::btree_map<evmc::address, uint64_t> incarnations_;
     absl::btree_map<evmc::bytes32, Bytes> hash_to_code_;

--- a/silkworm/node/db/buffer_test.cpp
+++ b/silkworm/node/db/buffer_test.cpp
@@ -109,7 +109,11 @@ TEST_CASE("Account update") {
         Buffer buffer{txn, 0};
         buffer.begin_block(1);
         buffer.update_account(address, /*initial=*/std::nullopt, current_account);
-        REQUIRE(buffer.account_changes().empty() == false);
+        REQUIRE(!buffer.account_changes().empty());
+        // Current state batch: current account address + current account encoding
+        CHECK(buffer.current_batch_state_size() == kAddressLength + current_account.encoding_length_for_storage());
+        // State history batch: current block + initial account address + initial account encoding (empty)
+        CHECK(buffer.current_batch_history_size() == sizeof(uint64_t) + kAddressLength);
         REQUIRE_NOTHROW(buffer.write_to_db());
 
         auto account_changeset{db::open_cursor(txn, table::kAccountChangeSet)};
@@ -140,7 +144,11 @@ TEST_CASE("Account update") {
         Buffer buffer{txn, 0};
         buffer.begin_block(1);
         buffer.update_account(address, /*initial=*/initial_account, current_account);
-        REQUIRE(buffer.account_changes().empty() == false);
+        REQUIRE(!buffer.account_changes().empty());
+        // Current state batch: current account address + current account encoding
+        CHECK(buffer.current_batch_state_size() == kAddressLength + current_account.encoding_length_for_storage());
+        // State history batch: current block + initial account address + initial account encoding
+        CHECK(buffer.current_batch_history_size() == sizeof(uint64_t) + kAddressLength + initial_account.encoding_length_for_storage());
         REQUIRE_NOTHROW(buffer.write_to_db());
 
         auto account_changeset{db::open_cursor(txn, table::kAccountChangeSet)};
@@ -170,7 +178,11 @@ TEST_CASE("Account update") {
         Buffer buffer{txn, 0};
         buffer.begin_block(1);
         buffer.update_account(address, /*initial=*/account, /*current=*/std::nullopt);
-        REQUIRE(buffer.account_changes().empty() == false);
+        REQUIRE(!buffer.account_changes().empty());
+        // Current state batch: initial account for delete + (initial account + incarnation) for incarnation
+        CHECK(buffer.current_batch_state_size() == kAddressLength + (kAddressLength + kIncarnationLength));
+        // State history batch: current block + initial account address + initial account encoding
+        CHECK(buffer.current_batch_history_size() == sizeof(uint64_t) + kAddressLength + account.encoding_length_for_storage());
         REQUIRE_NOTHROW(buffer.write_to_db());
 
         auto incarnations{db::open_cursor(txn, table::kIncarnationMap)};
@@ -222,6 +234,8 @@ TEST_CASE("Account update") {
         buffer.begin_block(1);
         buffer.update_account(address, /*initial=*/initial_account, current_account);
         REQUIRE(buffer.account_changes().empty());
+        CHECK(buffer.current_batch_state_size() == 0);    // No change in current state batch
+        CHECK(buffer.current_batch_history_size() == 0);  // No change in state history batch
         REQUIRE_NOTHROW(buffer.write_to_db());
 
         auto account_changeset{db::open_cursor(txn, table::kAccountChangeSet)};

--- a/silkworm/node/db/mdbx.cpp
+++ b/silkworm/node/db/mdbx.cpp
@@ -269,7 +269,9 @@ void RWTxnManaged::commit_and_stop() {
 }
 
 RWTxnUnmanaged::~RWTxnUnmanaged() {
-    abort();
+    if (handle_) {
+        abort();
+    }
 }
 
 void RWTxnUnmanaged::abort() {
@@ -310,6 +312,7 @@ void RWTxnUnmanaged::commit() {
     if (err.code() != MDBX_SUCCESS) {
         err.throw_exception();
     }
+    SILKWORM_ASSERT(!handle_);
     SILK_TRACE << "Commit latency" << detail::log_args_for_commit_latency(commit_latency);
 }
 

--- a/silkworm/node/db/mdbx.hpp
+++ b/silkworm/node/db/mdbx.hpp
@@ -319,15 +319,18 @@ class RWTxnManaged : public RWTxn {
 };
 
 //! \brief ROTxnUnmanaged wraps an *unmanaged* read-write transaction, which means the underlying transaction
-//! lifecycle is not touched by this class. This implies that this class does not commit nor abort the transaction.
+//! is not created by this class, but can be committed or aborted.
 class RWTxnUnmanaged : public RWTxn, protected ::mdbx::txn {
   public:
     explicit RWTxnUnmanaged(MDBX_txn* ptr) : RWTxn{static_cast<::mdbx::txn&>(*this)}, ::mdbx::txn{ptr} {}
-    ~RWTxnUnmanaged() override = default;
+    ~RWTxnUnmanaged() override;
 
-    void abort() override {}
-    void commit_and_renew() override {}
-    void commit_and_stop() override {}
+    void abort() override;
+    void commit_and_renew() override;
+    void commit_and_stop() override;
+
+  private:
+    void commit();
 };
 
 //! \brief This class create ROTxn(s) on demand, it is used to enforce in some method signatures the type of db access

--- a/silkworm/node/db/mdbx.hpp
+++ b/silkworm/node/db/mdbx.hpp
@@ -394,12 +394,12 @@ struct EnvConfig {
 //! \return A handle to the opened cursor
 ::mdbx::cursor_managed open_cursor(::mdbx::txn& tx, const MapConfig& config);
 
-//! \brief Computes the max size of value data to fit in a leaf data page
-//! \param [in] page_size : the actually configured MDBX's page size
+//! \brief Computes the max size of single-value data to fit into a leaf data page
+//! \param [in] page_size : the actually configured MDBX page size
 //! \param [in] key_size : the known key size to fit in bundle computed value size
 size_t max_value_size_for_leaf_page(size_t page_size, size_t key_size);
 
-//! \brief Computes the max size of value data to fit in a leaf data page
+//! \brief Computes the max size of single-value data to fit into a leaf data page
 //! \param [in] txn : the transaction used to derive pagesize from
 //! \param [in] key_size : the known key size to fit in bundle computed value size
 size_t max_value_size_for_leaf_page(const ::mdbx::txn& txn, size_t key_size);


### PR DESCRIPTION
This PR contains the following changes related to block execution API implementation:
- commit the current state when the batch size crosses over threshold
- commit the state history after each block 
- change the batch size unit from cumulated gas to bytes
- fix many batch size computations in db buffer
- avoid caching read values in db buffer
- sort storage locations to insert ordered data into db
- fix empty element in call traces
- fix unmanaged RW txn destruction

Moreover, some other things as well:
- improve logging in block execution
- add unit tests

All these changes have been made in the process of reaching full binary data compatibility between Erigon and Erigon+Silkworm, step by step, over a long sequence of comparative tests: that's why this PR required quite a long time to be finalised.