### PR TITLE
build: no debug info in release builds

### DIFF
--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -65,10 +65,6 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 
 elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
 
-  if(CMAKE_BUILD_TYPE STREQUAL "Release")
-    add_compile_options(-g1)
-  endif()
-
   # coroutines support
   if(NOT SILKWORM_WASM_API)
     add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fcoroutines>)
@@ -79,10 +75,6 @@ elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES ".*Clang$")
   if(SILKWORM_CLANG_COVERAGE)
     add_compile_options(-fprofile-instr-generate -fcoverage-mapping)
     add_link_options(-fprofile-instr-generate -fcoverage-mapping)
-  endif()
-
-  if(CMAKE_BUILD_TYPE STREQUAL "Release")
-    add_compile_options(-gline-tables-only)
   endif()
 
   # coroutines support


### PR DESCRIPTION
This significantly reduces the size of the binaries. for example, `libsilkworm_api.so` shrinks from 106 MiB to 34 MiB. If one needs the debug info, CMAKE_BUILD_TYPE `RelWithDebInfo` is the recommended way.