### PR TITLE
capi: correct signal handling

### DIFF
--- a/silkworm/infra/common/bounded_buffer_test.cpp
+++ b/silkworm/infra/common/bounded_buffer_test.cpp
@@ -166,4 +166,24 @@ TEST_CASE("BoundedBuffer multiple cycles over the buffer with delayed consumer")
     consume.join();
 }
 
+TEST_CASE("BoundedBuffer can terminate producer") {
+    BoundedBuffer<std::string> buffer(10);
+    const int iterations = 100;
+    std::thread produce(Producer<BoundedBuffer<std::string>>(&buffer, iterations, true));
+
+    buffer.terminate_and_release_all();
+
+    produce.join();
+}
+
+TEST_CASE("BoundedBuffer can terminate consumer") {
+    BoundedBuffer<std::string> buffer(10);
+    const int iterations = 100;
+    std::thread consume(Consumer<BoundedBuffer<std::string>>(&buffer, iterations, true));
+
+    buffer.terminate_and_release_all();
+
+    consume.join();
+}
+
 }  // namespace silkworm


### PR DESCRIPTION
Silkworm CAPI has two threads:
- main: for block execution and writing state changes 
- block provider: for pre-loading blocks into the buffer

This PR makes sure that when the termination signal (Ctrl+C) is issued then:
- all open db transactions are closed 
- threads are joined
- operations can be resumed (db integrity preserved)

Test notes: I've added some unit tests, but the true tests were conducted manually. I ran Erigon with Silkworm and then during the Execution stage pressed Ctrl+C to terminate. Then I restarted Erigon to make sure that the execution was resumed at the point of the last state write. Then I repeated the process multiple times.