### PR TITLE
capi: internal/external txn handling in block execution

### DIFF
--- a/silkworm/capi/silkworm.cpp
+++ b/silkworm/capi/silkworm.cpp
@@ -311,8 +311,6 @@ SILKWORM_EXPORT int silkworm_add_snapshot(SilkwormHandle handle, SilkwormChainSn
     if (!headers_segment_path) {
         return SILKWORM_INVALID_PATH;
     }
-    SILK_INFO << "[Silkworm AddSnapshot] Header segment: " << hs.segment.file_path << " length: " << hs.segment.memory_length
-              << " index: " << hs.header_hash_index.file_path << " length: " << hs.header_hash_index.memory_length;
     snapshots::MappedHeadersSnapshot mapped_h_snapshot{
         .segment = make_region(hs.segment),
         .header_hash_index = make_region(hs.header_hash_index)};
@@ -328,8 +326,6 @@ SILKWORM_EXPORT int silkworm_add_snapshot(SilkwormHandle handle, SilkwormChainSn
     if (!bodies_segment_path) {
         return SILKWORM_INVALID_PATH;
     }
-    SILK_INFO << "[Silkworm AddSnapshot] Body segment: " << bs.segment.file_path << " length: " << bs.segment.memory_length
-              << " index: " << bs.block_num_index.file_path << " length: " << bs.block_num_index.memory_length;
     snapshots::MappedBodiesSnapshot mapped_b_snapshot{
         .segment = make_region(bs.segment),
         .block_num_index = make_region(bs.block_num_index)};
@@ -345,9 +341,6 @@ SILKWORM_EXPORT int silkworm_add_snapshot(SilkwormHandle handle, SilkwormChainSn
     if (!transactions_segment_path) {
         return SILKWORM_INVALID_PATH;
     }
-    SILK_INFO << "[Silkworm AddSnapshot] Tx segment: " << ts.segment.file_path << " length: " << ts.segment.memory_length
-              << " hash index: " << ts.tx_hash_index.file_path << " length: " << ts.tx_hash_index.memory_length
-              << " hash2block index: " << ts.tx_hash_2_block_index.file_path << " length: " << ts.tx_hash_2_block_index.memory_length;
     snapshots::MappedTransactionsSnapshot mapped_t_snapshot{
         .segment = make_region(ts.segment),
         .tx_hash_index = make_region(ts.tx_hash_index),
@@ -363,9 +356,7 @@ SILKWORM_EXPORT int silkworm_add_snapshot(SilkwormHandle handle, SilkwormChainSn
         .bodies_snapshot = std::move(bodies_snapshot),
         .tx_snapshot_path = *transactions_segment_path,
         .tx_snapshot = std::move(transactions_snapshot)};
-    SILK_INFO << "[Silkworm AddSnapshot] before add_snapshot_bundle";
     handle->snapshot_repository->add_snapshot_bundle(std::move(bundle));
-    SILK_INFO << "[Silkworm AddSnapshot] END";
     return SILKWORM_OK;
 }
 
@@ -505,7 +496,7 @@ int silkworm_execute_blocks(SilkwormHandle handle, MDBX_env* mdbx_env, MDBX_txn*
 
     // Wrap MDBX env into an internal *unmanaged* env, i.e. MDBX env is only used but its lifecycle is untouched
     db::EnvUnmanaged unmanaged_env{mdbx_env};
-    SILK_INFO << "[Silkworm Exec] env=" << unmanaged_env.get_path().string() << " external_txn=" << std::boolalpha << use_external_txn;
+    SILK_TRACE << "[Silkworm Exec] env=" << unmanaged_env.get_path().string() << " external_txn=" << std::boolalpha << use_external_txn;
 
     SignalHandlerGuard signal_guard;
     try {

--- a/silkworm/capi/silkworm.h
+++ b/silkworm/capi/silkworm.h
@@ -174,7 +174,7 @@ struct SilkwormSentrySettings {
 /**
  * \brief Start Silkworm Sentry.
  * \param[in] handle A valid Silkworm instance handle, got with silkworm_init.Must not be zero.
- * \param[in] env An valid MDBX environment. Must not be zero.
+ * \param[in] settings The Sentry configuration settings. Must not be zero.
  * \return SILKWORM_OK (=0) on success, a non-zero error value on failure.
  */
 SILKWORM_EXPORT int silkworm_sentry_start(SilkwormHandle handle, const struct SilkwormSentrySettings* settings) SILKWORM_NOEXCEPT;

--- a/silkworm/capi/silkworm.h
+++ b/silkworm/capi/silkworm.h
@@ -47,7 +47,7 @@ extern "C" {
 #define SILKWORM_INVALID_HANDLE 3
 #define SILKWORM_INVALID_PATH 4
 #define SILKWORM_INVALID_SNAPSHOT 5
-#define SILKWORM_INVALID_MDBX_TXN 6
+#define SILKWORM_INVALID_MDBX_ENV 6
 #define SILKWORM_INVALID_BLOCK_RANGE 7
 #define SILKWORM_BLOCK_NOT_FOUND 8
 #define SILKWORM_UNKNOWN_CHAIN_ID 9
@@ -95,12 +95,13 @@ struct SilkwormChainSnapshot {
 };
 
 #define SILKWORM_PATH_SIZE 260
+#define SILKWORM_GIT_VERSION_SIZE 32
 
 struct SilkwormSettings {
     //! Data directory path in UTF-8.
     char data_dir_path[SILKWORM_PATH_SIZE];
     //! libmdbx version string in git describe format.
-    char libmdbx_version[32];
+    char libmdbx_version[SILKWORM_GIT_VERSION_SIZE];
 };
 
 /**
@@ -109,9 +110,7 @@ struct SilkwormSettings {
  * \param[in] settings General Silkworm settings.
  * \return SILKWORM_OK (=0) on success, a non-zero error value on failure.
  */
-SILKWORM_EXPORT int silkworm_init(
-    SilkwormHandle* handle,
-    const struct SilkwormSettings* settings) SILKWORM_NOEXCEPT;
+SILKWORM_EXPORT int silkworm_init(SilkwormHandle* handle, const struct SilkwormSettings* settings) SILKWORM_NOEXCEPT;
 
 /**
  * \brief Build a set of indexes for the given snapshots.
@@ -149,7 +148,6 @@ SILKWORM_EXPORT int silkworm_start_rpcdaemon(SilkwormHandle handle, MDBX_env* en
 /**
  * \brief Stop Silkworm RPC daemon and wait for its termination.
  * \param[in] handle A valid Silkworm instance handle, got with silkworm_init. Must not be zero.
- * \param[in] snapshot A snapshot to use.
  * \return SILKWORM_OK (=0) on success, a non-zero error value on failure.
  */
 SILKWORM_EXPORT int silkworm_stop_rpcdaemon(SilkwormHandle handle) SILKWORM_NOEXCEPT;
@@ -173,13 +171,26 @@ struct SilkwormSentrySettings {
     size_t max_peers;
 };
 
+/**
+ * \brief Start Silkworm Sentry.
+ * \param[in] handle A valid Silkworm instance handle, got with silkworm_init.Must not be zero.
+ * \param[in] env An valid MDBX environment. Must not be zero.
+ * \return SILKWORM_OK (=0) on success, a non-zero error value on failure.
+ */
 SILKWORM_EXPORT int silkworm_sentry_start(SilkwormHandle handle, const struct SilkwormSentrySettings* settings) SILKWORM_NOEXCEPT;
+
+/**
+ * \brief Stop Silkworm Sentry and wait for its termination.
+ * \param[in] handle A valid Silkworm instance handle, got with silkworm_init. Must not be zero.
+ * \return SILKWORM_OK (=0) on success, a non-zero error value on failure.
+ */
 SILKWORM_EXPORT int silkworm_sentry_stop(SilkwormHandle handle) SILKWORM_NOEXCEPT;
 
 /**
  * \brief Execute a batch of blocks and write resulting changes into the database.
  * \param[in] handle A valid Silkworm instance handle, got with silkworm_init.
- * \param[in] txn A valid read-write MDBX transaction. Must not be zero.
+ * \param[in] env An valid MDBX environment. Must not be zero.
+ * \param[in] txn A valid external read-write MDBX transaction or zero if an internal one must be used.
  * This function does not commit nor abort the transaction.
  * \param[in] chain_id EIP-155 chain ID. SILKWORM_UNKNOWN_CHAIN_ID is returned in case of an unknown or unsupported chain.
  * \param[in] start_block The block height to start the execution from.
@@ -199,7 +210,7 @@ SILKWORM_EXPORT int silkworm_sentry_stop(SilkwormHandle handle) SILKWORM_NOEXCEP
  * (blocks up to and incl. last_executed_block were still executed).
  */
 SILKWORM_EXPORT int silkworm_execute_blocks(
-    SilkwormHandle handle, MDBX_txn* txn, uint64_t chain_id, uint64_t start_block, uint64_t max_block,
+    SilkwormHandle handle, MDBX_env* env, MDBX_txn* txn, uint64_t chain_id, uint64_t start_block, uint64_t max_block,
     uint64_t batch_size, bool write_change_sets, bool write_receipts, bool write_call_traces,
     uint64_t* last_executed_block, int* mdbx_error_code) SILKWORM_NOEXCEPT;
 

--- a/silkworm/capi/silkworm_test.cpp
+++ b/silkworm/capi/silkworm_test.cpp
@@ -239,7 +239,7 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_execute_blocks single block: OK", "[si
     block.header.gas_limit = 5'000'000;
     block.header.gas_used = 21'000;
 
-    static constexpr auto kEncoder = [](Bytes& to, const Receipt& r) { rlp::encode(to, r); };
+    static constexpr auto kEncoder = [](Bytes& dest, const Receipt& r) { rlp::encode(dest, r); };
     std::vector<Receipt> receipts{
         {TransactionType::kLegacy, true, block.header.gas_used, {}, {}},
     };
@@ -325,7 +325,7 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_execute_blocks multiple blocks: OK", "
     block.header.gas_limit = 5'000'000;
     block.header.gas_used = 21'000;
 
-    static constexpr auto kEncoder = [](Bytes& to, const Receipt& r) { rlp::encode(to, r); };
+    static constexpr auto kEncoder = [](Bytes& dest, const Receipt& r) { rlp::encode(dest, r); };
     std::vector<Receipt> receipts{
         {TransactionType::kLegacy, true, block.header.gas_used, {}, {}},
     };

--- a/silkworm/capi/silkworm_test.cpp
+++ b/silkworm/capi/silkworm_test.cpp
@@ -20,14 +20,19 @@
 
 #include <catch2/catch.hpp>
 
+#include <silkworm/core/trie/vector_root.hpp>
 #include <silkworm/infra/test_util/log.hpp>
 #include <silkworm/node/db/mdbx.hpp>
+#include <silkworm/node/snapshots/index.hpp>
+#include <silkworm/node/snapshots/snapshot.hpp>
+#include <silkworm/node/snapshots/test_util/common.hpp>
+#include <silkworm/rpc/test/api_test_database.hpp>
 
 namespace silkworm {
 
-#define SILKWORM_CAPI_TEST_DATA_DIR_PATH "/tmp"
+namespace snapshot_test = snapshots::test_util;
 
-struct CApiTest {
+struct CApiTest : public rpc::test::TestDatabaseContext {
   private:
     // TODO(canepat) remove test_util::StreamSwap objects when C API settings include log level
     std::stringstream string_cout, string_cerr;
@@ -37,10 +42,21 @@ struct CApiTest {
     test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
 };
 
+//! Utility to copy `src` C-string to `dst` fixed-size char array
 template <size_t N>
 static void c_string_copy(char dst[N], const char* src) {
     std::strncpy(dst, src, N - 1);
     dst[N - 1] = '\0';
+}
+
+//! Utility to copy `src` C-string in 'git describe' format to `dst`
+static void copy_git_version(char dst[SILKWORM_GIT_VERSION_SIZE], const char* src) {
+    c_string_copy<SILKWORM_GIT_VERSION_SIZE>(dst, src);
+}
+
+//! Utility to copy `src` C-string fixed-size path to `dst`
+static void copy_path(char dst[SILKWORM_PATH_SIZE], const char* src) {
+    c_string_copy<SILKWORM_PATH_SIZE>(dst, src);
 }
 
 TEST_CASE_METHOD(CApiTest, "CAPI silkworm_libmdbx_version: OK", "[silkworm][capi]") {
@@ -55,40 +71,36 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_init: empty settings", "[silkworm][cap
 }
 
 TEST_CASE_METHOD(CApiTest, "CAPI silkworm_init: empty data folder path", "[silkworm][capi]") {
-    SilkwormSettings settings{
-        .data_dir_path = "",
-    };
-    c_string_copy<32>(settings.libmdbx_version, silkworm_libmdbx_version());
+    SilkwormSettings settings{};
+    copy_path(settings.data_dir_path, "");
+    copy_git_version(settings.libmdbx_version, silkworm_libmdbx_version());
     SilkwormHandle handle{nullptr};
     CHECK(silkworm_init(&handle, &settings) == SILKWORM_INVALID_PATH);
     CHECK(!handle);
 }
 
 TEST_CASE_METHOD(CApiTest, "CAPI silkworm_init: empty MDBX version", "[silkworm][capi]") {
-    SilkwormSettings settings{
-        .data_dir_path = SILKWORM_CAPI_TEST_DATA_DIR_PATH,
-        .libmdbx_version = "",
-    };
+    SilkwormSettings settings{};
+    copy_path(settings.data_dir_path, db.get_path().c_str());
+    copy_git_version(settings.libmdbx_version, "");
     SilkwormHandle handle{nullptr};
     CHECK(silkworm_init(&handle, &settings) == SILKWORM_INCOMPATIBLE_LIBMDBX);
     CHECK(!handle);
 }
 
 TEST_CASE_METHOD(CApiTest, "CAPI silkworm_init: incompatible MDBX version", "[silkworm][capi]") {
-    SilkwormSettings settings{
-        .data_dir_path = SILKWORM_CAPI_TEST_DATA_DIR_PATH,
-        .libmdbx_version = "v0.1.0",
-    };
+    SilkwormSettings settings{};
+    copy_path(settings.data_dir_path, db.get_path().c_str());
+    copy_git_version(settings.libmdbx_version, "v0.1.0");
     SilkwormHandle handle{nullptr};
     CHECK(silkworm_init(&handle, &settings) == SILKWORM_INCOMPATIBLE_LIBMDBX);
     CHECK(!handle);
 }
 
 TEST_CASE_METHOD(CApiTest, "CAPI silkworm_init: OK", "[silkworm][capi]") {
-    SilkwormSettings settings{
-        .data_dir_path = SILKWORM_CAPI_TEST_DATA_DIR_PATH,
-    };
-    c_string_copy<32>(settings.libmdbx_version, silkworm_libmdbx_version());
+    SilkwormSettings settings{};
+    copy_path(settings.data_dir_path, db.get_path().c_str());
+    copy_git_version(settings.libmdbx_version, silkworm_libmdbx_version());
     SilkwormHandle handle{nullptr};
     CHECK(silkworm_init(&handle, &settings) == SILKWORM_OK);
     CHECK(handle);
@@ -101,13 +113,426 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_fini: not initialized", "[silkworm][ca
 }
 
 TEST_CASE_METHOD(CApiTest, "CAPI silkworm_fini: OK", "[silkworm][capi]") {
-    SilkwormSettings settings{
-        .data_dir_path = SILKWORM_CAPI_TEST_DATA_DIR_PATH,
-    };
-    c_string_copy<32>(settings.libmdbx_version, silkworm_libmdbx_version());
+    SilkwormSettings settings{};
+    copy_path(settings.data_dir_path, db.get_path().c_str());
+    copy_git_version(settings.libmdbx_version, silkworm_libmdbx_version());
     SilkwormHandle handle{nullptr};
     REQUIRE(silkworm_init(&handle, &settings) == SILKWORM_OK);
     CHECK(silkworm_fini(handle) == SILKWORM_OK);
+}
+
+//! \brief Utility class using RAII pattern to wrap the Silkworm C API.
+//! \note This is useful for tests that do *not* specifically play with silkworm_init/silkworm_fini or invalid handles
+struct SilkwormLibrary {
+    explicit SilkwormLibrary(const std::filesystem::path& db_path) {
+        SilkwormSettings settings{};
+        copy_path(settings.data_dir_path, db_path.c_str());
+        copy_git_version(settings.libmdbx_version, silkworm_libmdbx_version());
+        silkworm_init(&handle_, &settings);
+    }
+    ~SilkwormLibrary() {
+        silkworm_fini(handle_);
+    }
+
+    struct ExecutionResult {
+        int execute_block_result{0};
+        BlockNum last_executed_block{0};
+        int mdbx_error_code{0};
+    };
+
+    ExecutionResult execute_blocks(MDBX_env* env,
+                                   MDBX_txn* txn,
+                                   uint64_t chain_id,
+                                   uint64_t start_block,
+                                   uint64_t max_block,
+                                   uint64_t batch_size,
+                                   bool write_change_sets,
+                                   bool write_receipts,
+                                   bool write_call_traces) {
+        ExecutionResult result;
+        result.execute_block_result =
+            silkworm_execute_blocks(handle_, env, txn,
+                                    chain_id, start_block, max_block, batch_size,
+                                    write_change_sets, write_receipts, write_call_traces,
+                                    &result.last_executed_block, &result.mdbx_error_code);
+        return result;
+    }
+
+    int add_snapshot(SilkwormChainSnapshot* snapshot) {
+        return silkworm_add_snapshot(handle_, snapshot);
+    }
+
+  private:
+    SilkwormHandle handle_{nullptr};
+};
+
+TEST_CASE_METHOD(CApiTest, "CAPI silkworm_execute_blocks: block not found", "[silkworm][capi]") {
+    // Use Silkworm as a library with silkworm_init/silkworm_fini automated by RAII
+    SilkwormLibrary silkworm_lib{db.get_path()};
+
+    const int chain_id{1};
+    const uint64_t batch_size{256 * kMebi};
+    BlockNum start_block{10};  // This does not exist, TestDatabaseContext db contains up to block 9
+    BlockNum end_block{100};
+    const auto result0{
+        silkworm_lib.execute_blocks(db, nullptr, chain_id, start_block, end_block, batch_size,
+                                    true, true, true)};
+    CHECK(result0.execute_block_result == SILKWORM_BLOCK_NOT_FOUND);
+    CHECK(result0.last_executed_block == 0);
+    CHECK(result0.mdbx_error_code == 0);
+}
+
+static void insert_block(mdbx::env& env, Block& block) {
+    auto block_hash = block.header.hash();
+    auto block_hash_key = db::block_key(block.header.number, block_hash.bytes);
+
+    db::RWTxnManaged rw_txn{env};
+    db::write_senders(rw_txn, block_hash, block.header.number, block);
+
+    intx::uint256 max_priority_fee_per_gas =
+        block.transactions.empty() ? block.header.base_fee_per_gas.value_or(0) : block.transactions[0].max_priority_fee_per_gas;
+    intx::uint256 max_fee_per_gas =
+        block.transactions.empty() ? block.header.base_fee_per_gas.value_or(0) : block.transactions[0].max_fee_per_gas;
+    silkworm::Transaction system_transaction;
+    system_transaction.max_priority_fee_per_gas = max_priority_fee_per_gas;
+    system_transaction.max_fee_per_gas = max_fee_per_gas;
+    block.transactions.emplace(block.transactions.begin(), system_transaction);
+    block.transactions.emplace_back(system_transaction);
+
+    db::write_header(rw_txn, block.header, true);
+    db::write_raw_body(rw_txn, block, block_hash, block.header.number);
+    db::write_canonical_header_hash(rw_txn, block_hash.bytes, block.header.number);
+    rw_txn.commit_and_stop();
+}
+
+TEST_CASE_METHOD(CApiTest, "CAPI silkworm_execute_blocks single block: OK", "[silkworm][capi]") {
+    // Use Silkworm as a library with silkworm_init/silkworm_fini automated by RAII
+    SilkwormLibrary silkworm_lib{db.get_path()};
+
+    const int chain_id{1};
+    const uint64_t batch_size{256 * kMebi};
+    const bool write_change_sets{false};  // We CANNOT write changesets here, TestDatabaseContext db already has them
+    const bool write_receipts{false};     // We CANNOT write receipts here, TestDatabaseContext db already has them
+    const bool write_call_traces{false};  // For coherence but don't care
+
+    auto execute_blocks = [&](auto tx, auto start_block, auto end_block) {
+        return silkworm_lib.execute_blocks(db,
+                                           tx,
+                                           chain_id,
+                                           start_block,
+                                           end_block,
+                                           batch_size,
+                                           write_change_sets,
+                                           write_receipts,
+                                           write_call_traces);
+    };
+
+    /* TestDatabaseContext db contains a test chain made up of 9 blocks */
+
+    // Prepare and insert block 10 (just 1 tx w/ value transfer)
+    evmc::address from{0x658bdf435d810c91414ec09147daa6db62406379_address};  // funded in genesis
+    evmc::address to{0x8b299e2b7d7f43c0ce3068263545309ff4ffb521_address};    // untouched address
+    intx::uint256 value{1 * kEther};
+
+    Block block{};
+    block.header.number = 10;
+    block.header.gas_limit = 5'000'000;
+    block.header.gas_used = 21'000;
+
+    static constexpr auto kEncoder = [](Bytes& to, const Receipt& r) { rlp::encode(to, r); };
+    std::vector<Receipt> receipts{
+        {TransactionType::kLegacy, true, block.header.gas_used, {}, {}},
+    };
+    block.header.receipts_root = trie::root_hash(receipts, kEncoder);
+    block.transactions.resize(1);
+    block.transactions[0].to = to;
+    block.transactions[0].gas_limit = block.header.gas_limit;
+    block.transactions[0].type = TransactionType::kLegacy;
+    block.transactions[0].max_priority_fee_per_gas = 0;
+    block.transactions[0].max_fee_per_gas = 20 * kGiga;
+    block.transactions[0].value = value;
+    block.transactions[0].r = 1;  // dummy
+    block.transactions[0].s = 1;  // dummy
+    block.transactions[0].set_sender(from);
+
+    insert_block(db, block);
+
+    // Execute block 10 using an *internal* txn
+    BlockNum start_block{10}, end_block{10};
+    const auto result0{execute_blocks(nullptr, start_block, end_block)};
+    CHECK(result0.execute_block_result == SILKWORM_OK);
+    CHECK(result0.last_executed_block == end_block);
+    CHECK(result0.mdbx_error_code == 0);
+
+    db::ROTxnManaged ro_txn{db};
+    REQUIRE(db::read_account(ro_txn, to));
+    CHECK(db::read_account(ro_txn, to)->balance == value);
+    ro_txn.abort();
+
+    // Prepare and insert block 11 (same as block 10)
+    block.transactions.erase(block.transactions.cbegin());
+    block.transactions.pop_back();
+    block.header.number = 11;
+    block.transactions[0].nonce++;
+
+    insert_block(db, block);
+
+    // Execute block 11 using an *external* txn, then commit
+    db::RWTxnManaged external_txn{db};
+
+    start_block = 11, end_block = 11;
+    const auto result1{execute_blocks(*external_txn, start_block, end_block)};
+    CHECK_NOTHROW(external_txn.commit_and_stop());
+    CHECK(result1.execute_block_result == SILKWORM_OK);
+    CHECK(result1.last_executed_block == end_block);
+    CHECK(result1.mdbx_error_code == 0);
+
+    ro_txn = db::ROTxnManaged{db};
+    REQUIRE(db::read_account(ro_txn, to));
+    CHECK(db::read_account(ro_txn, to)->balance == 2 * value);
+}
+
+TEST_CASE_METHOD(CApiTest, "CAPI silkworm_execute_blocks multiple blocks: OK", "[silkworm][capi]") {
+    // Use Silkworm as a library with silkworm_init/silkworm_fini automated by RAII
+    SilkwormLibrary silkworm_lib{db.get_path()};
+
+    const int chain_id{1};
+    const uint64_t batch_size{256 * kMebi};
+    const bool write_change_sets{false};  // We CANNOT write changesets here, TestDatabaseContext db already has them
+    const bool write_receipts{false};     // We CANNOT write receipts here, TestDatabaseContext db already has them
+    const bool write_call_traces{false};  // For coherence but don't care
+
+    auto execute_blocks = [&](auto tx, auto start_block, auto end_block) {
+        return silkworm_lib.execute_blocks(db,
+                                           tx,
+                                           chain_id,
+                                           start_block,
+                                           end_block,
+                                           batch_size,
+                                           write_change_sets,
+                                           write_receipts,
+                                           write_call_traces);
+    };
+
+    /* TestDatabaseContext db contains a test chain made up of 9 blocks */
+
+    // Prepare block template (just 1 tx w/ value transfer)
+    evmc::address from{0x658bdf435d810c91414ec09147daa6db62406379_address};  // funded in genesis
+    evmc::address to{0x8b299e2b7d7f43c0ce3068263545309ff4ffb521_address};    // untouched address
+    intx::uint256 value{1};
+
+    Block block{};
+    block.header.gas_limit = 5'000'000;
+    block.header.gas_used = 21'000;
+
+    static constexpr auto kEncoder = [](Bytes& to, const Receipt& r) { rlp::encode(to, r); };
+    std::vector<Receipt> receipts{
+        {TransactionType::kLegacy, true, block.header.gas_used, {}, {}},
+    };
+    block.header.receipts_root = trie::root_hash(receipts, kEncoder);
+    block.transactions.resize(1);
+    block.transactions[0].to = to;
+    block.transactions[0].gas_limit = block.header.gas_limit;
+    block.transactions[0].type = TransactionType::kLegacy;
+    block.transactions[0].max_priority_fee_per_gas = 0;
+    block.transactions[0].max_fee_per_gas = 20 * kGiga;
+    block.transactions[0].value = value;
+    block.transactions[0].r = 1;  // dummy
+    block.transactions[0].s = 1;  // dummy
+    block.transactions[0].set_sender(from);
+
+    constexpr size_t kBlocks{130};
+
+    // Insert N blocks
+    for (size_t i{10}; i < 10 + kBlocks; ++i) {
+        block.header.number = i;
+        insert_block(db, block);
+        block.transactions.erase(block.transactions.cbegin());
+        block.transactions.pop_back();
+        block.transactions[0].nonce++;
+    }
+
+    // Execute N blocks using an *internal* txn
+    BlockNum start_block{10}, end_block{10 + kBlocks - 1};
+    const auto result0{execute_blocks(nullptr, start_block, end_block)};
+    CHECK(result0.execute_block_result == SILKWORM_OK);
+    CHECK(result0.last_executed_block == end_block);
+    CHECK(result0.mdbx_error_code == 0);
+
+    db::ROTxnManaged ro_txn{db};
+    REQUIRE(db::read_account(ro_txn, to));
+    CHECK(db::read_account(ro_txn, to)->balance == kBlocks * value);
+    ro_txn.abort();
+
+    // Insert N blocks again
+    for (size_t i{10 + kBlocks}; i < (10 + 2 * kBlocks); ++i) {
+        block.header.number = i;
+        insert_block(db, block);
+        block.transactions.erase(block.transactions.cbegin());
+        block.transactions.pop_back();
+        block.transactions[0].nonce++;
+    }
+
+    // Execute N blocks using an *external* txn, then commit
+    db::RWTxnManaged external_txn{db};
+
+    start_block = 10 + kBlocks, end_block = 10 + 2 * kBlocks - 1;
+    const auto result1{execute_blocks(*external_txn, start_block, end_block)};
+    CHECK_NOTHROW(external_txn.commit_and_stop());
+    CHECK(result1.execute_block_result == SILKWORM_OK);
+    CHECK(result1.last_executed_block == end_block);
+    CHECK(result1.mdbx_error_code == 0);
+
+    ro_txn = db::ROTxnManaged{db};
+    REQUIRE(db::read_account(ro_txn, to));
+    CHECK(db::read_account(ro_txn, to)->balance == 2 * kBlocks * value);
+}
+
+TEST_CASE_METHOD(CApiTest, "CAPI silkworm_add_snapshot", "[silkworm][capi]") {
+    snapshot_test::SampleHeaderSnapshotFile valid_header_snapshot{};
+    snapshot_test::SampleHeaderSnapshotPath header_snapshot_path{valid_header_snapshot.path()};
+    snapshot_test::SampleBodySnapshotFile valid_body_snapshot{};
+    snapshot_test::SampleBodySnapshotPath body_snapshot_path{valid_body_snapshot.path()};
+    snapshot_test::SampleTransactionSnapshotFile valid_tx_snapshot{};
+    snapshot_test::SampleTransactionSnapshotPath tx_snapshot_path{valid_tx_snapshot.path()};
+
+    snapshots::HeaderIndex header_index{header_snapshot_path};
+    REQUIRE_NOTHROW(header_index.build());
+    snapshots::HeaderSnapshot header_snapshot{header_snapshot_path};
+    header_snapshot.reopen_segment();
+    header_snapshot.reopen_index();
+    snapshots::BodyIndex body_index{body_snapshot_path};
+    REQUIRE_NOTHROW(body_index.build());
+    snapshots::BodySnapshot body_snapshot{body_snapshot_path};
+    body_snapshot.reopen_segment();
+    body_snapshot.reopen_index();
+    snapshots::TransactionIndex tx_index{tx_snapshot_path};
+    REQUIRE_NOTHROW(tx_index.build());
+    snapshots::TransactionSnapshot tx_snapshot{tx_snapshot_path};
+    tx_snapshot.reopen_segment();
+    tx_snapshot.reopen_index();
+
+    const auto header_snapshot_path_string{header_snapshot_path.path().string()};
+    const auto header_index_path_string{header_index.path().path().string()};
+    const auto body_snapshot_path_string{body_snapshot_path.path().string()};
+    const auto body_index_path_string{body_index.path().path().string()};
+    const auto tx_snapshot_path_string{tx_snapshot_path.path().string()};
+    const auto tx_hash_index_path_string{tx_snapshot_path.index_file().path().string()};
+    const auto tx_hash2block_index_path_string{
+        tx_snapshot_path.index_file_for_type(snapshots::SnapshotType::transactions_to_block).path().string()};
+
+    // Prepare templates for valid header/body/transaction C data structures
+    SilkwormHeadersSnapshot valid_shs{
+        .segment = SilkwormMemoryMappedFile{
+            .file_path = header_snapshot_path_string.c_str(),
+            .memory_address = header_snapshot.memory_file_address(),
+            .memory_length = header_snapshot.memory_file_size(),
+        },
+        .header_hash_index = SilkwormMemoryMappedFile{
+            .file_path = header_index_path_string.c_str(),
+            .memory_address = header_snapshot.idx_header_hash()->memory_file_address(),
+            .memory_length = header_snapshot.idx_header_hash()->memory_file_size(),
+        },
+    };
+    SilkwormBodiesSnapshot valid_sbs{
+        .segment = SilkwormMemoryMappedFile{
+            .file_path = body_snapshot_path_string.c_str(),
+            .memory_address = body_snapshot.memory_file_address(),
+            .memory_length = body_snapshot.memory_file_size(),
+        },
+        .block_num_index = SilkwormMemoryMappedFile{
+            .file_path = body_index_path_string.c_str(),
+            .memory_address = body_snapshot.idx_body_number()->memory_file_address(),
+            .memory_length = body_snapshot.idx_body_number()->memory_file_size(),
+        },
+    };
+    SilkwormTransactionsSnapshot valid_sts{
+        .segment = SilkwormMemoryMappedFile{
+            .file_path = tx_snapshot_path_string.c_str(),
+            .memory_address = tx_snapshot.memory_file_address(),
+            .memory_length = tx_snapshot.memory_file_size(),
+        },
+        .tx_hash_index = SilkwormMemoryMappedFile{
+            .file_path = tx_hash_index_path_string.c_str(),
+            .memory_address = tx_snapshot.idx_txn_hash()->memory_file_address(),
+            .memory_length = tx_snapshot.idx_txn_hash()->memory_file_size(),
+        },
+        .tx_hash_2_block_index = SilkwormMemoryMappedFile{
+            .file_path = tx_hash2block_index_path_string.c_str(),
+            .memory_address = tx_snapshot.idx_txn_hash_2_block()->memory_file_address(),
+            .memory_length = tx_snapshot.idx_txn_hash_2_block()->memory_file_size(),
+        },
+    };
+
+    SECTION("invalid handle") {
+        // We purposely do not call silkworm_init to provide a null handle
+        SilkwormHandle handle{nullptr};
+        SilkwormChainSnapshot snapshot{valid_shs, valid_sbs, valid_sts};
+        CHECK(silkworm_add_snapshot(handle, &snapshot) == SILKWORM_INVALID_HANDLE);
+    }
+
+    // Use Silkworm as a library with silkworm_init/silkworm_fini automated by RAII
+    SilkwormLibrary silkworm_lib{db.get_path()};
+
+    SECTION("invalid header segment path") {
+        SilkwormHeadersSnapshot invalid_shs{valid_shs};
+        invalid_shs.segment.file_path = nullptr;  // as if left unassigned, i.e. empty
+        SilkwormChainSnapshot snapshot{invalid_shs, valid_sbs, valid_sts};
+        const int result{silkworm_lib.add_snapshot(&snapshot)};
+        CHECK(result == SILKWORM_INVALID_PATH);
+    }
+    SECTION("invalid header index path") {
+        SilkwormHeadersSnapshot invalid_shs{valid_shs};
+        invalid_shs.header_hash_index.file_path = nullptr;  // as if left unassigned, i.e. empty
+        SilkwormChainSnapshot snapshot{invalid_shs, valid_sbs, valid_sts};
+        const int result{silkworm_lib.add_snapshot(&snapshot)};
+        CHECK(result == SILKWORM_INVALID_PATH);
+    }
+    SECTION("invalid body segment path") {
+        SilkwormBodiesSnapshot invalid_sbs{valid_sbs};
+        invalid_sbs.segment.file_path = nullptr;  // as if left unassigned, i.e. empty
+        SilkwormChainSnapshot snapshot{valid_shs, invalid_sbs, valid_sts};
+        const int result{silkworm_lib.add_snapshot(&snapshot)};
+        CHECK(result == SILKWORM_INVALID_PATH);
+    }
+    SECTION("invalid body index path") {
+        SilkwormBodiesSnapshot invalid_sbs{valid_sbs};
+        invalid_sbs.block_num_index.file_path = nullptr;  // as if left unassigned, i.e. empty
+        SilkwormChainSnapshot snapshot{valid_shs, invalid_sbs, valid_sts};
+        const int result{silkworm_lib.add_snapshot(&snapshot)};
+        CHECK(result == SILKWORM_INVALID_PATH);
+    }
+    SECTION("invalid transaction segment path") {
+        SilkwormTransactionsSnapshot invalid_sts{valid_sts};
+        invalid_sts.segment.file_path = nullptr;  // as if left unassigned, i.e. empty
+        SilkwormChainSnapshot snapshot{valid_shs, valid_sbs, invalid_sts};
+        const int result{silkworm_lib.add_snapshot(&snapshot)};
+        CHECK(result == SILKWORM_INVALID_PATH);
+    }
+    SECTION("invalid transaction hash index path") {
+        SilkwormTransactionsSnapshot invalid_sts{valid_sts};
+        invalid_sts.tx_hash_index.file_path = nullptr;  // as if left unassigned, i.e. empty
+        SilkwormChainSnapshot snapshot{valid_shs, valid_sbs, invalid_sts};
+        const int result{silkworm_lib.add_snapshot(&snapshot)};
+        CHECK(result == SILKWORM_INVALID_PATH);
+    }
+    SECTION("invalid transaction hash2block index path") {
+        SilkwormTransactionsSnapshot invalid_sts{valid_sts};
+        invalid_sts.tx_hash_2_block_index.file_path = nullptr;  // as if left unassigned, i.e. empty
+        SilkwormChainSnapshot snapshot{valid_shs, valid_sbs, invalid_sts};
+        const int result{silkworm_lib.add_snapshot(&snapshot)};
+        CHECK(result == SILKWORM_INVALID_PATH);
+    }
+    SECTION("invalid empty chain snapshot") {
+        SilkwormChainSnapshot snapshot{};
+        const int result{silkworm_lib.add_snapshot(&snapshot)};
+        CHECK(result == SILKWORM_INVALID_PATH);
+    }
+    SECTION("valid") {
+        SilkwormChainSnapshot snapshot{valid_shs, valid_sbs, valid_sts};
+        const int result{silkworm_lib.add_snapshot(&snapshot)};
+        CHECK(result == SILKWORM_OK);
+    }
 }
 
 }  // namespace silkworm

--- a/silkworm/node/db/mdbx.cpp
+++ b/silkworm/node/db/mdbx.cpp
@@ -268,54 +268,6 @@ void RWTxnManaged::commit_and_stop() {
     }
 }
 
-RWTxnUnmanaged::~RWTxnUnmanaged() {
-    if (handle_) {
-        RWTxnUnmanaged::abort();
-    }
-}
-
-void RWTxnUnmanaged::abort() {
-    const ::mdbx::error err = static_cast<MDBX_error_t>(::mdbx_txn_abort(handle_));
-    if (err.code() != MDBX_THREAD_MISMATCH) {
-        handle_ = nullptr;
-    }
-    if (err.code() != MDBX_SUCCESS) {
-        err.throw_exception();
-    }
-}
-
-void RWTxnUnmanaged::commit_and_renew() {
-    if (commit_disabled_) {
-        return;
-    }
-    mdbx::env env = db();
-    commit();
-    // Renew transaction
-    ::mdbx::error::success_or_throw(
-        ::mdbx_txn_begin(env, nullptr, MDBX_TXN_READWRITE, &handle_));
-    SILKWORM_ASSERT(handle_);
-}
-
-void RWTxnUnmanaged::commit_and_stop() {
-    if (commit_disabled_) {
-        return;
-    }
-    commit();
-}
-
-void RWTxnUnmanaged::commit() {
-    MDBX_commit_latency commit_latency{};
-    const ::mdbx::error err = static_cast<MDBX_error_t>(::mdbx_txn_commit_ex(handle_, &commit_latency));
-    if (err.code() != MDBX_THREAD_MISMATCH) {
-        handle_ = nullptr;
-    }
-    if (err.code() != MDBX_SUCCESS) {
-        err.throw_exception();
-    }
-    SILKWORM_ASSERT(!handle_);
-    SILK_TRACE << "Commit latency" << detail::log_args_for_commit_latency(commit_latency);
-}
-
 thread_local ObjectPool<MDBX_cursor, detail::cursor_handle_deleter> PooledCursor::handles_pool_{};
 
 PooledCursor::PooledCursor() {

--- a/silkworm/node/db/mdbx_test.cpp
+++ b/silkworm/node/db/mdbx_test.cpp
@@ -346,7 +346,9 @@ TEST_CASE("RWTxn") {
                 table_cursor.upsert(mdbx::slice{key}, mdbx::slice{value});
             }
 
-            tx.commit_and_renew();
+            CHECK_THROWS_AS(tx.commit_and_renew(), std::runtime_error);
+
+            ::mdbx::error::success_or_throw(::mdbx_txn_commit(rw_txn));
         }
         auto ro_txn{env.start_read()};
         db::PooledCursor cursor(ro_txn, {table_name});
@@ -366,7 +368,9 @@ TEST_CASE("RWTxn") {
                 table_cursor.upsert(mdbx::slice{key}, mdbx::slice{value});
             }
 
-            tx.commit_and_stop();
+            CHECK_THROWS_AS(tx.commit_and_stop(), std::runtime_error);
+
+            ::mdbx::error::success_or_throw(::mdbx_txn_commit(rw_txn));
         }
         auto ro_txn{env.start_read()};
         db::PooledCursor cursor(ro_txn, {table_name});

--- a/silkworm/node/db/test_util/temp_chain_data.hpp
+++ b/silkworm/node/db/test_util/temp_chain_data.hpp
@@ -25,9 +25,9 @@
 
 namespace silkworm::db::test_util {
 
-//! \brief Context is a helper resource manager for test temporary directory and inmemory database.
-//! Upon construction, it creates all the necessary data directories and DB tables.
-//! \remarks Context follows the RAII idiom and cleans up its temporary directory upon destruction.
+//! \brief TempChainData is a helper resource manager for a temporary directory plus an in-memory database.
+//! Upon construction, it creates all the necessary data directories and database tables.
+//! \remarks TempChainData follows the RAII idiom and cleans up its temporary directory upon destruction.
 class TempChainData {
   public:
     explicit TempChainData(bool with_create_tables = true, bool in_memory = true);
@@ -51,6 +51,8 @@ class TempChainData {
     [[nodiscard]] db::RWTxn& rw_txn() const { return *txn_; }
 
     void commit_txn() const { txn_->commit_and_stop(); }
+
+    void renew_txn() { txn_ = std::make_unique<db::RWTxnManaged>(env_); }
 
     void commit_and_renew_txn() const { txn_->commit_and_renew(); }
 

--- a/silkworm/node/db/test_util/temp_chain_data.hpp
+++ b/silkworm/node/db/test_util/temp_chain_data.hpp
@@ -52,8 +52,6 @@ class TempChainData {
 
     void commit_txn() const { txn_->commit_and_stop(); }
 
-    void renew_txn() { txn_ = std::make_unique<db::RWTxnManaged>(env_); }
-
     void commit_and_renew_txn() const { txn_->commit_and_renew(); }
 
     [[nodiscard]] const db::PruneMode& prune_mode() const { return prune_mode_; }


### PR DESCRIPTION
This PR mainly deals with providing a proper MDBX transaction handling at the C API interface, namely ensuring the all-or-nothing guarantee when paired the associated `silkworm-go` bindings and the correct usage on the Erigon side.

This is a detailed list of the changes:
- add internal/external MDBX support in C API `silkworm_execute_blocks`: when passed `mdbx_txn` is null, Silkworm will start an internal MDBX transaction and manage its lifecycle (i.e. always either commits or aborts the internal transaction, guaranteed by RAII); on the other hand, if a valid `mdbx_txn` is passed, Silkworm will use such external MDBX transaction to read/write data but it won't touch its lifecycle (i.e. neither commit nor abort is called). Of course, this change has some implications:
  - every time we hit the state batch threshold and flush it, we need to go back to the caller managing the external transaction to commit, we simply handle this scenario by returning `SILKWORM_OK` and letting the `last_executed_block` output parameter indicate to the caller where Silkworm stopped (so that the caller can commit and call `silkworm_execute_blocks` again)
  - one more argument `MDBX_env* env` is required, which Silkworm treats as unmanaged
- use the block read-ahead off-loading only in the internal transaction mode because, when an external transaction is passed by Erigon during the fork validation pipeline run, uncommitted blocks can be found only if searched through such read-write transaction. The external transaction mode then requires to load the blocks in the execution thread, this makes the code look a bit ugly but doing more changes here seemed even worse (see note below).
- use custom `boost::strict_scoped_thread` and related synchronisation facilities for the off-loading block provider and bounded buffer because `std::thread` triggers program termination on destruction if not joined and `std::jthread` seems to be still not well supported on macOS platform
- add complete exception handling in `BlockProvider` call operator
- additional validation checks performed in C API `silkworm_add_snapshot`
- tiny fix on C API logging format to avoid spurious characters in execution progress logs
- add more unit tests
- the `execute` development tool for C API is updated to run with both external and internal MDBX transaction (default: external)


Note:
IMO we should definitely do at least one more iteration on the `silkworm_execute_blocks` C API to have split it into two different functions, one for the internal transaction mode and another for the external one: this would make the interface easier to understand and use for any caller and also allow for some code cleanup in the implementation (see `use_external_txn` branches)

@JacekGlen as agreed, it's probably better to make this go through and then rebase your #1873 and #1875