### PR TITLE
core: collect missing information in call traces

### DIFF
--- a/silkworm/api/silkworm_api.cpp
+++ b/silkworm/api/silkworm_api.cpp
@@ -25,6 +25,7 @@
 
 #include <silkworm/buildinfo.h>
 #include <silkworm/core/chain/config.hpp>
+#include <silkworm/core/execution/call_tracer.hpp>
 #include <silkworm/core/execution/execution.hpp>
 #include <silkworm/core/types/call_traces.hpp>
 #include <silkworm/infra/common/log.hpp>

--- a/silkworm/core/execution/call_tracer.hpp
+++ b/silkworm/core/execution/call_tracer.hpp
@@ -34,6 +34,8 @@ class CallTracer : public EvmTracer {
     CallTracer& operator=(const CallTracer&) = delete;
 
     void on_execution_start(evmc_revision rev, const evmc_message& msg, evmone::bytes_view code) noexcept override;
+    void on_self_destruct(const evmc::address& address, const evmc::address& beneficiary) noexcept override;
+    void on_block_end(const silkworm::Block& block) noexcept override;
 
   private:
     CallTraces& traces_;

--- a/silkworm/core/execution/execution.hpp
+++ b/silkworm/core/execution/execution.hpp
@@ -19,7 +19,6 @@
 #include <vector>
 
 #include <silkworm/core/chain/config.hpp>
-#include <silkworm/core/execution/call_tracer.hpp>
 #include <silkworm/core/execution/processor.hpp>
 #include <silkworm/core/protocol/rule_set.hpp>
 #include <silkworm/core/state/state.hpp>

--- a/silkworm/core/execution/execution_test.cpp
+++ b/silkworm/core/execution/execution_test.cpp
@@ -20,6 +20,7 @@
 #include <ethash/keccak.hpp>
 
 #include <silkworm/core/common/test_util.hpp>
+#include <silkworm/core/execution/call_tracer.hpp>
 #include <silkworm/core/protocol/param.hpp>
 #include <silkworm/core/state/in_memory_state.hpp>
 #include <silkworm/core/trie/vector_root.hpp>
@@ -168,9 +169,16 @@ TEST_CASE("Execute block with tracing") {
 
     BlockTracer block_tracer{};
     processor.evm().add_tracer(block_tracer);
+    CallTraces call_traces{};
+    CallTracer call_tracer{call_traces};
+    processor.evm().add_tracer(call_tracer);
+
     REQUIRE(processor.execute_and_write_block(receipts) == ValidationResult::kOk);
 
     CHECK((block_tracer.block_start_called() && block_tracer.block_end_called()));
+    CHECK(call_traces.senders.empty());
+    CHECK(call_traces.recipients.size() == 1);
+    CHECK(call_traces.recipients.contains(kMiner));  // header beneficiary
 }
 
 }  // namespace silkworm


### PR DESCRIPTION
core: add block and ommer beneficiary as call trace recipients
core: add call tracing for SELFDESTRUCT
core: fix call tracing for CALLCODE and DELEGATECALL