### PR TITLE
core: empty virtual hooks in EVM tracer

### DIFF
--- a/silkworm/core/execution/call_tracer.hpp
+++ b/silkworm/core/execution/call_tracer.hpp
@@ -34,17 +34,6 @@ class CallTracer : public EvmTracer {
     CallTracer& operator=(const CallTracer&) = delete;
 
     void on_execution_start(evmc_revision rev, const evmc_message& msg, evmone::bytes_view code) noexcept override;
-    void on_instruction_start(uint32_t /*pc*/, const intx::uint256* /*stack_top*/, int /*stack_height*/, int64_t /*gas*/,
-                              const evmone::ExecutionState& /*execution_state*/,
-                              const silkworm::IntraBlockState& /*intra_block_state*/) noexcept override {}
-    void on_execution_end(const evmc_result& /*result*/,
-                          const silkworm::IntraBlockState& /*intra_block_state*/) noexcept override {}
-    void on_precompiled_run(const evmc_result& /*result*/, int64_t /*gas*/,
-                            const silkworm::IntraBlockState& /*intra_block_state*/) noexcept override {}
-    void on_reward_granted(const silkworm::CallResult& /*result*/,
-                           const silkworm::IntraBlockState& /*intra_block_state*/) noexcept override {}
-    void on_creation_completed(const evmc_result& /*result*/,
-                               const silkworm::IntraBlockState& /*intra_block_state*/) noexcept override {}
 
   private:
     CallTraces& traces_;

--- a/silkworm/core/execution/evm.hpp
+++ b/silkworm/core/execution/evm.hpp
@@ -47,20 +47,20 @@ class EvmTracer {
 
     virtual void on_block_start(const Block& /*block*/) noexcept {}
 
-    virtual void on_execution_start(evmc_revision rev, const evmc_message& msg, evmone::bytes_view code) noexcept = 0;
+    virtual void on_execution_start(evmc_revision /*rev*/, const evmc_message& /*msg*/, evmone::bytes_view /*code*/) noexcept {}
 
-    virtual void on_instruction_start(uint32_t pc, const intx::uint256* stack_top, int stack_height,
-                                      int64_t gas, const evmone::ExecutionState& state,
-                                      const IntraBlockState& intra_block_state) noexcept = 0;
+    virtual void on_instruction_start(uint32_t /*pc*/, const intx::uint256* /*stack_top*/, int /*stack_height*/,
+                                      int64_t /*gas*/, const evmone::ExecutionState& /*state*/,
+                                      const IntraBlockState& /*intra_block_state*/) noexcept {}
 
-    virtual void on_execution_end(const evmc_result& result, const IntraBlockState& intra_block_state) noexcept = 0;
+    virtual void on_execution_end(const evmc_result& /*result*/, const IntraBlockState& /*intra_block_state*/) noexcept {}
 
-    virtual void on_creation_completed(const evmc_result& result, const IntraBlockState& intra_block_state) noexcept = 0;
+    virtual void on_creation_completed(const evmc_result& /*result*/, const IntraBlockState& /*intra_block_state*/) noexcept {}
 
-    virtual void on_precompiled_run(const evmc_result& result, int64_t gas,
-                                    const IntraBlockState& intra_block_state) noexcept = 0;
+    virtual void on_precompiled_run(const evmc_result& /*result*/, int64_t /*gas*/,
+                                    const IntraBlockState& /*intra_block_state*/) noexcept {}
 
-    virtual void on_reward_granted(const CallResult& result, const IntraBlockState& intra_block_state) noexcept = 0;
+    virtual void on_reward_granted(const CallResult& /*result*/, const IntraBlockState& /*intra_block_state*/) noexcept {}
 
     virtual void on_self_destruct(const evmc::address& /*address*/, const evmc::address& /*beneficiary*/) noexcept {}
 

--- a/silkworm/core/execution/evm_test.cpp
+++ b/silkworm/core/execution/evm_test.cpp
@@ -443,15 +443,9 @@ class TestTracer : public EvmTracer {
                 intra_block_state.get_current_storage(contract_address_.value(), key_.value_or(evmc::bytes32{}));
         }
     }
-
     void on_creation_completed(const evmc_result& /*result*/, const IntraBlockState& /*intra_block_state*/) noexcept override {
         creation_completed_called_ = true;
     }
-
-    void on_precompiled_run(const evmc_result& /*result*/, int64_t /*gas*/,
-                            const IntraBlockState& /*intra_block_state*/) noexcept override {}
-    void on_reward_granted(const CallResult& /*result*/,
-                           const IntraBlockState& /*intra_block_state*/) noexcept override {}
     void on_self_destruct(const evmc::address& /*address*/, const evmc::address& /*beneficiary*/) noexcept override {
         self_destruct_called_ = true;
     }

--- a/silkworm/core/execution/execution_test.cpp
+++ b/silkworm/core/execution/execution_test.cpp
@@ -130,18 +130,6 @@ class BlockTracer : public EvmTracer {
     void on_block_end(const silkworm::Block& /*block*/) noexcept override {
         block_end_called_ = true;
     }
-    void on_execution_start(evmc_revision /*rev*/, const evmc_message& /*msg*/,
-                            evmone::bytes_view /*code*/) noexcept override {}
-    void on_instruction_start(uint32_t, const intx::uint256*, int,
-                              int64_t, const evmone::ExecutionState&,
-                              const IntraBlockState&) noexcept override {}
-    void on_execution_end(const evmc_result&, const IntraBlockState&) noexcept override {}
-    void on_creation_completed(const evmc_result& /*result*/,
-                               const IntraBlockState& /*intra_block_state*/) noexcept override {}
-    void on_precompiled_run(const evmc_result& /*result*/, int64_t /*gas*/,
-                            const IntraBlockState& /*intra_block_state*/) noexcept override {}
-    void on_reward_granted(const CallResult& /*result*/,
-                           const IntraBlockState& /*intra_block_state*/) noexcept override {}
 
     [[nodiscard]] bool block_start_called() const { return block_start_called_; }
     [[nodiscard]] bool block_end_called() const { return block_end_called_; }

--- a/silkworm/silkrpc/core/evm_access_list_tracer.hpp
+++ b/silkworm/silkrpc/core/evm_access_list_tracer.hpp
@@ -43,10 +43,6 @@ class AccessListTracer : public silkworm::EvmTracer {
     void on_execution_start(evmc_revision rev, const evmc_message& msg, evmone::bytes_view code) noexcept override;
     void on_instruction_start(uint32_t pc, const intx::uint256* stack_top, int stack_height, int64_t gas,
                               const evmone::ExecutionState& execution_state, const silkworm::IntraBlockState& intra_block_state) noexcept override;
-    void on_execution_end(const evmc_result& /*result*/, const silkworm::IntraBlockState& /*intra_block_state*/) noexcept override {}
-    void on_precompiled_run(const evmc_result& /*result*/, int64_t /*gas*/, const silkworm::IntraBlockState& /*intra_block_state*/) noexcept override {}
-    void on_reward_granted(const silkworm::CallResult& /*result*/, const silkworm::IntraBlockState& /*intra_block_state*/) noexcept override {}
-    void on_creation_completed(const evmc_result& /*result*/, const silkworm::IntraBlockState& /*intra_block_state*/) noexcept override {}
 
     void reset_access_list() { access_list_.clear(); }
     static void dump(const std::string& str, const AccessList& acl);

--- a/silkworm/silkrpc/core/evm_debug.hpp
+++ b/silkworm/silkrpc/core/evm_debug.hpp
@@ -71,7 +71,7 @@ struct DebugLog {
     Storage storage;
 };
 
-class DebugTracer : public silkworm::EvmTracer {
+class DebugTracer : public EvmTracer {
   public:
     explicit DebugTracer(json::Stream& stream, const DebugConfig& config = {})
         : stream_(stream), config_(config) {}
@@ -80,13 +80,12 @@ class DebugTracer : public silkworm::EvmTracer {
     DebugTracer& operator=(const DebugTracer&) = delete;
 
     void on_execution_start(evmc_revision rev, const evmc_message& msg, evmone::bytes_view code) noexcept override;
-
     void on_instruction_start(uint32_t pc, const intx::uint256* stack_top, int stack_height, int64_t gas,
-                              const evmone::ExecutionState& execution_state, const silkworm::IntraBlockState& intra_block_state) noexcept override;
+                              const evmone::ExecutionState& execution_state,
+                              const silkworm::IntraBlockState& intra_block_state) noexcept override;
     void on_execution_end(const evmc_result& result, const silkworm::IntraBlockState& intra_block_state) noexcept override;
-    void on_precompiled_run(const evmc_result& result, int64_t gas, const silkworm::IntraBlockState& intra_block_state) noexcept override;
-    void on_reward_granted(const silkworm::CallResult& /*result*/, const silkworm::IntraBlockState& /*intra_block_state*/) noexcept override {}
-    void on_creation_completed(const evmc_result& /*result*/, const silkworm::IntraBlockState& /*intra_block_state*/) noexcept override {}
+    void on_precompiled_run(const evmc_result& result, int64_t gas,
+                            const silkworm::IntraBlockState& intra_block_state) noexcept override;
 
     void flush_logs();
 
@@ -102,21 +101,14 @@ class DebugTracer : public silkworm::EvmTracer {
     std::int64_t gas_on_precompiled_{0};
 };
 
-class AccountTracer : public silkworm::EvmTracer {
+class AccountTracer : public EvmTracer {
   public:
     explicit AccountTracer(const evmc::address& address) : address_{address} {}
 
     AccountTracer(const AccountTracer&) = delete;
     AccountTracer& operator=(const AccountTracer&) = delete;
 
-    void on_execution_start(evmc_revision, const evmc_message&, evmone::bytes_view) noexcept override{};
-
-    void on_instruction_start(uint32_t, const intx::uint256*, int, int64_t,
-                              const evmone::ExecutionState&, const silkworm::IntraBlockState&) noexcept override{};
     void on_execution_end(const evmc_result& result, const silkworm::IntraBlockState& intra_block_state) noexcept override;
-    void on_precompiled_run(const evmc_result&, int64_t, const silkworm::IntraBlockState&) noexcept override{};
-    void on_reward_granted(const silkworm::CallResult& /*result*/, const silkworm::IntraBlockState& /*intra_block_state*/) noexcept override {}
-    void on_creation_completed(const evmc_result& /*result*/, const silkworm::IntraBlockState& /*intra_block_state*/) noexcept override {}
 
   private:
     const evmc::address& address_;
@@ -173,4 +165,5 @@ class DebugExecutor {
     ethdb::Transaction& tx_;
     DebugConfig config_;
 };
+
 }  // namespace silkworm::rpc::debug

--- a/silkworm/silkrpc/core/evm_trace.hpp
+++ b/silkworm/silkrpc/core/evm_trace.hpp
@@ -144,8 +144,6 @@ class VmTraceTracer : public silkworm::EvmTracer {
                               const silkworm::IntraBlockState& intra_block_state) noexcept override;
     void on_execution_end(const evmc_result& result, const silkworm::IntraBlockState& intra_block_state) noexcept override;
     void on_precompiled_run(const evmc_result& result, int64_t gas, const silkworm::IntraBlockState& intra_block_state) noexcept override;
-    void on_reward_granted(const silkworm::CallResult& /*result*/, const silkworm::IntraBlockState& /*intra_block_state*/) noexcept override {}
-    void on_creation_completed(const evmc_result& /*result*/, const silkworm::IntraBlockState& /*intra_block_state*/) noexcept override {}
 
   private:
     VmTrace& vm_trace_;
@@ -224,7 +222,6 @@ class TraceTracer : public silkworm::EvmTracer {
                               int64_t gas, const evmone::ExecutionState& execution_state,
                               const silkworm::IntraBlockState& intra_block_state) noexcept override;
     void on_execution_end(const evmc_result& result, const silkworm::IntraBlockState& intra_block_state) noexcept override;
-    void on_precompiled_run(const evmc_result& /*result*/, int64_t /*gas*/, const silkworm::IntraBlockState& /*intra_block_state*/) noexcept override {}
     void on_reward_granted(const silkworm::CallResult& result, const silkworm::IntraBlockState& intra_block_state) noexcept override;
     void on_creation_completed(const evmc_result& result, const silkworm::IntraBlockState& intra_block_state) noexcept override;
 
@@ -295,9 +292,7 @@ class StateDiffTracer : public silkworm::EvmTracer {
                               int64_t gas, const evmone::ExecutionState& execution_state,
                               const silkworm::IntraBlockState& intra_block_state) noexcept override;
     void on_execution_end(const evmc_result& result, const silkworm::IntraBlockState& intra_block_state) noexcept override;
-    void on_precompiled_run(const evmc_result& /*result*/, int64_t /*gas*/, const silkworm::IntraBlockState& /*intra_block_state*/) noexcept override {}
     void on_reward_granted(const silkworm::CallResult& result, const silkworm::IntraBlockState& intra_block_state) noexcept override;
-    void on_creation_completed(const evmc_result& /*result*/, const silkworm::IntraBlockState& /*intra_block_state*/) noexcept override {}
 
   private:
     StateDiff& state_diff_;
@@ -370,14 +365,7 @@ class IntraBlockStateTracer : public silkworm::EvmTracer {
     IntraBlockStateTracer(const IntraBlockStateTracer&) = delete;
     IntraBlockStateTracer& operator=(const IntraBlockStateTracer&) = delete;
 
-    void on_execution_start(evmc_revision /*rev*/, const evmc_message& /*msg*/, evmone::bytes_view /*code*/) noexcept override {}
-    void on_instruction_start(uint32_t /*pc*/, const intx::uint256* /*stack_top*/, int /*stack_height*/,
-                              int64_t /*gas*/, const evmone::ExecutionState& /*execution_state*/,
-                              const silkworm::IntraBlockState& /*intra_block_state*/) noexcept override {}
-    void on_execution_end(const evmc_result& /*result*/, const silkworm::IntraBlockState& /*intra_block_state*/) noexcept override {}
-    void on_precompiled_run(const evmc_result& /*result*/, int64_t /*gas*/, const silkworm::IntraBlockState& /*intra_block_state*/) noexcept override {}
     void on_reward_granted(const silkworm::CallResult& result, const silkworm::IntraBlockState& intra_block_state) noexcept override;
-    void on_creation_completed(const evmc_result& /*result*/, const silkworm::IntraBlockState& /*intra_block_state*/) noexcept override {}
 
   private:
     StateAddresses& state_addresses_;
@@ -391,13 +379,7 @@ class CreateTracer : public silkworm::EvmTracer {
     CreateTracer& operator=(const CreateTracer&) = delete;
 
     void on_execution_start(evmc_revision rev, const evmc_message& msg, evmone::bytes_view code) noexcept override;
-    void on_instruction_start(uint32_t /*pc*/, const intx::uint256* /*stack_top*/, int /*stack_height*/,
-                              int64_t /*gas*/, const evmone::ExecutionState& /*execution_state*/,
-                              const silkworm::IntraBlockState& /*intra_block_state*/) noexcept override {}
-    void on_execution_end(const evmc_result& /*result*/, const silkworm::IntraBlockState& /*intra_block_state*/) noexcept override {}
-    void on_precompiled_run(const evmc_result& /*result*/, int64_t /*gas*/, const silkworm::IntraBlockState& /*intra_block_state*/) noexcept override {}
-    void on_reward_granted(const silkworm::CallResult& /*result*/, const silkworm::IntraBlockState& /*intra_block_state*/) noexcept override {}
-    void on_creation_completed(const evmc_result& /*result*/, const silkworm::IntraBlockState& /*intra_block_state*/) noexcept override {}
+
     bool found() const { return found_; }
 
   private:
@@ -414,13 +396,7 @@ class EntryTracer : public silkworm::EvmTracer {
     EntryTracer& operator=(const EntryTracer&) = delete;
 
     void on_execution_start(evmc_revision rev, const evmc_message& msg, evmone::bytes_view code) noexcept override;
-    void on_instruction_start(uint32_t /*pc*/, const intx::uint256* /*stack_top*/, int /*stack_height*/,
-                              int64_t /*gas*/, const evmone::ExecutionState& /*execution_state*/,
-                              const silkworm::IntraBlockState& /*intra_block_state*/) noexcept override {}
-    void on_execution_end(const evmc_result& /*result*/, const silkworm::IntraBlockState& /*intra_block_state*/) noexcept override {}
-    void on_precompiled_run(const evmc_result& /*result*/, int64_t /*gas*/, const silkworm::IntraBlockState& /*intra_block_state*/) noexcept override {}
-    void on_reward_granted(const silkworm::CallResult& /*result*/, const silkworm::IntraBlockState& /*intra_block_state*/) noexcept override {}
-    void on_creation_completed(const evmc_result& /*result*/, const silkworm::IntraBlockState& /*intra_block_state*/) noexcept override {}
+
     TraceEntriesResult result() const { return result_; }
 
   private:
@@ -436,13 +412,7 @@ class OperationTracer : public silkworm::EvmTracer {
     OperationTracer& operator=(const OperationTracer&) = delete;
 
     void on_execution_start(evmc_revision rev, const evmc_message& msg, evmone::bytes_view code) noexcept override;
-    void on_instruction_start(uint32_t /*pc*/, const intx::uint256* /*stack_top*/, int /*stack_height*/,
-                              int64_t /*gas*/, const evmone::ExecutionState& /*execution_state*/,
-                              const silkworm::IntraBlockState& /*intra_block_state*/) noexcept override {}
-    void on_execution_end(const evmc_result& /*result*/, const silkworm::IntraBlockState& /*intra_block_state*/) noexcept override {}
-    void on_precompiled_run(const evmc_result& /*result*/, int64_t /*gas*/, const silkworm::IntraBlockState& /*intra_block_state*/) noexcept override {}
-    void on_reward_granted(const silkworm::CallResult& /*result*/, const silkworm::IntraBlockState& /*intra_block_state*/) noexcept override {}
-    void on_creation_completed(const evmc_result& /*result*/, const silkworm::IntraBlockState& /*intra_block_state*/) noexcept override {}
+
     TraceOperationsResult result() const { return result_; }
 
   private:
@@ -458,13 +428,7 @@ class TouchTracer : public silkworm::EvmTracer {
     TouchTracer& operator=(const TouchTracer&) = delete;
 
     void on_execution_start(evmc_revision rev, const evmc_message& msg, evmone::bytes_view code) noexcept override;
-    void on_instruction_start(uint32_t /*pc*/, const intx::uint256* /*stack_top*/, int /*stack_height*/,
-                              int64_t /*gas*/, const evmone::ExecutionState& /*execution_state*/,
-                              const silkworm::IntraBlockState& /*intra_block_state*/) noexcept override {}
-    void on_execution_end(const evmc_result& /*result*/, const silkworm::IntraBlockState& /*intra_block_state*/) noexcept override {}
-    void on_precompiled_run(const evmc_result& /*result*/, int64_t /*gas*/, const silkworm::IntraBlockState& /*intra_block_state*/) noexcept override {}
-    void on_reward_granted(const silkworm::CallResult& /*result*/, const silkworm::IntraBlockState& /*intra_block_state*/) noexcept override {}
-    void on_creation_completed(const evmc_result& /*result*/, const silkworm::IntraBlockState& /*intra_block_state*/) noexcept override {}
+
     bool found() const { return found_; }
 
   private:


### PR DESCRIPTION
Introduce empty non-pure virtual methods in `EvmTracer` in order not to force subclasses to implement all of them.