### PR TITLE
cmd: diff paging in compare command of db toolbox

### DIFF
--- a/cmd/dev/toolbox.cpp
+++ b/cmd/dev/toolbox.cpp
@@ -953,6 +953,7 @@ void do_copy(db::EnvConfig& src_config, const std::string& target_dir, bool crea
 }
 
 static void print_multi_table_diff(db::ROCursorDupSort* cursor1, db::ROCursorDupSort* cursor2) {
+    size_t diff_count{0};
     auto result1{cursor1->to_first()};
     auto result2{cursor2->to_first()};
     while (result1.done && result2.done) {
@@ -976,6 +977,12 @@ static void print_multi_table_diff(db::ROCursorDupSort* cursor1, db::ROCursorDup
                 const auto v1_hex{silkworm::to_hex({static_cast<const uint8_t*>(value1.data()), value1.size()})};
                 const auto v2_hex{silkworm::to_hex({static_cast<const uint8_t*>(value2.data()), value2.size()})};
                 std::cout << "v1=" << v1_hex << " v2=" << v2_hex << "\n";
+                ++diff_count;
+                if (diff_count % 100 == 0) {
+                    if (!user_confirmation("Do you need more diff?")) {
+                        return;
+                    }
+                }
             }
             result1 = cursor1->to_current_next_multi(/*throw_notfound=*/false);
             result2 = cursor2->to_current_next_multi(/*throw_notfound=*/false);
@@ -1089,8 +1096,12 @@ static DbComparisonResult compare_db_content(db::ROTxn& txn1, db::ROTxn& txn2, c
         }
 
         if (db1_table.size() != db2_table.size()) {
-            return tl::make_unexpected("mismatch in size of table " + db1_table.name + ": db1 has " + std::to_string(db1_table.size()) +
-                                       ", db2 has " + std::to_string(db2_table.size()));
+            if (db1_table.name == "FREE_DBI") {
+                SILK_WARN << "mismatch in size of table FREE_DBI, you should check MDBX freelist";
+            } else {
+                return tl::make_unexpected("mismatch in size of table " + db1_table.name + ": db1 has " + std::to_string(db1_table.size()) +
+                                           ", db2 has " + std::to_string(db2_table.size()));
+            }
         }
     }
 

--- a/cmd/dev/toolbox.cpp
+++ b/cmd/dev/toolbox.cpp
@@ -979,7 +979,7 @@ static void print_multi_table_diff(db::ROCursorDupSort* cursor1, db::ROCursorDup
                 std::cout << "v1=" << v1_hex << " v2=" << v2_hex << "\n";
                 ++diff_count;
                 if (diff_count % 100 == 0) {
-                    if (!user_confirmation("Do you need more diff?")) {
+                    if (!user_confirmation("Do you need any more diffs?")) {
                         return;
                     }
                 }
@@ -993,6 +993,7 @@ static void print_multi_table_diff(db::ROCursorDupSort* cursor1, db::ROCursorDup
 }
 
 static void print_single_table_diff(db::ROCursor* cursor1, db::ROCursor* cursor2) {
+    size_t diff_count{0};
     auto result1{cursor1->to_first()};
     auto result2{cursor2->to_first()};
     while (result1.done && result2.done) {
@@ -1015,6 +1016,12 @@ static void print_single_table_diff(db::ROCursor* cursor1, db::ROCursor* cursor2
             const auto v1_hex{silkworm::to_hex({static_cast<const uint8_t*>(value1.data()), value1.size()})};
             const auto v2_hex{silkworm::to_hex({static_cast<const uint8_t*>(value2.data()), value2.size()})};
             std::cout << "v1=" << v1_hex << " v2=" << v2_hex << "\n";
+            ++diff_count;
+            if (diff_count % 100 == 0) {
+                if (!user_confirmation("Do you need any more diffs?")) {
+                    return;
+                }
+            }
         }
         result1 = cursor1->to_next(/*throw_notfound=*/false);
         result2 = cursor2->to_next(/*throw_notfound=*/false);


### PR DESCRIPTION
Moreover, any size mismatch in `FREE_DBI` table gets treated differently from other tables: it does not halt the comparison, but emits a warning.