### PR TITLE
conan: fix Windows build and upgrade to 1.60.2 for macOS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ commands:
     steps:
       - run:
           name: "Install Conan"
-          command: sudo pip3 install conan==1.60.0 chardet
+          command: sudo pip3 install conan==1.60.2 chardet
       - run:
           name: "Select Conan profile"
           command: |
@@ -303,7 +303,7 @@ jobs:
             sudo apt-get install -y texinfo libtinfo5
       - run:
           name: "Install Conan"
-          command: sudo pip3 install conan==1.60.0 chardet
+          command: sudo pip3 install conan==1.60.2 chardet
       - run:
           name: "Install Wasmer"
           working_directory: ~/tmp2

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -44,7 +44,7 @@ jobs:
       with:
         submodules: recursive
         fetch-depth: "0"
-    - uses: actions/setup-python@v4 # Explicitly avoiding Python 3.12 can be removed when Conan 1.62 will be available
+    - uses: actions/setup-python@v4 # Hopefully this step can be removed when Conan 1.62 will be available
       with:
         python-version: '<3.12' 
 

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -49,13 +49,8 @@ jobs:
       run: |
         brew install gmp
         pip3 install --user conan==1.60.2 chardet
-        echo "which python: $(which python)"
-        echo "which python3: $(which python3)"
-        echo "$(pip3 show conan)"
-        echo "python bin: $(python3 -m site --user-base)/bin"
-        echo "$HOME/Library/Python/$(ls $HOME/Library/Python)/bin" >> "$GITHUB_PATH"
+        echo "$(python3 -m site --user-base)/bin" >> $GITHUB_PATH
         echo "$($(python3 -m site --user-base)/bin/conan --version)"
-        echo "$(conan --version)"
 
     - name: Create Build Environment
       # Some projects don't allow in-source building, so create a separate build directory

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Install Prerequisites
       run: |
         brew install gmp
-        pip3 install --user conan==1.60.0 chardet
+        pip3 install --user conan==1.61.0 chardet
         echo "$HOME/Library/Python/$(ls $HOME/Library/Python)/bin" >> "$GITHUB_PATH"
 
     - name: Create Build Environment

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Install Prerequisites
       run: |
         brew install gmp
-        pip3 install --user conan==1.61.0 chardet
+        pip3 install --user conan==1.60.2 chardet
         echo "$HOME/Library/Python/$(ls $HOME/Library/Python)/bin" >> "$GITHUB_PATH"
 
     - name: Create Build Environment

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -49,6 +49,8 @@ jobs:
       run: |
         brew install gmp
         pip3 install --user conan==1.60.2 chardet
+        echo "which python: $(which python)"
+        echo "which python3: $(which python3)"
         echo "$HOME/Library/Python/$(ls $HOME/Library/Python)/bin" >> "$GITHUB_PATH"
 
     - name: Create Build Environment

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -44,11 +44,14 @@ jobs:
       with:
         submodules: recursive
         fetch-depth: "0"
+    - uses: actions/setup-python@v4 # Explicitly avoiding Python 3.12 can be removed when Conan 1.62 will be available
+      with:
+        python-version: '<3.12' 
 
     - name: Install Prerequisites
       run: |
         brew install gmp
-        pip3 install --user conan==1.62.0 chardet
+        pip3 install --user conan==1.60.2 chardet
         echo "$(python3 -m site --user-base)/bin" >> $GITHUB_PATH
         echo "$($(python3 -m site --user-base)/bin/conan --version)"
 

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -52,6 +52,7 @@ jobs:
         echo "which python: $(which python)"
         echo "which python3: $(which python3)"
         echo "$(pip3 show conan)"
+        echo "python bin: $(python3 -m site --user-base)/bin"
         echo "$HOME/Library/Python/$(ls $HOME/Library/Python)/bin" >> "$GITHUB_PATH"
 
     - name: Create Build Environment

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Install Prerequisites
       run: |
         brew install gmp
-        pip3 install --user conan==1.60.2 chardet
+        pip3 install --user conan==1.62.0 chardet
         echo "$(python3 -m site --user-base)/bin" >> $GITHUB_PATH
         echo "$($(python3 -m site --user-base)/bin/conan --version)"
 

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -54,6 +54,8 @@ jobs:
         echo "$(pip3 show conan)"
         echo "python bin: $(python3 -m site --user-base)/bin"
         echo "$HOME/Library/Python/$(ls $HOME/Library/Python)/bin" >> "$GITHUB_PATH"
+        echo "$($(python3 -m site --user-base)/bin/conan --version)"
+        echo "$(conan --version)"
 
     - name: Create Build Environment
       # Some projects don't allow in-source building, so create a separate build directory

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -51,6 +51,7 @@ jobs:
         pip3 install --user conan==1.60.2 chardet
         echo "which python: $(which python)"
         echo "which python3: $(which python3)"
+        echo "$(pip3 show conan)"
         echo "$HOME/Library/Python/$(ls $HOME/Library/Python)/bin" >> "$GITHUB_PATH"
 
     - name: Create Build Environment

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -47,7 +47,7 @@ jobs:
       id: conan
       uses: turtlebrowser/get-conan@main
       with:
-        version: 1.60.0
+        version: 1.60.2
 
     - name: Create Build Environment
       # Some projects don't allow in-source building, so create a separate build directory

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ or AppleClang ([Xcode](https://developer.apple.com/xcode/) >= 14.3)
 
 Conan requires Python, and can be installed using:
 
-    pip3 install --user conan==1.60.0 chardet
+    pip3 install --user conan==1.60.2 chardet
 
 and adding its binary to PATH:
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -45,12 +45,12 @@ class SilkwormRecipe(ConanFile):
         self.requires('tomlplusplus/3.3.0')
 
     def configure(self):
-        self.options['boost'].asio_no_deprecated = True
-
         self.options['asio-grpc'].local_allocator = 'boost_container'
 
         # Currently Conan Center has Windows binaries built only with msvc 16 only and mimalloc built only with option override=False
-        # In order to build mimalloc with override=True we need to switch to msvc 17 compiler but this would trigger a full rebuild from sources
-        # of all dependencies wasting a lot of time, so we prefer to turn off mimalloc override
+        # In order to build mimalloc with override=True we need to switch to msvc 17 compiler but this would trigger a full rebuild from
+        # sources of all dependencies wasting a lot of time, so we prefer to turn off mimalloc override
+        # The same applies also for boost with option asio_no_deprecated
         if self.settings.os != 'Windows':
+            self.options['boost'].asio_no_deprecated = True
             self.options['mimalloc'].override = True


### PR DESCRIPTION
This PR was initially conceived to fix the build on Windows after #1593, but then macOS job started to fail intermittently 😭 so, in order to restore full CI green status, it now contains the following changes:

- fix Windows build broken after #1593 by not enabling option `asio_no_deprecated`
- update Conan to version [1.60.2](https://docs.conan.io/1/changelog.html) on macOS CI job to avoid [this error](https://github.com/conan-io/conan/pull/14363) occurred [here](https://github.com/erigontech/silkworm/actions/runs/6736269123/job/18315664966)
- downgrade Python to version 3.11 because version 3.12 (now present in `macos-13` GA image) triggers [another error](https://github.com/conan-io/conan/issues/14801), which will be fixed in not-yet-available Conan 1.62.0
