### PR TITLE
rpcdaemon: workaround for Windows build error after PR 1777

### DIFF
--- a/silkworm/rpc/json/stream.cpp
+++ b/silkworm/rpc/json/stream.cpp
@@ -66,7 +66,7 @@ Stream::Stream(boost::asio::any_io_executor& executor, StreamWriter& writer, std
             co_await self->run();
         }(this),
         boost::asio::detached);
-#endif  // _WIN32
+#endif                                                         // _WIN32
     buffer_.reserve(buffer_capacity_ + buffer_capacity_ / 4);  // try to prevent reallocation when buffer overflows
 }
 

--- a/silkworm/rpc/json/stream.hpp
+++ b/silkworm/rpc/json/stream.hpp
@@ -20,6 +20,9 @@
 #include <stack>
 #include <string>
 #include <string_view>
+#ifdef _WIN32
+#include <tuple>
+#endif  // _WIN32
 
 #include <silkworm/infra/concurrency/task.hpp>
 


### PR DESCRIPTION
After #1777 build is broken on Windows due to [some compiler bug](https://developercommunity.visualstudio.com/t/use-of-undefined-type-std::tuplelt;_Ty/10342164). This PR replaces usage of Asio `promise` with `concurrent_channel` in our JSON stream.