### PR TITLE
rpcdaemon: do not set log verbosity twice to fix TSAN error

### DIFF
--- a/silkworm/rpc/json/stream_test.cpp
+++ b/silkworm/rpc/json/stream_test.cpp
@@ -18,13 +18,9 @@
 
 #include <silkworm/infra/concurrency/task.hpp>
 
-#include <boost/asio/co_spawn.hpp>
-#include <boost/asio/thread_pool.hpp>
 #include <catch2/catch.hpp>
-#include <gmock/gmock.h>
 
 #include <silkworm/infra/common/log.hpp>
-#include <silkworm/infra/test_util/log.hpp>
 #include <silkworm/rpc/test/context_test_base.hpp>
 
 namespace silkworm::rpc::json {
@@ -33,8 +29,6 @@ struct JsonStreamTest : test::ContextTestBase {
 };
 
 TEST_CASE_METHOD(JsonStreamTest, "JsonStream[json]") {
-    silkworm::test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
-
     ClientContextPool pool{1};
     pool.start();
     boost::asio::any_io_executor io_executor = pool.next_io_context().get_executor();
@@ -82,8 +76,6 @@ TEST_CASE_METHOD(JsonStreamTest, "JsonStream[json]") {
 }
 
 TEST_CASE_METHOD(JsonStreamTest, "JsonStream calls") {
-    silkworm::test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
-
     ClientContextPool pool{1};
     pool.start();
     boost::asio::any_io_executor io_executor = pool.next_io_context().get_executor();
@@ -333,4 +325,5 @@ TEST_CASE_METHOD(JsonStreamTest, "JsonStream calls") {
         CHECK(string_writer.get_content() == "[10,10.3,true]");
     }
 }
+
 }  // namespace silkworm::rpc::json

--- a/silkworm/rpc/types/writer_test.cpp
+++ b/silkworm/rpc/types/writer_test.cpp
@@ -21,8 +21,6 @@
 #include <catch2/catch.hpp>
 #include <nlohmann/json.hpp>
 
-#include <silkworm/infra/common/log.hpp>
-#include <silkworm/infra/test_util/log.hpp>
 #include <silkworm/rpc/test/context_test_base.hpp>
 
 namespace silkworm::rpc {

--- a/silkworm/rpc/types/writer_test.cpp
+++ b/silkworm/rpc/types/writer_test.cpp
@@ -31,8 +31,6 @@ struct WriterTest : test::ContextTestBase {
 };
 
 TEST_CASE_METHOD(WriterTest, "StringWriter") {
-    silkworm::test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
-
     SECTION("write") {
         StringWriter writer;
         std::string test = "test";
@@ -53,8 +51,6 @@ TEST_CASE_METHOD(WriterTest, "StringWriter") {
 }
 
 TEST_CASE_METHOD(WriterTest, "ChunksWriter") {
-    silkworm::test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
-
     SECTION("write&close under chunk size") {
         StringWriter s_writer;
         ChunksWriter writer(s_writer);
@@ -115,8 +111,6 @@ TEST_CASE_METHOD(WriterTest, "ChunksWriter") {
 }
 
 TEST_CASE_METHOD(WriterTest, "JsonChunksWriter") {
-    silkworm::test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
-
     SECTION("write&close under chunk size") {
         StringWriter s_writer;
         JsonChunksWriter writer(s_writer, 16);
@@ -179,4 +173,5 @@ TEST_CASE_METHOD(WriterTest, "JsonChunksWriter") {
         CHECK(s_writer.get_content() == "30\r\n{\"accounts\":{},\"next\":\"next\",\"root\":\"root\"}     \r\n0\r\n\r\n");
     }
 }
+
 }  // namespace silkworm::rpc


### PR DESCRIPTION
This PR fixes the [TSAN error](https://app.circleci.com/pipelines/github/erigontech/silkworm/10139/workflows/4e7d81e6-5e8e-4de9-930d-2ee5a50db174/jobs/44884) introduced by #1714 