### PR TITLE
rpcdaemon: fix json rpc validation and enable for integration tests

### DIFF
--- a/silkworm/rpc/http/json_rpc_validator.cpp
+++ b/silkworm/rpc/http/json_rpc_validator.cpp
@@ -114,7 +114,7 @@ void JsonRpcValidator::validate_params(const nlohmann::json& request, JsonRpcVal
     }
     const auto& method_spec = method_spec_field->second;
 
-    if (params.size() > method_spec.size() + 1) { // allow one extra parameter for optimize_gas
+    if (params.size() > method_spec.size() + 1) {  // allow one extra parameter for optimize_gas
         result.is_valid = false;
         result.error_message = "Invalid number of parameters";
         return;
@@ -272,7 +272,7 @@ void JsonRpcValidator::validate_object(const nlohmann::json& object, const nlohm
                 if (!result.is_valid) {
                     return;
                 }
-            } else if (item.key() == "data") { //backward compability: optional `data` field is hex data
+            } else if (item.key() == "data") {  // backward compability: optional `data` field is hex data
                 validate_string(item.value(), R"({"pattern": "^0x[0-9a-f]*$"})"_json, result);
                 if (!result.is_valid) {
                     return;

--- a/silkworm/rpc/http/json_rpc_validator.cpp
+++ b/silkworm/rpc/http/json_rpc_validator.cpp
@@ -114,7 +114,7 @@ void JsonRpcValidator::validate_params(const nlohmann::json& request, JsonRpcVal
     }
     const auto& method_spec = method_spec_field->second;
 
-    if (params.size() > method_spec.size()) {
+    if (params.size() > method_spec.size() + 1) { // allow one extra parameter for optimize_gas
         result.is_valid = false;
         result.error_message = "Invalid number of parameters";
         return;
@@ -205,7 +205,7 @@ void JsonRpcValidator::validate_string(const nlohmann::json& string, const nlohm
         if (pattern_field != patterns_.end()) {
             pattern = pattern_field->second;
         } else {
-            pattern = boost::regex(schema_pattern, boost::regex::optimize);
+            pattern = boost::regex(schema_pattern, boost::regex::optimize | boost::regex::icase);
             patterns_[schema_pattern] = pattern;
         }
 
@@ -235,14 +235,14 @@ void JsonRpcValidator::validate_string(const nlohmann::json& string, const nlohm
 }
 
 void JsonRpcValidator::validate_array(const nlohmann::json& array_, const nlohmann::json& schema, JsonRpcValidationResult& result) {
-    if (!array_.is_array()) {
+    if (!array_.is_array() && !array_.is_null()) {
         result.is_valid = false;
         result.error_message = "Invalid array";
     }
 
     const auto& schema_items = schema["items"];
     for (const auto& item : array_) {
-        validate_type(item, schema_items, result);
+        validate_schema(item, schema_items, result);
         if (!result.is_valid) {
             break;
         }
@@ -269,6 +269,11 @@ void JsonRpcValidator::validate_object(const nlohmann::json& object, const nlohm
         for (const auto& item : object.items()) {
             if (schema["properties"].contains(item.key())) {
                 validate_schema(item.value(), schema["properties"][item.key()], result);
+                if (!result.is_valid) {
+                    return;
+                }
+            } else if (item.key() == "data") { //backward compability: optional `data` field is hex data
+                validate_string(item.value(), R"({"pattern": "^0x[0-9a-f]*$"})"_json, result);
                 if (!result.is_valid) {
                     return;
                 }

--- a/silkworm/rpc/http/json_rpc_validator_test.cpp
+++ b/silkworm/rpc/http/json_rpc_validator_test.cpp
@@ -488,4 +488,5 @@ TEST_CASE("rpc::http::JsonRpcValidator validates spec test request", "[rpc][http
         }
     }
 }
+
 }  // namespace silkworm::rpc::http

--- a/silkworm/rpc/http/json_rpc_validator_test.cpp
+++ b/silkworm/rpc/http/json_rpc_validator_test.cpp
@@ -383,6 +383,89 @@ TEST_CASE("rpc::http::JsonRpcValidator validates object", "[rpc][http][json_rpc_
     CHECK(!result.is_valid);
 }
 
+TEST_CASE("rpc::http::JsonRpcValidator validates uppercase hex value", "[rpc][http][json_rpc_validator]") {
+    JsonRpcValidator validator{create_validator_for_test()};
+
+    nlohmann::json request = {
+        {"jsonrpc", "2.0"},
+        {"method", "eth_getBlockByNumber"},
+        {"params", {"0xF42405", true}},
+        {"id", 1},
+    };
+
+    JsonRpcValidationResult result = validator.validate(request);
+    CHECK(result.is_valid);
+}
+
+TEST_CASE("rpc::http::JsonRpcValidator validates `data` field", "[rpc][http][json_rpc_validator]") {
+    JsonRpcValidator validator{create_validator_for_test()};
+
+    nlohmann::json request = {
+        {"jsonrpc", "2.0"},
+        {"method", "eth_getBlockByNumber"},
+        {"params", {"0xF42405", true}},
+        {"id", 1},
+    };
+
+    JsonRpcValidationResult result = validator.validate(request);
+    CHECK(result.is_valid);
+}
+
+TEST_CASE("rpc::http::JsonRpcValidator validates nested arrays", "[rpc][http][json_rpc_validator]") {
+    JsonRpcValidator validator{create_validator_for_test()};
+
+    auto request1 = R"({
+            "jsonrpc":"2.0",
+            "method":"eth_getLogs",
+            "params":[
+                {
+                    "fromBlock": "0x10B10B2",
+                    "toBlock": "0x10B10B3",
+                    "address": ["0x00000000219ab540356cbb839cbe05303d7705fa"],
+                    "topics": null
+                }
+            ],
+            "id":3
+    })"_json;
+    JsonRpcValidationResult result1 = validator.validate(request1);
+    CHECK(result1.is_valid);
+
+    auto request2 = R"({
+            "jsonrpc":"2.0",
+            "method":"eth_getLogs",
+            "params":[
+                {
+                    "fromBlock": "0x10B10B2",
+                    "toBlock": "0x10B10B3",
+                    "address": ["0x00000000219ab540356cbb839cbe05303d7705fa"],
+                    "topics": "0x76734e0205d8c4b711990ab957e86d3dc56d129600e60750552c95448a449794"
+                }
+            ],
+            "id":3
+    })"_json;
+    JsonRpcValidationResult result2 = validator.validate(request2);
+    CHECK(result2.is_valid);
+
+    auto request3 = R"({
+            "jsonrpc":"2.0",
+            "method":"eth_getLogs",
+            "params":[
+                {
+                    "fromBlock": "0x10B10B2",
+                    "toBlock": "0x10B10B3",
+                    "address": ["0x00000000219ab540356cbb839cbe05303d7705fa"],
+                    "topics": [
+                        "0x76734e0205d8c4b711990ab957e86d3dc56d129600e60750552c95448a449794",
+                        "0x76734e0205d8c4b711990ab957e86d3dc56d129600e60750552c95448a449795"
+                        ]
+                }
+            ],
+            "id":3
+    })"_json;
+    JsonRpcValidationResult result3 = validator.validate(request3);
+    CHECK(result3.is_valid);
+}
+
 TEST_CASE("rpc::http::JsonRpcValidator validates spec test request", "[rpc][http][json_rpc_validator]") {
     JsonRpcValidator validator{create_validator_for_test()};
 
@@ -405,5 +488,4 @@ TEST_CASE("rpc::http::JsonRpcValidator validates spec test request", "[rpc][http
         }
     }
 }
-
 }  // namespace silkworm::rpc::http

--- a/silkworm/rpc/http/request_handler.cpp
+++ b/silkworm/rpc/http/request_handler.cpp
@@ -76,7 +76,7 @@ Task<void> RequestHandler::handle(const std::string& content) {
     SILK_TRACE << "handle HTTP request t=" << clock_time::since(start) << "ns";
 }
 
-bool RequestHandler::is_valid_jsonrpc(const nlohmann::json&  request_json ) {
+bool RequestHandler::is_valid_jsonrpc(const nlohmann::json& request_json) {
     auto validation_result = json_rpc_validator_.validate(request_json);
     return validation_result.is_valid;
 }

--- a/silkworm/rpc/http/request_handler.cpp
+++ b/silkworm/rpc/http/request_handler.cpp
@@ -76,10 +76,9 @@ Task<void> RequestHandler::handle(const std::string& content) {
     SILK_TRACE << "handle HTTP request t=" << clock_time::since(start) << "ns";
 }
 
-bool RequestHandler::is_valid_jsonrpc(const nlohmann::json& /* request_json */) {
-    // auto validation_result = json_rpc_validator_.validate(request_json);
-    // return validation_result.is_valid;
-    return true;
+bool RequestHandler::is_valid_jsonrpc(const nlohmann::json&  request_json ) {
+    auto validation_result = json_rpc_validator_.validate(request_json);
+    return validation_result.is_valid;
 }
 
 Task<bool> RequestHandler::handle_request_and_create_reply(const nlohmann::json& request_json, std::string& response) {

--- a/silkworm/rpc/http/request_handler.cpp
+++ b/silkworm/rpc/http/request_handler.cpp
@@ -38,7 +38,7 @@ Task<void> RequestHandler::handle(const std::string& content) {
         request_json = nlohmann::json::parse(content);
         if (request_json.is_object()) {
             if (!is_valid_jsonrpc(request_json)) {
-                response = make_json_error(0, -32600, "invalid request").dump() + "\n";
+                response = make_json_error(request_json, -32600, "invalid request").dump() + "\n";
             } else {
                 send_reply = co_await handle_request_and_create_reply(request_json, response);
                 response += "\n";
@@ -53,7 +53,7 @@ Task<void> RequestHandler::handle(const std::string& content) {
                 }
 
                 if (!is_valid_jsonrpc(item.value())) {
-                    batch_reply_content << make_json_error(0, -32600, "invalid request").dump();
+                    batch_reply_content << make_json_error(request_json, -32600, "invalid request").dump();
                 } else {
                     std::string single_reply;
                     send_reply = co_await handle_request_and_create_reply(item.value(), single_reply);
@@ -66,7 +66,7 @@ Task<void> RequestHandler::handle(const std::string& content) {
         }
     } catch (const nlohmann::json::exception& e) {
         SILK_ERROR << "Connection::do_read json_parse: " << e.what();
-        response = make_json_error(0, -32600, "invalid request").dump() + "\n";
+        response = make_json_error(request_json, -32600, "invalid request").dump() + "\n";
         send_reply = true;
     }
 

--- a/silkworm/rpc/json/call.cpp
+++ b/silkworm/rpc/json/call.cpp
@@ -60,10 +60,17 @@ void from_json(const nlohmann::json& json, Call& call) {
     if (json.count("value") != 0) {
         call.value = json.at("value").get<intx::uint256>();
     }
+
+    // backward compatibility: both `data` and `input` fields are accepted as input
     if (json.count("data") != 0) {
         const auto json_data = json.at("data").get<std::string>();
         call.data = silkworm::from_hex(json_data);
     }
+    if (json.count("input") != 0) {
+        const auto json_data = json.at("input").get<std::string>();
+        call.data = silkworm::from_hex(json_data);
+    }
+
     if (json.count("accessList") != 0) {
         call.access_list = json.at("accessList").get<AccessList>();
     }

--- a/silkworm/rpc/json/call_test.cpp
+++ b/silkworm/rpc/json/call_test.cpp
@@ -96,6 +96,24 @@ TEST_CASE("deserialize full call", "[silkworm::json][from_json]") {
     CHECK(c2.data == silkworm::from_hex("0xdaa6d5560000000000000000000000000000000000000000000000000000000000000000"));
     CHECK(c2.value == intx::uint256{1200000});
     CHECK(c2.nonce == intx::uint256{1});
+
+    auto j3 = R"({
+        "from":"0x52c24586c31cff0485a6208bb63859290fba5bce",
+        "to":"0x0715a7794a1dc8e42615f059dd6e406a6594651a",
+        "gas":1000000,
+        "gasPrice":"0x10C388C00",
+        "input":"0xdaa6d5560000000000000000000000000000000000000000000000000000000000000000",
+        "value":"0x124F80",
+        "nonce": 1
+    })"_json;
+    auto c3 = j3.get<Call>();
+    CHECK(c3.from == 0x52c24586c31cff0485a6208bb63859290fba5bce_address);
+    CHECK(c3.to == 0x0715a7794a1dc8e42615f059dd6e406a6594651a_address);
+    CHECK(c3.gas == intx::uint256{1000000});
+    CHECK(c3.gas_price == intx::uint256{4499999744});
+    CHECK(c3.data == silkworm::from_hex("0xdaa6d5560000000000000000000000000000000000000000000000000000000000000000"));
+    CHECK(c3.value == intx::uint256{1200000});
+    CHECK(c3.nonce == intx::uint256{1});
 }
 
 TEST_CASE("make glaze content (data)", "[make_glaze_json_error]") {


### PR DESCRIPTION
Some RPC methods like eth_createAccessList, eth_estimateGas or eth_call take a generic transaction object as a parameter. This is called `silkworm::rpc::Call` in Silkworm. The object has the `input` field to pass some data. 
Check [specification source code](https://github.com/ethereum/execution-apis/blob/main/src/eth/execute.yaml) and [API documentaion](https://ethereum.github.io/execution-apis/api-documentation/) for the field definition.

Confusingly this field used to be called `data` in the past. And that is how it is referred to in our tests.

This PR makes the validation and parameters backwards compatible, accepting both `input` and `data` for the same field. This is in line with Erigon's approach, see https://github.com/ledgerwatch/erigon/blob/devel/turbo/adapter/ethapi/api.go#L146.

Also minor fixes to the JSON RPC validator, unit tests included.