### PR TITLE
core: avoid account spurious update for create+delete in same block

### DIFF
--- a/silkworm/core/state/intra_block_state.cpp
+++ b/silkworm/core/state/intra_block_state.cpp
@@ -332,13 +332,17 @@ void IntraBlockState::write_to_db(uint64_t block_number) {
     }
 
     for (const auto& [address, obj] : objects_) {
+        // Skip update if both initial and final state are empty (i.e. contract creation+destruction within the same block)
+        if (!obj.initial && !obj.current) {
+            continue;
+        }
         db_.update_account(address, obj.initial, obj.current);
-        if (!obj.current.has_value()) {
+        if (!obj.current) {
             continue;
         }
         const auto& code_hash{obj.current->code_hash};
         if (code_hash != kEmptyHash &&
-            (!obj.initial.has_value() || obj.initial->incarnation != obj.current->incarnation)) {
+            (!obj.initial || obj.initial->incarnation != obj.current->incarnation)) {
             if (auto it{new_code_.find(code_hash)}; it != new_code_.end()) {
                 ByteView code_view{it->second.data(), it->second.size()};
                 db_.update_account_code(address, obj.current->incarnation, code_hash, code_view);


### PR DESCRIPTION
This PR fixes one incompatibility between Silkworm and Erigon database content related to account state changes.

Specifically, the discrepancy happened on mainnet at block [116525](https://etherscan.io/block/116525), where a contract was deployed at address [0xb214cbce30676bd117f95a8695d34427295cd6f7](https://etherscan.io/address/0xb214cbce30676bd117f95a8695d34427295cd6f7) in transaction 71 and then immediately destroyed in next transaction 72.

When such a sequence happens, i.e. creation followed by self-destruction in the same block, the account state effectively does not change if observed at the start and the end of the block. Hence, such account should not be marked as updated to avoid spurious state changes.