### PR TITLE
CI: restore codecov upload

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,8 @@
 #   limitations under the License.
 
 version: 2.1
+orbs:
+  codecov: codecov/codecov@3.3.0
 
 commands:
   checkout_with_submodules:
@@ -247,6 +249,8 @@ jobs:
             llvm-profdata merge *.profraw -o profdata
             llvm-cov export -instr-profile profdata ~/build/cmd/silkworm '-ignore-filename-regex=(third_party|silkworm/interfaces|test)' -format=lcov > /tmp/silkworm.lcov
             llvm-cov report -instr-profile profdata ~/build/cmd/silkworm '-ignore-filename-regex=(third_party|silkworm/interfaces|test)' > /tmp/report.txt
+      - codecov/upload:
+          file: /tmp/silkworm.lcov
       - store_artifacts:
           path: /tmp/silkworm.lcov
       - store_artifacts:

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ C++ implementation of the Ethereum Execution Layer (EL) protocol based on the [E
 [![Linux](https://circleci.com/gh/erigontech/silkworm.svg?style=shield)](https://circleci.com/gh/erigontech/silkworm)
 [![macOS](https://github.com/erigontech/silkworm/actions/workflows/macOS.yml/badge.svg)](https://github.com/erigontech/silkworm/actions/workflows/macOS.yml)
 [![Windows](https://github.com/erigontech/silkworm/actions/workflows/windows.yml/badge.svg)](https://github.com/erigontech/silkworm/actions/workflows/windows.yml)
+[![codecov](https://codecov.io/gh/erigontech/silkworm/graph/badge.svg?token=89IPVJGR4Q)](https://codecov.io/gh/erigontech/silkworm)
 
 ## Table of Contents
 


### PR DESCRIPTION
Restore upload of code coverage report to codecov.io removed by PR #1232. I find the [website reports](https://app.codecov.io/gh/erigontech/silkworm) easier to navigate than the text artefacts.