### PR TITLE
cmake: remove ntdll.lib duplication

### DIFF
--- a/silkworm/infra/CMakeLists.txt
+++ b/silkworm/infra/CMakeLists.txt
@@ -56,9 +56,6 @@ set(LIBS_PRIVATE
     magic_enum::magic_enum
 )
 # cmake-format: on
-if(MSVC)
-  list(APPEND LIBS_PRIVATE ntdll.lib)
-endif(MSVC)
 
 target_link_libraries(
   ${TARGET}

--- a/silkworm/node/CMakeLists.txt
+++ b/silkworm/node/CMakeLists.txt
@@ -70,9 +70,6 @@ set(SILKWORM_NODE_PRIVATE_LIBS
     silkworm_interfaces
 )
 # cmake-format: on
-if(MSVC)
-  list(APPEND SILKWORM_NODE_PRIVATE_LIBS ntdll.lib)
-endif(MSVC)
 
 target_link_libraries(
   silkworm_node

--- a/silkworm/sentry/CMakeLists.txt
+++ b/silkworm/sentry/CMakeLists.txt
@@ -55,9 +55,6 @@ set(LIBS_PRIVATE
     silkworm_sentry_discovery_enr
     silkworm_sentry_disc_v4
 )
-if(MSVC)
-  list(APPEND LIBS_PRIVATE ntdll.lib)
-endif(MSVC)
 
 # cmake-format: off
 set(LIBS_PUBLIC

--- a/silkworm/sync/CMakeLists.txt
+++ b/silkworm/sync/CMakeLists.txt
@@ -41,9 +41,6 @@ set(SILKWORM_SYNC_PRIVATE_LIBS
     magic_enum::magic_enum
 )
 # cmake-format: on
-if(MSVC)
-  list(APPEND SILKWORM_SYNC_PRIVATE_LIBS ntdll.lib)
-endif(MSVC)
 
 target_link_libraries(
   silkworm_sync


### PR DESCRIPTION
ntdll.lib propagates from silkworm_interfaces to all dependent libs