### PR TITLE
rpcdaemon: fix wrong dump of stack entries in DebugTracer

### DIFF
--- a/silkworm/silkrpc/core/evm_debug.cpp
+++ b/silkworm/silkrpc/core/evm_debug.cpp
@@ -62,7 +62,7 @@ std::string uint256_to_hex(const evmone::uint256& x) {
     bool leading_zeros = true;
     const uint64_t* px = &x[0];
     for (int i = 3; i >= 0; i--) {
-        if (px[i] == 0) {
+        if (px[i] == 0 && leading_zeros) {
             continue;
         }
         if (leading_zeros) {


### PR DESCRIPTION
Fix for wrong dump of stack entries in DebugTracer class