### PR TITLE
snapshots: support features flag in recsplit index

### DIFF
--- a/silkworm/snapshots/rec_split/encoding/sequence.hpp
+++ b/silkworm/snapshots/rec_split/encoding/sequence.hpp
@@ -31,7 +31,7 @@ template <UnsignedIntegral T>
 using UnsignedIntegralSequence = std::vector<T>;
 
 //! Max integer sequence length capped at some arbitrary hard limit
-constexpr std::size_t kMaxUnsignedIntegralSequenceSize{1 * kMebi};
+constexpr std::size_t kMaxUnsignedIntegralSequenceSize{10 * kMebi};
 
 using Uint32Sequence = UnsignedIntegralSequence<uint32_t>;
 using Uint64Sequence = UnsignedIntegralSequence<uint64_t>;

--- a/silkworm/snapshots/rec_split/encoding/sequence.hpp
+++ b/silkworm/snapshots/rec_split/encoding/sequence.hpp
@@ -30,7 +30,7 @@ namespace silkworm::snapshots::rec_split::encoding {
 template <UnsignedIntegral T>
 using UnsignedIntegralSequence = std::vector<T>;
 
-//! Max integer sequence length capped at some arbitrary hard limit
+//! Max integer sequence length capped at hard limit to fit in memory
 constexpr std::size_t kMaxUnsignedIntegralSequenceSize{10 * kMebi};
 
 using Uint32Sequence = UnsignedIntegralSequence<uint32_t>;

--- a/silkworm/snapshots/rec_split/encoding/sequence_test.cpp
+++ b/silkworm/snapshots/rec_split/encoding/sequence_test.cpp
@@ -17,14 +17,17 @@
 #include "sequence.hpp"
 
 #include <sstream>
+#include <stdexcept>
 
 #include <catch2/catch.hpp>
 
+#include <silkworm/core/common/bytes_to_string.hpp>
+#include <silkworm/core/common/endian.hpp>
 #include <silkworm/infra/test_util/log.hpp>
 
 namespace silkworm::snapshots::rec_split::encoding {
 
-TEST_CASE("Uint64Sequence", "[silkworm][recsplit][sequence]") {
+TEST_CASE("Uint64Sequence", "[silkworm][snapshots][recsplit][sequence]") {
     test_util::SetLogVerbosityGuard guard{log::Level::kNone};
     Uint64Sequence output_sequence{0, 11, 21, 31, 41, 51, 61};
 
@@ -35,6 +38,18 @@ TEST_CASE("Uint64Sequence", "[silkworm][recsplit][sequence]") {
     ss >> input_sequence;
 
     CHECK(input_sequence == output_sequence);
+}
+
+TEST_CASE("Uint64Sequence: size too big", "[silkworm][snapshots][recsplit][sequence]") {
+    test_util::SetLogVerbosityGuard guard{log::Level::kNone};
+
+    std::stringstream ss;
+    Bytes invalid_size_buffer(sizeof(uint64_t), '\0');
+    endian::store_big_u64(invalid_size_buffer.data(), 49287623586282974);
+    ss.write(byte_ptr_cast(invalid_size_buffer.data()), static_cast<std::streamsize>(invalid_size_buffer.size()));
+
+    Uint64Sequence input_sequence;
+    CHECK_THROWS_AS((ss >> input_sequence), std::logic_error);
 }
 
 }  // namespace silkworm::snapshots::rec_split::encoding


### PR DESCRIPTION
This PR introduces features flag in RecSplit indices for compatibility with Erigon format: https://github.com/ledgerwatch/erigon/pull/9501.

Moreover, this also fixes how an invalid size is handled in integral sequence deserialisation, specifically for GR codes.