### PR TITLE
rpcdaemon: JsonRpcValidator perf improvements

### DIFF
--- a/silkworm/rpc/http/json_rpc_validator_test.cpp
+++ b/silkworm/rpc/http/json_rpc_validator_test.cpp
@@ -117,7 +117,6 @@ TEST_CASE("rpc::http::JsonRpcValidator validates invalid request fields", "[rpc]
     CHECK(result.error_message == "Invalid field: id");
 }
 
-
 TEST_CASE("rpc::http::JsonRpcValidator accepts missing params field", "[rpc][http][json_rpc_validator]") {
     JsonRpcValidator validator{};
 

--- a/silkworm/rpc/http/json_rpc_validator_test.cpp
+++ b/silkworm/rpc/http/json_rpc_validator_test.cpp
@@ -72,6 +72,52 @@ TEST_CASE("rpc::http::JsonRpcValidator detects missing request field", "[rpc][ht
     CHECK(result.error_message == "Request not valid, required fields: jsonrpc,id,method,params");
 }
 
+TEST_CASE("rpc::http::JsonRpcValidator validates invalid request fields", "[rpc][http][json_rpc_validator]") {
+    JsonRpcValidator validator{};
+
+    nlohmann::json request = {
+        {"jsonrpc", 2},
+        {"method", "eth_getBlockByNumber"},
+        {"params", {"0x0", true}},
+        {"id", 1},
+    };
+
+    JsonRpcValidationResult result = validator.validate(request);
+    CHECK(!result.is_valid);
+    CHECK(result.error_message == "Invalid field: jsonrpc");
+
+    request = {
+        {"jsonrpc", "2.0"},
+        {"method", 1},
+        {"params", {"0x0", true}},
+        {"id", 1},
+    };
+    result = validator.validate(request);
+    CHECK(!result.is_valid);
+    CHECK(result.error_message == "Invalid field: method");
+
+    request = {
+        {"jsonrpc", "2.0"},
+        {"method", "eth_getBlockByNumber"},
+        {"params", "params"},
+        {"id", 1},
+    };
+    result = validator.validate(request);
+    CHECK(!result.is_valid);
+    CHECK(result.error_message == "Invalid field: params");
+
+    request = {
+        {"jsonrpc", "2.0"},
+        {"method", "eth_getBlockByNumber"},
+        {"params", {"0x0", true}},
+        {"id", "1"},
+    };
+    result = validator.validate(request);
+    CHECK(!result.is_valid);
+    CHECK(result.error_message == "Invalid field: id");
+}
+
+
 TEST_CASE("rpc::http::JsonRpcValidator accepts missing params field", "[rpc][http][json_rpc_validator]") {
     JsonRpcValidator validator{};
 


### PR DESCRIPTION
As noted in https://github.com/erigontech/silkworm/pull/1749, accessing JSON from `std::map<std::string, nlohmann::json>` seemed to be unusually slow. It turns out it was a simple reference issue and the compiler created a new JSON instance on each access. Fixed.

Before:
```
[ RUN      ] `json_rpc_validator/0`
│ threads: 1
│ iterations: 18165
│ real_time: 38484.28863197544
│ cpu_time: 38483.96917148362
│ time_unit: "ns"
[       OK ] `json_rpc_validator/0
```

After:
```
[ RUN      ] `json_rpc_validator/0`
│ threads: 1
│ iterations: 78563
│ real_time: 9262.071547666672
│ cpu_time: 9261.998650764355
│ time_unit: "ns"
[       OK ] `json_rpc_validator/0`
```

Plus some small fixes and better test coverage