### PR TITLE
core: make Transaction::hash() thread-safe

### DIFF
--- a/silkworm/core/concurrency/resettable_once_flag.hpp
+++ b/silkworm/core/concurrency/resettable_once_flag.hpp
@@ -21,6 +21,9 @@
 
 namespace silkworm {
 
+// Resettable std::once_flag. Helper class for lazy evaluation of derived fields such as transaction hash & sender.
+// On one hand, we want such evaluation to happen exactly once and be safe to invoke concurrently (std::call_once).
+// On the other hand, we need to re-calculate when the inputs to the evaluation change (thus resettable).
 class ResettableOnceFlag {
   public:
     ResettableOnceFlag() {

--- a/silkworm/core/concurrency/resettable_once_flag.hpp
+++ b/silkworm/core/concurrency/resettable_once_flag.hpp
@@ -1,0 +1,51 @@
+/*
+   Copyright 2023 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <memory>
+#include <mutex>
+
+namespace silkworm {
+
+class ResettableOnceFlag {
+  public:
+    ResettableOnceFlag() {
+        reset();
+    }
+
+    ResettableOnceFlag(const ResettableOnceFlag&) {
+        reset();
+    }
+    ResettableOnceFlag& operator=(const ResettableOnceFlag&) {
+        reset();
+        return *this;
+    }
+
+    ResettableOnceFlag(ResettableOnceFlag&&) = default;
+    ResettableOnceFlag& operator=(ResettableOnceFlag&&) = default;
+
+    [[nodiscard]] std::once_flag& get() { return *flag_; }
+
+    void reset() {
+        flag_ = std::make_unique<std::once_flag>();
+    }
+
+  private:
+    std::unique_ptr<std::once_flag> flag_;
+};
+
+}  // namespace silkworm

--- a/silkworm/core/types/transaction.hpp
+++ b/silkworm/core/types/transaction.hpp
@@ -23,6 +23,7 @@
 
 #include <silkworm/core/common/base.hpp>
 #include <silkworm/core/common/bytes.hpp>
+#include <silkworm/core/concurrency/resettable_once_flag.hpp>
 #include <silkworm/core/rlp/decode.hpp>
 #include <silkworm/core/types/hash.hpp>
 
@@ -81,7 +82,8 @@ struct UnsignedTransaction {
     friend bool operator==(const UnsignedTransaction&, const UnsignedTransaction&) = default;
 };
 
-struct Transaction : public UnsignedTransaction {
+class Transaction : public UnsignedTransaction {
+  public:
     bool odd_y_parity{false};
     intx::uint256 r{0}, s{0};  // signature
 
@@ -107,7 +109,8 @@ struct Transaction : public UnsignedTransaction {
 
   private:
     // cached value for hash if already computed
-    mutable std::optional<evmc::bytes32> cached_hash_{std::nullopt};
+    mutable evmc::bytes32 cached_hash_;
+    mutable ResettableOnceFlag hash_computed_;
 };
 
 namespace rlp {


### PR DESCRIPTION
According to [Google's style guide](https://google.github.io/styleguide/cppguide.html#Use_of_const), all of a class's `const` operations should be safe to invoke concurrently with each other.