### PR TITLE
capi, infra: add TTY detection to customize log format

### DIFF
--- a/silkworm/capi/silkworm.cpp
+++ b/silkworm/capi/silkworm.cpp
@@ -53,7 +53,6 @@ static MemoryMappedRegion make_region(const SilkwormMemoryMappedFile& mmf) {
 static log::Settings kLogSettingsLikeErigon{
     .log_utc = false,       // display local time
     .log_timezone = false,  // no timezone ID
-    .log_nocolor = true,    // do not use colors
     .log_trim = true,       // compact rendering (i.e. no whitespaces)
 };
 static constexpr size_t kMaxBlockBufferSize{100};

--- a/silkworm/infra/common/terminal.cpp
+++ b/silkworm/infra/common/terminal.cpp
@@ -16,11 +16,16 @@
 
 #include "terminal.hpp"
 
+#include <cstdio>
+
 #if defined(_WIN32)
+#include <io.h>
 #include <windows.h>
 #if !defined(ENABLE_VIRTUAL_TERMINAL_PROCESSING)
 #define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
 #endif
+#else
+#include <unistd.h>
 #endif
 
 namespace silkworm {
@@ -39,6 +44,30 @@ void init_terminal() {
         }
     }
 #endif
+}
+
+bool is_terminal(int fd) {
+#if defined(_WIN32)
+    return _isatty(fd);
+#else
+    return isatty(fd);
+#endif
+}
+
+static bool is_terminal_stream(FILE* stream) {
+#if defined(_WIN32)
+    return is_terminal(_fileno(stream));
+#else
+    return is_terminal(fileno(stream));
+#endif
+}
+
+bool is_terminal_stdout() {
+    return is_terminal_stream(stdout);
+}
+
+bool is_terminal_stderr() {
+    return is_terminal_stream(stderr);
 }
 
 }  // namespace silkworm

--- a/silkworm/infra/common/terminal.hpp
+++ b/silkworm/infra/common/terminal.hpp
@@ -89,4 +89,13 @@ inline constexpr const char* kColorTealUnderline = "\x1b[4;36m";    // Cyan
 //! \remarks Is actually needed on Windows only
 void init_terminal();
 
+//! Check if specified file descriptor is a teletype (TTY) terminal
+bool is_terminal(int fd);
+
+//! Check if standard output is a TTY terminal
+bool is_terminal_stdout();
+
+//! Check if standard error is a TTY terminal
+bool is_terminal_stderr();
+
 }  // namespace silkworm


### PR DESCRIPTION
This PR fixes the log format used in C API to reproduce the Erigon format exactly.