### PR TITLE
node: in-memory ETL collector

### DIFF
--- a/silkworm/node/etl/in_memory_collector.hpp
+++ b/silkworm/node/etl/in_memory_collector.hpp
@@ -163,7 +163,9 @@ class InMemoryCollector {
 
     CollectorStorage entries_;
 
-    void sort_entries() {}  // does nothing, std::map is always sorted
+    void sort_entries() {
+        entries_.sort();
+    }
 
     // for progress tracking only
     void set_loading_key(ByteView key) {

--- a/silkworm/node/etl/in_memory_collector.hpp
+++ b/silkworm/node/etl/in_memory_collector.hpp
@@ -31,29 +31,46 @@
 namespace silkworm::etl {
 
 // Function pointer to process Load on before Load data into tables
-using MiniLoadFunc = std::function<void(const Bytes& key, const Bytes& value,
+using KVLoadFunc = std::function<void(const Bytes& key, const Bytes& value,
                                         db::RWCursorDupSort&, MDBX_put_flags_t)>;
 
 inline const Bytes& key(const std::pair<Bytes, Bytes>& entry) { return entry.first; }
 inline const Bytes& value(const std::pair<Bytes, Bytes>& entry) { return entry.second; }
 
+// An adaptor to use map as a collector storage
+struct MapStorage: public std::map<Bytes, Bytes> {
+    void reserve(size_t) {}  // does nothing, std::map doesn't need to reserve space
+    void emplace(const Bytes& key, const Bytes& value) { std::map<Bytes, Bytes>::emplace(key, value); }
+    void emplace(Bytes&& key, Bytes&& value) { std::map<Bytes, Bytes>::emplace(std::move(key), std::move(value)); }
+    void sort() {}  // does nothing, std::map is always sorted
+};
+
+// An adaptor to use vector as a collector storage
+struct VectorStorage: public std::vector<std::pair<Bytes, Bytes>> {
+    void reserve(size_t size) { std::vector<std::pair<Bytes, Bytes>>::reserve(size); }
+    void emplace(const Bytes& key, const Bytes& value) { emplace_back(key, value); }
+    void emplace(Bytes&& key, Bytes&& value) { emplace_back(std::move(key), std::move(value)); }
+    void sort() { std::sort(begin(), end()); }
+};
+
 // Collects data Extracted from db
-class MiniCollector {
+template <typename CollectorStorage = MapStorage>
+class InMemoryCollector {
   public:
     // Not copyable nor movable
-    MiniCollector(const MiniCollector&) = delete;
-    MiniCollector& operator=(const MiniCollector&) = delete;
+    InMemoryCollector(const InMemoryCollector&) = delete;
+    InMemoryCollector& operator=(const InMemoryCollector&) = delete;
 
-    explicit MiniCollector() = default;
+    explicit InMemoryCollector() = default;
 
-    explicit MiniCollector([[maybe_unused]] const NodeSettings* node_settings) {
-        // entries_.reserve(node_settings->etl_buffer_size)
+    explicit InMemoryCollector([[maybe_unused]] const NodeSettings* node_settings) {
+        entries_.reserve(node_settings->etl_buffer_size);
     }
-    explicit MiniCollector(const std::filesystem::path&, [[maybe_unused]] size_t optimal_size) {
-        // entries_.reserve(optimal_size)
+    explicit InMemoryCollector(const std::filesystem::path&, [[maybe_unused]] size_t optimal_size) {
+        entries_.reserve(optimal_size);
     }
-    explicit MiniCollector([[maybe_unused]] size_t optimal_size) {
-        // entries_.reserve(optimal_size)
+    explicit InMemoryCollector([[maybe_unused]] size_t optimal_size) {
+        entries_.reserve(optimal_size);
     }
 
     void collect(const Bytes& key, const Bytes& value) {
@@ -68,12 +85,20 @@ class MiniCollector {
         entries_.emplace(std::move(key), std::move(value));
     }
 
+    void collect(const Entry& entry) {
+        collect(entry.key, entry.value);
+    }
+
+    void collect(Entry&& entry) {
+        collect(std::move(entry.key), std::move(entry.value));
+    }
+
     //! \brief Loads and optionally transforms collected entries into db
     //! \param [in] target : a cursor opened on target table and owned by caller (can be empty)
     //! \param [in] load_func : Pointer to function transforming collected entries. If NULL no transform is executed
     //! \param [in] flags : Optional put flags for append or upsert (default)
     //! items
-    void load(db::RWCursorDupSort& target, const MiniLoadFunc& load_func = {},
+    void load(db::RWCursorDupSort& target, const KVLoadFunc& load_func = {},
               MDBX_put_flags_t flags = MDBX_put_flags_t::MDBX_UPSERT) {
         using namespace std::chrono_literals;
         [[maybe_unused]] static const auto kLogInterval{5s};               // Updates processing key (for log purposes) every this time
@@ -90,12 +115,12 @@ class MiniCollector {
                 if (SignalHandler::signalled()) {
                     throw std::runtime_error("Operation cancelled");
                 }
-                set_loading_key(entry.first);
+                set_loading_key(key(entry));
                 log_time = now + kLogInterval;
             }
 
             if (load_func) {
-                load_func(entry.first, entry.second, target, flags);
+                load_func(key(entry), value(entry), target, flags);
             } else {
                 mdbx::slice k{db::to_slice(key(entry))};
                 if (value(entry).empty()) {
@@ -136,9 +161,7 @@ class MiniCollector {
     size_t size_{0};        // Count of total collected items
     size_t bytes_size_{0};  // Count of total collected bytes
 
-    std::map<Bytes,  // key
-             Bytes>  // value
-        entries_;
+    CollectorStorage entries_;
 
     void sort_entries() {}  // does nothing, std::map is always sorted
 

--- a/silkworm/node/etl/in_memory_collector.hpp
+++ b/silkworm/node/etl/in_memory_collector.hpp
@@ -32,13 +32,13 @@ namespace silkworm::etl {
 
 // Function pointer to process Load on before Load data into tables
 using KVLoadFunc = std::function<void(const Bytes& key, const Bytes& value,
-                                        db::RWCursorDupSort&, MDBX_put_flags_t)>;
+                                      db::RWCursorDupSort&, MDBX_put_flags_t)>;
 
 inline const Bytes& key(const std::pair<Bytes, Bytes>& entry) { return entry.first; }
 inline const Bytes& value(const std::pair<Bytes, Bytes>& entry) { return entry.second; }
 
 // An adaptor to use map as a collector storage
-struct MapStorage: public std::map<Bytes, Bytes> {
+struct MapStorage : public std::map<Bytes, Bytes> {
     void reserve(size_t) {}  // does nothing, std::map doesn't need to reserve space
     void emplace(const Bytes& key, const Bytes& value) { std::map<Bytes, Bytes>::emplace(key, value); }
     void emplace(Bytes&& key, Bytes&& value) { std::map<Bytes, Bytes>::emplace(std::move(key), std::move(value)); }
@@ -46,7 +46,7 @@ struct MapStorage: public std::map<Bytes, Bytes> {
 };
 
 // An adaptor to use vector as a collector storage
-struct VectorStorage: public std::vector<std::pair<Bytes, Bytes>> {
+struct VectorStorage : public std::vector<std::pair<Bytes, Bytes>> {
     void reserve(size_t size) { std::vector<std::pair<Bytes, Bytes>>::reserve(size); }
     void emplace(const Bytes& key, const Bytes& value) { emplace_back(key, value); }
     void emplace(Bytes&& key, Bytes&& value) { emplace_back(std::move(key), std::move(value)); }

--- a/silkworm/node/etl/in_memory_collector_test.cpp
+++ b/silkworm/node/etl/in_memory_collector_test.cpp
@@ -98,7 +98,7 @@ void run_collector_test(const KVLoadFunc& load_func, bool do_copy = true) {
         size_t found_items{0};
         db::PooledCursor from{context.rw_txn(), db::table::kHeaderNumbers};
         auto data = from.to_first();
-        while(data) {
+        while (data) {
             auto key = db::from_slice(data.key);
             auto value = db::from_slice(data.value);
             found_items++;

--- a/silkworm/node/etl/in_memory_collector_test.cpp
+++ b/silkworm/node/etl/in_memory_collector_test.cpp
@@ -1,0 +1,157 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "in_memory_collector.hpp"
+
+#include <set>
+#include <thread>
+
+#include <catch2/catch.hpp>
+
+#include <silkworm/infra/common/log.hpp>
+#include <silkworm/infra/test_util/log.hpp>
+#include <silkworm/node/test/context.hpp>
+
+namespace silkworm::etl {
+
+static std::vector<Entry> generate_entry_set(size_t size) {
+    std::vector<Entry> pairs;
+    std::set<Bytes> keys;
+    while (pairs.size() < size) {
+        Bytes key(8, '\0');
+        endian::store_big_u64(&key[0], static_cast<unsigned>(std::rand()) % 200000000u);
+
+        if (keys.count(key)) {
+            // we want unique keys
+            continue;
+        } else {
+            keys.insert(key);
+        }
+        if (pairs.size() % 100) {
+            Bytes value(8, '\0');
+            endian::store_big_u64(&value[0], static_cast<unsigned>(std::rand()) % 200000000u);
+            pairs.push_back({key, value});
+        } else {
+            Bytes value;
+            pairs.push_back({key, value});
+        }
+    }
+    return pairs;
+}
+
+template <typename COLLECTOR>
+void run_collector_test(const KVLoadFunc& load_func, bool do_copy = true) {
+    test::Context context;
+
+    // Initialize random seed
+    std::srand(static_cast<unsigned>(std::time(nullptr)));
+
+    // Generate Test Entries
+    auto set{generate_entry_set(1000)};  // 1000 entries in total
+    size_t generated_size{0};
+    for (const auto& entry : set) {
+        generated_size += entry.size();
+    }
+
+    // Collection
+    COLLECTOR collector{set.size()};
+
+    for (auto&& entry : set) {
+        if (do_copy)
+            collector.collect(entry);  // copy is slower... do only if entry is reused afterwards
+        else
+            collector.collect(std::move(entry));
+    }
+
+    // Check size
+    CHECK(collector.size() == set.size());
+    CHECK(collector.bytes_size() == generated_size);
+
+    // Reading loading key from another thread
+    auto key_reader_thread = std::thread([&collector]() -> void {
+        size_t max_tries{10};
+        while (--max_tries) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            const auto read_key = collector.get_load_key();
+            log::Info("Loading ...", {"key", read_key});
+        }
+    });
+
+    // Load data
+    db::PooledCursor to{context.rw_txn(), db::table::kHeaderNumbers};
+    collector.load(to, load_func);
+
+    if (load_func) {
+        size_t found_items{0};
+        db::PooledCursor from{context.rw_txn(), db::table::kHeaderNumbers};
+        auto data = from.to_first();
+        while(data) {
+            auto key = db::from_slice(data.key);
+            auto value = db::from_slice(data.value);
+            found_items++;
+
+            // find key in set and compare value
+            auto it = std::find_if(set.begin(), set.end(), [&key](const Entry& entry) {
+                return entry.key == key;
+            });
+            CHECK(it != set.end());
+            CHECK(it->value == value);
+
+            data = from.to_next(/*throw_notfound =*/false);
+        }
+        CHECK(found_items == set.size());
+    }
+
+    key_reader_thread.join();
+}
+
+TEST_CASE("collect_and_default_load_in_memory_map") {
+    test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
+    run_collector_test<InMemoryCollector<MapStorage>>(nullptr);
+}
+
+TEST_CASE("collect_and_default_load_in_memory_vector") {
+    test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
+    run_collector_test<InMemoryCollector<VectorStorage>>(nullptr);
+}
+
+TEST_CASE("collect_and_default_load_move_in_memory_map") {
+    test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
+    run_collector_test<InMemoryCollector<MapStorage>>(nullptr, false);
+}
+
+TEST_CASE("collect_and_default_load_move_in_memory_vector") {
+    test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
+    run_collector_test<InMemoryCollector<VectorStorage>>(nullptr, false);
+}
+
+TEST_CASE("collect_and_load_in_memory_map") {
+    test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
+    run_collector_test<InMemoryCollector<MapStorage>>([](const Bytes& ekey, const Bytes& evalue, auto& table, MDBX_put_flags_t) {
+        Bytes key{ekey};
+        table.upsert(db::to_slice(key), db::to_slice(evalue));
+    });
+}
+
+TEST_CASE("collect_and_load_in_memory_vector") {
+    test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
+    run_collector_test<InMemoryCollector<VectorStorage>>([](const Bytes& ekey, const Bytes& evalue, auto& table, MDBX_put_flags_t) {
+        Bytes key{ekey};
+        table.upsert(db::to_slice(key), db::to_slice(evalue));
+    });
+}
+
+}  // namespace silkworm::etl

--- a/silkworm/node/etl/mini_collector.hpp
+++ b/silkworm/node/etl/mini_collector.hpp
@@ -1,0 +1,154 @@
+/*
+Copyright 2023 The Silkworm Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+#include <mutex>
+
+#include <silkworm/infra/concurrency/signal_handler.hpp>
+#include <silkworm/node/common/settings.hpp>
+#include <silkworm/node/db/mdbx.hpp>
+#include <silkworm/node/etl/util.hpp>
+
+/*
+ * This is a memory-only reduced version of ETL Collector, with compatible interface
+ * It can be used to prototype code that will use the full ETL collector or to do performance comparisons
+ * between a memory-only impl. and a file-based impl.
+ */
+namespace silkworm::etl {
+
+// Function pointer to process Load on before Load data into tables
+using MiniLoadFunc = std::function<void(const Bytes& key, const Bytes& value,
+                                        db::RWCursorDupSort&, MDBX_put_flags_t)>;
+
+inline const Bytes& key(const std::pair<Bytes, Bytes>& entry) { return entry.first; }
+inline const Bytes& value(const std::pair<Bytes, Bytes>& entry) { return entry.second; }
+
+// Collects data Extracted from db
+class MiniCollector {
+  public:
+    // Not copyable nor movable
+    MiniCollector(const MiniCollector&) = delete;
+    MiniCollector& operator=(const MiniCollector&) = delete;
+
+    explicit MiniCollector() = default;
+
+    explicit MiniCollector([[maybe_unused]] const NodeSettings* node_settings) {
+        // entries_.reserve(node_settings->etl_buffer_size)
+    }
+    explicit MiniCollector(const std::filesystem::path&, [[maybe_unused]] size_t optimal_size) {
+        // entries_.reserve(optimal_size)
+    }
+    explicit MiniCollector([[maybe_unused]] size_t optimal_size) {
+        // entries_.reserve(optimal_size)
+    }
+
+    void collect(const Bytes& key, const Bytes& value) {
+        ++size_;
+        bytes_size_ += key.size() + value.size();
+        entries_.emplace(key, value);
+    }
+
+    void collect(Bytes&& key, Bytes&& value) {
+        ++size_;
+        bytes_size_ += key.size() + value.size();
+        entries_.emplace(std::move(key), std::move(value));
+    }
+
+    //! \brief Loads and optionally transforms collected entries into db
+    //! \param [in] target : a cursor opened on target table and owned by caller (can be empty)
+    //! \param [in] load_func : Pointer to function transforming collected entries. If NULL no transform is executed
+    //! \param [in] flags : Optional put flags for append or upsert (default)
+    //! items
+    void load(db::RWCursorDupSort& target, const MiniLoadFunc& load_func = {},
+              MDBX_put_flags_t flags = MDBX_put_flags_t::MDBX_UPSERT) {
+        using namespace std::chrono_literals;
+        [[maybe_unused]] static const auto kLogInterval{5s};               // Updates processing key (for log purposes) every this time
+        [[maybe_unused]] auto log_time{std::chrono::steady_clock::now()};  // To check if an update of key is needed
+
+        set_loading_key({});
+
+        if (empty()) return;
+
+        sort_entries();
+
+        for (const auto& entry : entries_) {
+            if (const auto now{std::chrono::steady_clock::now()}; log_time <= now) {
+                if (SignalHandler::signalled()) {
+                    throw std::runtime_error("Operation cancelled");
+                }
+                set_loading_key(entry.first);
+                log_time = now + kLogInterval;
+            }
+
+            if (load_func) {
+                load_func(entry.first, entry.second, target, flags);
+            } else {
+                mdbx::slice k{db::to_slice(key(entry))};
+                if (value(entry).empty()) {
+                    target.erase(k);
+                } else {
+                    mdbx::slice v{db::to_slice(value(entry))};
+                    mdbx::error::success_or_throw(target.put(k, &v, flags));
+                }
+            }
+        }
+
+        clear();
+    }
+
+    //! \brief Returns the number of actually collected items
+    [[nodiscard]] size_t size() const { return size_; }
+
+    //! \brief Returns the number of actually collected bytes
+    [[nodiscard]] size_t bytes_size() const { return bytes_size_; }
+
+    //! \brief Returns whether this instance is empty (i.e. no items)
+    [[nodiscard]] bool empty() const { return size_ == 0; }
+
+    //! \brief Clears contents of collector and reset
+    void clear() {
+        entries_.clear();
+        size_ = 0;
+        bytes_size_ = 0;
+    }
+
+    //! \brief Returns the hex representation of current load key (for progress tracking)
+    [[nodiscard]] std::string get_load_key() const {
+        std::unique_lock l{mutex_};
+        return loading_key_;
+    }
+
+  private:
+    size_t size_{0};        // Count of total collected items
+    size_t bytes_size_{0};  // Count of total collected bytes
+
+    std::map<Bytes,  // key
+             Bytes>  // value
+        entries_;
+
+    void sort_entries() {}  // does nothing, std::map is always sorted
+
+    // for progress tracking only
+    void set_loading_key(ByteView key) {
+        std::unique_lock l{mutex_};
+        loading_key_ = to_hex(key, true);
+    }
+    mutable std::mutex mutex_{};  // To sync loading_key_
+    std::string loading_key_{};   // Actual load key (for log purposes)
+};
+
+}  // namespace silkworm::etl

--- a/silkworm/node/etl/mini_collector.hpp
+++ b/silkworm/node/etl/mini_collector.hpp
@@ -1,17 +1,17 @@
 /*
-Copyright 2023 The Silkworm Authors
+   Copyright 2023 The Silkworm Authors
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+       http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
 */
 
 #pragma once


### PR DESCRIPTION
This is a memory-only reduced version of ETL Collector, with a compatible interface, that I used to measure the performance gain or loss when using only the memory to perform ETL tasks.
