### PR TITLE
rpcdaemon: fix JSON stream serialization for DebugLog::error

### DIFF
--- a/silkworm/silkrpc/core/evm_debug.cpp
+++ b/silkworm/silkrpc/core/evm_debug.cpp
@@ -307,7 +307,9 @@ void DebugTracer::write_log(const DebugLog& log) {
         stream_.close_object();
     }
     if (log.error) {
-        stream_.write_field("error", "{}");
+        stream_.write_field("error");
+        stream_.open_object();
+        stream_.close_object();
     }
 
     stream_.close_object();


### PR DESCRIPTION
Fix for wrong JSON serialization for error field of DebugLog structure