### PR TITLE
sentry: fix co_await Operation canceled crash (#1530)

### DIFF
--- a/silkworm/infra/concurrency/co_spawn_sw.hpp
+++ b/silkworm/infra/concurrency/co_spawn_sw.hpp
@@ -31,6 +31,7 @@
 #include <boost/asio/associated_cancellation_slot.hpp>
 #include <boost/asio/async_result.hpp>
 #include <boost/asio/awaitable.hpp>
+#include <boost/asio/cancellation_signal.hpp>
 #include <boost/asio/cancellation_state.hpp>
 #include <boost/asio/co_spawn.hpp>
 #include <boost/asio/dispatch.hpp>
@@ -42,7 +43,10 @@
 namespace silkworm::concurrency::detail {
 
 using boost::asio::awaitable;
+using boost::asio::cancellation_signal;
+using boost::asio::cancellation_slot;
 using boost::asio::cancellation_state;
+using boost::asio::cancellation_type_t;
 using boost::asio::dispatch;
 using boost::asio::enable_total_cancellation;
 using boost::asio::get_associated_cancellation_slot;
@@ -141,6 +145,48 @@ awaitable<awaitable_thread_entry_point, Executor> co_spawn_entry_point(
                });
 }
 
+template <typename Handler, typename Executor, typename = void>
+class co_spawn_cancellation_handler {
+  public:
+    co_spawn_cancellation_handler(const Handler&, const Executor& ex)
+        : ex_(ex) {
+    }
+
+    cancellation_slot slot() {
+        return signal_.slot();
+    }
+
+    void operator()(cancellation_type_t type) {
+        cancellation_signal* sig = &signal_;
+        boost::asio::dispatch(ex_, [sig, type] { sig->emit(type); });
+    }
+
+  private:
+    cancellation_signal signal_;
+    Executor ex_;
+};
+
+template <typename Handler, typename Executor>
+class co_spawn_cancellation_handler<
+    Handler,
+    Executor,
+    typename std::enable_if<std::is_same<typename boost::asio::associated_executor<Handler, Executor>::asio_associated_executor_is_unspecialised, void>::value>::type> {
+  public:
+    co_spawn_cancellation_handler(const Handler&, const Executor&) {
+    }
+
+    cancellation_slot slot() {
+        return signal_.slot();
+    }
+
+    void operator()(cancellation_type_t type) {
+        signal_.emit(type);
+    }
+
+  private:
+    cancellation_signal signal_;
+};
+
 template <typename Executor>
 class initiate_co_spawn {
   public:
@@ -158,12 +204,21 @@ class initiate_co_spawn {
     template <typename Handler, typename F>
     void operator()(Handler&& handler, F&& f) const {
         typedef typename result_of<F()>::type awaitable_type;
+        typedef typename std::decay<Handler>::type handler_type;
+        typedef co_spawn_cancellation_handler<handler_type, Executor> cancel_handler_type;
 
-        cancellation_state proxy_cancel_state(
-            get_associated_cancellation_slot(handler),
-            enable_total_cancellation());
+        auto slot = boost::asio::get_associated_cancellation_slot(handler);
+        cancel_handler_type* cancel_handler =
+            slot.is_connected()
+                ? &slot.template emplace<cancel_handler_type>(handler, ex_)
+                : nullptr;
 
-        cancellation_state cancel_state(proxy_cancel_state.slot());
+        cancellation_slot proxy_slot(
+            cancel_handler
+                ? cancel_handler->slot()
+                : cancellation_slot());
+
+        cancellation_state cancel_state(proxy_slot);
 
         auto a = (co_spawn_entry_point)(static_cast<awaitable_type*>(nullptr),
                                         ex_,
@@ -172,7 +227,7 @@ class initiate_co_spawn {
         awaitable_handler<executor_type, void>(
             std::move(a),
             ex_,
-            proxy_cancel_state.slot(),
+            proxy_slot,
             cancel_state)
             .launch();
     }

--- a/silkworm/sentry/discovery/discovery.cpp
+++ b/silkworm/sentry/discovery/discovery.cpp
@@ -35,7 +35,7 @@ using namespace boost::asio;
 class DiscoveryImpl {
   public:
     explicit DiscoveryImpl(
-        boost::asio::any_io_executor executor,
+        concurrency::ExecutorPool& executor_pool,
         std::vector<EnodeUrl> peer_urls,
         bool with_dynamic_discovery,
         const std::filesystem::path& data_dir_path,
@@ -74,7 +74,7 @@ class DiscoveryImpl {
 };
 
 DiscoveryImpl::DiscoveryImpl(
-    boost::asio::any_io_executor executor,
+    concurrency::ExecutorPool& executor_pool,
     std::vector<EnodeUrl> peer_urls,
     bool with_dynamic_discovery,
     const std::filesystem::path& data_dir_path,
@@ -89,9 +89,9 @@ DiscoveryImpl::DiscoveryImpl(
       data_dir_path_(data_dir_path),
       node_id_([node_key] { return node_key().public_key(); }),
       network_id_(network_id),
-      node_db_(executor),
+      node_db_(executor_pool.any_executor()),
       bootnodes_(std::move(bootnodes)),
-      disc_v4_discovery_(executor, disc_v4_port, node_key, node_url, node_record, node_db_.interface()) {
+      disc_v4_discovery_(executor_pool.any_executor(), disc_v4_port, node_key, node_url, node_record, node_db_.interface()) {
 }
 
 Task<void> DiscoveryImpl::run() {
@@ -206,7 +206,7 @@ Discovery::Discovery(
     std::vector<EnodeUrl> bootnodes,
     uint16_t disc_v4_port)
     : p_impl_(std::make_unique<DiscoveryImpl>(
-          executor_pool.any_executor(),
+          executor_pool,
           std::move(peer_urls),
           with_dynamic_discovery,
           data_dir_path,

--- a/silkworm/sentry/discovery/node_db/serial_node_db.hpp
+++ b/silkworm/sentry/discovery/node_db/serial_node_db.hpp
@@ -29,7 +29,7 @@ class SerialNodeDb : public NodeDb {
         NodeDb& db,
         boost::asio::any_io_executor executor)
         : db_(db),
-          strand_(std::move(executor)) {}
+          strand_(boost::asio::make_strand(std::move(executor))) {}
     ~SerialNodeDb() override = default;
 
     Task<bool> upsert_node_address(NodeId id, NodeAddress address) override;
@@ -75,7 +75,7 @@ class SerialNodeDb : public NodeDb {
 
   private:
     NodeDb& db_;
-    boost::asio::any_io_executor strand_;
+    boost::asio::strand<boost::asio::any_io_executor> strand_;
 };
 
 }  // namespace silkworm::sentry::discovery::node_db


### PR DESCRIPTION
Fixes #1530

* revert #1531
* bring back co_spawn_cancellation_handler with buggy dispatch from asio
* fix co_spawn_cancellation_handler using a shared_ptr
