### PR TITLE
sentry: assertion in ping_check.cpp (#1855)

### DIFF
--- a/silkworm/sentry/discovery/disc_v4/ping/ping_handler.cpp
+++ b/silkworm/sentry/discovery/disc_v4/ping/ping_handler.cpp
@@ -59,6 +59,11 @@ Task<bool> PingHandler::handle(
         co_return false;
     }
 
+    // in misconfigured systems we might receive a ping from "ourselves"
+    if (sender_public_key == local_node_id) {
+        co_return false;
+    }
+
     // save a ping sender node as if it was discovered by find_neighbors()
     bool is_inserted = co_await db.upsert_node_address(sender_public_key, message.sender_node_address());
     if (is_inserted) {


### PR DESCRIPTION
Make sure that we never insert the local node into the nodes database. Warn if it did happen by accident with a fix suggestion.