### PR TITLE
capi: some basic unit tests

### DIFF
--- a/cmake/common/targets.cmake
+++ b/cmake/common/targets.cmake
@@ -29,14 +29,14 @@ function(silkworm_library TARGET)
     "ARG"
     ""
     ""
-    "PUBLIC;PRIVATE;EXCLUDE_REGEX"
+    "PUBLIC;PRIVATE;EXCLUDE_REGEX;TYPE"
   )
 
-  file(GLOB_RECURSE SRC CONFIGURE_DEPENDS "*.cpp" "*.hpp")
+  file(GLOB_RECURSE SRC CONFIGURE_DEPENDS "*.cpp" "*.hpp" "*.c" "*.h")
   list(FILTER SRC EXCLUDE REGEX "_test\\.cpp$")
   list(FILTER SRC EXCLUDE REGEX "_benchmark\\.cpp$")
   list_filter(SRC ARG_EXCLUDE_REGEX)
-  add_library(${TARGET} ${SRC})
+  add_library(${TARGET} ${TYPE} ${SRC})
 
   target_include_directories(${TARGET} PUBLIC "${SILKWORM_MAIN_DIR}")
   target_link_libraries(

--- a/cmake/common/targets.cmake
+++ b/cmake/common/targets.cmake
@@ -32,7 +32,15 @@ function(silkworm_library TARGET)
     "PUBLIC;PRIVATE;EXCLUDE_REGEX;TYPE"
   )
 
-  file(GLOB_RECURSE SRC CONFIGURE_DEPENDS "*.cpp" "*.hpp" "*.c" "*.h")
+  file(
+    GLOB_RECURSE
+    SRC
+    CONFIGURE_DEPENDS
+    "*.cpp"
+    "*.hpp"
+    "*.c"
+    "*.h"
+  )
   list(FILTER SRC EXCLUDE REGEX "_test\\.cpp$")
   list(FILTER SRC EXCLUDE REGEX "_benchmark\\.cpp$")
   list_filter(SRC ARG_EXCLUDE_REGEX)

--- a/silkworm/capi/CMakeLists.txt
+++ b/silkworm/capi/CMakeLists.txt
@@ -31,10 +31,9 @@ set(PRIVATE_LIBS
 
 set(TARGET silkworm_capi)
 silkworm_library(
-    ${TARGET}
-    PUBLIC ${PUBLIC_LIBS}
-    PRIVATE ${PRIVATE_LIBS}
-    TYPE SHARED
+  ${TARGET}
+  PUBLIC ${PUBLIC_LIBS}
+  PRIVATE ${PRIVATE_LIBS} TYPE SHARED
 )
 
 # Remove custom stack_size linker option for this target

--- a/silkworm/capi/CMakeLists.txt
+++ b/silkworm/capi/CMakeLists.txt
@@ -14,29 +14,9 @@
    limitations under the License.
 ]]
 
+include("${SILKWORM_MAIN_DIR}/cmake/common/targets.cmake")
+
 find_package(Microsoft.GSL REQUIRED)
