### PR TITLE
cmd: fix CLI11 parse regression in snapshots utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,9 @@ build*
 venv
 xcode
 *.code-workspace
+.DS_Store
 .idea
 .vscode
 .vs
 CMakeFiles
 cmake-build-*
-tests/integration/goerly/results
-

--- a/cmd/dev/snapshots.cpp
+++ b/cmd/dev/snapshots.cpp
@@ -134,7 +134,6 @@ void parse_command_line(int argc, char* argv[], CLI::App& app, SnapshotToolboxSe
         {"sync", SnapshotTool::sync},
     };
     app.add_option("--tool", settings.tool, "The snapshot tool to use")
-        ->capture_default_str()
         ->check(CLI::Range(SnapshotTool::count_bodies, SnapshotTool::sync))
         ->transform(CLI::Transformer(snapshot_tool_mapping, CLI::ignore_case))
         ->default_val(SnapshotTool::download);

--- a/cmd/dev/snapshots.cpp
+++ b/cmd/dev/snapshots.cpp
@@ -63,8 +63,9 @@ struct DownloadSettings : public bittorrent::BitTorrentSettings {
     std::string magnet_uri;
 };
 
-//! The Snapshots tools
-enum class SnapshotTool : uint8_t {
+//! The available tools in snapshots facility
+//! \warning reducing the enum base type size as suggested by clang-tidy breaks CLI11
+enum class SnapshotTool {  // NOLINT(performance-enum-size)
     count_bodies,
     count_headers,
     create_index,

--- a/cmd/dev/snapshots.cpp
+++ b/cmd/dev/snapshots.cpp
@@ -63,7 +63,7 @@ struct DownloadSettings : public bittorrent::BitTorrentSettings {
     std::string magnet_uri;
 };
 
-//! The available tools in snapshots facility
+//! The available subcommands in snapshots utility
 //! \warning reducing the enum base type size as suggested by clang-tidy breaks CLI11
 enum class SnapshotTool {  // NOLINT(performance-enum-size)
     count_bodies,


### PR DESCRIPTION
Using enumerated parameters with base type size different from `int` breaks CLI11 parsing:
```
% cmd/dev/snapshots --tool decode_segment --snapshot_file /tmp/v1-018300-018400-transactions.seg
--tool: Value  not in range [
Run with --help for more information.
```
```
% cmd/dev/snapshots --help
--tool: Value  not in range [
Run with --help for more information.
```