### PR TITLE
fix calculation AggregationBound

### DIFF
--- a/silkworm/node/recsplit/rec_split.hpp
+++ b/silkworm/node/recsplit/rec_split.hpp
@@ -131,7 +131,7 @@ class SplittingStrategy {
     static inline const std::size_t kLowerAggregationBound = LEAF_SIZE * static_cast<uint64_t>(std::max(2.0, std::ceil(0.35 * LEAF_SIZE + 0.5)));
 
     //! The lower bound for secondary (upper) key aggregation
-    static inline const std::size_t kUpperAggregationBound = kLowerAggregationBound * (LEAF_SIZE < 7 ? 2 : std::ceil(0.21 * LEAF_SIZE + 0.9));
+    static inline const std::size_t kUpperAggregationBound = kLowerAggregationBound * static_cast<uint64_t>(LEAF_SIZE < 7 ? 2 : std::ceil(0.21 * LEAF_SIZE + 0.9));
 
     static inline std::pair<std::size_t, std::size_t> split_params(const std::size_t m) {
         std::size_t fanout{0}, unit{0};

--- a/silkworm/node/recsplit/rec_split.hpp
+++ b/silkworm/node/recsplit/rec_split.hpp
@@ -128,10 +128,10 @@ class SplittingStrategy {
     static_assert(1 <= LEAF_SIZE && LEAF_SIZE <= kMaxLeafSize);
 
   public:
-    static inline const std::size_t kLowerAggregationBound = LEAF_SIZE * max(2, ceil(0.35 * LEAF_SIZE + 0.5));
+    static inline const std::size_t kLowerAggregationBound = LEAF_SIZE * std::max(2.0, std::ceil(0.35 * LEAF_SIZE + 0.5));
 
     //! The lower bound for secondary (upper) key aggregation
-    static inline const std::size_t kUpperAggregationBound = kLowerAggregationBound * (LEAF_SIZE < 7 ? 2 : ceil(0.21 * LEAF_SIZE + 0.9));
+    static inline const std::size_t kUpperAggregationBound = kLowerAggregationBound * (LEAF_SIZE < 7 ? 2 : std::ceil(0.21 * LEAF_SIZE + 0.9));
 
     static inline std::pair<std::size_t, std::size_t> split_params(const std::size_t m) {
         std::size_t fanout{0}, unit{0};

--- a/silkworm/node/recsplit/rec_split.hpp
+++ b/silkworm/node/recsplit/rec_split.hpp
@@ -128,7 +128,7 @@ class SplittingStrategy {
     static_assert(1 <= LEAF_SIZE && LEAF_SIZE <= kMaxLeafSize);
 
   public:
-    static inline const std::size_t kLowerAggregationBound = LEAF_SIZE * std::max(2.0, std::ceil(0.35 * LEAF_SIZE + 0.5));
+    static inline const std::size_t kLowerAggregationBound = LEAF_SIZE * static_cast<uint64_t>(std::max(2.0, std::ceil(0.35 * LEAF_SIZE + 0.5)));
 
     //! The lower bound for secondary (upper) key aggregation
     static inline const std::size_t kUpperAggregationBound = kLowerAggregationBound * (LEAF_SIZE < 7 ? 2 : std::ceil(0.21 * LEAF_SIZE + 0.9));

--- a/silkworm/node/recsplit/rec_split.hpp
+++ b/silkworm/node/recsplit/rec_split.hpp
@@ -131,11 +131,11 @@ class SplittingStrategy {
     //! The lower bound for primary (lower) key aggregation
     static constexpr std::size_t kLowerAggregationBound = LEAF_SIZE * max(2,
                                                                           // NOLINTNEXTLINE(bugprone-incorrect-roundings)
-                                                                          static_cast<int64_t>(0.35 * LEAF_SIZE + 0.5 + 1));
+                                                                          std::ceil(0.35 * LEAF_SIZE + 0.5));
 
     //! The lower bound for secondary (upper) key aggregation
     static constexpr std::size_t kUpperAggregationBound = kLowerAggregationBound *
-                                                          (LEAF_SIZE < 7 ? 2 : static_cast<int64_t>(0.21 * LEAF_SIZE + 0.9 + 1));
+                                                          (LEAF_SIZE < 7 ? 2 : std::ceil(0.21 * LEAF_SIZE + 0.9));
 
     static inline std::pair<std::size_t, std::size_t> split_params(const std::size_t m) {
         std::size_t fanout{0}, unit{0};

--- a/silkworm/node/recsplit/rec_split.hpp
+++ b/silkworm/node/recsplit/rec_split.hpp
@@ -128,14 +128,10 @@ class SplittingStrategy {
     static_assert(1 <= LEAF_SIZE && LEAF_SIZE <= kMaxLeafSize);
 
   public:
-    //! The lower bound for primary (lower) key aggregation
-    static constexpr std::size_t kLowerAggregationBound = LEAF_SIZE * max(2,
-                                                                          // NOLINTNEXTLINE(bugprone-incorrect-roundings)
-                                                                          std::ceil(0.35 * LEAF_SIZE + 0.5));
+    static inline const std::size_t kLowerAggregationBound = LEAF_SIZE * max(2, ceil(0.35 * LEAF_SIZE + 0.5));
 
     //! The lower bound for secondary (upper) key aggregation
-    static constexpr std::size_t kUpperAggregationBound = kLowerAggregationBound *
-                                                          (LEAF_SIZE < 7 ? 2 : std::ceil(0.21 * LEAF_SIZE + 0.9));
+    static inline const std::size_t kUpperAggregationBound = kLowerAggregationBound * (LEAF_SIZE < 7 ? 2 : ceil(0.21 * LEAF_SIZE + 0.9));
 
     static inline std::pair<std::size_t, std::size_t> split_params(const std::size_t m) {
         std::size_t fanout{0}, unit{0};

--- a/silkworm/node/recsplit/rec_split.hpp
+++ b/silkworm/node/recsplit/rec_split.hpp
@@ -131,11 +131,11 @@ class SplittingStrategy {
     //! The lower bound for primary (lower) key aggregation
     static constexpr std::size_t kLowerAggregationBound = LEAF_SIZE * max(2,
                                                                           // NOLINTNEXTLINE(bugprone-incorrect-roundings)
-                                                                          static_cast<int64_t>(0.35 * LEAF_SIZE + 0.5));
+                                                                          static_cast<int64_t>(0.35 * LEAF_SIZE + 0.5 + 1));
 
     //! The lower bound for secondary (upper) key aggregation
     static constexpr std::size_t kUpperAggregationBound = kLowerAggregationBound *
-                                                          (LEAF_SIZE < 7 ? 2 : static_cast<int64_t>(0.21 * LEAF_SIZE + 0.9));
+                                                          (LEAF_SIZE < 7 ? 2 : static_cast<int64_t>(0.21 * LEAF_SIZE + 0.9 + 1));
 
     static inline std::pair<std::size_t, std::size_t> split_params(const std::size_t m) {
         std::size_t fanout{0}, unit{0};


### PR DESCRIPTION
Fix after PR #1675
Problems emerged after integration tests when it is necessary returns block from tx-hash
Restore call to std:.ceil() because:
- ceil() returns the smallest possible integer value which is "greater than or equal to input" (3.3 -> 4; 3 -> 3) 
- cast returns always the integer smaller the input value
