### PR TITLE
core: fix missing call trace for create/create2 w/ early return

### DIFF
--- a/silkworm/core/execution/call_tracer.cpp
+++ b/silkworm/core/execution/call_tracer.cpp
@@ -17,7 +17,11 @@
 #include "call_tracer.hpp"
 
 #include <evmc/hex.hpp>
+#include <evmc/instructions.h>
 #include <evmone/execution_state.hpp>
+#include <evmone/instructions.hpp>
+
+#include <silkworm/core/types/address.hpp>
 
 namespace silkworm {
 
@@ -31,6 +35,30 @@ void CallTracer::on_execution_start(evmc_revision /*rev*/, const evmc_message& m
     } else {
         traces_.senders.insert(msg.sender);
         traces_.recipients.insert(msg.recipient);
+    }
+}
+
+void CallTracer::on_instruction_start(uint32_t pc, const intx::uint256* stack_top, int stack_height, int64_t /*gas*/,
+                                      const evmone::ExecutionState& state, const IntraBlockState& intra_block_state) noexcept {
+    const auto op_code = state.original_code[pc];
+    if (op_code == evmc_opcode::OP_CREATE) {
+        const uint64_t nonce{intra_block_state.get_nonce(state.msg->recipient)};
+        const auto& contract_address{create_address(state.msg->recipient, nonce)};
+
+        traces_.senders.insert(state.msg->recipient);
+        traces_.recipients.insert(contract_address);
+    } else if (op_code == evmc_opcode::OP_CREATE2) {
+        SILKWORM_ASSERT(stack_height >= 4);
+        const auto init_code_offset = static_cast<size_t>(stack_top[-1]);
+        const auto init_code_size = static_cast<size_t>(stack_top[-2]);
+        const evmc::bytes32 salt2{intx::be::store<evmc::bytes32>(stack_top[-3])};
+        SILKWORM_ASSERT(init_code_offset < state.memory.size());
+        auto init_code_hash{
+            init_code_size > 0 ? ethash::keccak256(&state.memory.data()[init_code_offset], init_code_size) : ethash_hash256{}};
+        const auto& contract_address{create2_address(state.msg->recipient, salt2, init_code_hash.bytes)};
+
+        traces_.senders.insert(state.msg->recipient);
+        traces_.recipients.insert(contract_address);
     }
 }
 

