### PR TITLE
rpcdaemon: use of OverrideState in CallExecutor::executes_all_bundles

### DIFF
--- a/silkworm/rpc/core/call_many.cpp
+++ b/silkworm/rpc/core/call_many.cpp
@@ -49,8 +49,7 @@ CallManyResult CallExecutor::executes_all_bundles(const silkworm::ChainConfig& c
     const auto& block = block_with_hash->block;
     const auto& block_transactions = block.transactions;
     auto state = transaction_.create_state(this_executor, tx_database, storage, block.header.number);
-    auto override_state = std::make_shared<state::OverrideState>(state::OverrideState{*state, accounts_overrides});
-    EVMExecutor executor{config, workers_, override_state};
+    EVMExecutor executor{config, workers_, std::make_shared<state::OverrideState>(*state, accounts_overrides)};
 
     std::uint64_t timeout = opt_timeout.value_or(5000);
     const auto start_time = clock_time::now();

--- a/silkworm/rpc/core/call_many.cpp
+++ b/silkworm/rpc/core/call_many.cpp
@@ -104,7 +104,7 @@ CallManyResult CallExecutor::executes_all_bundles(const silkworm::ChainConfig& c
             if (call_execution_result.pre_check_error) {
                 result.error = call_execution_result.pre_check_error;
                 return result;
-                            }
+            }
 
             if ((clock_time::since(start_time) / 1000000) > timeout) {
                 std::ostringstream oss;

--- a/silkworm/rpc/core/call_many.cpp
+++ b/silkworm/rpc/core/call_many.cpp
@@ -49,8 +49,8 @@ CallManyResult CallExecutor::executes_all_bundles(const silkworm::ChainConfig& c
     const auto& block = block_with_hash->block;
     const auto& block_transactions = block.transactions;
     auto state = transaction_.create_state(this_executor, tx_database, storage, block.header.number);
-    state::OverrideState override_state{*state, accounts_overrides};
-    EVMExecutor executor{config, workers_, state};
+    auto override_state = std::make_shared<state::OverrideState>(state::OverrideState{*state, accounts_overrides});
+    EVMExecutor executor{config, workers_, override_state};
 
     std::uint64_t timeout = opt_timeout.value_or(5000);
     const auto start_time = clock_time::now();
@@ -104,7 +104,7 @@ CallManyResult CallExecutor::executes_all_bundles(const silkworm::ChainConfig& c
             if (call_execution_result.pre_check_error) {
                 result.error = call_execution_result.pre_check_error;
                 return result;
-            }
+                            }
 
             if ((clock_time::since(start_time) / 1000000) > timeout) {
                 std::ostringstream oss;

--- a/silkworm/rpc/core/evm_executor.hpp
+++ b/silkworm/rpc/core/evm_executor.hpp
@@ -89,7 +89,7 @@ class EVMExecutor {
         bool gas_bailout = false);
     static std::string get_error_message(int64_t error_code, const Bytes& error_data, bool full_error = true);
 
-    EVMExecutor(const silkworm::ChainConfig& config, boost::asio::thread_pool& workers, std::shared_ptr<silkworm::State>& state)
+    EVMExecutor(const silkworm::ChainConfig& config, boost::asio::thread_pool& workers, std::shared_ptr<silkworm::State> state)
         : config_(config),
           workers_{workers},
           state_{state},

--- a/silkworm/rpc/core/evm_executor.hpp
+++ b/silkworm/rpc/core/evm_executor.hpp
@@ -18,6 +18,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <silkworm/infra/concurrency/task.hpp>
@@ -76,7 +77,8 @@ using Tracers = std::vector<std::shared_ptr<EvmTracer>>;
 
 class EVMExecutor {
   public:
-    using StateFactory = std::function<std::shared_ptr<silkworm::State>(boost::asio::any_io_executor&, BlockNum, const ChainStorage& chain_storage)>;
+    using StateFactory = std::function<std::shared_ptr<State>(boost::asio::any_io_executor&, BlockNum, const ChainStorage&)>;
+
     static Task<ExecutionResult> call(
         const silkworm::ChainConfig& config,
         const ChainStorage& storage,
@@ -89,12 +91,12 @@ class EVMExecutor {
         bool gas_bailout = false);
     static std::string get_error_message(int64_t error_code, const Bytes& error_data, bool full_error = true);
 
-    EVMExecutor(const silkworm::ChainConfig& config, boost::asio::thread_pool& workers, std::shared_ptr<silkworm::State> state)
+    EVMExecutor(const silkworm::ChainConfig& config, boost::asio::thread_pool& workers, std::shared_ptr<State> state)
         : config_(config),
           workers_{workers},
-          state_{state},
+          state_{std::move(state)},
           ibs_state_{*state_},
-          rule_set_(protocol::rule_set_factory(config)) {
+          rule_set_{protocol::rule_set_factory(config)} {
         SILKWORM_ASSERT(rule_set_);
         if (!has_service<AnalysisCacheService>(workers_)) {
             make_service<AnalysisCacheService>(workers_);
@@ -123,7 +125,7 @@ class EVMExecutor {
 
     const silkworm::ChainConfig& config_;
     boost::asio::thread_pool& workers_;
-    std::shared_ptr<silkworm::State> state_;
+    std::shared_ptr<State> state_;
     IntraBlockState ibs_state_;
     protocol::RuleSetPtr rule_set_;
 };


### PR DESCRIPTION
Fix for using OverrideState in CallExecutor::executes_all_bundles