### PR TITLE
snapshots: restores binary equality with Erigon indices

### DIFF
--- a/silkworm/node/snapshot/index.hpp
+++ b/silkworm/node/snapshot/index.hpp
@@ -28,7 +28,7 @@ namespace silkworm::snapshot {
 class Index {
   public:
     static constexpr uint64_t kPageSize{4096};
-    static constexpr std::size_t kBucketSize{2'048};
+    static constexpr std::size_t kBucketSize{2'000};
 
     explicit Index(SnapshotPath segment_path, std::optional<MemoryMappedRegion> segment_region = {})
         : segment_path_(std::move(segment_path)), segment_region_{std::move(segment_region)} {}


### PR DESCRIPTION
This PR restores the size of the recsplit buckets to [that of Erigon](https://github.com/ledgerwatch/erigon/blob/a5ff5247409edbffe8f52c451a4ad45eb27767b9/erigon-lib/state/domain.go#L1100), after an erroneous change of mine, thus restoring binary equality with Erigon indices.