--- a/silkworm/core/execution/call_tracer.hpp
+++ b/silkworm/core/execution/call_tracer.hpp
@@ -34,6 +34,8 @@ class CallTracer : public EvmTracer {
     CallTracer& operator=(const CallTracer&) = delete;
 
     void on_execution_start(evmc_revision rev, const evmc_message& msg, evmone::bytes_view code) noexcept override;
+    void on_instruction_start(uint32_t pc, const intx::uint256* stack_top, int stack_height, int64_t gas,
+                              const evmone::ExecutionState& state, const IntraBlockState& intra_block_state) noexcept override;
     void on_self_destruct(const evmc::address& address, const evmc::address& beneficiary) noexcept override;
     void on_block_end(const silkworm::Block& block) noexcept override;
 

--- a/silkworm/core/execution/evm_test.cpp
+++ b/silkworm/core/execution/evm_test.cpp
@@ -635,7 +635,7 @@ TEST_CASE("Tracing smart contract with storage", "[core][execution]") {
     CHECK(call_traces3.recipients.contains(contract_address1));
 }
 
-TEST_CASE("Tracing creation smart contract with CREATE2", "[core][execution]") {
+TEST_CASE("Tracing smart contract creation with CREATE2", "[core][execution]") {
     Block block{};
     block.header.number = 10'336'006;
     const evmc::address caller{0x0a6bb546b9208cfab9e8fa2b9b2c042b18df7030_address};
@@ -1022,6 +1022,164 @@ TEST_CASE("Missing sender in call traces for DELEGATECALL", "[core][execution]")
     CHECK(call_traces.recipients.contains(zero_address));    // 1st+2nd txs go to zero_address (contract creation)
     CHECK(call_traces.recipients.contains(caller_address));  // 3rd tx goes to caller_address
     CHECK(call_traces.recipients.contains(callee_address));  // 3rd tx triggers one delegate call to callee_address
+}
+
+// First occurrence at mainnet block 1'305'821
+TEST_CASE("Missing call traces for CREATE/CREATE2 when completed w/o executing", "[core][execution]") {
+    const evmc::address external_account{0x0a6bb546b9208cfab9e8fa2b9b2c042b18df7030_address};
+
+    // Bytecode compiled using solc 0.8.19+commit.4fc1097e
+    const Bytes item_code{*from_hex(
+        "6080604052348015600f57600080fd5b50603f80601d6000396000f3fe60806040"
+        "52600080fdfea2646970667358221220a3544cc91a06a14e2a9610d3b786201808"
+        "2accb02f8555e847bc238a80ec0ec664736f6c63430008130033")};
+    // pragma solidity 0.8.19;
+    //
+    // contract Item {
+    //     constructor() {}
+    // }
+
+    const Bytes factory_and_test_contract_code{*from_hex(
+        "608060405234801561001057600080fd5b5061014d806100206000396000f3fe60"
+        "8060405234801561001057600080fd5b50600436106100365760003560e01c8063"
+        "efc81a8c1461003b578063f5eacece14610045575b600080fd5b61004361004f56"
+        "5b005b61004d61007b565b005b60405161005b906100af565b6040518091039060"
+        "00f080158015610077573d6000803e3d6000fd5b5050565b6000801b6040516100"
+        "8b906100af565b8190604051809103906000f59050801580156100ab573d600080"
+        "3e3d6000fd5b5050565b605c806100bc8339019056fe6080604052348015600f57"
+        "600080fd5b50603f80601d6000396000f3fe6080604052600080fdfea264697066"
+        "7358221220a3544cc91a06a14e2a9610d3b7862018082accb02f8555e847bc238a"
+        "80ec0ec664736f6c63430008130033a26469706673582212207dbb3b4abbeee927"
+        "e9bf764d2f83d595ce57ab4f1a5f5db3b84aaa22d5cdf4a264736f6c6343000813"
+        "0033")};
+    // pragma solidity 0.8.19;
+    //
+    // contract Factory {
+    //     constructor() {}
+    //
+    //     function create() public {
+    //         new Item();
+    //     }
+    //
+    //     function create2() public {
+    //         new Item{salt: 0}();
+    //     }
+    // }
+    //
+    // contract Item {
+    //     constructor() {}
+    // }
+
+    // Bytecode contains PUSH0 opcode so requires EIP-3855, hence at least Shanghai HF
+    const auto chain_config{kMainnetConfig};
+    REQUIRE(chain_config.shanghai_time);
+
+    Block block{};
+    block.header.number = 18'700'000;
+
+    InMemoryState db;
+    IntraBlockState state{db};
+    EVM evm{block, state, kMainnetConfig};
+
+    // 1st tx deploys the factory at factory_address
+    const auto factory_address{create_address(external_account, 0)};
+
+    Transaction txn1{};
+    txn1.from = external_account;
+    txn1.data = factory_and_test_contract_code;
+
+    TestTracer tracer;
+    evm.add_tracer(tracer);
+    CallTraces call_traces;
+    CallTracer call_tracer{call_traces};
+    evm.add_tracer(call_tracer);
+    CHECK(evm.tracers().size() == 2);
+
+    uint64_t gas1 = {1'000'000};  // largely abundant
+    CallResult res1{evm.execute(txn1, gas1)};
+
+    CHECK(res1.status == EVMC_SUCCESS);
+    CHECK(call_traces.senders.size() == 1);
+    CHECK(call_traces.senders.contains(external_account));  // 1st tx originates from external_account
+    CHECK(call_traces.recipients.size() == 1);
+    CHECK(call_traces.recipients.contains(factory_address));  // 1st tx goes to factory_address
+
+    call_traces.senders.clear();
+    call_traces.recipients.clear();
+
+    // 2nd tx asks the factory to deploy an item using CREATE at item1_address
+    const auto item1_address{create_address(factory_address, 1)};
+
+    Transaction txn2{};
+    txn2.from = external_account;
+    txn2.to = factory_address;
+    txn2.data = ByteView{*from_hex("efc81a8c")};  // methodID for create
+
+    uint64_t gas2 = {1'000'000};  // largely abundant
+    CallResult res2{evm.execute(txn2, gas2)};
+
+    CHECK(res2.status == EVMC_SUCCESS);
+    CHECK(call_traces.senders.size() == 2);
+    CHECK(call_traces.senders.contains(external_account));  // 2nd tx originates from external_account
+    CHECK(call_traces.senders.contains(factory_address));
+    CHECK(call_traces.recipients.size() == 2);
+    CHECK(call_traces.recipients.contains(factory_address));  // 2nd tx goes to factory_address
+    CHECK(call_traces.recipients.contains(item1_address));
+
+    call_traces.senders.clear();
+    call_traces.recipients.clear();
+
+    // 3rd tx asks the factory to deploy an item using CREATE2 at item2_address
+    ethash::hash256 item_code_hash{keccak256(item_code)};
+    const auto item2_address{create2_address(factory_address, evmc::bytes32{0}, item_code_hash.bytes)};
+
+    Transaction txn3{};
+    txn3.from = external_account;
+    txn3.to = factory_address;
+    txn3.data = ByteView{*from_hex("f5eacece")};  // methodID for create2
+
+    uint64_t gas3 = {1'000'000};  // largely abundant
+    CallResult res3{evm.execute(txn3, gas3)};
+
+    CHECK(res3.status == EVMC_SUCCESS);
+    CHECK(call_traces.senders.size() == 2);
+    CHECK(call_traces.senders.contains(external_account));  // 3rd tx originates from external_account
+    CHECK(call_traces.senders.contains(factory_address));   // item creation originates from factory_address
+    CHECK(call_traces.recipients.size() == 2);
+    CHECK(call_traces.recipients.contains(factory_address));  // 3rd tx goes to factory_address
+    CHECK(call_traces.recipients.contains(item2_address));    // item gets deployed at item2_address
+
+    call_traces.senders.clear();
+    call_traces.recipients.clear();
+
+    // 4th execution is like 2nd but triggers early failure due to insufficient gas
+    const auto item1bis_address{create_address(factory_address, 3)};
+
+    uint64_t gas4 = {10'000};
+    CallResult res4{evm.execute(txn2, gas4)};
+
+    CHECK(res4.status == EVMC_OUT_OF_GAS);
+    CHECK(call_traces.senders.size() == 2);
+    CHECK(call_traces.senders.contains(external_account));  // 2nd tx originates from external_account
+    CHECK(call_traces.senders.contains(factory_address));
+    CHECK(call_traces.recipients.size() == 2);
+    CHECK(call_traces.recipients.contains(factory_address));  // 2nd tx goes to factory_address
+    CHECK(call_traces.recipients.contains(item1bis_address));
+
+    call_traces.senders.clear();
+    call_traces.recipients.clear();
+
+    // 5th execution is like 3rd but triggers early failure due to insufficient gas
+    uint64_t gas5 = {10'000};
+    CallResult res5{evm.execute(txn3, gas5)};
+
+    CHECK(res5.status == EVMC_OUT_OF_GAS);
+    CHECK(call_traces.senders.size() == 2);
+    CHECK(call_traces.senders.contains(external_account));  // 3rd tx originates from external_account
+    CHECK(call_traces.senders.contains(factory_address));   // item creation originates from factory_address
+    CHECK(call_traces.recipients.size() == 2);
+    CHECK(call_traces.recipients.contains(factory_address));  // 3rd tx goes to factory_address
+    CHECK(call_traces.recipients.contains(item2_address));    // failed item creation at item2_address
 }
 
 }  // namespace silkworm


### PR DESCRIPTION
This PR fixes another incompatibility between Silkworm and Erigon database content related to call traces.

Specifically, the discrepancy happened on mainnet at block [1305821](https://etherscan.io/block/1305821), where transaction 0 hits the fallback function of contract [0xFDf3D6c72F8aF59Fd1D7Fa65D1C12f89f12F9394](https://etherscan.io/address/0xFDf3D6c72F8aF59Fd1D7Fa65D1C12f89f12F9394). After some interactions with another address, such a contract executes a `CREATE` opcode to deploy another contract: this operation "silently succeeds" during one early check before the code deployment, i.e. in this specific case the deploying contract has insufficient balance to cover the expected endowment for the new contract.

When an early return happens (positive or negative, it doesn't matter) during preliminary checks performed by the `evmone`, no invocation of `evmone::Host::call` hook takes place, hence no proper execution context gets activated for the `CREATE` operation. This in turns means that any registered EVM tracer does not receive any notification on its `on_execution_start` callback, as it is the case instead when a `CREATE` operation is effectively executed (independently from its final result).

So, the only way to intercept any `CREATE` operation executing an early return for the purpose of tracing its sender and recipient is then by the `on_instruction_start` callback.

All the above considerations can be applied to the `CREATE2` operation as well.