### PR TITLE
core: exclude tracing for create/create2 failing pre-checks

### DIFF
--- a/silkworm/core/execution/call_tracer.cpp
+++ b/silkworm/core/execution/call_tracer.cpp
@@ -68,7 +68,7 @@ inline evmc_status_code check_requirements(const CostTable& cost_table, int64_t&
 
     return EVMC_SUCCESS;
 }
-}
+}  // namespace
 
 namespace silkworm {
 

--- a/silkworm/core/execution/call_tracer.cpp
+++ b/silkworm/core/execution/call_tracer.cpp
@@ -18,10 +18,57 @@
 
 #include <evmc/hex.hpp>
 #include <evmc/instructions.h>
+#include <evmone/baseline_instruction_table.hpp>
 #include <evmone/execution_state.hpp>
 #include <evmone/instructions.hpp>
 
 #include <silkworm/core/types/address.hpp>
+
+using namespace evmone;
+using namespace evmone::baseline;
+
+// The following check_requirements function has been temporarily copied from evmone because it is not exported.
+// We need to ask evmone for it to be exported or for a tracing interface extension (e.g. on_instruction_end?).
+namespace {
+template <Opcode Op>
+inline evmc_status_code check_requirements(const CostTable& cost_table, int64_t& gas_left,
+                                           const uint256* stack_top, const uint256* stack_bottom) noexcept {
+    static_assert(
+        !instr::has_const_gas_cost(Op) || instr::gas_costs[EVMC_FRONTIER][Op] != instr::undefined,
+        "undefined instructions must not be handled by check_requirements()");
+
+    auto gas_cost = instr::gas_costs[EVMC_FRONTIER][Op];  // Init assuming const cost.
+    if constexpr (!instr::has_const_gas_cost(Op)) {
+        gas_cost = cost_table[Op];  // If not, load the cost from the table.
+
+        // Negative cost marks an undefined instruction.
+        // This check must be first to produce correct error code.
+        if (INTX_UNLIKELY(gas_cost < 0))
+            return EVMC_UNDEFINED_INSTRUCTION;
+    }
+
+    // Check stack requirements first. This is order is not required,
+    // but it is nicer because complete gas check may need to inspect operands.
+    if constexpr (instr::traits[Op].stack_height_change > 0) {
+        static_assert(instr::traits[Op].stack_height_change == 1,
+                      "unexpected instruction with multiple results");
+        if (INTX_UNLIKELY(stack_top == stack_bottom + StackSpace::limit))
+            return EVMC_STACK_OVERFLOW;
+    }
+    if constexpr (instr::traits[Op].stack_height_required > 0) {
+        // Check stack underflow using pointer comparison <= (better optimization).
+        static constexpr auto min_offset = instr::traits[Op].stack_height_required - 1;
+        if (INTX_UNLIKELY(stack_top <= stack_bottom + min_offset))
+            return EVMC_STACK_UNDERFLOW;
+    }
+
+    if (INTX_UNLIKELY((gas_left -= gas_cost) < 0)) {
+        return EVMC_OUT_OF_GAS;
+    }
+
+    return EVMC_SUCCESS;
+}
+}
 
 namespace silkworm {
 
@@ -38,25 +85,33 @@ void CallTracer::on_execution_start(evmc_revision /*rev*/, const evmc_message& m
     }
 }
 
-void CallTracer::on_instruction_start(uint32_t pc, const intx::uint256* stack_top, int stack_height, int64_t /*gas*/,
+void CallTracer::on_instruction_start(uint32_t pc, const intx::uint256* stack_top, int stack_height, int64_t gas,
                                       const evmone::ExecutionState& state, const IntraBlockState& intra_block_state) noexcept {
     const auto op_code = state.original_code[pc];
     if (op_code == evmc_opcode::OP_CREATE) {
+        const auto& cost_table{get_baseline_cost_table(state.rev, state.analysis.baseline->eof_header.version)};
+        if (const auto status{check_requirements<Opcode::OP_CREATE>(cost_table, gas, stack_top, stack_top - stack_height)}; status != EVMC_SUCCESS) {
+            return;  // Early failure in pre-execution checks, do not trace anything for compatibility w/ Erigon
+        }
         const uint64_t nonce{intra_block_state.get_nonce(state.msg->recipient)};
         const auto& contract_address{create_address(state.msg->recipient, nonce)};
 
         traces_.senders.insert(state.msg->recipient);
         traces_.recipients.insert(contract_address);
     } else if (op_code == evmc_opcode::OP_CREATE2) {
+        const auto& cost_table{get_baseline_cost_table(state.rev, state.analysis.baseline->eof_header.version)};
+        if (const auto status{check_requirements<Opcode::OP_CREATE2>(cost_table, gas, stack_top, stack_top - stack_height)}; status != EVMC_SUCCESS) {
+            return;  // Early failure in pre-execution checks, do not trace anything for compatibility w/ Erigon
+        }
         if (stack_height < 4) {
             return;  // Invariant break for current implementation of OP_CREATE2, let's handle this gracefully.
         }
         const auto init_code_offset = static_cast<size_t>(stack_top[-1]);
-        const auto init_code_size = static_cast<size_t>(stack_top[-2]);
-        const evmc::bytes32 salt2{intx::be::store<evmc::bytes32>(stack_top[-3])};
         if (init_code_offset >= state.memory.size()) {
             return;  // Invariant break for current implementation of OP_CREATE2, let's handle this gracefully.
         }
+        const auto init_code_size = static_cast<size_t>(stack_top[-2]);
+        const evmc::bytes32 salt2{intx::be::store<evmc::bytes32>(stack_top[-3])};
         auto init_code_hash{
             init_code_size > 0 ? ethash::keccak256(&state.memory.data()[init_code_offset], init_code_size) : ethash_hash256{}};
         const auto& contract_address{create2_address(state.msg->recipient, salt2, init_code_hash.bytes)};

--- a/silkworm/core/execution/evm_test.cpp
+++ b/silkworm/core/execution/evm_test.cpp
@@ -664,8 +664,7 @@ TEST_CASE("Tracing smart contract creation with CREATE", "[core][execution]") {
         "a26fcd81322047223364736f6c634300081300336080604052348015600f5760"
         "0080fd5b50603f80601d6000396000f3fe6080604052600080fdfea264697066"
         "7358221220f6587bd1dd592bb64698cf04f378d03a5f9e55c27c86df8890b628"
-        "7d8694a43164736f6c63430008130033"
-        )};
+        "7d8694a43164736f6c63430008130033")};
     // pragma solidity 0.8.19;
     //
     // contract Factory {

--- a/silkworm/core/execution/evm_test.cpp
+++ b/silkworm/core/execution/evm_test.cpp
@@ -458,6 +458,22 @@ class TestTracer : public EvmTracer {
         self_destruct_called_ = true;
     }
 
+    void reset() {
+        execution_start_called_ = false;
+        execution_end_called_ = false;
+        creation_completed_called_ = false;
+        self_destruct_called_ = false;
+        contract_address_.reset();
+        key_.reset();
+        rev_ = EVMC_FRONTIER;
+        msg_stack_.clear();
+        bytecode_.clear();
+        pc_stack_.clear();
+        memory_size_stack_.clear();
+        storage_stack_.clear();
+        result_ = {};
+    }
+
     [[nodiscard]] bool execution_start_called() const { return execution_start_called_; }
     [[nodiscard]] bool execution_end_called() const { return execution_end_called_; }
     [[nodiscard]] bool creation_completed_called() const { return creation_completed_called_; }
@@ -633,6 +649,98 @@ TEST_CASE("Tracing smart contract with storage", "[core][execution]") {
     CHECK(tracer3.result().data.empty());
     CHECK(call_traces3.senders.contains(caller));
     CHECK(call_traces3.recipients.contains(contract_address1));
+}
+
+TEST_CASE("Tracing smart contract creation with CREATE", "[core][execution]") {
+    Block block{};
+    block.header.number = 10'336'006;
+    const evmc::address caller{0x0a6bb546b9208cfab9e8fa2b9b2c042b18df7030_address};
+
+    Bytes code{*from_hex(
+        "6080604052348015600f57600080fd5b50604051601a90603b565b6040518091"
+        "03906000f0801580156035573d6000803e3d6000fd5b50506047565b605c8061"
+        "009483390190565b603f806100556000396000f3fe6080604052600080fdfea2"
+        "646970667358221220a6baacd5f97c2b771bee61b48c72a104dab25ffee7f1d6"
+        "a26fcd81322047223364736f6c634300081300336080604052348015600f5760"
+        "0080fd5b50603f80601d6000396000f3fe6080604052600080fdfea264697066"
+        "7358221220f6587bd1dd592bb64698cf04f378d03a5f9e55c27c86df8890b628"
+        "7d8694a43164736f6c63430008130033"
+        )};
+    // pragma solidity 0.8.19;
+    //
+    // contract Factory {
+    //     constructor() {
+    //         new Item();
+    //     }
+    // }
+    // contract Item {
+    //     constructor() {}
+    // }
+
+    InMemoryState db;
+    IntraBlockState state{db};
+    EVM evm{block, state, kMainnetConfig};
+
+    Transaction txn{};
+    txn.from = caller;
+    txn.data = code;
+
+    TestTracer tracer;
+    evm.add_tracer(tracer);
+    CallTraces call_traces;
+    CallTracer call_tracer{call_traces};
+    evm.add_tracer(call_tracer);
+    CHECK(evm.tracers().size() == 2);
+
+    const auto factory0_address{create_address(caller, state.get_nonce(caller))};
+    const auto item0_address{create_address(factory0_address, 1)};
+
+    uint64_t gas1 = {100'000};  // largely abundant (required 57'470)
+    CallResult res1{evm.execute(txn, gas1)};
+
+    CHECK(res1.status == EVMC_SUCCESS);
+    CHECK(tracer.msg_stack().size() == 2);
+    if (tracer.msg_stack().size() == 2) {
+        CHECK(tracer.msg_stack().at(0).depth == 0);
+        CHECK(tracer.msg_stack().at(0).kind == evmc_call_kind::EVMC_CALL);
+        CHECK(tracer.msg_stack().at(0).recipient == factory0_address);
+        CHECK(evmc::is_zero(tracer.msg_stack().at(0).code_address));
+        CHECK(tracer.msg_stack().at(1).depth == 1);
+        CHECK(tracer.msg_stack().at(1).kind == evmc_call_kind::EVMC_CREATE);
+        CHECK(tracer.msg_stack().at(1).recipient == item0_address);
+    }
+    CHECK(evmc::is_zero(tracer.msg_stack().at(1).code_address));
+    CHECK(call_traces.senders.size() == 2);
+    CHECK(call_traces.senders.contains(caller));
+    CHECK(call_traces.senders.contains(factory0_address));
+    CHECK(call_traces.recipients.size() == 2);
+    CHECK(call_traces.recipients.contains(factory0_address));
+    CHECK(call_traces.recipients.contains(item0_address));
+
+    tracer.reset();
+    call_traces.senders.clear();
+    call_traces.recipients.clear();
+
+    // Trigger an early failure in evmone::baseline::check_requirements for CREATE opcode
+    const auto factory1_address{create_address(caller, state.get_nonce(caller))};
+    const auto item1_address{create_address(factory1_address, 1)};
+
+    uint64_t gas2 = {138};  // causes out-of-gas at instruction 34 opcode CREATE in check_requirements
+    CallResult res2 = evm.execute(txn, gas2);
+    CHECK(res2.status == EVMC_OUT_OF_GAS);
+    CHECK(tracer.msg_stack().size() == 1);
+    if (tracer.msg_stack().size() == 1) {
+        CHECK(tracer.msg_stack().at(0).depth == 0);
+        CHECK(tracer.msg_stack().at(0).kind == evmc_call_kind::EVMC_CALL);
+        CHECK(tracer.msg_stack().at(0).recipient == factory1_address);
+        CHECK(evmc::is_zero(tracer.msg_stack().at(0).code_address));
+    }
+    CHECK(call_traces.senders.size() == 1);
+    CHECK(call_traces.senders.contains(caller));
+    CHECK(!call_traces.senders.contains(factory1_address));
+    CHECK(call_traces.recipients.size() == 1);
+    CHECK(call_traces.recipients.contains(factory1_address));
+    CHECK(!call_traces.recipients.contains(item1_address));
 }
 
 TEST_CASE("Tracing smart contract creation with CREATE2", "[core][execution]") {
@@ -1187,34 +1295,34 @@ TEST_CASE("Missing call traces for CREATE/CREATE2 when completed w/o executing",
     call_traces.senders.clear();
     call_traces.recipients.clear();
 
-    // 4th execution is like 2nd but triggers early failure due to insufficient gas
+    // 4th execution is like 2nd but triggers early failure in check_requirements due to insufficient gas
     const auto item1bis_address{create_address(factory_address, 3)};
 
     uint64_t gas4 = {10'000};
     CallResult res4{evm.execute(txn2, gas4)};
 
     CHECK(res4.status == EVMC_OUT_OF_GAS);
-    CHECK(call_traces.senders.size() == 2);
+    CHECK(call_traces.senders.size() == 1);
     CHECK(call_traces.senders.contains(external_account));  // 2nd tx originates from external_account
-    CHECK(call_traces.senders.contains(factory_address));
-    CHECK(call_traces.recipients.size() == 2);
-    CHECK(call_traces.recipients.contains(factory_address));  // 2nd tx goes to factory_address
-    CHECK(call_traces.recipients.contains(item1bis_address));
+    CHECK(!call_traces.senders.contains(factory_address));  // factory_address not traced because creation failed
+    CHECK(call_traces.recipients.size() == 1);
+    CHECK(call_traces.recipients.contains(factory_address));    // 2nd tx goes to factory_address
+    CHECK(!call_traces.recipients.contains(item1bis_address));  // item1bis_address not traced because creation failed
 
     call_traces.senders.clear();
     call_traces.recipients.clear();
 
-    // 5th execution is like 3rd but triggers early failure due to insufficient gas
+    // 5th execution is like 3rd but triggers early failure in check_requirements due to insufficient gas
     uint64_t gas5 = {10'000};
     CallResult res5{evm.execute(txn3, gas5)};
 
     CHECK(res5.status == EVMC_OUT_OF_GAS);
-    CHECK(call_traces.senders.size() == 2);
+    CHECK(call_traces.senders.size() == 1);
     CHECK(call_traces.senders.contains(external_account));  // 3rd tx originates from external_account
-    CHECK(call_traces.senders.contains(factory_address));   // item creation originates from factory_address
-    CHECK(call_traces.recipients.size() == 2);
+    CHECK(!call_traces.senders.contains(factory_address));  // factory_address not traced because creation failed
+    CHECK(call_traces.recipients.size() == 1);
     CHECK(call_traces.recipients.contains(factory_address));  // 3rd tx goes to factory_address
-    CHECK(call_traces.recipients.contains(item2_address));    // failed item creation at item2_address
+    CHECK(!call_traces.recipients.contains(item2_address));   // item2_address not traced because creation failed
 }
 
 }  // namespace silkworm


### PR DESCRIPTION
This PR fixes yet another incompatibility between Silkworm and Erigon database content related to call traces.

Specifically, the discrepancy happens on mainnet at block [1878695](https://etherscan.io/block/1878695), where transaction [5](https://etherscan.io/tx/0x0ccccec7ba6a56abfcf0c5c82688de0ddfdeee3176316cf69ff39797b654d308) runs out of gas trying to deploy contract [0xAE050f0402c2F4C7fe0Abb0ea1F0A466061AE967](https://etherscan.io/address/0xAE050f0402c2F4C7fe0Abb0ea1F0A466061AE967): the failure is triggered within `evmone::baseline` in function [`check_requirements`](https://github.com/ethereum/evmone/blob/781875d95dd186ab1bf36712979b479f884a3748/lib/evmone/baseline.cpp#L147) for opcode `CREATE`.

In this specific case, Erigon does not include the `CREATE` sender and recipient into the call trace set for the block. On the other hand, Silkworm does after the changes introduced by #1706, namely using the `on_instruction_start` callback to trace sender and recipient of early-returning `CREATE` operations. Hence, given that we need to correlate the out-of-gas failure with the `CREATE` opcode execution, what we can do with the current tracing interface is just reproducing the same requirement failure here.

Moreover the `check_requirements` function, which detects the out-of-gas condition during pre-execution checks, is currently not exported by `evmone`, so this PR temporarily copies the code here.

@chfast for a proper solution we either need to export the `check_requirements` function from `evmone` or even better to extend the tracing interface (perhaps by adding `on_instruction_end` hook or carrying over the last executed opcode in `on_execution_end`? not sure) so that we don't need to redo the check

All the above considerations can be applied to the `CREATE2` operation as well.