### PR TITLE
capi: correct signal handling

### DIFF
--- a/silkworm/capi/silkworm.cpp
+++ b/silkworm/capi/silkworm.cpp
@@ -610,9 +610,6 @@ int silkworm_execute_blocks(SilkwormHandle handle, MDBX_env* mdbx_env, MDBX_txn*
             if (signal_check_time <= now) {
                 if (SignalHandler::signalled()) {
                     block_buffer.terminate_and_release_all();
-                    if (!use_external_txn) {
-                        txn->abort();
-                    }
                     return SILKWORM_TERMINATION_SIGNAL;
                 }
                 signal_check_time = now + 5s;

--- a/silkworm/capi/silkworm_test.cpp
+++ b/silkworm/capi/silkworm_test.cpp
@@ -23,9 +23,9 @@
 #include <silkworm/core/trie/vector_root.hpp>
 #include <silkworm/infra/test_util/log.hpp>
 #include <silkworm/node/db/mdbx.hpp>
-#include <silkworm/node/snapshots/index.hpp>
-#include <silkworm/node/snapshots/snapshot.hpp>
-#include <silkworm/node/snapshots/test_util/common.hpp>
+#include <silkworm/snapshots/index.hpp>
+#include <silkworm/snapshots/snapshot.hpp>
+#include <silkworm/snapshots/test_util/common.hpp>
 #include <silkworm/rpc/test/api_test_database.hpp>
 
 namespace silkworm {

--- a/silkworm/infra/common/bounded_buffer.hpp
+++ b/silkworm/infra/common/bounded_buffer.hpp
@@ -48,7 +48,13 @@ class BoundedBuffer {
 
     void push_front(value_type&& item) {
         boost::unique_lock<boost::mutex> lock(mutex_);
-        not_full_.wait(lock, [&] { return is_not_full(); });
+
+        not_full_.wait(lock, [&] { return is_stopped() || is_not_full(); });
+
+        if (is_stopped()) {  // If the buffer is stopped, do not push the item
+            return;
+        }
+
         container_.push_front(std::move(item));
         ++unread_;
         lock.unlock();
@@ -57,10 +63,29 @@ class BoundedBuffer {
 
     void pop_back(value_type* item) {
         boost::unique_lock<boost::mutex> lock(mutex_);
-        not_empty_.wait(lock, [&] { return is_not_empty(); });
+
+        not_empty_.wait(lock, [&] { return is_stopped() || is_not_empty(); });
+
+        if (is_stopped()) {  // If the buffer is stopped, do not pop the item
+            item = nullptr;
+            return;
+        }
+
         *item = container_[--unread_];
         lock.unlock();
         not_full_.notify_one();
+    }
+
+    void terminate_and_release_all() {
+        boost::unique_lock<boost::mutex> lock(mutex_);
+        stop_ = true;
+        lock.unlock();
+        not_empty_.notify_all();
+        not_full_.notify_all();
+    }
+
+    bool is_stopped() const {
+        return stop_;
     }
 
     size_type size() const {
@@ -75,6 +100,7 @@ class BoundedBuffer {
     bool is_not_empty() const { return unread_ > 0; }
     bool is_not_full() const { return unread_ < capacity_; }
 
+    bool stop_{false};
     size_type capacity_;
     size_type unread_;
     boost::circular_buffer<T> container_;

--- a/silkworm/infra/common/bounded_buffer_test.cpp
+++ b/silkworm/infra/common/bounded_buffer_test.cpp
@@ -166,4 +166,24 @@ TEST_CASE("BoundedBuffer multiple cycles over the buffer with delayed consumer")
     consume.join();
 }
 
+TEST_CASE("BoundedBuffer can terminate producer") {
+    BoundedBuffer<std::string> buffer(10);
+    const int iterations = 100;
+    std::thread produce(Producer<BoundedBuffer<std::string>>(&buffer, iterations, true));
+
+    buffer.terminate_and_release_all();
+
+    produce.join();
+}
+
+TEST_CASE("BoundedBuffer can terminate consumer") {
+    BoundedBuffer<std::string> buffer(10);
+    const int iterations = 100;
+    std::thread consume(Consumer<BoundedBuffer<std::string>>(&buffer, iterations, true));
+
+    buffer.terminate_and_release_all();
+
+    consume.join();
+}
+
 }  // namespace silkworm


### PR DESCRIPTION
Silkworm CAPI has two threads:

- main: for block execution and writing state changes
- block provider: for pre-loading blocks into the buffer

This PR makes sure that when the termination signal (Ctrl+C) is issued then:
- all open db transactions are closed
- threads are joined
- operations can be resumed (db integrity preserved)

Test notes: I've added some unit tests, but the true tests were conducted manually. I ran Erigon with Silkworm and then during the Execution stage pressed Ctrl+C to terminate. Then I restarted Erigon to make sure that the execution was resumed at the point of the last state write. Then I repeated the process multiple times.
