### PR TITLE
rpcdaemon: block number as string in debug_traceBlockByNumber

### DIFF
--- a/silkworm/rpc/commands/debug_api.cpp
+++ b/silkworm/rpc/commands/debug_api.cpp
@@ -545,7 +545,12 @@ Task<void> DebugRpcApi::handle_debug_trace_block_by_number(const nlohmann::json&
         stream.write_json(reply);
         co_return;
     }
-    const auto block_number = params[0].get<BlockNum>();
+    BlockNum block_number;
+    if (params[0].is_string()) {
+        block_number = std::stoul(params[0].get<std::string>(), nullptr, 10);
+    } else {
+        block_number = params[0].get<BlockNum>();
+    }
 
     debug::DebugConfig config;
     if (params.size() > 1) {


### PR DESCRIPTION
Managed block number passed as string in debug_traceBlockByNumber API (as erigon does)