### PR TITLE
rpcdaemon: fix missing logging initialization

### DIFF
--- a/silkworm/infra/common/log.cpp
+++ b/silkworm/infra/common/log.cpp
@@ -39,7 +39,7 @@ static std::mutex out_mtx{};
 static std::unique_ptr<std::fstream> file_{nullptr};
 thread_local std::string thread_name_{};
 
-void init(Settings& settings) {
+void init(const Settings& settings) {
     settings_ = settings;
     if (!settings_.log_file.empty()) {
         tee_file(std::filesystem::path(settings.log_file));

--- a/silkworm/infra/common/log.hpp
+++ b/silkworm/infra/common/log.hpp
@@ -51,7 +51,7 @@ struct Settings {
 
 //! \brief Initializes logging facilities
 //! \note This function is not thread safe as it's meant to be used at start of process and never called again
-void init(Settings& settings);
+void init(const Settings& settings);
 
 //! \brief Get the current logging verbosity
 //! \note This function is not thread safe as it's meant to be used in tests

--- a/silkworm/rpc/daemon.cpp
+++ b/silkworm/rpc/daemon.cpp
@@ -71,7 +71,7 @@ int Daemon::run(const DaemonSettings& settings, const DaemonInfo& info) {
     auto& log_settings = settings.log_settings;
     auto& context_pool_settings = settings.context_pool_settings;
 
-    log::set_verbosity(log_settings.log_verbosity);
+    log::init(log_settings);
     log::set_thread_name("main-thread");
 
     auto mdbx_ver{mdbx::get_version()};


### PR DESCRIPTION
This PR fixes logging initialisation in standalone `rpcdaemon` component.