### PR TITLE
sentry: treat invalid snappy data

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -60,6 +60,7 @@ Checks: >
   -misc-redundant-expression,
   -misc-unused-using-decls,
   -misc-use-anonymous-namespace,
+  -misc-include-cleaner,
   modernize-*,
   -modernize-avoid-c-arrays,
   -modernize-macro-to-enum,

--- a/silkworm/sentry/common/message.hpp
+++ b/silkworm/sentry/common/message.hpp
@@ -16,7 +16,8 @@
 
 #pragma once
 
-#include <silkworm/core/common/base.hpp>
+#include <cstdint>
+
 #include <silkworm/core/common/bytes.hpp>
 
 namespace silkworm::sentry {

--- a/silkworm/sentry/rlpx/common/disconnect_reason.hpp
+++ b/silkworm/sentry/rlpx/common/disconnect_reason.hpp
@@ -23,6 +23,7 @@ namespace silkworm::sentry::rlpx {
 enum class DisconnectReason : uint8_t {
     DisconnectRequested = 0,
     NetworkError = 1,
+    ProtocolError = 2,
     UselessPeer = 3,
     TooManyPeers = 4,
     ClientQuitting = 8,

--- a/silkworm/sentry/rlpx/framing/message_frame_codec.cpp
+++ b/silkworm/sentry/rlpx/framing/message_frame_codec.cpp
@@ -64,7 +64,7 @@ static Bytes snappy_decompress(ByteView data) {
         data.size(),
         reinterpret_cast<char*>(output.data()));
     if (!ok)
-        throw std::runtime_error("MessageFrameCodec: invalid snappy data");
+        throw MessageFrameCodec::DecompressionError();
     return output;
 }
 

--- a/silkworm/sentry/rlpx/framing/message_frame_codec.hpp
+++ b/silkworm/sentry/rlpx/framing/message_frame_codec.hpp
@@ -16,6 +16,9 @@
 
 #pragma once
 
+#include <stdexcept>
+
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/sentry/common/message.hpp>
 
 namespace silkworm::sentry::rlpx::framing {
@@ -26,6 +29,11 @@ class MessageFrameCodec {
     [[nodiscard]] Message decode(ByteView frame_data) const;
 
     void enable_compression() { is_compression_enabled_ = true; }
+
+    class DecompressionError : public std::runtime_error {
+      public:
+        DecompressionError() : std::runtime_error("MessageFrameCodec: invalid snappy data") {}
+    };
 
     static const size_t kMaxFrameSize;
 

--- a/silkworm/sentry/rlpx/framing/message_stream.hpp
+++ b/silkworm/sentry/rlpx/framing/message_stream.hpp
@@ -39,6 +39,8 @@ class MessageStream {
 
     void enable_compression();
 
+    using DecompressionError = MessageFrameCodec::DecompressionError;
+
   private:
     FramingCipher cipher_;
     SocketStream& stream_;

--- a/silkworm/sentry/rlpx/peer.cpp
+++ b/silkworm/sentry/rlpx/peer.cpp
@@ -185,6 +185,9 @@ Task<void> Peer::handle() {
     } catch (const auth::Handshake::DisconnectError& ex) {
         log::Debug("sentry") << "Peer::handle DisconnectError reason: " << static_cast<int>(ex.reason());
         disconnect_reason_.set({ex.reason()});
+    } catch (const framing::MessageStream::DecompressionError& ex) {
+        log::Debug("sentry") << "Peer::handle DecompressionError: " << ex.what();
+        disconnect_reason_.set({DisconnectReason::ProtocolError});
     } catch (const auth::Handshake::CapabilityMismatchError& ex) {
         log::Debug("sentry") << "Peer::handle CapabilityMismatchError: " << ex.what();
         disconnect_reason_.set({DisconnectReason::UselessPeer});


### PR DESCRIPTION
Some crawler clients (Nodecrawler/v1.13.10-stable) send an uncompressed Disconnect message after the handshake, which is an RLPx protocol violation.