### PR TITLE
snapshots: fix seg_unzip

### DIFF
--- a/silkworm/node/snapshots/seg/seg_zip.cpp
+++ b/silkworm/node/snapshots/seg/seg_zip.cpp
@@ -52,6 +52,7 @@ void seg_unzip(const std::filesystem::path& path) {
     decompressor.read_ahead([&](Decompressor::Iterator it) -> bool {
         Bytes word;
         while (it.has_next()) {
+            word.clear();
             it.next(word);
             words.write_word(word);
         }


### PR DESCRIPTION
* fix the last uncovered part calculation in case of a non-empty initial buffer
* seg_unzip: clear the buffer before calling next()
* use append in next_uncompressed() as the doc comment says
* use size() instead of length() for consistency