### PR TITLE
build: dockerize silkworm builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,35 @@
+# Include any files or directories that you don't want to be copied to your
+# container here (e.g., local build artifacts, temporary files, etc.).
+#
+# For more help, visit the .dockerignore file reference guide at
+# https://docs.docker.com/engine/reference/builder/#dockerignore-file
+
+**/.DS_Store
+**/__pycache__
+**/.venv
+**/.classpath
+**/.dockerignore
+**/.env
+**/.git
+**/.gitignore
+**/.project
+**/.settings
+**/.toolstarget
+**/.vs
+**/.vscode
+**/*.*proj.user
+**/*.dbmdl
+**/*.jfm
+**/bin
+**/build
+**/charts
+**/docker-compose*
+**/compose*
+**/Dockerfile*
+**/node_modules
+**/npm-debug.log
+**/obj
+**/secrets.dev.yaml
+**/values.dev.yaml
+LICENSE
+README.md

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -1,0 +1,82 @@
+# ↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓
+# Avoid changes in the code below this point to avoid re-building everything 
+
+FROM cimg/python:3.12.0 as base
+
+# 1 Install dependencies
+RUN sudo apt-get update
+RUN sudo apt install -y python3-pip
+RUN sudo pip install conan==1.60.2 chardet
+RUN sudo apt-get update
+
+# 2 Get repo and submodules
+WORKDIR /app
+RUN git clone https://github.com/erigontech/silkworm.git project
+WORKDIR /app/project
+RUN git config submodule.ethereum-tests.update none
+RUN git submodule sync
+RUN git submodule update --init --recursive
+
+# 3 Install compiler
+RUN cmake/setup/compiler_install.sh clang 15
+# Alternative way to install clang > 15
+# WORKDIR /app
+# ARG LLVM_VERSION=16
+# RUN sudo wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+# RUN wget https://apt.llvm.org/llvm.sh
+# RUN chmod +x llvm.sh
+# RUN sudo ./llvm.sh ${LLVM_VERSION} all
+# RUN sudo ln -sfv /usr/bin/clang-${LLVM_VERSION} /usr/bin/clang
+# RUN sudo ln -sfv /usr/bin/clang++-${LLVM_VERSION} /usr/bin/clang++
+# RUN sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang-${LLVM_VERSION} 100
+# RUN sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-${LLVM_VERSION} 100
+
+# 4 Build all targets
+WORKDIR /app/build
+RUN cmake ../project -DCMAKE_BUILD_TYPE=Debug -DCONAN_PROFILE=linux_clang_13_debug
+WORKDIR /app/project
+RUN cmake --build /app/build -j4 
+
+# Avoid changes in the code after this point to avoid re-building everything
+# ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑
+
+
+# Invalidate cache to force rebuild
+ARG CACHEBUST
+RUN echo $CACHEBUST
+
+# Option 1: Build from branch
+RUN echo "Pulling branch" ${BRANCH}
+ARG BRANCH=main
+WORKDIR /app/project
+RUN git checkout ${BRANCH}
+RUN git pull origin ${BRANCH}
+
+# Option 2: Build from local files
+# COPY ./silkworm/ /app/project/silkworm/
+# COPY ./cmd/ /app/project/cmd/
+
+# Rebuild all targets
+RUN echo "Rebuilding"
+WORKDIR /app/build
+RUN sudo cmake ../project -DCMAKE_BUILD_TYPE=Debug -DCONAN_PROFILE=linux_clang_13_debug
+WORKDIR /app/project
+RUN sudo cmake --build /app/build -j4 
+
+
+# Example of how to run a fuzzer:
+# # Copy corpus files
+# WORKDIR /app/build
+# RUN mkdir -p ~/corpus
+# RUN mkdir -p ~/crashes
+# RUN mkdir -p ~/artifacts
+# RUN for file in ../project/third_party/execution-apis/tests/*/*.io; do cp --backup=numbered "$file" ~/artifacts; done
+# RUN for file in ~/artifacts/*; do sed -i '2,$d' "$file"; done
+# RUN for file in ~/artifacts/*; do sed -i 's/^>> //' "$file"; done
+# # Rebuild fuzzer
+# WORKDIR /app/build
+# RUN sudo cmake ../project -DCMAKE_BUILD_TYPE=Debug -DCONAN_PROFILE=linux_clang_13_debug -DSILKWORM_FUZZING=ON
+# WORKDIR /app/project
+# RUN sudo cmake --build /app/build -j4 --target rpcdaemon_fuzzer_test
+# # Run fuzzer
+# RUN ./cmd/test/rpcdaemon_fuzzer_test -max_total_time=1000 ~/corpus ~/crashes ~/artifacts

--- a/tests/docker/README.md
+++ b/tests/docker/README.md
@@ -1,0 +1,25 @@
+This docker setup is designed to provide a consistent environment for running tests and building the project. 
+
+It's is made of two parts. The first part downloads the project into a docker container, installs all the dependencies, configures the packages and builds all the binaries. This part is cached so that it doesn't have to be run every time.
+In the second part, an up-to-date version of the project is downloaded into a new container and the build is ran again. This guarantees the quickness of the build.
+
+To build and run docker image simply run:
+```bash
+./run-docker.sh master
+```
+
+You can also run the docker image with a specific branch or tag:
+```bash
+./run-docker.sh my-branch
+```
+
+From time to time it is necessary to rebuild the whole docker image and refresh any cached parts. To do so, run:
+```bash
+./run-docker.sh -r master
+```
+Inside the Dockefile you can find a certain variations:
+- build using different clang versions
+- build using local changes
+- run tests
+- run fuzzer
+To run them, simply uncomment or change the desired lines and run the script again.

--- a/tests/docker/run-docker.sh
+++ b/tests/docker/run-docker.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+while [ True ]; do
+if [ "$1" = "--refresh-cache" -o "$1" = "-r" ]; then
+    RENEW=1
+    shift 1
+else
+    break
+fi
+done
+
+if (( $# != 1 )); then
+    echo "Usage: $0 [--refresh-cache|-r] <branch>"
+    exit 1
+fi
+
+BRANCH=$1
+
+if [ -z "$RENEW" ]; then
+    echo docker build --tag silkworm-clang:15 --progress=plain --build-arg="CACHEBUST=$(date +%s)" --build-arg="BRANCH=$BRANCH" -f ./Dockerfile ../..
+else    
+    echo docker build --tag silkworm-clang:15 --progress=plain --no-cache --build-arg="BRANCH=$BRANCH" -f ./Dockerfile ../..
+fi
+
+echo docker rm -f $(docker ps -aq --filter name=silkworm-clang-15)
+echo docker run --name silkworm-clang-15 -d -t silkworm-clang:15


### PR DESCRIPTION
This PR introduces a docker container to build silkworm. 

The motivation is to have an environment close to the CI that can be run locally. To speed up builds, the Dockerfile is constructed in a way that caches as much as possible, but still enables fresh builds.

Documentation and scripts provided.