### PR TITLE
node: make stage TxLookup start from last frozen block

### DIFF
--- a/silkworm/node/db/access_layer.cpp
+++ b/silkworm/node/db/access_layer.cpp
@@ -1001,6 +1001,11 @@ BlockNum DataModel::highest_block_number() const {
     return repository_ ? repository_->max_block_available() : 0;
 }
 
+BlockNum DataModel::highest_frozen_block_number() const {
+    // Ask the snapshot repository (if any) for highest block
+    return repository_ ? repository_->max_block_available() : 0;
+}
+
 std::optional<BlockHeader> DataModel::read_header(BlockNum block_number, HashAsArray block_hash) const {
     return read_header(block_number, Hash(block_hash));
 }

--- a/silkworm/node/db/access_layer.hpp
+++ b/silkworm/node/db/access_layer.hpp
@@ -264,6 +264,9 @@ class DataModel {
     //! Get the highest block number
     [[nodiscard]] BlockNum highest_block_number() const;
 
+    //! Get the highest block number frozen into snapshots
+    [[nodiscard]] BlockNum highest_frozen_block_number() const;
+
     //! Read block header with the specified key (block number, hash)
     [[nodiscard]] std::optional<BlockHeader> read_header(BlockNum block_number, HashAsArray hash) const;
 

--- a/silkworm/node/stagedsync/stages/stage.cpp
+++ b/silkworm/node/stagedsync/stages/stage.cpp
@@ -25,9 +25,17 @@ namespace silkworm::stagedsync {
 Stage::Stage(SyncContext* sync_context, const char* stage_name, NodeSettings* node_settings)
     : sync_context_{sync_context}, stage_name_{stage_name}, node_settings_{node_settings} {}
 
-BlockNum Stage::get_progress(db::ROTxn& txn) { return db::stages::read_stage_progress(txn, stage_name_); }
+BlockNum Stage::get_progress(db::ROTxn& txn) {
+    return db::stages::read_stage_progress(txn, stage_name_);
+}
 
-BlockNum Stage::get_prune_progress(db::ROTxn& txn) { return db::stages::read_stage_prune_progress(txn, stage_name_); }
+BlockNum Stage::get_prune_progress(db::ROTxn& txn) {
+    return db::stages::read_stage_prune_progress(txn, stage_name_);
+}
+
+void Stage::set_prune_progress(db::RWTxn& txn, BlockNum progress) {
+    db::stages::write_stage_prune_progress(txn, stage_name_, progress);
+}
 
 void Stage::update_progress(db::RWTxn& txn, BlockNum progress) {
     db::stages::write_stage_progress(txn, stage_name_, progress);

--- a/silkworm/node/stagedsync/stages/stage.hpp
+++ b/silkworm/node/stagedsync/stages/stage.hpp
@@ -104,6 +104,11 @@ class Stage : public Stoppable {
     //! \brief Returns the actual prune progress recorded into db
     BlockNum get_prune_progress(db::ROTxn& txn);
 
+    //! \brief Set the prune progress into db
+    //! \param [in] txn : A R/W db transaction
+    //! \param [in] progress : Block number reached by pruning process
+    void set_prune_progress(db::RWTxn& txn, BlockNum progress);
+
     //! \brief Updates current stage progress
     void update_progress(db::RWTxn& txn, BlockNum progress);
 

--- a/silkworm/node/stagedsync/stages/stage_tx_lookup.cpp
+++ b/silkworm/node/stagedsync/stages/stage_tx_lookup.cpp
@@ -45,6 +45,16 @@ Stage::Result TxLookup::forward(db::RWTxn& txn) {
                                  " greater than Execution progress " + std::to_string(target_progress));
         }
 
+        // Snapshots already have TxLookup index, so we must start after max frozen block here
+        const auto highest_frozen_block_number{db::DataModel{txn}.highest_frozen_block_number()};
+        if (highest_frozen_block_number > previous_progress) {
+            previous_progress = highest_frozen_block_number;
+            // If pruning is enabled, make it start from max frozen block as well
+            if (node_settings_->prune_mode->tx_index().enabled()) {
+                set_prune_progress(txn, highest_frozen_block_number);
+            }
+        }
+
         reset_log_progress();
         const BlockNum segment_width{target_progress - previous_progress};
         if (segment_width > db::stages::kSmallBlockSegmentWidth) {
@@ -94,7 +104,7 @@ Stage::Result TxLookup::unwind(db::RWTxn& txn) {
     Stage::Result ret{Stage::Result::kSuccess};
 
     if (!sync_context_->unwind_point.has_value()) return ret;
-    const BlockNum to{sync_context_->unwind_point.value()};
+    BlockNum to{sync_context_->unwind_point.value()};
 
     operation_ = OperationType::Unwind;
     try {
@@ -107,6 +117,12 @@ Stage::Result TxLookup::unwind(db::RWTxn& txn) {
             // Nothing to process
             operation_ = OperationType::None;
             return ret;
+        }
+
+        // Snapshots already have TxLookup index, so we must stop before max frozen block here
+        db::DataModel access_layer{txn};
+        if (access_layer.highest_frozen_block_number() > to) {
+            to = access_layer.highest_frozen_block_number();
         }
 
         reset_log_progress();
@@ -220,7 +236,7 @@ Stage::Result TxLookup::prune(db::RWTxn& txn) {
 void TxLookup::forward_impl(db::RWTxn& txn, const BlockNum from, const BlockNum to) {
     std::unique_lock log_lck(sl_mutex_);
     operation_ = OperationType::Forward;
-    loading_ = false;
+    loading_.store(false);
     collector_ = std::make_unique<etl::Collector>(node_settings_);
     current_source_ = std::string(db::table::kBlockBodies.name);
     current_target_.clear();
@@ -231,7 +247,7 @@ void TxLookup::forward_impl(db::RWTxn& txn, const BlockNum from, const BlockNum 
     collect_transaction_hashes_from_canonical_bodies(txn, from, to, /*for_deletion=*/false);
 
     log_lck.lock();
-    loading_ = true;
+    loading_.store(true);
     current_target_ = std::string(db::table::kTxLookup.name);
     current_key_.clear();
     log_lck.unlock();
@@ -241,7 +257,7 @@ void TxLookup::forward_impl(db::RWTxn& txn, const BlockNum from, const BlockNum 
                      target->empty() ? MDBX_put_flags_t::MDBX_APPEND : MDBX_put_flags_t::MDBX_UPSERT);
 
     log_lck.lock();
-    loading_ = false;
+    loading_.store(false);
     current_source_.clear();
     current_target_.clear();
     current_key_.clear();
@@ -252,7 +268,7 @@ void TxLookup::forward_impl(db::RWTxn& txn, const BlockNum from, const BlockNum 
 void TxLookup::unwind_impl(db::RWTxn& txn, BlockNum from, BlockNum to) {
     std::unique_lock log_lck(sl_mutex_);
     operation_ = OperationType::Unwind;
-    loading_ = false;
+    loading_.store(false);
     collector_ = std::make_unique<etl::Collector>(node_settings_);
     current_source_ = std::string(db::table::kBlockBodies.name);
     current_target_.clear();
@@ -263,7 +279,7 @@ void TxLookup::unwind_impl(db::RWTxn& txn, BlockNum from, BlockNum to) {
     collect_transaction_hashes_from_canonical_bodies(txn, from, to, /*for_deletion=*/true);
 
     log_lck.lock();
-    loading_ = true;
+    loading_.store(true);
     current_target_ = std::string(db::table::kTxLookup.name);
     current_key_.clear();
     log_lck.unlock();
@@ -272,7 +288,7 @@ void TxLookup::unwind_impl(db::RWTxn& txn, BlockNum from, BlockNum to) {
     collector_->load(*target, nullptr, MDBX_put_flags_t::MDBX_UPSERT);
 
     log_lck.lock();
-    loading_ = false;
+    loading_.store(false);
     current_source_.clear();
     current_target_.clear();
     current_key_.clear();
@@ -285,7 +301,7 @@ void TxLookup::prune_impl(db::RWTxn& txn, BlockNum from, BlockNum to) {
 
     std::unique_lock log_lck(sl_mutex_);
     operation_ = OperationType::Prune;
-    loading_ = false;
+    loading_.store(false);
     collector_ = std::make_unique<etl::Collector>(node_settings_);
     current_source_ = std::string(source_config.name);
     current_target_.clear();
@@ -296,7 +312,7 @@ void TxLookup::prune_impl(db::RWTxn& txn, BlockNum from, BlockNum to) {
     collect_transaction_hashes_from_canonical_bodies(txn, from, to, /*for_deletion=*/true);
 
     log_lck.lock();
-    loading_ = true;
+    loading_.store(true);
     current_target_ = std::string(db::table::kTxLookup.name);
     current_key_.clear();
     log_lck.unlock();
@@ -305,7 +321,7 @@ void TxLookup::prune_impl(db::RWTxn& txn, BlockNum from, BlockNum to) {
     collector_->load(*target, nullptr, MDBX_put_flags_t::MDBX_UPSERT);
 
     log_lck.lock();
-    loading_ = false;
+    loading_.store(false);
     current_source_.clear();
     current_target_.clear();
     current_key_.clear();

--- a/silkworm/node/stagedsync/stages/stage_tx_lookup.cpp
+++ b/silkworm/node/stagedsync/stages/stage_tx_lookup.cpp
@@ -120,9 +120,9 @@ Stage::Result TxLookup::unwind(db::RWTxn& txn) {
         }
 
         // Snapshots already have TxLookup index, so we must stop before max frozen block here
-        db::DataModel access_layer{txn};
-        if (access_layer.highest_frozen_block_number() > to) {
-            to = access_layer.highest_frozen_block_number();
+        const auto highest_frozen_block_number{db::DataModel{txn}.highest_frozen_block_number()};
+        if (highest_frozen_block_number > to) {
+            to = highest_frozen_block_number;
         }
 
         reset_log_progress();


### PR DESCRIPTION
This PR introduces the following changes:

- add capability to set prune progress for staged-sync stages
- make the `TxLookup` stage forward start from last frozen block
- make the `TxLookup` stage unwind stop at last frozen block

Moreover, this PR replaces `std::atomic_bool::operator=` with `std::atomic_bool::store` to remove warning `The value is never used` in CLion.