### PR TITLE
core: refactor core/common/empty_hashes.hpp

### DIFF
--- a/cmd/state-transition/state_transition.cpp
+++ b/cmd/state-transition/state_transition.cpp
@@ -25,6 +25,7 @@
 #include <nlohmann/json.hpp>
 
 #include <silkworm/core/chain/genesis.hpp>
+#include <silkworm/core/common/empty_hashes.hpp>
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/core/execution/execution.hpp>
 #include <silkworm/core/protocol/param.hpp>

--- a/silkworm/core/chain/config.hpp
+++ b/silkworm/core/chain/config.hpp
@@ -134,6 +134,8 @@ struct ChainConfig {
 
 std::ostream& operator<<(std::ostream& out, const ChainConfig& obj);
 
+using namespace evmc::literals;
+
 inline constexpr evmc::bytes32 kMainnetGenesisHash{0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3_bytes32};
 SILKWORM_CONSTINIT extern const ChainConfig kMainnetConfig;
 

--- a/silkworm/core/chain/genesis.cpp
+++ b/silkworm/core/chain/genesis.cpp
@@ -26,6 +26,7 @@
 #include <silkworm/core/chain/genesis_sepolia.hpp>
 #include <silkworm/core/common/assert.hpp>
 #include <silkworm/core/common/bytes_to_string.hpp>
+#include <silkworm/core/common/empty_hashes.hpp>
 #include <silkworm/core/protocol/param.hpp>
 #include <silkworm/core/types/address.hpp>
 #include <silkworm/core/types/evmc_bytes32.hpp>

--- a/silkworm/core/common/base.hpp
+++ b/silkworm/core/common/base.hpp
@@ -23,7 +23,6 @@
 #include <cstdint>
 #include <tuple>
 
-#include <evmc/evmc.hpp>
 #include <intx/intx.hpp>
 
 // TODO(yperbasis): get rid of this hack
@@ -41,7 +40,6 @@
 
 namespace silkworm {
 
-using namespace evmc::literals;
 using namespace std::string_view_literals;
 
 template <class T>
@@ -55,16 +53,6 @@ using BlockTime = uint64_t;
 inline constexpr size_t kAddressLength{20};
 
 inline constexpr size_t kHashLength{32};
-
-// Keccak-256 hash of an empty string, KEC("").
-inline constexpr evmc::bytes32 kEmptyHash{0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470_bytes32};
-
-// Keccak-256 hash of the RLP of an empty list, KEC("\xc0").
-inline constexpr evmc::bytes32 kEmptyListHash{
-    0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347_bytes32};
-
-// Root hash of an empty trie.
-inline constexpr evmc::bytes32 kEmptyRoot{0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421_bytes32};
 
 // https://en.wikipedia.org/wiki/Binary_prefix
 inline constexpr uint64_t kKibi{1024};

--- a/silkworm/core/common/bytes_test.cpp
+++ b/silkworm/core/common/bytes_test.cpp
@@ -14,15 +14,9 @@
    limitations under the License.
 */
 
-#include "base.hpp"
-
-#include <bit>
+#include "bytes.hpp"
 
 #include <catch2/catch.hpp>
-
-#include <silkworm/core/rlp/encode.hpp>
-
-#include "util.hpp"
 
 namespace silkworm {
 
@@ -36,21 +30,6 @@ TEST_CASE("Byteviews") {
     REQUIRE(bv1 == bv2);
     REQUIRE_FALSE(bv1.data() == bv2.data());
     REQUIRE(bv2.is_null());
-}
-
-TEST_CASE("Empty hashes") {
-    const ByteView empty_string;
-    const ethash::hash256 hash_of_empty_string{keccak256(empty_string)};
-    CHECK(std::bit_cast<evmc_bytes32>(hash_of_empty_string) == kEmptyHash);
-
-    const Bytes empty_list_rlp(1, rlp::kEmptyListCode);
-    const ethash::hash256 hash_of_empty_list_rlp{keccak256(empty_list_rlp)};
-    CHECK(std::bit_cast<evmc_bytes32>(hash_of_empty_list_rlp) == kEmptyListHash);
-
-    // See https://github.com/ethereum/yellowpaper/pull/852
-    const Bytes empty_string_rlp(1, rlp::kEmptyStringCode);
-    const ethash::hash256 hash_of_empty_string_rlp{keccak256(empty_string_rlp)};
-    CHECK(std::bit_cast<evmc_bytes32>(hash_of_empty_string_rlp) == kEmptyRoot);
 }
 
 }  // namespace silkworm

--- a/silkworm/core/common/empty_hashes.hpp
+++ b/silkworm/core/common/empty_hashes.hpp
@@ -14,19 +14,22 @@
    limitations under the License.
 */
 
-#include "hash.hpp"
+#pragma once
 
-#include <catch2/catch.hpp>
+#include <evmc/evmc.hpp>
 
 namespace silkworm {
 
 using namespace evmc::literals;
 
-TEST_CASE("from_hex") {
-    CHECK(Hash::from_hex("foo") == std::nullopt);
+// Keccak-256 hash of an empty string, KEC("").
+inline constexpr evmc::bytes32 kEmptyHash{0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470_bytes32};
 
-    const auto kHashValue{0x2d690516512020171c1ec870f6ff45398cc8609250326be89915fb538e7b_bytes32};
-    CHECK(Hash::from_hex("0x2d690516512020171c1ec870f6ff45398cc8609250326be89915fb538e7b") == kHashValue);
-}
+// Keccak-256 hash of the RLP of an empty list, KEC("\xc0").
+inline constexpr evmc::bytes32 kEmptyListHash{
+    0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347_bytes32};
+
+// Root hash of an empty trie.
+inline constexpr evmc::bytes32 kEmptyRoot{0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421_bytes32};
 
 }  // namespace silkworm

--- a/silkworm/core/common/empty_hashes_test.cpp
+++ b/silkworm/core/common/empty_hashes_test.cpp
@@ -1,0 +1,45 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "empty_hashes.hpp"
+
+#include <bit>
+
+#include <catch2/catch.hpp>
+
+#include <silkworm/core/rlp/encode.hpp>
+
+#include "bytes.hpp"
+#include "util.hpp"
+
+namespace silkworm {
+
+TEST_CASE("Empty hashes") {
+    const ByteView empty_string;
+    const ethash::hash256 hash_of_empty_string{keccak256(empty_string)};
+    CHECK(std::bit_cast<evmc_bytes32>(hash_of_empty_string) == kEmptyHash);
+
+    const Bytes empty_list_rlp(1, rlp::kEmptyListCode);
+    const ethash::hash256 hash_of_empty_list_rlp{keccak256(empty_list_rlp)};
+    CHECK(std::bit_cast<evmc_bytes32>(hash_of_empty_list_rlp) == kEmptyListHash);
+
+    // See https://github.com/ethereum/yellowpaper/pull/852
+    const Bytes empty_string_rlp(1, rlp::kEmptyStringCode);
+    const ethash::hash256 hash_of_empty_string_rlp{keccak256(empty_string_rlp)};
+    CHECK(std::bit_cast<evmc_bytes32>(hash_of_empty_string_rlp) == kEmptyRoot);
+}
+
+}  // namespace silkworm

--- a/silkworm/core/common/util_test.cpp
+++ b/silkworm/core/common/util_test.cpp
@@ -22,6 +22,8 @@
 
 namespace silkworm {
 
+using namespace evmc::literals;
+
 TEST_CASE("Hex") {
     CHECK(decode_hex_digit('g').has_value() == false);
 

--- a/silkworm/core/execution/evm.cpp
+++ b/silkworm/core/execution/evm.cpp
@@ -27,6 +27,7 @@
 #include <evmone/evmone.h>
 #include <evmone/tracing.hpp>
 
+#include <silkworm/core/common/empty_hashes.hpp>
 #include <silkworm/core/execution/precompile.hpp>
 #include <silkworm/core/protocol/param.hpp>
 #include <silkworm/core/types/address.hpp>

--- a/silkworm/core/execution/precompile.cpp
+++ b/silkworm/core/execution/precompile.cpp
@@ -524,6 +524,8 @@ std::optional<Bytes> point_evaluation_run(ByteView input) noexcept {
 }
 
 bool is_precompile(const evmc::address& address, evmc_revision rev) noexcept {
+    using namespace evmc::literals;
+
     static_assert(std::size(kContracts) < 256);
     static constexpr evmc::address kMaxOneByteAddress{0x00000000000000000000000000000000000000ff_address};
     if (address > kMaxOneByteAddress) {

--- a/silkworm/core/execution/precompile.hpp
+++ b/silkworm/core/execution/precompile.hpp
@@ -18,9 +18,8 @@
 
 #include <optional>
 
-#include <evmc/evmc.h>
+#include <evmc/evmc.hpp>
 
-#include <silkworm/core/common/base.hpp>
 #include <silkworm/core/common/bytes.hpp>
 
 // See Yellow Paper, Appendix E "Precompiled Contracts"

--- a/silkworm/core/execution/precompile_test.cpp
+++ b/silkworm/core/execution/precompile_test.cpp
@@ -22,6 +22,8 @@
 
 namespace silkworm::precompile {
 
+using namespace evmc::literals;
+
 TEST_CASE("Ecrecover") {
     Bytes in{
         *from_hex("18c547e4f7b0f325ad1e56f57e26c745b09a3e503d86e00e5255ff7f715d3d1c0000000000000000000000000000"

--- a/silkworm/core/protocol/base_rule_set.cpp
+++ b/silkworm/core/protocol/base_rule_set.cpp
@@ -18,6 +18,8 @@
 
 #include <algorithm>
 
+#include <silkworm/core/common/empty_hashes.hpp>
+
 #include "param.hpp"
 
 namespace silkworm::protocol {

--- a/silkworm/core/protocol/bor_config.hpp
+++ b/silkworm/core/protocol/bor_config.hpp
@@ -19,6 +19,7 @@
 #include <optional>
 #include <string_view>
 
+#include <evmc/evmc.hpp>
 #include <nlohmann/json.hpp>
 
 #include <silkworm/core/common/base.hpp>

--- a/silkworm/core/protocol/bor_config_test.cpp
+++ b/silkworm/core/protocol/bor_config_test.cpp
@@ -24,6 +24,8 @@ using namespace std::string_view_literals;
 
 namespace silkworm::protocol {
 
+using namespace evmc::literals;
+
 TEST_CASE("BorConfig JSON") {
     const auto json = nlohmann::json::parse(R"({
             "period": {

--- a/silkworm/core/protocol/ethash_rule_set.cpp
+++ b/silkworm/core/protocol/ethash_rule_set.cpp
@@ -17,6 +17,7 @@
 #include "ethash_rule_set.hpp"
 
 #include <silkworm/core/chain/dao.hpp>
+#include <silkworm/core/common/empty_hashes.hpp>
 #include <silkworm/core/common/endian.hpp>
 
 #include "param.hpp"

--- a/silkworm/core/protocol/merge_rule_set_test.cpp
+++ b/silkworm/core/protocol/merge_rule_set_test.cpp
@@ -18,6 +18,7 @@
 
 #include <catch2/catch.hpp>
 
+#include <silkworm/core/common/empty_hashes.hpp>
 #include <silkworm/core/state/in_memory_state.hpp>
 
 #include "ethash_rule_set.hpp"

--- a/silkworm/core/protocol/param.hpp
+++ b/silkworm/core/protocol/param.hpp
@@ -18,8 +18,9 @@
 
 #include <cstdint>
 
+#include <evmc/evmc.hpp>
+
 #include <silkworm/core/common/base.hpp>
-#include <silkworm/core/common/bytes.hpp>
 
 namespace silkworm::protocol {
 
@@ -74,6 +75,7 @@ inline constexpr uint64_t kMinBlobGasPrice{1};
 inline constexpr uint64_t kBlobGasPriceUpdateFraction{3338477};
 
 // EIP-4788: Beacon block root in the EVM
+using namespace evmc::literals;
 inline constexpr uint64_t kSystemCallGasLimit{30'000'000};
 inline constexpr auto kSystemAddress{0xfffffffffffffffffffffffffffffffffffffffe_address};
 inline constexpr auto kBeaconRootsAddress{0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02_address};

--- a/silkworm/core/protocol/validation.cpp
+++ b/silkworm/core/protocol/validation.cpp
@@ -18,6 +18,7 @@
 
 #include <bit>
 
+#include <silkworm/core/common/empty_hashes.hpp>
 #include <silkworm/core/crypto/secp256k1n.hpp>
 #include <silkworm/core/rlp/encode_vector.hpp>
 #include <silkworm/core/trie/vector_root.hpp>

--- a/silkworm/core/protocol/validation_test.cpp
+++ b/silkworm/core/protocol/validation_test.cpp
@@ -18,6 +18,7 @@
 
 #include <catch2/catch.hpp>
 
+#include <silkworm/core/common/empty_hashes.hpp>
 #include <silkworm/core/common/test_util.hpp>
 #include <silkworm/core/state/in_memory_state.hpp>
 

--- a/silkworm/core/state/in_memory_state.cpp
+++ b/silkworm/core/state/in_memory_state.cpp
@@ -20,6 +20,7 @@
 
 #include <ethash/keccak.hpp>
 
+#include <silkworm/core/common/empty_hashes.hpp>
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/core/rlp/encode.hpp>
 #include <silkworm/core/trie/hash_builder.hpp>

--- a/silkworm/core/state/intra_block_state.cpp
+++ b/silkworm/core/state/intra_block_state.cpp
@@ -18,6 +18,7 @@
 
 #include <bit>
 
+#include <silkworm/core/common/empty_hashes.hpp>
 #include <silkworm/core/common/util.hpp>
 
 namespace silkworm {

--- a/silkworm/core/trie/hash_builder.cpp
+++ b/silkworm/core/trie/hash_builder.cpp
@@ -23,6 +23,7 @@
 #include <ethash/keccak.hpp>
 
 #include <silkworm/core/common/assert.hpp>
+#include <silkworm/core/common/empty_hashes.hpp>
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/core/rlp/encode.hpp>
 

--- a/silkworm/core/trie/hash_builder_test.cpp
+++ b/silkworm/core/trie/hash_builder_test.cpp
@@ -19,6 +19,7 @@
 #include <catch2/catch.hpp>
 #include <ethash/keccak.hpp>
 
+#include <silkworm/core/common/empty_hashes.hpp>
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/core/rlp/encode.hpp>
 #include <silkworm/core/trie/hash_builder.hpp>

--- a/silkworm/core/trie/node.hpp
+++ b/silkworm/core/trie/node.hpp
@@ -19,7 +19,8 @@
 #include <optional>
 #include <vector>
 
-#include <silkworm/core/common/base.hpp>
+#include <evmc/evmc.hpp>
+
 #include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/common/decoding_result.hpp>
 

--- a/silkworm/core/trie/node_test.cpp
+++ b/silkworm/core/trie/node_test.cpp
@@ -25,6 +25,8 @@
 
 namespace silkworm::trie {
 
+using namespace evmc::literals;
+
 TEST_CASE("Node marshalling") {
     Node n{/*state_mask*/ 0xf607,
            /*tree_mask*/ 0x0005,

--- a/silkworm/core/trie/vector_root_test.cpp
+++ b/silkworm/core/trie/vector_root_test.cpp
@@ -18,6 +18,7 @@
 
 #include <catch2/catch.hpp>
 
+#include <silkworm/core/common/empty_hashes.hpp>
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/core/types/receipt.hpp>

--- a/silkworm/core/types/account.cpp
+++ b/silkworm/core/types/account.cpp
@@ -16,6 +16,7 @@
 
 #include "account.hpp"
 
+#include <silkworm/core/common/empty_hashes.hpp>
 #include <silkworm/core/common/endian.hpp>
 #include <silkworm/core/rlp/encode.hpp>
 #include <silkworm/core/types/evmc_bytes32.hpp>

--- a/silkworm/core/types/account.hpp
+++ b/silkworm/core/types/account.hpp
@@ -18,9 +18,9 @@
 
 #include <intx/intx.hpp>
 
-#include <silkworm/core/common/base.hpp>
 #include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/common/decoding_result.hpp>
+#include <silkworm/core/common/empty_hashes.hpp>
 
 namespace silkworm {
 

--- a/silkworm/core/types/block_test.cpp
+++ b/silkworm/core/types/block_test.cpp
@@ -19,6 +19,7 @@
 #include <catch2/catch.hpp>
 
 #include <silkworm/core/common/bytes_to_string.hpp>
+#include <silkworm/core/common/empty_hashes.hpp>
 
 namespace silkworm {
 

--- a/silkworm/core/types/bloom_test.cpp
+++ b/silkworm/core/types/bloom_test.cpp
@@ -21,6 +21,9 @@
 #include <silkworm/core/common/util.hpp>
 
 namespace silkworm {
+
+using namespace evmc::literals;
+
 TEST_CASE("Hardcoded Bloom") {
     std::vector<Log> logs{
         {

--- a/silkworm/core/types/log.hpp
+++ b/silkworm/core/types/log.hpp
@@ -18,7 +18,8 @@
 
 #include <vector>
 
-#include <silkworm/core/common/base.hpp>
+#include <evmc/evmc.hpp>
+
 #include <silkworm/core/common/bytes.hpp>
 
 namespace silkworm {

--- a/silkworm/core/types/log_test.cpp
+++ b/silkworm/core/types/log_test.cpp
@@ -25,6 +25,8 @@
 
 namespace silkworm {
 
+using namespace evmc::literals;
+
 TEST_CASE("Log RLP encoding") {
     Log sample_log1{
         0xea674fdde714fd979de3edf0f56aa9716b898ec8_address,

--- a/silkworm/core/types/transaction_test.cpp
+++ b/silkworm/core/types/transaction_test.cpp
@@ -22,6 +22,8 @@
 
 namespace silkworm {
 
+using namespace evmc::literals;
+
 const std::vector<AccessListEntry> access_list{
     {0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae_address,
      {

--- a/silkworm/core/types/withdrawal.hpp
+++ b/silkworm/core/types/withdrawal.hpp
@@ -16,7 +16,8 @@
 
 #pragma once
 
-#include <silkworm/core/common/base.hpp>
+#include <evmc/evmc.hpp>
+
 #include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/rlp/decode.hpp>
 

--- a/silkworm/core/types/withdrawal_test.cpp
+++ b/silkworm/core/types/withdrawal_test.cpp
@@ -24,6 +24,8 @@
 
 namespace silkworm {
 
+using namespace evmc::literals;
+
 TEST_CASE("Withdrawals hash") {
     std::vector<Withdrawal> withdrawals{
         {

--- a/silkworm/infra/common/environment.hpp
+++ b/silkworm/infra/common/environment.hpp
@@ -16,6 +16,9 @@
 
 #pragma once
 
+#include <optional>
+#include <string>
+
 #include <silkworm/core/common/base.hpp>
 
 namespace silkworm {

--- a/silkworm/node/backend/remote/backend_kv_server_test.cpp
+++ b/silkworm/node/backend/remote/backend_kv_server_test.cpp
@@ -31,6 +31,7 @@
 
 #include <silkworm/core/common/base.hpp>
 #include <silkworm/core/common/bytes.hpp>
+#include <silkworm/core/common/empty_hashes.hpp>
 #include <silkworm/infra/common/directories.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/common/os.hpp>

--- a/silkworm/node/common/preverified_hashes.hpp
+++ b/silkworm/node/common/preverified_hashes.hpp
@@ -20,6 +20,8 @@
 #include <set>
 #include <utility>
 
+#include <evmc/evmc.hpp>
+
 #include <silkworm/core/common/base.hpp>
 
 namespace silkworm {

--- a/silkworm/node/db/access_layer.cpp
+++ b/silkworm/node/db/access_layer.cpp
@@ -20,6 +20,7 @@
 #include <stdexcept>
 
 #include <silkworm/core/common/assert.hpp>
+#include <silkworm/core/common/empty_hashes.hpp>
 #include <silkworm/core/common/endian.hpp>
 #include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/infra/common/decoding_exception.hpp>

--- a/silkworm/node/db/access_layer_test.cpp
+++ b/silkworm/node/db/access_layer_test.cpp
@@ -22,6 +22,7 @@
 
 #include <silkworm/core/chain/genesis.hpp>
 #include <silkworm/core/common/bytes_to_string.hpp>
+#include <silkworm/core/common/empty_hashes.hpp>
 #include <silkworm/core/common/test_util.hpp>
 #include <silkworm/core/execution/execution.hpp>
 #include <silkworm/core/protocol/param.hpp>

--- a/silkworm/node/db/genesis.cpp
+++ b/silkworm/node/db/genesis.cpp
@@ -19,6 +19,7 @@
 #include <stdexcept>
 
 #include <silkworm/core/chain/genesis.hpp>
+#include <silkworm/core/common/empty_hashes.hpp>
 #include <silkworm/core/trie/nibbles.hpp>
 #include <silkworm/core/types/address.hpp>
 

--- a/silkworm/node/stagedsync/execution_engine_test.cpp
+++ b/silkworm/node/stagedsync/execution_engine_test.cpp
@@ -22,6 +22,7 @@
 #include <catch2/catch.hpp>
 
 #include <silkworm/core/common/bytes_to_string.hpp>
+#include <silkworm/core/common/empty_hashes.hpp>
 #include <silkworm/core/types/block.hpp>
 #include <silkworm/infra/common/environment.hpp>
 #include <silkworm/infra/test_util/log.hpp>

--- a/silkworm/node/stagedsync/forks/fork_test.cpp
+++ b/silkworm/node/stagedsync/forks/fork_test.cpp
@@ -21,7 +21,7 @@
 #include <boost/asio/io_context.hpp>
 #include <catch2/catch.hpp>
 
-#include <silkworm/core/common/bytes_to_string.hpp>
+#include <silkworm/core/common/empty_hashes.hpp>
 #include <silkworm/infra/common/environment.hpp>
 #include <silkworm/infra/test_util/log.hpp>
 #include <silkworm/node/common/preverified_hashes.hpp>

--- a/silkworm/node/stagedsync/forks/main_chain_test.cpp
+++ b/silkworm/node/stagedsync/forks/main_chain_test.cpp
@@ -22,6 +22,7 @@
 #include <catch2/catch.hpp>
 
 #include <silkworm/core/common/bytes_to_string.hpp>
+#include <silkworm/core/common/empty_hashes.hpp>
 #include <silkworm/core/types/block.hpp>
 #include <silkworm/infra/common/environment.hpp>
 #include <silkworm/infra/test_util/log.hpp>

--- a/silkworm/node/stagedsync/stages/stage_execution.cpp
+++ b/silkworm/node/stagedsync/stages/stage_execution.cpp
@@ -21,6 +21,7 @@
 
 #include <magic_enum.hpp>
 
+#include <silkworm/core/common/empty_hashes.hpp>
 #include <silkworm/core/common/endian.hpp>
 #include <silkworm/core/execution/processor.hpp>
 #include <silkworm/infra/common/decoding_exception.hpp>

--- a/silkworm/node/stagedsync/stages/stage_interhashes/_test.cpp
+++ b/silkworm/node/stagedsync/stages/stage_interhashes/_test.cpp
@@ -16,6 +16,7 @@
 
 #include <catch2/catch.hpp>
 
+#include <silkworm/core/common/empty_hashes.hpp>
 #include <silkworm/core/trie/hash_builder.hpp>
 #include <silkworm/core/trie/nibbles.hpp>
 #include <silkworm/core/types/account.hpp>

--- a/silkworm/node/stagedsync/stages/stage_interhashes/trie_loader.cpp
+++ b/silkworm/node/stagedsync/stages/stage_interhashes/trie_loader.cpp
@@ -18,6 +18,7 @@
 
 #include <stdexcept>
 
+#include <silkworm/core/common/empty_hashes.hpp>
 #include <silkworm/core/trie/nibbles.hpp>
 #include <silkworm/core/types/account.hpp>
 #include <silkworm/infra/common/decoding_exception.hpp>

--- a/silkworm/rpc/commands/ots_api.cpp
+++ b/silkworm/rpc/commands/ots_api.cpp
@@ -19,6 +19,7 @@
 #include <numeric>
 #include <string>
 
+#include <silkworm/core/common/empty_hashes.hpp>
 #include <silkworm/core/protocol/ethash_rule_set.hpp>
 #include <silkworm/core/types/address.hpp>
 #include <silkworm/core/types/evmc_bytes32.hpp>

--- a/silkworm/rpc/common/util_test.cpp
+++ b/silkworm/rpc/common/util_test.cpp
@@ -20,6 +20,7 @@
 
 #include <silkworm/core/common/base.hpp>
 #include <silkworm/core/common/bytes.hpp>
+#include <silkworm/core/common/empty_hashes.hpp>
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/core/types/address.hpp>
 #include <silkworm/core/types/evmc_bytes32.hpp>

--- a/silkworm/rpc/core/account_dumper.cpp
+++ b/silkworm/rpc/core/account_dumper.cpp
@@ -19,6 +19,7 @@
 #include <utility>
 
 #include <silkworm/core/common/decoding_result.hpp>
+#include <silkworm/core/common/empty_hashes.hpp>
 #include <silkworm/core/trie/hash_builder.hpp>
 #include <silkworm/core/trie/nibbles.hpp>
 #include <silkworm/core/types/address.hpp>

--- a/silkworm/rpc/core/evm_debug.hpp
+++ b/silkworm/rpc/core/evm_debug.hpp
@@ -30,6 +30,7 @@
 #include <nlohmann/json.hpp>
 
 #include <silkworm/core/common/block_cache.hpp>
+#include <silkworm/core/common/empty_hashes.hpp>
 #include <silkworm/core/execution/evm.hpp>
 #include <silkworm/core/state/intra_block_state.hpp>
 #include <silkworm/rpc/core/rawdb/accessors.hpp>

--- a/silkworm/rpc/core/rawdb/chain_test.cpp
+++ b/silkworm/rpc/core/rawdb/chain_test.cpp
@@ -26,7 +26,7 @@
 #include <gmock/gmock.h>
 #include <nlohmann/json.hpp>
 
-#include <silkworm/core/common/decoding_result.hpp>
+#include <silkworm/core/common/empty_hashes.hpp>
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/infra/test_util/log.hpp>
 #include <silkworm/node/db/tables.hpp>

--- a/silkworm/rpc/core/remote_state_test.cpp
+++ b/silkworm/rpc/core/remote_state_test.cpp
@@ -26,6 +26,7 @@
 
 #include <silkworm/core/common/base.hpp>
 #include <silkworm/core/common/bytes.hpp>
+#include <silkworm/core/common/empty_hashes.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/rpc/core/rawdb/accessors.hpp>
 #include <silkworm/rpc/storage/remote_chain_storage.hpp>

--- a/silkworm/rpc/core/state_reader.cpp
+++ b/silkworm/rpc/core/state_reader.cpp
@@ -16,6 +16,7 @@
 
 #include "state_reader.hpp"
 
+#include <silkworm/core/common/empty_hashes.hpp>
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/core/types/account.hpp>
 #include <silkworm/infra/common/decoding_exception.hpp>

--- a/silkworm/rpc/json/block_test.cpp
+++ b/silkworm/rpc/json/block_test.cpp
@@ -19,6 +19,8 @@
 #include <catch2/catch.hpp>
 #include <evmc/evmc.hpp>
 
+#include <silkworm/core/common/empty_hashes.hpp>
+
 namespace silkworm::rpc {
 
 TEST_CASE("serialize block with baseFeePerGas", "[rpc][to_json]") {

--- a/silkworm/rpc/json/fork_choice_test.cpp
+++ b/silkworm/rpc/json/fork_choice_test.cpp
@@ -21,6 +21,8 @@
 
 namespace silkworm::rpc {
 
+using namespace evmc::literals;
+
 TEST_CASE("serialize ForkChoiceStateV1", "[silkworm::json][to_json]") {
     ForkChoiceState forkchoice_state{
         .head_block_hash = 0x3559e851470f6e7bbed1db474980683e8c315bfce99b2a6ef47c057c04de7858_bytes32,

--- a/silkworm/rpc/test/api_test_database.hpp
+++ b/silkworm/rpc/test/api_test_database.hpp
@@ -26,6 +26,7 @@
 #include <nlohmann/json.hpp>
 
 #include <silkworm/core/chain/genesis.hpp>
+#include <silkworm/core/common/empty_hashes.hpp>
 #include <silkworm/core/execution/execution.hpp>
 #include <silkworm/core/state/in_memory_state.hpp>
 #include <silkworm/core/types/address.hpp>

--- a/silkworm/rpc/txpool/miner_test.cpp
+++ b/silkworm/rpc/txpool/miner_test.cpp
@@ -26,6 +26,7 @@
 
 #include <silkworm/core/common/base.hpp>
 #include <silkworm/core/common/bytes.hpp>
+#include <silkworm/core/common/empty_hashes.hpp>
 #include <silkworm/interfaces/txpool/mining.grpc.pb.h>
 #include <silkworm/rpc/test/api_test_base.hpp>
 #include <silkworm/rpc/test/grpc_actions.hpp>

--- a/silkworm/sync/internals/chain_fork_view.cpp
+++ b/silkworm/sync/internals/chain_fork_view.cpp
@@ -17,6 +17,7 @@
 #include "chain_fork_view.hpp"
 
 #include <silkworm/core/chain/genesis.hpp>
+#include <silkworm/core/common/empty_hashes.hpp>
 #include <silkworm/core/types/block.hpp>
 #include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/infra/common/log.hpp>

--- a/silkworm/sync/sync_pos.cpp
+++ b/silkworm/sync/sync_pos.cpp
@@ -23,6 +23,7 @@
 #include <boost/asio/use_awaitable.hpp>
 #include <magic_enum.hpp>
 
+#include <silkworm/core/common/empty_hashes.hpp>
 #include <silkworm/core/protocol/validation.hpp>
 #include <silkworm/core/types/hash.hpp>
 #include <silkworm/infra/common/ensure.hpp>


### PR DESCRIPTION
move kEmptyHash/kEmptyListHash/kEmptyRoot so that base.hpp doesn't depend on evmc