### PR TITLE
rpcdaemon: add optional interface log in JSON RPC end-points

### DIFF
--- a/cmd/common/rpcdaemon_options.cpp
+++ b/cmd/common/rpcdaemon_options.cpp
@@ -71,7 +71,27 @@ struct ApiSpecValidator : public CLI::Validator {
     }
 };
 
+static void add_options_interface_log(CLI::App& cli, const std::string& option_prefix, const std::string& end_point_descr,
+                                      rpc::InterfaceLogSettings& settings) {
+    cli.add_flag("--" + option_prefix + ".enabled", settings.enabled)
+        ->description("Enable interface log files for " + end_point_descr)
+        ->capture_default_str();
+
+    cli.add_option("--" + option_prefix + ".max_files", settings.max_files)
+        ->description("Maximum number of distinct interface log files for " + end_point_descr)
+        ->check(CLI::Range(1, 500))
+        ->capture_default_str();
+
+    cli.add_option("--" + option_prefix + ".max_file_size", settings.max_file_size_mb)
+        ->description("Maximum size in megabytes of each interface log file for " + end_point_descr)
+        ->check(CLI::Range(1, 1024))
+        ->capture_default_str();
+}
+
 void add_rpcdaemon_options(CLI::App& cli, silkworm::rpc::DaemonSettings& settings) {
+    add_options_interface_log(cli, "eth", "Execution Layer JSON RPC API", settings.eth_ifc_log_settings);
+    add_options_interface_log(cli, "engine", "Engine JSON RPC API", settings.engine_ifc_log_settings);
+
     add_option_ip_endpoint(cli, "--eth.addr", settings.eth_end_point,
                            "Execution Layer JSON RPC API local end-point as <address>:<port>");
     add_option_ip_endpoint(cli, "--engine.addr", settings.engine_end_point,

--- a/silkworm/node/snapshots/sync.cpp
+++ b/silkworm/node/snapshots/sync.cpp
@@ -215,9 +215,14 @@ void SnapshotSync::build_missing_indexes() {
     const auto missing_indexes = repository_->missing_indexes();
     for (const auto& index : missing_indexes) {
         workers.push_task([=]() {
-            SILK_INFO << "SnapshotSync: build index: " << index->path().filename() << " start";
-            index->build();
-            SILK_INFO << "SnapshotSync: build index: " << index->path().filename() << " end";
+            try {
+                SILK_INFO << "SnapshotSync: build index: " << index->path().filename() << " start";
+                index->build();
+                SILK_INFO << "SnapshotSync: build index: " << index->path().filename() << " end";
+            } catch (const std::exception& ex) {
+                SILK_CRIT << "SnapshotSync: build index: " << index->path().filename() << " failed [" << ex.what() << "]";
+                throw;
+            }
         });
     }
 

--- a/silkworm/node/snapshots/sync.cpp
+++ b/silkworm/node/snapshots/sync.cpp
@@ -215,14 +215,9 @@ void SnapshotSync::build_missing_indexes() {
     const auto missing_indexes = repository_->missing_indexes();
     for (const auto& index : missing_indexes) {
         workers.push_task([=]() {
-            try {
-                SILK_INFO << "SnapshotSync: build index: " << index->path().filename() << " start";
-                index->build();
-                SILK_INFO << "SnapshotSync: build index: " << index->path().filename() << " end";
-            } catch (const std::exception& ex) {
-                SILK_CRIT << "SnapshotSync: build index: " << index->path().filename() << " failed [" << ex.what() << "]";
-                throw;
-            }
+            SILK_INFO << "SnapshotSync: build index: " << index->path().filename() << " start";
+            index->build();
+            SILK_INFO << "SnapshotSync: build index: " << index->path().filename() << " end";
         });
     }
 

--- a/silkworm/rpc/common/interface_log.cpp
+++ b/silkworm/rpc/common/interface_log.cpp
@@ -19,7 +19,6 @@
 #include <spdlog/sinks/rotating_file_sink.h>
 #include <spdlog/spdlog.h>
 
-#include <silkworm/core/common/base.hpp>
 #include <silkworm/infra/common/ensure.hpp>
 
 namespace silkworm::log {
@@ -55,8 +54,8 @@ class InterfaceLogImpl final {
     std::string name_;
     bool auto_flush_;
     std::filesystem::path file_path_;
-    std::size_t max_file_size_{1 * kMebi};
-    std::size_t max_files_{10};
+    std::size_t max_file_size_;
+    std::size_t max_files_;
     std::shared_ptr<spdlog::sinks::rotating_file_sink_mt> rotating_sink_;
     std::shared_ptr<spdlog::logger> rotating_logger_;
 };
@@ -65,6 +64,8 @@ InterfaceLogImpl::InterfaceLogImpl(InterfaceLogConfig config)
     : name_{std::move(config.ifc_name)},
       auto_flush_{config.auto_flush},
       file_path_{std::move(config.container_folder) / std::filesystem::path{name_ + ".log"}},
+      max_file_size_{config.max_file_size},
+      max_files_{config.max_files},
       rotating_sink_{std::make_shared<spdlog::sinks::rotating_file_sink_mt>(file_path_.string(), max_file_size_, max_files_)},
       rotating_logger_{std::make_shared<spdlog::logger>(name_, rotating_sink_)} {
     ensure(!name_.empty(), "InterfaceLogImpl: name is empty");

--- a/silkworm/rpc/common/interface_log.cpp
+++ b/silkworm/rpc/common/interface_log.cpp
@@ -57,6 +57,7 @@ class InterfaceLogImpl final {
     std::filesystem::path file_path_;
     std::size_t max_file_size_{1 * kMebi};
     std::size_t max_files_{10};
+    std::shared_ptr<spdlog::sinks::rotating_file_sink_mt> rotating_sink_;
     std::shared_ptr<spdlog::logger> rotating_logger_;
 };
 
@@ -64,7 +65,8 @@ InterfaceLogImpl::InterfaceLogImpl(InterfaceLogConfig config)
     : name_{std::move(config.ifc_name)},
       auto_flush_{config.auto_flush},
       file_path_{std::move(config.container_folder) / std::filesystem::path{name_ + ".log"}},
-      rotating_logger_{spdlog::rotating_logger_mt(name_, file_path_.string(), max_file_size_, max_files_)} {
+      rotating_sink_{std::make_shared<spdlog::sinks::rotating_file_sink_mt>(file_path_.string(), max_file_size_, max_files_)},
+      rotating_logger_{std::make_shared<spdlog::logger>(name_, rotating_sink_)} {
     ensure(!name_.empty(), "InterfaceLogImpl: name is empty");
 
     // Hard-code log level because we want all-or-nothing in interface log

--- a/silkworm/rpc/common/interface_log.cpp
+++ b/silkworm/rpc/common/interface_log.cpp
@@ -26,7 +26,7 @@ namespace silkworm::log {
 
 class InterfaceLogImpl final {
   public:
-    explicit InterfaceLogImpl(std::string_view name, std::string_view folder, bool auto_flush);
+    explicit InterfaceLogImpl(InterfaceLogConfig config);
     ~InterfaceLogImpl() {
         flush();
     }
@@ -60,10 +60,10 @@ class InterfaceLogImpl final {
     std::shared_ptr<spdlog::logger> rotating_logger_;
 };
 
-InterfaceLogImpl::InterfaceLogImpl(std::string_view name, std::string_view folder, bool auto_flush)
-    : name_{name},
-      auto_flush_{auto_flush},
-      file_path_{folder / std::filesystem::path{name_ + ".log"}},
+InterfaceLogImpl::InterfaceLogImpl(InterfaceLogConfig config)
+    : name_{std::move(config.ifc_name)},
+      auto_flush_{config.auto_flush},
+      file_path_{std::move(config.container_folder) / std::filesystem::path{name_ + ".log"}},
       rotating_logger_{spdlog::rotating_logger_mt(name_, file_path_.string(), max_file_size_, max_files_)} {
     ensure(!name_.empty(), "InterfaceLogImpl: name is empty");
 
@@ -74,8 +74,8 @@ InterfaceLogImpl::InterfaceLogImpl(std::string_view name, std::string_view folde
     rotating_logger_->set_pattern("[%Y-%m-%d %H:%M:%S.%e] %v");
 }
 
-InterfaceLog::InterfaceLog(std::string_view name, std::string_view folder, bool auto_flush)
-    : p_impl_{std::make_unique<InterfaceLogImpl>(name, folder, auto_flush)} {
+InterfaceLog::InterfaceLog(InterfaceLogConfig config)
+    : p_impl_{std::make_unique<InterfaceLogImpl>(std::move(config))} {
 }
 
 // An explicit destructor is needed to avoid error:

--- a/silkworm/rpc/common/interface_log.hpp
+++ b/silkworm/rpc/common/interface_log.hpp
@@ -24,9 +24,16 @@ namespace silkworm::log {
 
 class InterfaceLogImpl;
 
+struct InterfaceLogConfig {
+    bool enabled{false};
+    std::string ifc_name;
+    std::string container_folder{"logs/"};
+    bool auto_flush{false};
+};
+
 class InterfaceLog final {
   public:
-    explicit InterfaceLog(std::string_view name, std::string_view folder = "logs/", bool auto_flush = false);
+    explicit InterfaceLog(InterfaceLogConfig config);
     ~InterfaceLog();
 
     [[nodiscard]] std::filesystem::path path() const;

--- a/silkworm/rpc/common/interface_log.hpp
+++ b/silkworm/rpc/common/interface_log.hpp
@@ -23,22 +23,22 @@
 
 #include <silkworm/core/common/base.hpp>
 
-namespace silkworm::log {
+namespace silkworm::rpc {
 
 class InterfaceLogImpl;
 
-struct InterfaceLogConfig {
+struct InterfaceLogSettings {
     bool enabled{false};
     std::string ifc_name;
     std::string container_folder{"logs/"};
-    std::size_t max_file_size{1 * kMebi};
+    std::size_t max_file_size_mb{1};
     std::size_t max_files{100};
     bool auto_flush{false};
 };
 
 class InterfaceLog final {
   public:
-    explicit InterfaceLog(InterfaceLogConfig config);
+    explicit InterfaceLog(InterfaceLogSettings settings);
     ~InterfaceLog();
 
     [[nodiscard]] std::filesystem::path path() const;
@@ -52,4 +52,4 @@ class InterfaceLog final {
     std::unique_ptr<InterfaceLogImpl> p_impl_;
 };
 
-}  // namespace silkworm::log
+}  // namespace silkworm::rpc

--- a/silkworm/rpc/common/interface_log.hpp
+++ b/silkworm/rpc/common/interface_log.hpp
@@ -16,9 +16,12 @@
 
 #pragma once
 
+#include <cstddef>
 #include <filesystem>
 #include <memory>
 #include <string_view>
+
+#include <silkworm/core/common/base.hpp>
 
 namespace silkworm::log {
 
@@ -28,6 +31,8 @@ struct InterfaceLogConfig {
     bool enabled{false};
     std::string ifc_name;
     std::string container_folder{"logs/"};
+    std::size_t max_file_size{1 * kMebi};
+    std::size_t max_files{100};
     bool auto_flush{false};
 };
 

--- a/silkworm/rpc/common/interface_log_test.cpp
+++ b/silkworm/rpc/common/interface_log_test.cpp
@@ -27,12 +27,11 @@
 
 namespace silkworm::log {
 
-TEST_CASE("InterfaceLog basic", "[infra][common][log]") {
+TEST_CASE("InterfaceLog basic", "[rpc][common][interface_log]") {
     const auto tmp_dir{TemporaryDirectory::get_unique_temporary_path()};
-    static int count{0};
     InterfaceLogConfig config{
         .enabled = true,
-        .ifc_name = "eth_rpc" + std::to_string(++count),
+        .ifc_name = "eth_rpc",
         .container_folder = tmp_dir.string(),
     };
     auto ifc_log{std::make_unique<InterfaceLog>(config)};

--- a/silkworm/rpc/common/interface_log_test.cpp
+++ b/silkworm/rpc/common/interface_log_test.cpp
@@ -25,16 +25,16 @@
 
 #include <silkworm/infra/common/directories.hpp>
 
-namespace silkworm::log {
+namespace silkworm::rpc {
 
 TEST_CASE("InterfaceLog basic", "[rpc][common][interface_log]") {
     const auto tmp_dir{TemporaryDirectory::get_unique_temporary_path()};
-    InterfaceLogConfig config{
+    InterfaceLogSettings settings{
         .enabled = true,
         .ifc_name = "eth_rpc",
         .container_folder = tmp_dir.string(),
     };
-    auto ifc_log{std::make_unique<InterfaceLog>(config)};
+    auto ifc_log{std::make_unique<InterfaceLog>(settings)};
     REQUIRE(!ifc_log->path().empty());
     ifc_log->log_req(R"({"json":"2.0"})");
     ifc_log->log_rsp(R"({"json":"2.0"})");
@@ -68,4 +68,4 @@ TEST_CASE("InterfaceLog basic", "[rpc][common][interface_log]") {
     CHECK(log_ifstream.eof());
 }
 
-}  // namespace silkworm::log
+}  // namespace silkworm::rpc

--- a/silkworm/rpc/common/interface_log_test.cpp
+++ b/silkworm/rpc/common/interface_log_test.cpp
@@ -30,7 +30,12 @@ namespace silkworm::log {
 TEST_CASE("InterfaceLog basic", "[infra][common][log]") {
     const auto tmp_dir{TemporaryDirectory::get_unique_temporary_path()};
     static int count{0};
-    auto ifc_log{std::make_unique<InterfaceLog>("eth_rpc" + std::to_string(++count), tmp_dir.string())};
+    InterfaceLogConfig config{
+        .enabled = true,
+        .ifc_name = "eth_rpc" + std::to_string(++count),
+        .container_folder = tmp_dir.string(),
+    };
+    auto ifc_log{std::make_unique<InterfaceLog>(config)};
     REQUIRE(!ifc_log->path().empty());
     ifc_log->log_req(R"({"json":"2.0"})");
     ifc_log->log_rsp(R"({"json":"2.0"})");

--- a/silkworm/rpc/daemon.cpp
+++ b/silkworm/rpc/daemon.cpp
@@ -316,6 +316,9 @@ void Daemon::start() {
                 .enabled = true,
                 .ifc_name = "engine_api",
             };
+            if (settings_.datadir) {
+                ifc_config.container_folder = *settings_.datadir / "logs";
+            }
             rpc_services_.emplace_back(make_rpc_server(kDefaultEth2ApiSpec, ioc, jwt_secret_, ifc_config));
         }
     }

--- a/silkworm/rpc/daemon.cpp
+++ b/silkworm/rpc/daemon.cpp
@@ -296,30 +296,32 @@ DaemonChecklist Daemon::run_checklist() {
 }
 
 void Daemon::start() {
-    auto make_rpc_server = [this](const std::string& api_spec,
+    auto make_rpc_server = [this](const std::string& end_point,
+                                  const std::string& api_spec,
                                   boost::asio::io_context& ioc,
                                   std::optional<std::string> jwt_secret,
-                                  log::InterfaceLogConfig config = {}) {
+                                  InterfaceLogSettings ilog_settings) {
         return std::make_unique<http::Server>(
-            settings_.engine_end_point, api_spec, ioc, worker_pool_, settings_.cors_domain, std::move(jwt_secret),
-            settings_.use_websocket, settings_.ws_compression, std::move(config));
+            end_point, api_spec, ioc, worker_pool_, settings_.cors_domain, std::move(jwt_secret),
+            settings_.use_websocket, settings_.ws_compression, std::move(ilog_settings));
     };
 
+    if (settings_.datadir) {
+        settings_.eth_ifc_log_settings.container_folder = *settings_.datadir / "logs";
+        settings_.engine_ifc_log_settings.container_folder = *settings_.datadir / "logs";
+    }
     for (std::size_t i{0}; i < settings_.context_pool_settings.num_contexts; ++i) {
         auto& ioc = context_pool_.next_io_context();
 
-        if (not settings_.eth_end_point.empty()) {
-            rpc_services_.emplace_back(make_rpc_server(settings_.eth_api_spec, ioc, /*jwt_secret=*/std::nullopt));
+        if (!settings_.eth_end_point.empty()) {
+            // ETH RPC API accepts customized namespaces and does not support JWT authentication
+            rpc_services_.emplace_back(make_rpc_server(
+                settings_.eth_end_point, settings_.eth_api_spec, ioc, /*jwt_secret=*/std::nullopt, settings_.eth_ifc_log_settings));
         }
-        if (not settings_.engine_end_point.empty()) {
-            log::InterfaceLogConfig ifc_config{
-                .enabled = true,
-                .ifc_name = "engine_api",
-            };
-            if (settings_.datadir) {
-                ifc_config.container_folder = *settings_.datadir / "logs";
-            }
-            rpc_services_.emplace_back(make_rpc_server(kDefaultEth2ApiSpec, ioc, jwt_secret_, ifc_config));
+        if (!settings_.engine_end_point.empty()) {
+            // Engine RPC API has fixed namespaces and supports JWT authentication
+            rpc_services_.emplace_back(make_rpc_server(
+                settings_.engine_end_point, kDefaultEth2ApiSpec, ioc, jwt_secret_, settings_.engine_ifc_log_settings));
         }
     }
 

--- a/silkworm/rpc/http/connection.cpp
+++ b/silkworm/rpc/http/connection.cpp
@@ -39,11 +39,11 @@ Connection::Connection(boost::asio::io_context& io_context,
                        std::optional<std::string> jwt_secret,
                        bool use_websocket,
                        bool ws_compression,
-                       log::InterfaceLogConfig ifc_config)
+                       InterfaceLogSettings ifc_log_settings)
     : socket_{io_context},
       api_{api},
       handler_table_{handler_table},
-      request_handler_{this, api, handler_table, std::move(ifc_config)},
+      request_handler_{this, api, handler_table, std::move(ifc_log_settings)},
       allowed_origins_{allowed_origins},
       jwt_secret_{std ::move(jwt_secret)},
       use_websocket_{use_websocket},

--- a/silkworm/rpc/http/connection.cpp
+++ b/silkworm/rpc/http/connection.cpp
@@ -24,7 +24,6 @@
 #include <boost/asio/use_awaitable.hpp>
 #include <boost/asio/write.hpp>
 #include <boost/beast/http/write.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
 #include <jwt-cpp/jwt.h>
 #include <jwt-cpp/traits/nlohmann-json/defaults.h>
 
@@ -39,11 +38,12 @@ Connection::Connection(boost::asio::io_context& io_context,
                        const std::vector<std::string>& allowed_origins,
                        std::optional<std::string> jwt_secret,
                        bool use_websocket,
-                       bool ws_compression)
+                       bool ws_compression,
+                       log::InterfaceLogConfig ifc_config)
     : socket_{io_context},
       api_{api},
       handler_table_{handler_table},
-      request_handler_{this, api, handler_table},
+      request_handler_{this, api, handler_table, std::move(ifc_config)},
       allowed_origins_{allowed_origins},
       jwt_secret_{std ::move(jwt_secret)},
       use_websocket_{use_websocket},

--- a/silkworm/rpc/http/connection.hpp
+++ b/silkworm/rpc/http/connection.hpp
@@ -30,6 +30,7 @@
 
 #include <silkworm/rpc/commands/rpc_api_table.hpp>
 #include <silkworm/rpc/common/constants.hpp>
+#include <silkworm/rpc/common/interface_log.hpp>
 #include <silkworm/rpc/http/channel.hpp>
 #include <silkworm/rpc/http/request_handler.hpp>
 #include <silkworm/rpc/ws/connection.hpp>
@@ -49,7 +50,8 @@ class Connection : public Channel {
                const std::vector<std::string>& allowed_origins,
                std::optional<std::string> jwt_secret,
                bool use_websocket,
-               bool ws_compression);
+               bool ws_compression,
+               log::InterfaceLogConfig ifc_config);
     ~Connection() override;
 
     boost::asio::ip::tcp::socket& socket() { return socket_; }

--- a/silkworm/rpc/http/connection.hpp
+++ b/silkworm/rpc/http/connection.hpp
@@ -51,7 +51,7 @@ class Connection : public Channel {
                std::optional<std::string> jwt_secret,
                bool use_websocket,
                bool ws_compression,
-               log::InterfaceLogConfig ifc_config);
+               InterfaceLogSettings ifc_log_settings);
     ~Connection() override;
 
     boost::asio::ip::tcp::socket& socket() { return socket_; }

--- a/silkworm/rpc/http/request_handler.cpp
+++ b/silkworm/rpc/http/request_handler.cpp
@@ -76,7 +76,7 @@ Task<void> RequestHandler::handle(const std::string& request) {
         }
     } catch (const nlohmann::json::exception& e) {
         SILK_ERROR << "RequestHandler::handle nlohmann::json::exception: " << e.what();
-        response = make_json_error(request_json, -32600, "invalid request").dump() + "\n";
+        response = make_json_error(0, -32600, "invalid request").dump() + "\n";
         send_reply = true;
     }
 

--- a/silkworm/rpc/http/request_handler.cpp
+++ b/silkworm/rpc/http/request_handler.cpp
@@ -46,7 +46,7 @@ Task<void> RequestHandler::handle(const std::string& request) {
         if (ifc_log_) {
             ifc_log_->log_req(request);
         }
-        const auto request_json{nlohmann::json::parse(request)};
+        const auto request_json = nlohmann::json::parse(request);
         if (request_json.is_object()) {
             if (!is_valid_jsonrpc(request_json)) {
                 response = make_json_error(0, -32600, "invalid request").dump() + "\n";
@@ -75,7 +75,7 @@ Task<void> RequestHandler::handle(const std::string& request) {
             response = batch_reply_content.str();
         }
     } catch (const nlohmann::json::exception& e) {
-        SILK_ERROR << "Connection::do_read json_parse: " << e.what();
+        SILK_ERROR << "RequestHandler::handle nlohmann::json::exception: " << e.what();
         response = make_json_error(0, -32600, "invalid request").dump() + "\n";
         send_reply = true;
     }

--- a/silkworm/rpc/http/request_handler.cpp
+++ b/silkworm/rpc/http/request_handler.cpp
@@ -32,11 +32,11 @@ namespace silkworm::rpc::http {
 RequestHandler::RequestHandler(Channel* channel,
                                commands::RpcApi& rpc_api,
                                const commands::RpcApiTable& rpc_api_table,
-                               log::InterfaceLogConfig ifc_config)
+                               InterfaceLogSettings ifc_log_settings)
     : channel_{channel},
       rpc_api_{rpc_api},
       rpc_api_table_{rpc_api_table},
-      ifc_log_{ifc_config.enabled ? std::make_optional<log::InterfaceLog>(ifc_config) : std::nullopt} {}
+      ifc_log_{ifc_log_settings.enabled ? std::make_optional<InterfaceLog>(ifc_log_settings) : std::nullopt} {}
 
 Task<void> RequestHandler::handle(const std::string& request) {
     const auto start = clock_time::now();

--- a/silkworm/rpc/http/request_handler.cpp
+++ b/silkworm/rpc/http/request_handler.cpp
@@ -36,7 +36,7 @@ RequestHandler::RequestHandler(Channel* channel,
     : channel_{channel},
       rpc_api_{rpc_api},
       rpc_api_table_{rpc_api_table},
-      ifc_log_ {ifc_config.enabled ? std::make_optional<log::InterfaceLog>(ifc_config) : std::nullopt} {}
+      ifc_log_{ifc_config.enabled ? std::make_optional<log::InterfaceLog>(ifc_config) : std::nullopt} {}
 
 Task<void> RequestHandler::handle(const std::string& request) {
     const auto start = clock_time::now();

--- a/silkworm/rpc/http/request_handler.hpp
+++ b/silkworm/rpc/http/request_handler.hpp
@@ -29,8 +29,8 @@
 #include <tl/expected.hpp>
 
 #include <silkworm/rpc/commands/rpc_api.hpp>
-#include <silkworm/rpc/common/interface_log.hpp>
 #include <silkworm/rpc/commands/rpc_api_table.hpp>
+#include <silkworm/rpc/common/interface_log.hpp>
 #include <silkworm/rpc/http/channel.hpp>
 #include <silkworm/rpc/http/json_rpc_validator.hpp>
 

--- a/silkworm/rpc/http/request_handler.hpp
+++ b/silkworm/rpc/http/request_handler.hpp
@@ -29,6 +29,7 @@
 #include <tl/expected.hpp>
 
 #include <silkworm/rpc/commands/rpc_api.hpp>
+#include <silkworm/rpc/common/interface_log.hpp>
 #include <silkworm/rpc/commands/rpc_api_table.hpp>
 #include <silkworm/rpc/http/channel.hpp>
 #include <silkworm/rpc/http/json_rpc_validator.hpp>
@@ -37,8 +38,10 @@ namespace silkworm::rpc::http {
 
 class RequestHandler {
   public:
-    RequestHandler(Channel* channel, commands::RpcApi& rpc_api, const commands::RpcApiTable& rpc_api_table)
-        : channel_{channel}, rpc_api_{rpc_api}, rpc_api_table_{rpc_api_table} {}
+    RequestHandler(Channel* channel,
+                   commands::RpcApi& rpc_api,
+                   const commands::RpcApiTable& rpc_api_table,
+                   log::InterfaceLogConfig ifc_config = {});
     virtual ~RequestHandler() = default;
 
     RequestHandler(const RequestHandler&) = delete;
@@ -69,6 +72,8 @@ class RequestHandler {
     const commands::RpcApiTable& rpc_api_table_;
 
     JsonRpcValidator json_rpc_validator_;
+
+    std::optional<log::InterfaceLog> ifc_log_;
 };
 
 }  // namespace silkworm::rpc::http

--- a/silkworm/rpc/http/request_handler.hpp
+++ b/silkworm/rpc/http/request_handler.hpp
@@ -41,7 +41,7 @@ class RequestHandler {
     RequestHandler(Channel* channel,
                    commands::RpcApi& rpc_api,
                    const commands::RpcApiTable& rpc_api_table,
-                   log::InterfaceLogConfig ifc_config = {});
+                   InterfaceLogSettings ifc_log_settings = {});
     virtual ~RequestHandler() = default;
 
     RequestHandler(const RequestHandler&) = delete;
@@ -73,7 +73,7 @@ class RequestHandler {
 
     JsonRpcValidator json_rpc_validator_;
 
-    std::optional<log::InterfaceLog> ifc_log_;
+    std::optional<InterfaceLog> ifc_log_;
 };
 
 }  // namespace silkworm::rpc::http

--- a/silkworm/rpc/http/server.cpp
+++ b/silkworm/rpc/http/server.cpp
@@ -48,7 +48,8 @@ Server::Server(const std::string& end_point,
                std::vector<std::string> allowed_origins,
                std::optional<std::string> jwt_secret,
                bool use_websocket,
-               bool ws_compression)
+               bool ws_compression,
+               log::InterfaceLogConfig ifc_config)
     : rpc_api_{io_context, workers},
       handler_table_{api_spec},
       io_context_(io_context),
@@ -56,7 +57,8 @@ Server::Server(const std::string& end_point,
       allowed_origins_{std::move(allowed_origins)},
       jwt_secret_(std::move(jwt_secret)),
       use_websocket_{use_websocket},
-      ws_compression_{ws_compression} {
+      ws_compression_{ws_compression},
+      ifc_config_{std::move(ifc_config)} {
     const auto [host, port] = parse_endpoint(end_point);
 
     // Open the acceptor with the option to reuse the address (i.e. SO_REUSEADDR).
@@ -82,7 +84,7 @@ Task<void> Server::run() {
             SILK_DEBUG << "Server::run accepting using io_context " << &io_context_ << "...";
 
             auto new_connection = std::make_shared<Connection>(io_context_, rpc_api_, handler_table_, allowed_origins_, jwt_secret_,
-                                                               use_websocket_, ws_compression_);
+                                                               use_websocket_, ws_compression_, ifc_config_);
             co_await acceptor_.async_accept(new_connection->socket(), boost::asio::use_awaitable);
             if (!acceptor_.is_open()) {
                 SILK_TRACE << "Server::run returning...";

--- a/silkworm/rpc/http/server.hpp
+++ b/silkworm/rpc/http/server.hpp
@@ -34,6 +34,7 @@
 
 #include <silkworm/infra/grpc/client/client_context_pool.hpp>
 #include <silkworm/rpc/commands/rpc_api_table.hpp>
+#include <silkworm/rpc/common/interface_log.hpp>
 #include <silkworm/rpc/http/request_handler.hpp>
 
 namespace silkworm::rpc::http {
@@ -45,14 +46,15 @@ class Server {
     Server& operator=(const Server&) = delete;
 
     // Construct the server to listen on the specified local TCP end-point
-    explicit Server(const std::string& end_point,
-                    const std::string& api_spec,
-                    boost::asio::io_context& io_context,
-                    boost::asio::thread_pool& workers,
-                    std::vector<std::string> allowed_origins,
-                    std::optional<std::string> jwt_secret,
-                    bool use_websocket,
-                    bool compression);
+    Server(const std::string& end_point,
+           const std::string& api_spec,
+           boost::asio::io_context& io_context,
+           boost::asio::thread_pool& workers,
+           std::vector<std::string> allowed_origins,
+           std::optional<std::string> jwt_secret,
+           bool use_websocket,
+           bool compression,
+           log::InterfaceLogConfig ifc_config = {});
 
     void start();
 
@@ -81,9 +83,13 @@ class Server {
     //! The JSON Web Token (JWT) secret for secure channel communication
     std::optional<std::string> jwt_secret_;
 
+    //! Flag indicating if WebSocket protocol will be used instead of HTTP
     bool use_websocket_;
 
     bool ws_compression_;
+
+    //! The interface logging configuration
+    log::InterfaceLogConfig ifc_config_;
 };
 
 }  // namespace silkworm::rpc::http

--- a/silkworm/rpc/http/server.hpp
+++ b/silkworm/rpc/http/server.hpp
@@ -13,12 +13,6 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
-//
-// Copyright (c) 2003-2020 Christopher M. Kohlhoff (chris at kohlhoff dot com)
-//
-// Distributed under the Boost Software License, Version 1.0. (See accompanying
-// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-//
 
 #pragma once
 
@@ -53,7 +47,7 @@ class Server {
            std::vector<std::string> allowed_origins,
            std::optional<std::string> jwt_secret,
            bool use_websocket,
-           bool compression,
+           bool ws_compression,
            InterfaceLogSettings ifc_log_settings = {});
 
     void start();
@@ -86,6 +80,7 @@ class Server {
     //! Flag indicating if WebSocket protocol will be used instead of HTTP
     bool use_websocket_;
 
+    //! Flag indicating if WebSocket protocol compression will be used
     bool ws_compression_;
 
     //! The interface logging configuration

--- a/silkworm/rpc/http/server.hpp
+++ b/silkworm/rpc/http/server.hpp
@@ -54,7 +54,7 @@ class Server {
            std::optional<std::string> jwt_secret,
            bool use_websocket,
            bool compression,
-           log::InterfaceLogConfig ifc_config = {});
+           InterfaceLogSettings ifc_log_settings = {});
 
     void start();
 
@@ -89,7 +89,7 @@ class Server {
     bool ws_compression_;
 
     //! The interface logging configuration
-    log::InterfaceLogConfig ifc_config_;
+    InterfaceLogSettings ifc_log_settings_;
 };
 
 }  // namespace silkworm::rpc::http

--- a/silkworm/rpc/settings.hpp
+++ b/silkworm/rpc/settings.hpp
@@ -23,11 +23,14 @@
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/concurrency/context_pool_settings.hpp>
 #include <silkworm/rpc/common/constants.hpp>
+#include <silkworm/rpc/common/interface_log.hpp>
 
 namespace silkworm::rpc {
 
 struct DaemonSettings {
     log::Settings log_settings;
+    InterfaceLogSettings eth_ifc_log_settings{.ifc_name = "eth_rpc_api"};
+    InterfaceLogSettings engine_ifc_log_settings{.ifc_name = "engine_rpc_api"};
     concurrency::ContextPoolSettings context_pool_settings;
     std::optional<std::filesystem::path> datadir;
     std::string eth_end_point{kDefaultEth1EndPoint};


### PR DESCRIPTION
This PR introduces opt-in configurable interface log for both Execution Layer and Engine JSON RPC end-points.

The configuration settings for the JSON RPC end-points can be further aggregated to simplify the code but this is left for next PR.