-
-file(
-  GLOB_RECURSE
-  SRC
-  CONFIGURE_DEPENDS
-  "*.cpp"
-  "*.hpp"
-  "*.c"
-  "*.h"
-)
-list(FILTER SRC EXCLUDE REGEX "_test\\.cpp$")
-list(FILTER SRC EXCLUDE REGEX "_benchmark\\.cpp$")
-
-set(TARGET silkworm_capi)
-add_library(${TARGET} SHARED ${SRC})
-target_include_directories(${TARGET} PUBLIC ${SILKWORM_MAIN_DIR})
-
-# Remove custom stack_size linker option for this target
-get_target_property(LINK_OPTIONS ${TARGET} LINK_OPTIONS)
-list(REMOVE_ITEM LINK_OPTIONS "-Wl,-stack_size")
-list(REMOVE_ITEM LINK_OPTIONS "-Wl,${SILKWORM_STACK_SIZE}")
-set_target_properties(${TARGET} PROPERTIES LINK_OPTIONS "${LINK_OPTIONS}")
 
 set(PUBLIC_LIBS "")
 set(PRIVATE_LIBS
@@ -49,8 +29,16 @@ set(PRIVATE_LIBS
     silkworm_rpcdaemon
 )
 
-target_link_libraries(
-  ${TARGET}
-  PUBLIC ${PUBLIC_LIBS}
-  PRIVATE ${PRIVATE_LIBS}
+set(TARGET silkworm_capi)
+silkworm_library(
+    ${TARGET}
+    PUBLIC ${PUBLIC_LIBS}
+    PRIVATE ${PRIVATE_LIBS}
+    TYPE SHARED
 )
+
+# Remove custom stack_size linker option for this target
+get_target_property(LINK_OPTIONS ${TARGET} LINK_OPTIONS)
+list(REMOVE_ITEM LINK_OPTIONS "-Wl,-stack_size")
+list(REMOVE_ITEM LINK_OPTIONS "-Wl,${SILKWORM_STACK_SIZE}")
+set_target_properties(${TARGET} PROPERTIES LINK_OPTIONS "${LINK_OPTIONS}")

--- a/silkworm/capi/CMakeLists.txt
+++ b/silkworm/capi/CMakeLists.txt
@@ -30,11 +30,15 @@ set(PRIVATE_LIBS
 )
 
 set(TARGET silkworm_capi)
+
+# cmake-format: off
 silkworm_library(
   ${TARGET}
   PUBLIC ${PUBLIC_LIBS}
-  PRIVATE ${PRIVATE_LIBS} TYPE SHARED
+  PRIVATE ${PRIVATE_LIBS}
+  TYPE SHARED
 )
+# cmake-format: on
 
 # Remove custom stack_size linker option for this target
 get_target_property(LINK_OPTIONS ${TARGET} LINK_OPTIONS)

--- a/silkworm/capi/silkworm_test.cpp
+++ b/silkworm/capi/silkworm_test.cpp
@@ -1,0 +1,113 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "silkworm.h"
+
+#include <iostream>
+
+#include <catch2/catch.hpp>
+
+#include <silkworm/infra/test_util/log.hpp>
+#include <silkworm/node/db/mdbx.hpp>
+
+namespace silkworm {
+
+#define SILKWORM_CAPI_TEST_DATA_DIR_PATH "/tmp"
+
+struct CApiTest {
+  private:
+    // TODO(canepat) remove test_util::StreamSwap objects when C API settings include log level
+    std::stringstream string_cout, string_cerr;
+    test_util::StreamSwap cout_swap{std::cout, string_cout};
+    test_util::StreamSwap cerr_swap{std::cerr, string_cerr};
+
+    test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
+};
+
+template <size_t N = 32>
+static void c_string_copy(char dst[N], const char* src) {
+    std::strncpy(dst, src, N - 1);
+    dst[N - 1] = '\0';
+}
+
+TEST_CASE_METHOD(CApiTest, "CAPI silkworm_libmdbx_version: OK", "[silkworm][capi]") {
+    CHECK(std::strcmp(silkworm_libmdbx_version(), ::mdbx::get_version().git.describe) == 0);
+}
+
+TEST_CASE_METHOD(CApiTest, "CAPI silkworm_init: empty settings", "[silkworm][capi]") {
+    SilkwormSettings settings{};
+    SilkwormHandle handle{nullptr};
+    CHECK(silkworm_init(&handle, &settings) == SILKWORM_INVALID_PATH);
+    CHECK(!handle);
+}
+
+TEST_CASE_METHOD(CApiTest, "CAPI silkworm_init: empty data folder path", "[silkworm][capi]") {
+    SilkwormSettings settings{
+        .data_dir_path = "",
+    };
+    c_string_copy(settings.libmdbx_version, silkworm_libmdbx_version());
+    SilkwormHandle handle{nullptr};
+    CHECK(silkworm_init(&handle, &settings) == SILKWORM_INVALID_PATH);
+    CHECK(!handle);
+}
+
+TEST_CASE_METHOD(CApiTest, "CAPI silkworm_init: empty MDBX version", "[silkworm][capi]") {
+    SilkwormSettings settings{
+        .data_dir_path = SILKWORM_CAPI_TEST_DATA_DIR_PATH,
+        .libmdbx_version = "",
+    };
+    SilkwormHandle handle{nullptr};
+    CHECK(silkworm_init(&handle, &settings) == SILKWORM_INCOMPATIBLE_LIBMDBX);
+    CHECK(!handle);
+}
+
+TEST_CASE_METHOD(CApiTest, "CAPI silkworm_init: incompatible MDBX version", "[silkworm][capi]") {
+    SilkwormSettings settings{
+        .data_dir_path = SILKWORM_CAPI_TEST_DATA_DIR_PATH,
+        .libmdbx_version = "v0.1.0",
+    };
+    SilkwormHandle handle{nullptr};
+    CHECK(silkworm_init(&handle, &settings) == SILKWORM_INCOMPATIBLE_LIBMDBX);
+    CHECK(!handle);
+}
+
+TEST_CASE_METHOD(CApiTest, "CAPI silkworm_init: OK", "[silkworm][capi]") {
+    SilkwormSettings settings{
+        .data_dir_path = SILKWORM_CAPI_TEST_DATA_DIR_PATH,
+    };
+    c_string_copy(settings.libmdbx_version, silkworm_libmdbx_version());
+    SilkwormHandle handle{nullptr};
+    CHECK(silkworm_init(&handle, &settings) == SILKWORM_OK);
+    CHECK(handle);
+    CHECK(silkworm_fini(handle) == SILKWORM_OK);
+}
+
+TEST_CASE_METHOD(CApiTest, "CAPI silkworm_fini: not initialized", "[silkworm][capi]") {
+    SilkwormHandle handle{nullptr};
+    CHECK(silkworm_fini(handle) == SILKWORM_INVALID_HANDLE);
+}
+
+TEST_CASE_METHOD(CApiTest, "CAPI silkworm_fini: OK", "[silkworm][capi]") {
+    SilkwormSettings settings{
+        .data_dir_path = SILKWORM_CAPI_TEST_DATA_DIR_PATH,
+    };
+    c_string_copy(settings.libmdbx_version, silkworm_libmdbx_version());
+    SilkwormHandle handle{nullptr};
+    REQUIRE(silkworm_init(&handle, &settings) == SILKWORM_OK);
+    CHECK(silkworm_fini(handle) == SILKWORM_OK);
+}
+
+}  // namespace silkworm

--- a/silkworm/infra/concurrency/signal_handler_test.cpp
+++ b/silkworm/infra/concurrency/signal_handler_test.cpp
@@ -22,15 +22,14 @@
 
 namespace silkworm {
 
-// TODO fails on macOS
-#ifndef __APPLE__
+#if !defined(__APPLE__) || defined(NDEBUG)
 TEST_CASE("Signal Handler") {
-    SignalHandler::init();
+    SignalHandler::init({}, /*silent=*/true);
     CHECK(std::raise(SIGINT) == 0);
     CHECK(SignalHandler::signalled());
     SignalHandler::reset();
     CHECK(SignalHandler::signalled() == false);
 }
-#endif  // __APPLE__
+#endif  // !defined(__APPLE__) || defined(NDEBUG)
 
 }  // namespace silkworm


### PR DESCRIPTION
This PR introduces very basic unit tests for C API, we will hopefully expand them in the near future.

Moreover, this PR also refactors the `silkworm_capi` target to use the existing `silkworm_library` CMake facility and fixes one unit test for macOS in `infra` library.