### PR TITLE
infra: migrate `ensure` to the dynamic format for performance reasons

### DIFF
--- a/cmd/capi/execute.cpp
+++ b/cmd/capi/execute.cpp
@@ -193,7 +193,7 @@ std::vector<SilkwormChainSnapshot> collect_all_snapshots(const SnapshotRepositor
                 transactions_snapshot_sequence.push_back(raw_transactions_snapshot);
             } break;
             default:
-                ensure(false, "unexpected snapshot type: " + std::string{magic_enum::enum_name(segment_file.type())});
+                ensure(false, [&]() { return "unexpected snapshot type: " + std::string{magic_enum::enum_name(segment_file.type())}; });
         }
     }
 

--- a/cmd/dev/check_log_indices.cpp
+++ b/cmd/dev/check_log_indices.cpp
@@ -141,34 +141,36 @@ void check_address_index(BlockNum block_number, const evmc::address& log_address
     // Transaction log address must be present in LogAddressIndex table
     const auto log_address_key{db::log_address_key(log_address, block_number)};
     const auto log_address_data{log_address_cursor->lower_bound(db::to_slice(log_address_key), false)};
-    ensure(log_address_data.done, "LogAddressIndex does not contain key " + to_hex(log_address_key));
+    ensure(log_address_data.done, [&]() { return "LogAddressIndex does not contain key " + to_hex(log_address_key); });
 
     const auto [address_view, address_upper_bound_block] = db::split_log_address_key(log_address_data.key);
-    ensure(to_hex(address_view) == to_hex(log_address.bytes), "address mismatch in LogAddressIndex table: " + to_hex(address_view));
-    ensure(address_upper_bound_block >= block_number, "upper bound mismatch in LogAddressIndex table: " + to_hex(address_view));
+    const auto& address_view_ref = address_view;
+    ensure(to_hex(address_view) == to_hex(log_address.bytes), [&]() { return "address mismatch in LogAddressIndex table: " + to_hex(address_view_ref); });
+    ensure(address_upper_bound_block >= block_number, [&]() { return "upper bound mismatch in LogAddressIndex table: " + to_hex(address_view_ref); });
 
     // Retrieved chunk of the address roaring bitmap must contain the transaction log block
     const auto& log_address_value{log_address_data.value};
     const auto address_bitmap_chunk{db::bitmap::parse32(log_address_value)};
     ensure(address_bitmap_chunk.contains(static_cast<uint32_t>(block_number)),
-           "address bitmap chunk " + address_bitmap_chunk.toString() + " does not contain block " + std::to_string(block_number));
+           [&]() { return "address bitmap chunk " + address_bitmap_chunk.toString() + " does not contain block " + std::to_string(block_number); });
 }
 
 void check_topic_index(BlockNum block_number, const evmc::bytes32& log_topic, db::ROCursor* log_topic_cursor) {
     // Each transaction log topic must be present in LogTopicIndex table
     const auto log_topic_key{db::log_topic_key(log_topic, block_number)};
     const auto log_topic_data{log_topic_cursor->lower_bound(db::to_slice(log_topic_key), false)};
-    ensure(log_topic_data.done, "LogTopicIndex does not contain key " + to_hex(log_topic_key));
+    ensure(log_topic_data.done, [&]() { return "LogTopicIndex does not contain key " + to_hex(log_topic_key); });
 
     const auto [topic_view, topic_upper_bound_block] = db::split_log_topic_key(log_topic_data.key);
-    ensure(to_hex(topic_view) == to_hex(log_topic.bytes), "topic mismatch in LogTopicIndex table: " + to_hex(topic_view));
-    ensure(topic_upper_bound_block >= block_number, "upper bound mismatch in LogTopicIndex table: " + to_hex(topic_view));
+    const auto& topic_view_ref = topic_view;
+    ensure(to_hex(topic_view) == to_hex(log_topic.bytes), [&]() { return "topic mismatch in LogTopicIndex table: " + to_hex(topic_view_ref); });
+    ensure(topic_upper_bound_block >= block_number, [&]() { return "upper bound mismatch in LogTopicIndex table: " + to_hex(topic_view_ref); });
 
     // Retrieved chunk of the topic roaring bitmap must contain the transaction log block
     const auto& log_topic_value{log_topic_data.value};
     const auto topic_bitmap_chunk{db::bitmap::parse32(log_topic_value)};
     ensure(topic_bitmap_chunk.contains(static_cast<uint32_t>(block_number)),
-           "topic bitmap chunk " + topic_bitmap_chunk.toString() + " does not contain block " + std::to_string(block_number));
+           [&]() { return "topic bitmap chunk " + topic_bitmap_chunk.toString() + " does not contain block " + std::to_string(block_number); });
 }
 
 int main(int argc, char* argv[]) {

--- a/cmd/dev/snapshots.cpp
+++ b/cmd/dev/snapshots.cpp
@@ -287,7 +287,7 @@ void open_index(const SnapSettings& settings) {
     std::filesystem::path segment_file_path{settings.repository_dir / *settings.snapshot_file_name};
     SILK_INFO << "Open index for snapshot: " << segment_file_path;
     const auto snapshot_path{snapshots::SnapshotPath::parse(segment_file_path)};
-    ensure(snapshot_path.has_value(), "open_index: invalid snapshot file " + segment_file_path.filename().string());
+    ensure(snapshot_path.has_value(), [&]() { return "open_index: invalid snapshot file " + segment_file_path.filename().string(); });
     const auto index_path{snapshot_path->index_file()};
     std::chrono::time_point start{std::chrono::steady_clock::now()};
     rec_split::RecSplitIndex idx{index_path.path()};
@@ -401,7 +401,7 @@ void lookup_header_by_number(const SnapSettings& settings) {
     if (header_snapshot) {
         const auto header{header_snapshot->header_by_number(block_number)};
         ensure(header.has_value(),
-               "lookup_header_by_number: " + std::to_string(block_number) + " NOT found in " + header_snapshot->path().filename());
+               [&]() { return "lookup_header_by_number: " + std::to_string(block_number) + " NOT found in " + header_snapshot->path().filename(); });
         SILK_INFO << "Lookup header number: " << block_number << " found in: " << header_snapshot->path().filename();
         if (settings.print) {
             print_header(*header, header_snapshot->path().filename());
@@ -438,7 +438,7 @@ void lookup_body_in_one(const SnapSettings& settings, BlockNum block_number, con
 
     std::chrono::time_point start{std::chrono::steady_clock::now()};
     const auto body_snapshot{snapshot_repository.get_body_segment(*snapshot_path)};
-    ensure(body_snapshot, "lookup_body: body segment not found for snapshot file: " + snapshot_path->path().string());
+    ensure(body_snapshot, [&]() { return "lookup_body: body segment not found for snapshot file: " + snapshot_path->path().string(); });
     const auto body{body_snapshot->body_by_number(block_number)};
     if (body) {
         SILK_INFO << "Lookup body number: " << block_number << " found in: " << body_snapshot->path().filename();
@@ -461,7 +461,7 @@ void lookup_body_in_all(const SnapSettings& settings, BlockNum block_number) {
     if (body_snapshot) {
         const auto body{body_snapshot->body_by_number(block_number)};
         ensure(body.has_value(),
-               "lookup_body: " + std::to_string(block_number) + " NOT found in " + body_snapshot->path().filename());
+               [&]() { return "lookup_body: " + std::to_string(block_number) + " NOT found in " + body_snapshot->path().filename(); });
         SILK_INFO << "Lookup body number: " << block_number << " found in: " << body_snapshot->path().filename();
         if (settings.print) {
             print_body(*body, body_snapshot->path().filename());

--- a/silkworm/infra/common/ensure.hpp
+++ b/silkworm/infra/common/ensure.hpp
@@ -21,10 +21,17 @@
 
 namespace silkworm {
 
-//! Ensure that condition is met, otherwise raise a logic error with specified message
+//! Ensure that condition is met, otherwise raise a logic error with specified message, only use for static messages
 inline void ensure(bool condition, const std::string& message) {
     if (!condition) [[unlikely]] {
         throw std::logic_error(message);
+    }
+}
+
+//! Ensure that condition is met, otherwise raise a logic error with dynamically built message
+inline void ensure(bool condition, const std::function<std::string()>& messageBuilder) {
+    if (!condition) {
+        throw std::logic_error(messageBuilder());
     }
 }
 

--- a/silkworm/infra/common/ensure.hpp
+++ b/silkworm/infra/common/ensure.hpp
@@ -21,35 +21,49 @@
 
 namespace silkworm {
 
-//! Ensure that condition is met, otherwise raise a logic error with specified message, only use for static messages
-inline void ensure(bool condition, const std::string& message) {
+//! Ensure that condition is met, otherwise raise a logic error with string literal message
+template <int N>
+inline void ensure(bool condition, const char (&message)[N]) {
     if (!condition) [[unlikely]] {
         throw std::logic_error(message);
     }
 }
 
 //! Ensure that condition is met, otherwise raise a logic error with dynamically built message
+//! Usage: `ensure(condition, [&]() { return "Message: " + get_str(); });`
 inline void ensure(bool condition, const std::function<std::string()>& messageBuilder) {
-    if (!condition) {
+    if (!condition) [[unlikely]] {
         throw std::logic_error(messageBuilder());
     }
 }
 
 //! Similar to \code ensure with emphasis on invariant violation
-inline void ensure_invariant(bool condition, const std::string& message) {
-    ensure(condition, "Invariant violation: " + message);
+template <int N>
+inline void ensure_invariant(bool condition, const char (&message)[N]) {
+    if (!condition) [[unlikely]] {
+        throw std::logic_error("Invariant violation: " + std::string{message});
+    }
+}
+
+//! Similar to \code ensure with emphasis on invariant violation
+inline void ensure_invariant(bool condition, const std::function<std::string()>& messageBuilder) {
+    if (!condition) [[unlikely]] {
+        throw std::logic_error("Invariant violation: " + messageBuilder());
+    }
 }
 
 //! Similar to \code ensure with emphasis on pre-condition violation
-inline void ensure_pre_condition(bool condition, const std::string& message) {
+inline void ensure_pre_condition(bool condition, const std::function<std::string()>& messageBuilder) {
     if (!condition) [[unlikely]] {
-        throw std::invalid_argument("Pre-condition violation: " + message);
+        throw std::invalid_argument("Pre-condition violation: " + messageBuilder());
     }
 }
 
 //! Similar to \code ensure with emphasis on post-condition violation
-inline void ensure_post_condition(bool condition, const std::string& message) {
-    ensure(condition, "Post-condition violation: " + message);
+inline void ensure_post_condition(bool condition, const std::function<std::string()>& messageBuilder) {
+    if (!condition) [[unlikely]] {
+        throw std::logic_error("Post-condition violation: " + messageBuilder());
+    }
 }
 
 }  // namespace silkworm

--- a/silkworm/infra/common/ensure.hpp
+++ b/silkworm/infra/common/ensure.hpp
@@ -16,13 +16,14 @@
 
 #pragma once
 
+#include <functional>
 #include <stdexcept>
 #include <string>
 
 namespace silkworm {
 
 //! Ensure that condition is met, otherwise raise a logic error with string literal message
-template <int N>
+template <unsigned int N>
 inline void ensure(bool condition, const char (&message)[N]) {
     if (!condition) [[unlikely]] {
         throw std::logic_error(message);
@@ -38,7 +39,7 @@ inline void ensure(bool condition, const std::function<std::string()>& messageBu
 }
 
 //! Similar to \code ensure with emphasis on invariant violation
-template <int N>
+template <unsigned int N>
 inline void ensure_invariant(bool condition, const char (&message)[N]) {
     if (!condition) [[unlikely]] {
         throw std::logic_error("Invariant violation: " + std::string{message});

--- a/silkworm/infra/common/ensure_test.cpp
+++ b/silkworm/infra/common/ensure_test.cpp
@@ -41,7 +41,6 @@ TEST_CASE("ensure_invariant") {
     CHECK_THROWS_MATCHES(ensure_invariant(false, "x"), std::logic_error, Message("Invariant violation: x"));
 }
 
-
 TEST_CASE("ensure_invariant dynamic message") {
     CHECK_NOTHROW(ensure_invariant(true, []() { return "ignored"; }));
     CHECK_THROWS_AS(ensure_invariant(false, []() { return "error"; }), std::logic_error);
@@ -62,6 +61,5 @@ TEST_CASE("ensure_post_condition") {
     CHECK_THROWS_MATCHES(ensure_post_condition(false, []() { return "x"; }), std::logic_error, Message("Post-condition violation: x"));
     CHECK_THROWS_MATCHES(ensure_post_condition(false, []() { return "x " + std::to_string(42); }), std::logic_error, Message("Post-condition violation: x 42"));
 }
-
 
 }  // namespace silkworm

--- a/silkworm/infra/common/ensure_test.cpp
+++ b/silkworm/infra/common/ensure_test.cpp
@@ -28,10 +28,40 @@ TEST_CASE("ensure") {
     CHECK_THROWS_MATCHES(ensure(false, "condition violation"), std::logic_error, Message("condition violation"));
 }
 
+TEST_CASE("ensure dynamic message") {
+    CHECK_NOTHROW(ensure(true, []() { return "ignored"; }));
+    CHECK_THROWS_AS(ensure(false, []() { return "error"; }), std::logic_error);
+    CHECK_THROWS_MATCHES(ensure(false, []() { return "condition violation"; }), std::logic_error, Message("condition violation"));
+    CHECK_THROWS_MATCHES(ensure(false, []() { return "condition violation " + std::to_string(42); }), std::logic_error, Message("condition violation 42"));
+}
+
 TEST_CASE("ensure_invariant") {
     CHECK_NOTHROW(ensure_invariant(true, "ignored"));
     CHECK_THROWS_AS(ensure_invariant(false, "error"), std::logic_error);
     CHECK_THROWS_MATCHES(ensure_invariant(false, "x"), std::logic_error, Message("Invariant violation: x"));
 }
+
+
+TEST_CASE("ensure_invariant dynamic message") {
+    CHECK_NOTHROW(ensure_invariant(true, []() { return "ignored"; }));
+    CHECK_THROWS_AS(ensure_invariant(false, []() { return "error"; }), std::logic_error);
+    CHECK_THROWS_MATCHES(ensure_invariant(false, []() { return "x"; }), std::logic_error, Message("Invariant violation: x"));
+    CHECK_THROWS_MATCHES(ensure_invariant(false, []() { return "x " + std::to_string(42); }), std::logic_error, Message("Invariant violation: x 42"));
+}
+
+TEST_CASE("ensure_pre_condition") {
+    CHECK_NOTHROW(ensure_pre_condition(true, []() { return "ignored"; }));
+    CHECK_THROWS_AS(ensure_pre_condition(false, []() { return "error"; }), std::logic_error);
+    CHECK_THROWS_MATCHES(ensure_pre_condition(false, []() { return "x"; }), std::logic_error, Message("Pre-condition violation: x"));
+    CHECK_THROWS_MATCHES(ensure_pre_condition(false, []() { return "x " + std::to_string(42); }), std::logic_error, Message("Pre-condition violation: x 42"));
+}
+
+TEST_CASE("ensure_post_condition") {
+    CHECK_NOTHROW(ensure_post_condition(true, []() { return "ignored"; }));
+    CHECK_THROWS_AS(ensure_post_condition(false, []() { return "error"; }), std::logic_error);
+    CHECK_THROWS_MATCHES(ensure_post_condition(false, []() { return "x"; }), std::logic_error, Message("Post-condition violation: x"));
+    CHECK_THROWS_MATCHES(ensure_post_condition(false, []() { return "x " + std::to_string(42); }), std::logic_error, Message("Post-condition violation: x 42"));
+}
+
 
 }  // namespace silkworm

--- a/silkworm/infra/common/memory_mapped_file.cpp
+++ b/silkworm/infra/common/memory_mapped_file.cpp
@@ -39,8 +39,8 @@ namespace silkworm {
 
 MemoryMappedFile::MemoryMappedFile(std::filesystem::path path, std::optional<MemoryMappedRegion> region, bool read_only)
     : path_(std::move(path)), managed_{not region.has_value()} {
-    ensure(std::filesystem::exists(path_), "MemoryMappedFile: " + path_.string() + " does not exist");
-    ensure(std::filesystem::is_regular_file(path_), "MemoryMappedFile: " + path_.string() + " is not regular file");
+    ensure(std::filesystem::exists(path_), [&]() { return "MemoryMappedFile: " + path_.string() + " does not exist"; });
+    ensure(std::filesystem::is_regular_file(path_), [&]() { return "MemoryMappedFile: " + path_.string() + " is not regular file"; });
 
     if (region) {
         ensure(region->address != nullptr, "MemoryMappedFile: address is null");

--- a/silkworm/node/db/access_layer.cpp
+++ b/silkworm/node/db/access_layer.cpp
@@ -405,7 +405,7 @@ size_t process_blocks_at_height(ROTxn& txn, BlockNum height, std::function<void(
             auto body = detail::decode_stored_block_body(raw_body);
             std::swap(block.ommers, body.ommers);
             // ...transactions
-            ensure(body.txn_count > 1, [&](){ return "unexpected txn_count=" + std::to_string(body.txn_count) + " for number=" + std::to_string(height);});
+            ensure(body.txn_count > 1, [&]() { return "unexpected txn_count=" + std::to_string(body.txn_count) + " for number=" + std::to_string(height); });
             read_transactions(txn, body.base_txn_id + 1, body.txn_count - 2, block.transactions);
             // ...senders
             if (!block.transactions.empty() && read_senders) {
@@ -417,7 +417,7 @@ size_t process_blocks_at_height(ROTxn& txn, BlockNum height, std::function<void(
             const bool present = read_header(txn, hash, block_num, block.header);
             auto ref_bn = block_num;
             auto ref_hash = hash;
-            ensure(present, [&](){ return "header not found for body number= " + std::to_string(ref_bn) + ", hash= " + silkworm::to_hex(ref_hash);});
+            ensure(present, [&]() { return "header not found for body number= " + std::to_string(ref_bn) + ", hash= " + silkworm::to_hex(ref_hash); });
             // invoke handler
             process_func(block);
         },
@@ -447,7 +447,7 @@ bool read_body(ROTxn& txn, const Bytes& key, bool read_senders, BlockBody& out) 
 
     std::swap(out.ommers, body.ommers);
     std::swap(out.withdrawals, body.withdrawals);
-    ensure(body.txn_count > 1,[&](){ return  "unexpected txn_count=" + std::to_string(body.txn_count) + " for key=" + to_hex(key);});
+    ensure(body.txn_count > 1, [&]() { return "unexpected txn_count=" + std::to_string(body.txn_count) + " for key=" + to_hex(key); });
     read_transactions(txn, body.base_txn_id + 1, body.txn_count - 2, out.transactions);
     if (!out.transactions.empty() && read_senders) {
         parse_senders(txn, key, out.transactions);
@@ -463,7 +463,7 @@ bool read_rlp_transactions(ROTxn& txn, BlockNum height, const evmc::bytes32& has
 
     ByteView data_view{from_slice(data.value)};
     const auto body{detail::decode_stored_block_body(data_view)};
-    ensure(body.txn_count > 1, [&](){ return "unexpected txn_count=" + std::to_string(body.txn_count) + " for key=" + std::to_string(height);});
+    ensure(body.txn_count > 1, [&]() { return "unexpected txn_count=" + std::to_string(body.txn_count) + " for key=" + std::to_string(height); });
     read_rlp_transactions(txn, body.base_txn_id + 1, body.txn_count - 2, rlp_txs);
 
     return true;

--- a/silkworm/node/db/bitmap.cpp
+++ b/silkworm/node/db/bitmap.cpp
@@ -229,7 +229,7 @@ void IndexLoader::prune_bitmaps_impl(RWTxn& txn, BlockNum threshold) {
         }
 
         // Suffix indicates the upper bound of the shard.
-        ensure(data_key_view.size() >= sizeof(BlockUpperBound), "invalid key size " + std::to_string(data_key_view.size()));
+        ensure(data_key_view.size() >= sizeof(BlockUpperBound), [&](){ return  "invalid key size " + std::to_string(data_key_view.size());});
         const auto suffix{intx::be::unsafe::load<BlockUpperBound>(&data_key_view[data_key_view.size() - sizeof(BlockUpperBound)])};
 
         // If below pruning threshold simply delete the record

--- a/silkworm/node/db/bitmap.cpp
+++ b/silkworm/node/db/bitmap.cpp
@@ -229,7 +229,7 @@ void IndexLoader::prune_bitmaps_impl(RWTxn& txn, BlockNum threshold) {
         }
 
         // Suffix indicates the upper bound of the shard.
-        ensure(data_key_view.size() >= sizeof(BlockUpperBound), [&](){ return  "invalid key size " + std::to_string(data_key_view.size());});
+        ensure(data_key_view.size() >= sizeof(BlockUpperBound), [&]() { return "invalid key size " + std::to_string(data_key_view.size()); });
         const auto suffix{intx::be::unsafe::load<BlockUpperBound>(&data_key_view[data_key_view.size() - sizeof(BlockUpperBound)])};
 
         // If below pruning threshold simply delete the record

--- a/silkworm/node/db/log_cbor.cpp
+++ b/silkworm/node/db/log_cbor.cpp
@@ -123,11 +123,11 @@ class LogCborListener : public cbor::listener {
         const auto data_size{static_cast<std::size_t>(size)};
 
         if (state_ == ProcessingState::kWaitAddress) {
-            ensure(data_size == kAddressLength, "Log CBOR: unexpected address size " + std::to_string(data_size));
+            ensure(data_size == kAddressLength, [&](){ return "Log CBOR: unexpected address size " + std::to_string(data_size);});
             consumer_.on_address(std::span<const uint8_t, kAddressLength>{data, data_size});
             state_ = ProcessingState::kWaitTopics;
         } else if (state_ == ProcessingState::kWaitTopic) {
-            ensure(data_size == kHashLength, "Log CBOR: unexpected topic size " + std::to_string(data_size));
+            ensure(data_size == kHashLength, [&](){ return "Log CBOR: unexpected topic size " + std::to_string(data_size);});
             consumer_.on_topic(HashAsSpan{data, data_size});
             if (++current_topic_ == current_num_topics_) {
                 state_ = ProcessingState::kWaitData;
@@ -150,7 +150,7 @@ class LogCborListener : public cbor::listener {
             current_num_logs_ = array_size;
             current_log_ = 0;
         } else if (state_ == ProcessingState::kWaitLog) {
-            ensure(array_size == 3, "Log CBOR: unexpected number of Log fields " + std::to_string(array_size));
+            ensure(array_size == 3, [&](){ return "Log CBOR: unexpected number of Log fields " + std::to_string(array_size);});
             state_ = ProcessingState::kWaitAddress;
         } else if (state_ == ProcessingState::kWaitTopics) {
             consumer_.on_num_topics(array_size);

--- a/silkworm/node/db/log_cbor.cpp
+++ b/silkworm/node/db/log_cbor.cpp
@@ -123,11 +123,11 @@ class LogCborListener : public cbor::listener {
         const auto data_size{static_cast<std::size_t>(size)};
 
         if (state_ == ProcessingState::kWaitAddress) {
-            ensure(data_size == kAddressLength, [&](){ return "Log CBOR: unexpected address size " + std::to_string(data_size);});
+            ensure(data_size == kAddressLength, [&]() { return "Log CBOR: unexpected address size " + std::to_string(data_size); });
             consumer_.on_address(std::span<const uint8_t, kAddressLength>{data, data_size});
             state_ = ProcessingState::kWaitTopics;
         } else if (state_ == ProcessingState::kWaitTopic) {
-            ensure(data_size == kHashLength, [&](){ return "Log CBOR: unexpected topic size " + std::to_string(data_size);});
+            ensure(data_size == kHashLength, [&]() { return "Log CBOR: unexpected topic size " + std::to_string(data_size); });
             consumer_.on_topic(HashAsSpan{data, data_size});
             if (++current_topic_ == current_num_topics_) {
                 state_ = ProcessingState::kWaitData;
@@ -150,7 +150,7 @@ class LogCborListener : public cbor::listener {
             current_num_logs_ = array_size;
             current_log_ = 0;
         } else if (state_ == ProcessingState::kWaitLog) {
-            ensure(array_size == 3, [&](){ return "Log CBOR: unexpected number of Log fields " + std::to_string(array_size);});
+            ensure(array_size == 3, [&]() { return "Log CBOR: unexpected number of Log fields " + std::to_string(array_size); });
             state_ = ProcessingState::kWaitAddress;
         } else if (state_ == ProcessingState::kWaitTopics) {
             consumer_.on_num_topics(array_size);

--- a/silkworm/node/snapshots/index.cpp
+++ b/silkworm/node/snapshots/index.cpp
@@ -85,12 +85,12 @@ void Index::build() {
 }
 
 bool HeaderIndex::walk(RecSplit8& rec_split, uint64_t i, uint64_t offset, ByteView word) {
-    ensure(!word.empty(), "HeaderIndex: word empty i=" + std::to_string(i));
+    ensure(!word.empty(), [&](){ return "HeaderIndex: word empty i=" + std::to_string(i);});
     const uint8_t first_hash_byte{word[0]};
     const ByteView rlp_encoded_header{word.data() + 1, word.size() - 1};
     const ethash::hash256 hash = keccak256(rlp_encoded_header);
     ensure(hash.bytes[0] == first_hash_byte,
-           "HeaderIndex: invalid prefix=" + to_hex(first_hash_byte) + " hash=" + to_hex(hash.bytes));
+           [&](){ return "HeaderIndex: invalid prefix=" + to_hex(first_hash_byte) + " hash=" + to_hex(hash.bytes);});
     rec_split.add_key(hash.bytes, kHashLength, offset);
     return true;
 }

--- a/silkworm/node/snapshots/index.cpp
+++ b/silkworm/node/snapshots/index.cpp
@@ -85,12 +85,12 @@ void Index::build() {
 }
 
 bool HeaderIndex::walk(RecSplit8& rec_split, uint64_t i, uint64_t offset, ByteView word) {
-    ensure(!word.empty(), [&](){ return "HeaderIndex: word empty i=" + std::to_string(i);});
+    ensure(!word.empty(), [&]() { return "HeaderIndex: word empty i=" + std::to_string(i); });
     const uint8_t first_hash_byte{word[0]};
     const ByteView rlp_encoded_header{word.data() + 1, word.size() - 1};
     const ethash::hash256 hash = keccak256(rlp_encoded_header);
     ensure(hash.bytes[0] == first_hash_byte,
-           [&](){ return "HeaderIndex: invalid prefix=" + to_hex(first_hash_byte) + " hash=" + to_hex(hash.bytes);});
+           [&]() { return "HeaderIndex: invalid prefix=" + to_hex(first_hash_byte) + " hash=" + to_hex(hash.bytes); });
     rec_split.add_key(hash.bytes, kHashLength, offset);
     return true;
 }

--- a/silkworm/node/snapshots/rec_split/rec_split.hpp
+++ b/silkworm/node/snapshots/rec_split/rec_split.hpp
@@ -538,7 +538,7 @@ class RecSplit {
 
         const auto address = encoded_file_->address();
         ensure(position + sizeof(uint64_t) < encoded_file_->length(),
-               "position: " + std::to_string(position) + " plus 8 exceeds file length");
+               [&](){ return "position: " + std::to_string(position) + " plus 8 exceeds file length";});
         return endian::load_big_u64(address + position) & record_mask_;
     }
 

--- a/silkworm/node/snapshots/rec_split/rec_split.hpp
+++ b/silkworm/node/snapshots/rec_split/rec_split.hpp
@@ -538,7 +538,7 @@ class RecSplit {
 
         const auto address = encoded_file_->address();
         ensure(position + sizeof(uint64_t) < encoded_file_->length(),
-               [&](){ return "position: " + std::to_string(position) + " plus 8 exceeds file length";});
+               [&]() { return "position: " + std::to_string(position) + " plus 8 exceeds file length"; });
         return endian::load_big_u64(address + position) & record_mask_;
     }
 

--- a/silkworm/node/snapshots/repository.cpp
+++ b/silkworm/node/snapshots/repository.cpp
@@ -271,7 +271,7 @@ void SnapshotRepository::reopen_list(const SnapshotPathList& segment_files, bool
                     SILKWORM_ASSERT(false);
                 }
             }
-            ensure(snapshot_valid, "invalid empty snapshot " + seg_file.filename());
+            ensure(snapshot_valid, [&]() { return "invalid empty snapshot " + seg_file.filename(); });
 
             if (seg_file.block_to() > segment_max_block) {
                 segment_max_block = seg_file.block_to() - 1;
@@ -330,9 +330,9 @@ bool SnapshotRepository::reopen(SnapshotsByPath<T>& segments, const SnapshotPath
 
 SnapshotPathList SnapshotRepository::get_files(const std::string& ext) const {
     ensure(fs::exists(settings_.repository_dir),
-           "SnapshotRepository: " + settings_.repository_dir.string() + " does not exist");
+           [&]() { return "SnapshotRepository: " + settings_.repository_dir.string() + " does not exist"; });
     ensure(fs::is_directory(settings_.repository_dir),
-           "SnapshotRepository: " + settings_.repository_dir.string() + " is a not folder");
+           [&]() { return "SnapshotRepository: " + settings_.repository_dir.string() + " is a not folder"; });
 
     // Load the resulting files w/ desired extension ensuring they are snapshots
     SnapshotPathList snapshot_files;

--- a/silkworm/node/snapshots/snapshot.cpp
+++ b/silkworm/node/snapshots/snapshot.cpp
@@ -185,7 +185,7 @@ std::optional<BlockHeader> HeaderSnapshot::header_by_number(BlockNum block_heigh
 
 bool HeaderSnapshot::decode_header(const Snapshot::WordItem& item, BlockHeader& header) const {
     // First byte in data is first byte of header hash.
-    ensure(!item.value.empty(), [&](){ return "HeaderSnapshot: hash first byte missing at offset=" + std::to_string(item.offset);});
+    ensure(!item.value.empty(), [&]() { return "HeaderSnapshot: hash first byte missing at offset=" + std::to_string(item.offset); });
 
     // Skip hash first byte to obtain encoded header RLP data
     ByteView encoded_header{item.value.data() + 1, item.value.length() - 1};
@@ -196,7 +196,7 @@ bool HeaderSnapshot::decode_header(const Snapshot::WordItem& item, BlockHeader& 
     }
 
     ensure(header.number >= path_.block_from(),
-           [&](){ return "HeaderSnapshot: number=" + std::to_string(header.number) + " < block_from=" + std::to_string(path_.block_from());});
+           [&]() { return "HeaderSnapshot: number=" + std::to_string(header.number) + " < block_from=" + std::to_string(path_.block_from()); });
     return true;
 }
 
@@ -272,7 +272,7 @@ std::optional<StoredBlockBody> BodySnapshot::next_body(uint64_t offset) const {
         return {};
     }
     ensure(stored_body->base_txn_id >= idx_body_number_->base_data_id(),
-           [&](){ return path().index_file().filename() + " has wrong base data ID for base txn ID: " + std::to_string(stored_body->base_txn_id);});
+           [&]() { return path().index_file().filename() + " has wrong base data ID for base txn ID: " + std::to_string(stored_body->base_txn_id); });
     return stored_body;
 }
 
@@ -436,7 +436,7 @@ std::pair<ByteView, ByteView> TransactionSnapshot::slice_tx_data(const WordItem&
     const auto buffer_size{buffer.size()};
     SILK_TRACE << "slice_tx_data offset: " << item.offset << " buffer: " << to_hex(buffer);
 
-    ensure(buffer_size >= kTxRlpDataOffset,[&](){ return  "TransactionSnapshot: too short record: " + std::to_string(buffer_size);});
+    ensure(buffer_size >= kTxRlpDataOffset, [&]() { return "TransactionSnapshot: too short record: " + std::to_string(buffer_size); });
 
     // Skip first byte in data as it is first byte of transaction hash
     ByteView senders_data{buffer.data() + 1, kAddressLength};

--- a/silkworm/node/stagedsync/execution_pipeline.cpp
+++ b/silkworm/node/stagedsync/execution_pipeline.cpp
@@ -242,7 +242,7 @@ Stage::Result ExecutionPipeline::forward(db::RWTxn& cycle_txn, BlockNum target_h
 
         head_header_hash_ = db::read_head_header_hash(cycle_txn).value_or(Hash{});
         const auto head_header = db::DataModel(cycle_txn).read_header(head_header_hash_);
-        ensure(head_header.has_value(), "Sync pipeline, missing head header hash " + to_hex(head_header_hash_));
+        ensure(head_header.has_value(), [&](){ return "Sync pipeline, missing head header hash " + to_hex(head_header_hash_);});
         head_header_number_ = head_header->number;
         if (head_header_number_ != target_height) {
             throw std::logic_error("Sync pipeline: head header not at target height " + to_string(target_height) +
@@ -302,7 +302,7 @@ Stage::Result ExecutionPipeline::unwind(db::RWTxn& cycle_txn, BlockNum unwind_po
 
         head_header_hash_ = db::read_head_header_hash(cycle_txn).value_or(Hash{});
         const auto head_header = db::DataModel(cycle_txn).read_header(head_header_hash_);
-        ensure(head_header.has_value(), "Sync pipeline, missing head header hash " + to_hex(head_header_hash_));
+        ensure(head_header.has_value(), [&](){ return "Sync pipeline, missing head header hash " + to_hex(head_header_hash_);});
         head_header_number_ = head_header->number;
         if (head_header_number_ != unwind_point) {
             throw std::logic_error("Sync pipeline: head header not at unwind point " + to_string(unwind_point) +
@@ -357,7 +357,7 @@ Stage::Result ExecutionPipeline::prune(db::RWTxn& cycle_txn) {
 
         head_header_hash_ = db::read_head_header_hash(cycle_txn).value_or(Hash{});
         const auto head_header = db::DataModel(cycle_txn).read_header(head_header_hash_);
-        ensure(head_header.has_value(), "Sync pipeline, missing head header hash " + to_hex(head_header_hash_));
+        ensure(head_header.has_value(), [&](){ return "Sync pipeline, missing head header hash " + to_hex(head_header_hash_);});
         head_header_number_ = head_header->number;
 
         return is_stopping() ? Stage::Result::kAborted : Stage::Result::kSuccess;

--- a/silkworm/node/stagedsync/execution_pipeline.cpp
+++ b/silkworm/node/stagedsync/execution_pipeline.cpp
@@ -242,7 +242,7 @@ Stage::Result ExecutionPipeline::forward(db::RWTxn& cycle_txn, BlockNum target_h
 
         head_header_hash_ = db::read_head_header_hash(cycle_txn).value_or(Hash{});
         const auto head_header = db::DataModel(cycle_txn).read_header(head_header_hash_);
-        ensure(head_header.has_value(), [&](){ return "Sync pipeline, missing head header hash " + to_hex(head_header_hash_);});
+        ensure(head_header.has_value(), [&]() { return "Sync pipeline, missing head header hash " + to_hex(head_header_hash_); });
         head_header_number_ = head_header->number;
         if (head_header_number_ != target_height) {
             throw std::logic_error("Sync pipeline: head header not at target height " + to_string(target_height) +
@@ -302,7 +302,7 @@ Stage::Result ExecutionPipeline::unwind(db::RWTxn& cycle_txn, BlockNum unwind_po
 
         head_header_hash_ = db::read_head_header_hash(cycle_txn).value_or(Hash{});
         const auto head_header = db::DataModel(cycle_txn).read_header(head_header_hash_);
-        ensure(head_header.has_value(), [&](){ return "Sync pipeline, missing head header hash " + to_hex(head_header_hash_);});
+        ensure(head_header.has_value(), [&]() { return "Sync pipeline, missing head header hash " + to_hex(head_header_hash_); });
         head_header_number_ = head_header->number;
         if (head_header_number_ != unwind_point) {
             throw std::logic_error("Sync pipeline: head header not at unwind point " + to_string(unwind_point) +
@@ -357,7 +357,7 @@ Stage::Result ExecutionPipeline::prune(db::RWTxn& cycle_txn) {
 
         head_header_hash_ = db::read_head_header_hash(cycle_txn).value_or(Hash{});
         const auto head_header = db::DataModel(cycle_txn).read_header(head_header_hash_);
-        ensure(head_header.has_value(), [&](){ return "Sync pipeline, missing head header hash " + to_hex(head_header_hash_);});
+        ensure(head_header.has_value(), [&]() { return "Sync pipeline, missing head header hash " + to_hex(head_header_hash_); });
         head_header_number_ = head_header->number;
 
         return is_stopping() ? Stage::Result::kAborted : Stage::Result::kSuccess;

--- a/silkworm/node/stagedsync/stages/stage_hashstate.cpp
+++ b/silkworm/node/stagedsync/stages/stage_hashstate.cpp
@@ -647,8 +647,8 @@ Stage::Result HashState::unwind_from_account_changeset(db::RWTxn& txn, BlockNum 
             while (changeset_data.done) {
                 auto changeset_value_view{db::from_slice(changeset_data.value)};
                 ensure(changeset_value_view.length() >= kAddressLength,
-                       [&](){ return "invalid account changeset value size=" + std::to_string(changeset_value_view.length()) +
-                           " at block " + std::to_string(reached_blocknum);});
+                       [&]() { return "invalid account changeset value size=" + std::to_string(changeset_value_view.length()) +
+                                      " at block " + std::to_string(reached_blocknum); });
                 evmc::address address{bytes_to_address(changeset_value_view)};
 
                 if (!changed_addresses.contains(address)) {
@@ -722,7 +722,7 @@ Stage::Result HashState::unwind_from_storage_changeset(db::RWTxn& txn, BlockNum 
         while (changeset_data.done) {
             auto changeset_key_view{db::from_slice(changeset_data.key)};
             ensure(changeset_key_view.length() == sizeof(BlockNum) + db::kPlainStoragePrefixLength,
-                   [&](){ return "invalid storage changeset key size=" + std::to_string(changeset_key_view.length());});
+                   [&]() { return "invalid storage changeset key size=" + std::to_string(changeset_key_view.length()); });
             reached_blocknum = endian::load_big_u64(changeset_key_view.data());
             if (reached_blocknum > previous_progress) {
                 break;
@@ -750,8 +750,8 @@ Stage::Result HashState::unwind_from_storage_changeset(db::RWTxn& txn, BlockNum 
             while (changeset_data.done) {
                 auto changeset_value_view{db::from_slice(changeset_data.value)};
                 ensure(changeset_value_view.length() >= kHashLength,
-                       [&](){ return "invalid storage changeset value size=" + std::to_string(changeset_value_view.length()) +
-                           " at block " + std::to_string(reached_blocknum);});
+                       [&]() { return "invalid storage changeset value size=" + std::to_string(changeset_value_view.length()) +
+                                      " at block " + std::to_string(reached_blocknum); });
                 auto location{to_bytes32(changeset_value_view)};
                 if (!storage_changes[address][incarnation].contains(location)) {
                     changeset_value_view.remove_prefix(kHashLength);

--- a/silkworm/node/stagedsync/stages/stage_hashstate.cpp
+++ b/silkworm/node/stagedsync/stages/stage_hashstate.cpp
@@ -647,8 +647,8 @@ Stage::Result HashState::unwind_from_account_changeset(db::RWTxn& txn, BlockNum 
             while (changeset_data.done) {
                 auto changeset_value_view{db::from_slice(changeset_data.value)};
                 ensure(changeset_value_view.length() >= kAddressLength,
-                       "invalid account changeset value size=" + std::to_string(changeset_value_view.length()) +
-                           " at block " + std::to_string(reached_blocknum));
+                       [&](){ return "invalid account changeset value size=" + std::to_string(changeset_value_view.length()) +
+                           " at block " + std::to_string(reached_blocknum);});
                 evmc::address address{bytes_to_address(changeset_value_view)};
 
                 if (!changed_addresses.contains(address)) {
@@ -722,7 +722,7 @@ Stage::Result HashState::unwind_from_storage_changeset(db::RWTxn& txn, BlockNum 
         while (changeset_data.done) {
             auto changeset_key_view{db::from_slice(changeset_data.key)};
             ensure(changeset_key_view.length() == sizeof(BlockNum) + db::kPlainStoragePrefixLength,
-                   "invalid storage changeset key size=" + std::to_string(changeset_key_view.length()));
+                   [&](){ return "invalid storage changeset key size=" + std::to_string(changeset_key_view.length());});
             reached_blocknum = endian::load_big_u64(changeset_key_view.data());
             if (reached_blocknum > previous_progress) {
                 break;
@@ -750,8 +750,8 @@ Stage::Result HashState::unwind_from_storage_changeset(db::RWTxn& txn, BlockNum 
             while (changeset_data.done) {
                 auto changeset_value_view{db::from_slice(changeset_data.value)};
                 ensure(changeset_value_view.length() >= kHashLength,
-                       "invalid storage changeset value size=" + std::to_string(changeset_value_view.length()) +
-                           " at block " + std::to_string(reached_blocknum));
+                       [&](){ return "invalid storage changeset value size=" + std::to_string(changeset_value_view.length()) +
+                           " at block " + std::to_string(reached_blocknum);});
                 auto location{to_bytes32(changeset_value_view)};
                 if (!storage_changes[address][incarnation].contains(location)) {
                     changeset_value_view.remove_prefix(kHashLength);

--- a/silkworm/node/stagedsync/stages/stage_headers.cpp
+++ b/silkworm/node/stagedsync/stages/stage_headers.cpp
@@ -32,12 +32,13 @@ namespace silkworm::stagedsync {
 
 HeadersStage::HeaderDataModel::HeaderDataModel(db::RWTxn& tx, BlockNum headers_height) : tx_(tx), data_model_(tx) {
     auto headers_hash = db::read_canonical_hash(tx, headers_height);
-    ensure(headers_hash.has_value(), "Headers stage, inconsistent canonical table: not found hash at height " +
-                                         std::to_string(headers_height));
+    ensure(headers_hash.has_value(),
+           [&]() { return "Headers stage, inconsistent canonical table: not found hash at height " + std::to_string(headers_height); });
 
     std::optional<intx::uint256> headers_head_td = db::read_total_difficulty(tx, headers_height, *headers_hash);
-    ensure(headers_head_td.has_value(), "Headers stage, inconsistent total-difficulty table: not found td at height " +
-                                            std::to_string(headers_height));
+    ensure(headers_head_td.has_value(),
+           [&]() { return "Headers stage, inconsistent total-difficulty table: not found td at height " +
+                          std::to_string(headers_height); });
 
     previous_hash_ = *headers_hash;
     previous_td_ = *headers_head_td;

--- a/silkworm/node/stagedsync/stages/stage_headers.cpp
+++ b/silkworm/node/stagedsync/stages/stage_headers.cpp
@@ -57,8 +57,8 @@ void HeadersStage::HeaderDataModel::update_tables(const BlockHeader& header) {
 
     // Admittance conditions
     ensure_invariant(header.parent_hash == previous_hash_,
-                     "Headers stage invariant violation: headers to process must be consecutive, at height=" +
-                         std::to_string(height) + ", prev.hash=" + previous_hash_.to_hex() + ", curr.hash=" + hash.to_hex());
+                     [&]() { return "Headers stage invariant violation: headers to process must be consecutive, at height=" +
+                                    std::to_string(height) + ", prev.hash=" + previous_hash_.to_hex() + ", curr.hash=" + hash.to_hex(); });
 
     // Calculate total difficulty of this header
     auto td = previous_td_ + header.difficulty;
@@ -73,7 +73,7 @@ void HeadersStage::HeaderDataModel::update_tables(const BlockHeader& header) {
 
 void HeadersStage::HeaderDataModel::remove_headers(BlockNum unwind_point, db::RWTxn& tx) {
     auto canonical_hash = db::read_canonical_hash(tx, unwind_point);
-    ensure(canonical_hash.has_value(), "Headers stage, expected canonical hash at height " + std::to_string(unwind_point));
+    ensure(canonical_hash.has_value(), [&]() { return "Headers stage, expected canonical hash at height " + std::to_string(unwind_point); });
 
     db::write_head_header_hash(tx, *canonical_hash);
 

--- a/silkworm/node/stagedsync/stages/stage_senders.cpp
+++ b/silkworm/node/stagedsync/stages/stage_senders.cpp
@@ -334,8 +334,8 @@ Stage::Result Senders::parallel_recover(db::RWTxn& txn) {
         }
 
         ensure(collector_.size() + total_empty_blocks == segment_width,
-               "Senders: invalid number of ETL keys expected=" + std::to_string(segment_width) +
-                   "got=" + std::to_string(collector_.size() + total_empty_blocks));
+               [&](){ return "Senders: invalid number of ETL keys expected=" + std::to_string(segment_width) +
+                   "got=" + std::to_string(collector_.size() + total_empty_blocks);});
 
         // Store all recovered senders into db
         log::Trace(log_prefix_, {"op", "store senders", "reached_block_num", std::to_string(target_block_num)});

--- a/silkworm/node/stagedsync/stages/stage_senders.cpp
+++ b/silkworm/node/stagedsync/stages/stage_senders.cpp
@@ -334,8 +334,8 @@ Stage::Result Senders::parallel_recover(db::RWTxn& txn) {
         }
 
         ensure(collector_.size() + total_empty_blocks == segment_width,
-               [&](){ return "Senders: invalid number of ETL keys expected=" + std::to_string(segment_width) +
-                   "got=" + std::to_string(collector_.size() + total_empty_blocks);});
+               [&]() { return "Senders: invalid number of ETL keys expected=" + std::to_string(segment_width) +
+                              "got=" + std::to_string(collector_.size() + total_empty_blocks); });
 
         // Store all recovered senders into db
         log::Trace(log_prefix_, {"op", "store senders", "reached_block_num", std::to_string(target_block_num)});

--- a/silkworm/rpc/commands/eth_api.cpp
+++ b/silkworm/rpc/commands/eth_api.cpp
@@ -204,7 +204,7 @@ Task<void> EthereumRpcApi::handle_eth_get_block_by_hash(const nlohmann::json& re
         if (block_with_hash) {
             BlockNum block_number = block_with_hash->block.header.number;
             const auto total_difficulty{co_await chain_storage->read_total_difficulty(block_with_hash->hash, block_number)};
-            ensure_post_condition(total_difficulty.has_value(), "no difficulty for block number=" + std::to_string(block_number));
+            ensure_post_condition(total_difficulty.has_value(), [&]() { return "no difficulty for block number=" + std::to_string(block_number); });
             const Block extended_block{block_with_hash, *total_difficulty, full_tx};
             make_glaze_json_content(request, extended_block, reply);
         } else {
@@ -246,7 +246,7 @@ Task<void> EthereumRpcApi::handle_eth_get_block_by_number(const nlohmann::json& 
         const auto block_with_hash = co_await core::read_block_by_number(*block_cache_, *chain_storage, block_number);
         if (block_with_hash) {
             const auto total_difficulty{co_await chain_storage->read_total_difficulty(block_with_hash->hash, block_number)};
-            ensure_post_condition(total_difficulty.has_value(), "no difficulty for block number=" + std::to_string(block_number));
+            ensure_post_condition(total_difficulty.has_value(), [&]() { return "no difficulty for block number=" + std::to_string(block_number); });
             const Block extended_block{block_with_hash, *total_difficulty, full_tx};
 
             make_glaze_json_content(request, extended_block, reply);

--- a/silkworm/rpc/commands/ots_api.cpp
+++ b/silkworm/rpc/commands/ots_api.cpp
@@ -113,7 +113,7 @@ Task<void> OtsRpcApi::handle_ots_get_block_details(const nlohmann::json& request
         const auto block_with_hash = co_await core::read_block_by_number(*block_cache_, *chain_storage, block_number);
         if (block_with_hash) {
             const auto total_difficulty{co_await chain_storage->read_total_difficulty(block_with_hash->hash, block_number)};
-            ensure_post_condition(total_difficulty.has_value(), "no difficulty for block number=" + std::to_string(block_number));
+            ensure_post_condition(total_difficulty.has_value(), [&]() { return "no difficulty for block number=" + std::to_string(block_number); });
             const Block extended_block{block_with_hash, *total_difficulty, false};
             const auto block_size = extended_block.get_block_size();
             const BlockDetails block_details{block_size, block_with_hash->hash, block_with_hash->block.header, *total_difficulty,
@@ -164,7 +164,7 @@ Task<void> OtsRpcApi::handle_ots_get_block_details_by_hash(const nlohmann::json&
         if (block_with_hash) {
             const auto block_number = block_with_hash->block.header.number;
             const auto total_difficulty{co_await chain_storage->read_total_difficulty(block_with_hash->hash, block_number)};
-            ensure_post_condition(total_difficulty.has_value(), "no difficulty for block number=" + std::to_string(block_number));
+            ensure_post_condition(total_difficulty.has_value(), [&]() { return "no difficulty for block number=" + std::to_string(block_number); });
             const Block extended_block{block_with_hash, *total_difficulty, false};
             const auto block_size = extended_block.get_block_size();
             const BlockDetails block_details{block_size, block_with_hash->hash, block_with_hash->block.header, *total_difficulty,
@@ -220,7 +220,7 @@ Task<void> OtsRpcApi::handle_ots_get_block_transactions(const nlohmann::json& re
         const auto block_with_hash = co_await core::read_block_by_number(*block_cache_, *chain_storage, block_number);
         if (block_with_hash) {
             const auto total_difficulty{co_await chain_storage->read_total_difficulty(block_with_hash->hash, block_number)};
-            ensure_post_condition(total_difficulty.has_value(), "no difficulty for block number=" + std::to_string(block_number));
+            ensure_post_condition(total_difficulty.has_value(), [&]() { return "no difficulty for block number=" + std::to_string(block_number); });
             const Block extended_block{block_with_hash, *total_difficulty, false};
             auto receipts = co_await core::get_receipts(tx_database, *block_with_hash);
             auto block_size = extended_block.get_block_size();
@@ -869,7 +869,7 @@ Task<void> OtsRpcApi::trace_block(ethdb::Transaction& tx, BlockNum block_number,
 
     const auto block_hash = block_with_hash->hash;
     const auto total_difficulty{co_await chain_storage->read_total_difficulty(block_with_hash->hash, block_number)};
-    ensure_post_condition(total_difficulty.has_value(), "no difficulty for block number=" + std::to_string(block_number));
+    ensure_post_condition(total_difficulty.has_value(), [&]() { return "no difficulty for block number=" + std::to_string(block_number); });
     const auto receipts = co_await core::get_receipts(tx_database, *block_with_hash);
     const Block extended_block{block_with_hash, *total_difficulty, false};
     const auto block_size = extended_block.get_block_size();


### PR DESCRIPTION
Both compilers, gcc and clang, do not efficiently optimize string arguments for inline methods. As the result, when the following function:
```c++
inline void ensure(bool condition, const std::string& message) {
    if (!condition) [[unlikely]] {
        throw std::logic_error(message);
    }
}
```

is called with the code:
```c++
ensure(envelope_result.has_value(),
           "TransactionSnapshot: cannot decode tx envelope: " + to_hex(tx_envelope) + " error: " + to_string(envelope_result));
```
then the string argument is built every time. This is unnecessary as the string argument is only required in the unlikely event of an unmet condition.

During the execution stage, those `ensure()` methods can be called many times per block. This results in wasted resources and additional time required for completion. The preliminary tests showed ~4.5% improvement in block execution performance after implementing this change. See the attached logs for comparison: 
[block_execution_silkworm.txt](https://github.com/erigontech/silkworm/files/14009949/block_execution_silkworm.txt)

