### PR TITLE
cmake: fix accidental linking with system libgmp

### DIFF
--- a/third_party/gmp/CMakeLists.txt
+++ b/third_party/gmp/CMakeLists.txt
@@ -33,5 +33,5 @@ else()
       CACHE PATH ""
   )
   get_target_property(GMP_LIBRARY_DIR gmp::GMP INTERFACE_LINK_DIRECTORIES)
-  find_library(GMP_LIBRARY gmp "${GMP_LIBRARY_DIR}")
+  find_library(GMP_LIBRARY gmp PATHS "${GMP_LIBRARY_DIR}" REQUIRED NO_DEFAULT_PATH)
 endif()

--- a/third_party/gmp/CMakeLists.txt
+++ b/third_party/gmp/CMakeLists.txt
@@ -33,5 +33,9 @@ else()
       CACHE PATH ""
   )
   get_target_property(GMP_LIBRARY_DIR gmp::GMP INTERFACE_LINK_DIRECTORIES)
-  find_library(GMP_LIBRARY gmp PATHS "${GMP_LIBRARY_DIR}" REQUIRED NO_DEFAULT_PATH)
+  find_library(
+    GMP_LIBRARY gmp
+    PATHS "${GMP_LIBRARY_DIR}" REQUIRED
+    NO_DEFAULT_PATH
+  )
 endif()


### PR DESCRIPTION
On some Linux distros libgmp is installed by default (as a shared library), and find_library() was returning it instead of using the static libgmp.a version from conan.