### PR TITLE
stagedsync: do not share global node_settings with stages

### DIFF
--- a/silkworm/node/stagedsync/execution_pipeline.hpp
+++ b/silkworm/node/stagedsync/execution_pipeline.hpp
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include <silkworm/core/types/hash.hpp>
+#include <silkworm/node/common/settings.hpp>
 #include <silkworm/node/stagedsync/stages/stage.hpp>
 
 namespace silkworm::stagedsync {
@@ -62,6 +63,7 @@ class ExecutionPipeline : public Stoppable {
 
     std::string get_log_prefix() const;  // Returns the current log lines prefix on behalf of current stage
     class LogTimer;                      // Timer for async log scheduling
+    std::unique_ptr<LogTimer> make_log_timer();
 };
 
 }  // namespace silkworm::stagedsync

--- a/silkworm/node/stagedsync/stages/stage.cpp
+++ b/silkworm/node/stagedsync/stages/stage.cpp
@@ -22,8 +22,8 @@
 
 namespace silkworm::stagedsync {
 
-Stage::Stage(SyncContext* sync_context, const char* stage_name, NodeSettings* node_settings)
-    : sync_context_{sync_context}, stage_name_{stage_name}, node_settings_{node_settings} {}
+Stage::Stage(SyncContext* sync_context, const char* stage_name)
+    : sync_context_{sync_context}, stage_name_{stage_name} {}
 
 BlockNum Stage::get_progress(db::ROTxn& txn) {
     return db::stages::read_stage_progress(txn, stage_name_);

--- a/silkworm/node/stagedsync/stages/stage.hpp
+++ b/silkworm/node/stagedsync/stages/stage.hpp
@@ -23,7 +23,6 @@
 #include <silkworm/infra/common/ensure.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/concurrency/stoppable.hpp>
-#include <silkworm/node/common/settings.hpp>
 #include <silkworm/node/db/etl_mdbx_collector.hpp>
 #include <silkworm/node/db/stages.hpp>
 #include <silkworm/node/db/tables.hpp>
@@ -56,7 +55,6 @@ class Stage : public Stoppable {
   public:
     enum class [[nodiscard]] Result {
         kSuccess,                 // valid chain
-        kUnknownChainId,          //
         kUnknownProtocolRuleSet,  //
         kBadChainSequence,        //
         kInvalidProgress,         //
@@ -78,7 +76,8 @@ class Stage : public Stoppable {
         Unwind,   // Executing Unwind
         Prune,    // Executing Prune
     };
-    explicit Stage(SyncContext* sync_context, const char* stage_name, NodeSettings* node_settings);
+
+    Stage(SyncContext* sync_context, const char* stage_name);
 
     //! \brief Forward is called when the stage is executed. The main logic of the stage must be here.
     //! \param [in] txn : A db transaction holder
@@ -128,7 +127,6 @@ class Stage : public Stoppable {
   protected:
     SyncContext* sync_context_;                                  // Shared context across stages
     const char* stage_name_;                                     // Human friendly identifier of the stage
-    NodeSettings* node_settings_;                                // Pointer to shared node configuration settings
     std::atomic<OperationType> operation_{OperationType::None};  // Actual operation being carried out
     std::mutex sl_mutex_;                                        // To synchronize access by outer sync loop
     std::string log_prefix_;                                     // Log lines prefix holding the progress among stages

--- a/silkworm/node/stagedsync/stages/stage_blockhashes.cpp
+++ b/silkworm/node/stagedsync/stages/stage_blockhashes.cpp
@@ -61,7 +61,7 @@ Stage::Result BlockHashes::forward(db::RWTxn& txn) {
                        "span", std::to_string(segment_width)});
         }
 
-        collector_ = std::make_unique<Collector>(node_settings_->etl());
+        collector_ = std::make_unique<Collector>(etl_settings_);
         collect_and_load(txn, previous_progress, headers_stage_progress);
         update_progress(txn, reached_block_num_);
         txn.commit_and_renew();
@@ -124,7 +124,7 @@ Stage::Result BlockHashes::unwind(db::RWTxn& txn) {
                        "span", std::to_string(segment_width)});
         }
 
-        collector_ = std::make_unique<Collector>(node_settings_->etl());
+        collector_ = std::make_unique<Collector>(etl_settings_);
         collect_and_load(txn, to, previous_progress);
         update_progress(txn, to);
         txn.commit_and_renew();

--- a/silkworm/node/stagedsync/stages/stage_blockhashes.hpp
+++ b/silkworm/node/stagedsync/stages/stage_blockhashes.hpp
@@ -16,14 +16,16 @@
 
 #pragma once
 
+#include <silkworm/node/db/etl/collector_settings.hpp>
 #include <silkworm/node/stagedsync/stages/stage.hpp>
 
 namespace silkworm::stagedsync {
 
 class BlockHashes final : public Stage {
   public:
-    explicit BlockHashes(NodeSettings* node_settings, SyncContext* sync_context)
-        : Stage(sync_context, db::stages::kBlockHashesKey, node_settings){};
+    explicit BlockHashes(SyncContext* sync_context, db::etl::CollectorSettings etl_settings)
+        : Stage(sync_context, db::stages::kBlockHashesKey),
+          etl_settings_(std::move(etl_settings)) {}
     ~BlockHashes() override = default;
 
     Stage::Result forward(db::RWTxn& txn) final;
@@ -32,6 +34,7 @@ class BlockHashes final : public Stage {
     std::vector<std::string> get_log_progress() final;
 
   private:
+    db::etl::CollectorSettings etl_settings_;
     std::unique_ptr<db::etl_mdbx::Collector> collector_{nullptr};
 
     /* Stats */

--- a/silkworm/node/stagedsync/stages/stage_bodies.cpp
+++ b/silkworm/node/stagedsync/stages/stage_bodies.cpp
@@ -95,9 +95,9 @@ bool BodiesStage::BodyDataModel::get_canonical_block(BlockNum height, Block& blo
     return data_model_.read_canonical_block(height, block);
 }
 
-BodiesStage::BodiesStage(NodeSettings* ns, SyncContext* sc)
-    : Stage(sc, db::stages::kBlockBodiesKey, ns) {
-}
+BodiesStage::BodiesStage(SyncContext* sync_context, const ChainConfig& chain_config)
+    : Stage(sync_context, db::stages::kBlockBodiesKey),
+      chain_config_(chain_config) {}
 
 Stage::Result BodiesStage::forward(db::RWTxn& tx) {
     using std::shared_ptr;
@@ -129,7 +129,7 @@ Stage::Result BodiesStage::forward(db::RWTxn& tx) {
                        "span", std::to_string(target_height - current_height_)});
         }
 
-        BodyDataModel body_persistence(tx, current_height_, node_settings_->chain_config.value());
+        BodyDataModel body_persistence(tx, current_height_, chain_config_);
         body_persistence.set_preverified_height(PreverifiedHashes::current.height);
 
         get_log_progress();  // this is a trick to set log progress initial value, please improve

--- a/silkworm/node/stagedsync/stages/stage_bodies.hpp
+++ b/silkworm/node/stagedsync/stages/stage_bodies.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <silkworm/core/chain/config.hpp>
 #include <silkworm/core/protocol/rule_set.hpp>
 #include <silkworm/core/types/block.hpp>
 #include <silkworm/infra/concurrency/containers.hpp>
@@ -27,7 +28,7 @@ namespace silkworm::stagedsync {
 
 class BodiesStage : public Stage {
   public:
-    BodiesStage(NodeSettings*, SyncContext*);
+    BodiesStage(SyncContext*, const ChainConfig&);
     BodiesStage(const BodiesStage&) = delete;  // not copyable
     BodiesStage(BodiesStage&&) = delete;       // nor movable
     ~BodiesStage() override = default;
@@ -38,6 +39,7 @@ class BodiesStage : public Stage {
 
   private:
     std::vector<std::string> get_log_progress() override;  // thread safe
+    const ChainConfig& chain_config_;
     std::atomic<BlockNum> current_height_{0};
 
   protected:

--- a/silkworm/node/stagedsync/stages/stage_execution.hpp
+++ b/silkworm/node/stagedsync/stages/stage_execution.hpp
@@ -18,17 +18,26 @@
 
 #include <boost/circular_buffer.hpp>
 
+#include <silkworm/core/chain/config.hpp>
 #include <silkworm/core/execution/evm.hpp>
 #include <silkworm/core/protocol/rule_set.hpp>
+#include <silkworm/node/db/prune_mode.hpp>
 #include <silkworm/node/stagedsync/stages/stage.hpp>
 
 namespace silkworm::stagedsync {
 
 class Execution final : public Stage {
   public:
-    explicit Execution(NodeSettings* node_settings, SyncContext* sync_context)
-        : Stage(sync_context, db::stages::kExecutionKey, node_settings),
-          rule_set_{protocol::rule_set_factory(node_settings->chain_config.value())} {}
+    Execution(
+        SyncContext* sync_context,
+        const ChainConfig& chain_config,
+        size_t batch_size,
+        db::PruneMode prune_mode)
+        : Stage(sync_context, db::stages::kExecutionKey),
+          chain_config_(chain_config),
+          batch_size_(batch_size),
+          prune_mode_(prune_mode),
+          rule_set_{protocol::rule_set_factory(chain_config)} {}
 
     ~Execution() override = default;
 
@@ -40,6 +49,9 @@ class Execution final : public Stage {
   private:
     static constexpr size_t kMaxPrefetchedBlocks{10240};
 
+    const ChainConfig& chain_config_;
+    size_t batch_size_;
+    db::PruneMode prune_mode_;
     protocol::RuleSetPtr rule_set_;
     BlockNum block_num_{0};
     boost::circular_buffer<Block> prefetched_blocks_{/*buffer_capacity=*/kMaxPrefetchedBlocks};

--- a/silkworm/node/stagedsync/stages/stage_finish.cpp
+++ b/silkworm/node/stagedsync/stages/stage_finish.cpp
@@ -50,7 +50,7 @@ Stage::Result Finish::forward(db::RWTxn& txn) {
 
         // Log the new version of app at this height
         if (sync_context_->is_first_cycle) {
-            Bytes build_info{byte_ptr_cast(node_settings_->build_info.data())};
+            Bytes build_info{byte_ptr_cast(build_info_.data()), build_info_.length()};
             db::write_build_info_height(txn, build_info, execution_stage_progress);
         }
         txn.commit_and_renew();

--- a/silkworm/node/stagedsync/stages/stage_finish.hpp
+++ b/silkworm/node/stagedsync/stages/stage_finish.hpp
@@ -16,14 +16,17 @@
 
 #pragma once
 
+#include <string>
+
 #include <silkworm/node/stagedsync/stages/stage.hpp>
 
 namespace silkworm::stagedsync {
 
 class Finish : public Stage {
   public:
-    explicit Finish(NodeSettings* node_settings, SyncContext* sync_context)
-        : Stage(sync_context, db::stages::kFinishKey, node_settings){};
+    explicit Finish(SyncContext* sync_context, std::string build_info)
+        : Stage(sync_context, db::stages::kFinishKey),
+          build_info_(std::move(build_info)) {}
     ~Finish() override = default;
 
     Stage::Result forward(db::RWTxn& txn) final;
@@ -31,5 +34,8 @@ class Finish : public Stage {
 
     // Finish does not prune.
     Stage::Result prune(db::RWTxn&) final { return Stage::Result::kSuccess; };
+
+  private:
+    std::string build_info_;
 };
 }  // namespace silkworm::stagedsync

--- a/silkworm/node/stagedsync/stages/stage_hashstate.hpp
+++ b/silkworm/node/stagedsync/stages/stage_hashstate.hpp
@@ -16,15 +16,18 @@
 
 #pragma once
 
+#include <silkworm/node/db/etl/collector_settings.hpp>
 #include <silkworm/node/stagedsync/stages/stage.hpp>
 
 namespace silkworm::stagedsync {
 
 class HashState final : public Stage {
   public:
-    explicit HashState(NodeSettings* node_settings, SyncContext* sync_context)
-        : Stage(sync_context, db::stages::kHashStateKey, node_settings),
-          collector_(std::make_unique<db::etl_mdbx::Collector>(node_settings->etl())) {}
+    HashState(
+        SyncContext* sync_context,
+        db::etl::CollectorSettings etl_settings)
+        : Stage(sync_context, db::stages::kHashStateKey),
+          collector_(std::make_unique<db::etl_mdbx::Collector>(etl_settings)) {}
     ~HashState() override = default;
     Stage::Result forward(db::RWTxn& txn) final;
     Stage::Result unwind(db::RWTxn& txn) final;

--- a/silkworm/node/stagedsync/stages/stage_headers.cpp
+++ b/silkworm/node/stagedsync/stages/stage_headers.cpp
@@ -85,8 +85,8 @@ std::optional<BlockHeader> HeadersStage::HeaderDataModel::get_canonical_header(B
 }
 
 // HeadersStage
-HeadersStage::HeadersStage(NodeSettings* ns, SyncContext* sc)
-    : Stage(sc, db::stages::kHeadersKey, ns) {
+HeadersStage::HeadersStage(SyncContext* sync_context)
+    : Stage(sync_context, db::stages::kHeadersKey) {
     // User can specify to stop downloading process at some block
     const auto stop_at_block = Environment::get_stop_at_block();
     if (stop_at_block.has_value()) {

--- a/silkworm/node/stagedsync/stages/stage_headers.hpp
+++ b/silkworm/node/stagedsync/stages/stage_headers.hpp
@@ -61,7 +61,7 @@ namespace silkworm::stagedsync {
  */
 class HeadersStage : public Stage {
   public:
-    HeadersStage(NodeSettings*, SyncContext*);
+    HeadersStage(SyncContext*);
     HeadersStage(const HeadersStage&) = delete;  // not copyable
     HeadersStage(HeadersStage&&) = delete;       // nor movable
 

--- a/silkworm/node/stagedsync/stages/stage_history_index.hpp
+++ b/silkworm/node/stagedsync/stages/stage_history_index.hpp
@@ -17,14 +17,23 @@
 #pragma once
 
 #include <silkworm/node/db/bitmap.hpp>
+#include <silkworm/node/db/etl/collector_settings.hpp>
+#include <silkworm/node/db/prune_mode.hpp>
 #include <silkworm/node/stagedsync/stages/stage.hpp>
 
 namespace silkworm::stagedsync {
 
 class HistoryIndex : public Stage {
   public:
-    explicit HistoryIndex(NodeSettings* node_settings, SyncContext* sync_context)
-        : Stage(sync_context, db::stages::kHistoryIndexKey, node_settings){};
+    HistoryIndex(
+        SyncContext* sync_context,
+        size_t batch_size,
+        db::etl::CollectorSettings etl_settings,
+        db::BlockAmount prune_mode_history)
+        : Stage(sync_context, db::stages::kHistoryIndexKey),
+          batch_size_(batch_size),
+          etl_settings_(std::move(etl_settings)),
+          prune_mode_history_(prune_mode_history) {}
     ~HistoryIndex() override = default;
 
     Stage::Result forward(db::RWTxn& txn) final;
@@ -33,6 +42,10 @@ class HistoryIndex : public Stage {
     std::vector<std::string> get_log_progress() final;
 
   private:
+    size_t batch_size_;
+    db::etl::CollectorSettings etl_settings_;
+    db::BlockAmount prune_mode_history_;
+
     std::unique_ptr<db::etl_mdbx::Collector> collector_{nullptr};
     std::unique_ptr<db::bitmap::IndexLoader> index_loader_{nullptr};
 

--- a/silkworm/node/stagedsync/stages/stage_interhashes.cpp
+++ b/silkworm/node/stagedsync/stages/stage_interhashes.cpp
@@ -443,8 +443,8 @@ Stage::Result InterHashes::regenerate_intermediate_hashes(db::RWTxn& txn, const 
         txn->clear_map(db::table::kTrieOfStorage.name);
         txn.commit_and_renew();
 
-        account_collector_ = std::make_unique<Collector>(node_settings_->etl());
-        storage_collector_ = std::make_unique<Collector>(node_settings_->etl());
+        account_collector_ = std::make_unique<Collector>(etl_settings_);
+        storage_collector_ = std::make_unique<Collector>(etl_settings_);
 
         log_lck.lock();
         current_source_ = "HashState";
@@ -499,8 +499,8 @@ Stage::Result InterHashes::increment_intermediate_hashes(db::RWTxn& txn, BlockNu
     Stage::Result ret{Stage::Result::kSuccess};
 
     try {
-        account_collector_ = std::make_unique<Collector>(node_settings_->etl());
-        storage_collector_ = std::make_unique<Collector>(node_settings_->etl());
+        account_collector_ = std::make_unique<Collector>(etl_settings_);
+        storage_collector_ = std::make_unique<Collector>(etl_settings_);
 
         // Cache of hashed addresses
         absl::btree_map<evmc::address, ethash_hash256> hashed_addresses{};

--- a/silkworm/node/stagedsync/stages/stage_interhashes.hpp
+++ b/silkworm/node/stagedsync/stages/stage_interhashes.hpp
@@ -19,6 +19,7 @@
 #include <silkworm/core/trie/hash_builder.hpp>
 #include <silkworm/core/trie/prefix_set.hpp>
 #include <silkworm/node/db/etl/collector.hpp>
+#include <silkworm/node/db/etl/collector_settings.hpp>
 #include <silkworm/node/stagedsync/stages/stage.hpp>
 #include <silkworm/node/stagedsync/stages/stage_interhashes/trie_loader.hpp>
 
@@ -26,8 +27,9 @@ namespace silkworm::stagedsync {
 
 class InterHashes final : public Stage {
   public:
-    explicit InterHashes(NodeSettings* node_settings, SyncContext* sync_context)
-        : Stage(sync_context, db::stages::kIntermediateHashesKey, node_settings){};
+    explicit InterHashes(SyncContext* sync_context, db::etl::CollectorSettings etl_settings)
+        : Stage(sync_context, db::stages::kIntermediateHashesKey),
+          etl_settings_(std::move(etl_settings)) {}
     ~InterHashes() override = default;
     Stage::Result forward(db::RWTxn& txn) final;
     Stage::Result unwind(db::RWTxn& txn) final;
@@ -104,6 +106,8 @@ class InterHashes final : public Stage {
 
     // The loader which (re)builds the trees
     std::unique_ptr<trie::TrieLoader> trie_loader_;
+
+    db::etl::CollectorSettings etl_settings_;
 
     std::unique_ptr<db::etl_mdbx::Collector> account_collector_;  // To accumulate new records for kTrieOfAccounts
     std::unique_ptr<db::etl_mdbx::Collector> storage_collector_;  // To accumulate new records for kTrieOfStorage

--- a/silkworm/node/stagedsync/stages/stage_senders.cpp
+++ b/silkworm/node/stagedsync/stages/stage_senders.cpp
@@ -33,11 +33,18 @@ namespace silkworm::stagedsync {
 
 using namespace std::chrono_literals;
 
-Senders::Senders(NodeSettings* node_settings, SyncContext* sync_context)
-    : Stage(sync_context, db::stages::kSendersKey, node_settings),
-      max_batch_size_{node_settings->batch_size / std::thread::hardware_concurrency() / sizeof(AddressRecovery)},
+Senders::Senders(
+    SyncContext* sync_context,
+    const ChainConfig& chain_config,
+    size_t batch_size,
+    db::etl::CollectorSettings etl_settings,
+    db::BlockAmount prune_mode_senders)
+    : Stage(sync_context, db::stages::kSendersKey),
+      chain_config_(chain_config),
+      prune_mode_senders_(prune_mode_senders),
+      max_batch_size_{batch_size / std::thread::hardware_concurrency() / sizeof(AddressRecovery)},
       batch_{std::make_shared<std::vector<AddressRecovery>>()},
-      collector_{node_settings->etl()} {
+      collector_{etl_settings} {
     // Reserve space for max batch in advance
     batch_->reserve(max_batch_size_);
 }
@@ -162,7 +169,7 @@ Stage::Result Senders::prune(db::RWTxn& txn) {
 
     try {
         throw_if_stopping();
-        if (!node_settings_->prune_mode.senders().enabled()) {
+        if (!prune_mode_senders_.enabled()) {
             operation_ = OperationType::None;
             return ret;
         }
@@ -175,7 +182,7 @@ Stage::Result Senders::prune(db::RWTxn& txn) {
 
         // Need to erase all history info below this threshold
         // If threshold is zero we don't have anything to prune
-        const auto prune_threshold{node_settings_->prune_mode.senders().value_from_head(forward_progress)};
+        const auto prune_threshold{prune_mode_senders_.value_from_head(forward_progress)};
         if (!prune_threshold) {
             operation_ = OperationType::None;
             return ret;
@@ -238,6 +245,10 @@ Stage::Result Senders::prune(db::RWTxn& txn) {
 
     operation_ = OperationType::None;
     return ret;
+}
+
+void Senders::set_prune_mode_senders(db::BlockAmount prune_mode_senders) {
+    prune_mode_senders_ = prune_mode_senders;
 }
 
 Stage::Result Senders::parallel_recover(db::RWTxn& txn) {
@@ -370,7 +381,7 @@ Stage::Result Senders::add_to_batch(BlockNum block_num, const Hash& block_hash, 
     }
 
     // We're only interested in revisions up to London, so it's OK to not detect time-based forks.
-    const evmc_revision rev{node_settings_->chain_config->revision(block_num, /*block_time=*/0)};
+    const evmc_revision rev{chain_config_.revision(block_num, /*block_time=*/0)};
     const bool has_homestead{rev >= EVMC_HOMESTEAD};
     const bool has_spurious_dragon{rev >= EVMC_SPURIOUS_DRAGON};
 
@@ -392,7 +403,7 @@ Stage::Result Senders::add_to_batch(BlockNum block_num, const Hash& block_hash, 
                 log::Error(log_prefix_) << "EIP-155 signature for transaction #" << tx_id << " in block #" << block_num
                                         << " before Spurious Dragon";
                 return Stage::Result::kInvalidTransaction;
-            } else if (transaction.chain_id.value() != node_settings_->chain_config->chain_id) {
+            } else if (transaction.chain_id.value() != chain_config_.chain_id) {
                 log::Error(log_prefix_) << "EIP-155 invalid signature for transaction #" << tx_id << " in block #" << block_num;
                 return Stage::Result::kInvalidTransaction;
             }

--- a/silkworm/node/stagedsync/stages/stage_senders.hpp
+++ b/silkworm/node/stagedsync/stages/stage_senders.hpp
@@ -25,10 +25,13 @@
 
 #include <evmc/evmc.h>
 
+#include <silkworm/core/chain/config.hpp>
 #include <silkworm/core/common/base.hpp>
 #include <silkworm/core/common/bytes.hpp>
 #include <silkworm/infra/concurrency/thread_pool.hpp>
 #include <silkworm/node/db/etl/collector.hpp>
+#include <silkworm/node/db/etl/collector_settings.hpp>
+#include <silkworm/node/db/prune_mode.hpp>
 #include <silkworm/node/stagedsync/stages/stage.hpp>
 
 namespace silkworm::stagedsync {
@@ -47,13 +50,20 @@ using AddressRecoveryBatch = std::vector<AddressRecovery>;
 
 class Senders final : public Stage {
   public:
-    explicit Senders(NodeSettings* node_settings, SyncContext* sync_context);
+    Senders(
+        SyncContext* sync_context,
+        const ChainConfig& chain_config,
+        size_t batch_size,
+        db::etl::CollectorSettings etl_settings,
+        db::BlockAmount prune_mode_senders);
     ~Senders() override = default;
 
     Stage::Result forward(db::RWTxn& txn) final;
     Stage::Result unwind(db::RWTxn& txn) final;
     Stage::Result prune(db::RWTxn& txn) final;
     std::vector<std::string> get_log_progress() final;
+
+    void set_prune_mode_senders(db::BlockAmount prune_mode_senders);
 
   private:
     Stage::Result parallel_recover(db::RWTxn& txn);
@@ -66,6 +76,9 @@ class Senders final : public Stage {
 
     void increment_total_processed_blocks();
     void increment_total_collected_transactions(std::size_t delta);
+
+    const ChainConfig& chain_config_;
+    db::BlockAmount prune_mode_senders_;
 
     //! The size of recovery batches
     std::size_t max_batch_size_;

--- a/silkworm/node/stagedsync/stages/stage_tx_lookup.cpp
+++ b/silkworm/node/stagedsync/stages/stage_tx_lookup.cpp
@@ -52,7 +52,7 @@ Stage::Result TxLookup::forward(db::RWTxn& txn) {
         if (highest_frozen_block_number > previous_progress) {
             previous_progress = std::min(highest_frozen_block_number, target_progress);
             // If pruning is enabled, make it start from max frozen block as well
-            if (node_settings_->prune_mode.tx_index().enabled()) {
+            if (prune_mode_tx_index_.enabled()) {
                 set_prune_progress(txn, previous_progress);
             }
         }
@@ -69,8 +69,8 @@ Stage::Result TxLookup::forward(db::RWTxn& txn) {
 
         // If this is first time we forward AND we have "prune history" set
         // do not process all blocks rather only what is needed
-        if (!previous_progress && node_settings_->prune_mode.tx_index().enabled())
-            previous_progress = node_settings_->prune_mode.tx_index().value_from_head(target_progress);
+        if (!previous_progress && prune_mode_tx_index_.enabled())
+            previous_progress = prune_mode_tx_index_.value_from_head(target_progress);
 
         if (previous_progress < target_progress)
             forward_impl(txn, previous_progress, target_progress);
@@ -173,7 +173,7 @@ Stage::Result TxLookup::prune(db::RWTxn& txn) {
 
     try {
         throw_if_stopping();
-        if (!node_settings_->prune_mode.tx_index().enabled()) {
+        if (!prune_mode_tx_index_.enabled()) {
             operation_ = OperationType::None;
             return ret;
         }
@@ -187,7 +187,7 @@ Stage::Result TxLookup::prune(db::RWTxn& txn) {
 
         // Need to erase all history info below this threshold
         // If threshold is zero we don't have anything to prune
-        const auto prune_threshold{node_settings_->prune_mode.tx_index().value_from_head(forward_progress)};
+        const auto prune_threshold{prune_mode_tx_index_.value_from_head(forward_progress)};
         if (!prune_threshold) {
             operation_ = OperationType::None;
             return ret;
@@ -204,8 +204,7 @@ Stage::Result TxLookup::prune(db::RWTxn& txn) {
         }
 
         if (!prune_progress || prune_progress < forward_progress) {
-            const auto previous_prune_threshold{
-                node_settings_->prune_mode.tx_index().value_from_head(prune_progress)};
+            const auto previous_prune_threshold = prune_mode_tx_index_.value_from_head(prune_progress);
             prune_impl(txn, previous_prune_threshold, prune_threshold);
         }
 
@@ -239,7 +238,7 @@ void TxLookup::forward_impl(db::RWTxn& txn, const BlockNum from, const BlockNum 
     std::unique_lock log_lck(sl_mutex_);
     operation_ = OperationType::Forward;
     loading_.store(false);
-    collector_ = std::make_unique<Collector>(node_settings_->etl());
+    collector_ = std::make_unique<Collector>(etl_settings_);
     current_source_ = std::string(db::table::kBlockBodies.name);
     current_target_.clear();
     current_key_.clear();
@@ -271,7 +270,7 @@ void TxLookup::unwind_impl(db::RWTxn& txn, BlockNum from, BlockNum to) {
     std::unique_lock log_lck(sl_mutex_);
     operation_ = OperationType::Unwind;
     loading_.store(false);
-    collector_ = std::make_unique<Collector>(node_settings_->etl());
+    collector_ = std::make_unique<Collector>(etl_settings_);
     current_source_ = std::string(db::table::kBlockBodies.name);
     current_target_.clear();
     current_key_.clear();
@@ -304,7 +303,7 @@ void TxLookup::prune_impl(db::RWTxn& txn, BlockNum from, BlockNum to) {
     std::unique_lock log_lck(sl_mutex_);
     operation_ = OperationType::Prune;
     loading_.store(false);
-    collector_ = std::make_unique<Collector>(node_settings_->etl());
+    collector_ = std::make_unique<Collector>(etl_settings_);
     current_source_ = std::string(source_config.name);
     current_target_.clear();
     current_key_.clear();

--- a/silkworm/node/stagedsync/stages/stage_tx_lookup.hpp
+++ b/silkworm/node/stagedsync/stages/stage_tx_lookup.hpp
@@ -17,14 +17,21 @@
 #pragma once
 
 #include <silkworm/node/db/bitmap.hpp>
+#include <silkworm/node/db/etl/collector_settings.hpp>
+#include <silkworm/node/db/prune_mode.hpp>
 #include <silkworm/node/stagedsync/stages/stage.hpp>
 
 namespace silkworm::stagedsync {
 
 class TxLookup : public Stage {
   public:
-    explicit TxLookup(NodeSettings* node_settings, SyncContext* sync_context)
-        : Stage(sync_context, db::stages::kTxLookupKey, node_settings){};
+    TxLookup(
+        SyncContext* sync_context,
+        db::etl::CollectorSettings etl_settings,
+        db::BlockAmount prune_mode_tx_index)
+        : Stage(sync_context, db::stages::kTxLookupKey),
+          etl_settings_(std::move(etl_settings)),
+          prune_mode_tx_index_(prune_mode_tx_index) {}
     ~TxLookup() override = default;
 
     Stage::Result forward(db::RWTxn& txn) final;
@@ -33,6 +40,9 @@ class TxLookup : public Stage {
     std::vector<std::string> get_log_progress() final;
 
   private:
+    db::etl::CollectorSettings etl_settings_;
+    db::BlockAmount prune_mode_tx_index_;
+
     std::unique_ptr<db::etl_mdbx::Collector> collector_{nullptr};
 
     std::atomic_bool loading_{false};  // Whether we're in ETL loading phase

--- a/silkworm/node/stagedsync/stages/stage_tx_lookup_test.cpp
+++ b/silkworm/node/stagedsync/stages/stage_tx_lookup_test.cpp
@@ -78,7 +78,7 @@ TEST_CASE("Stage Transaction Lookups") {
         // Execute stage forward
         NodeSettings node_settings = node::test_util::make_node_settings_from_temp_chain_data(context);
         stagedsync::SyncContext sync_context{};
-        stagedsync::TxLookup stage_tx_lookup(&node_settings, &sync_context);
+        stagedsync::TxLookup stage_tx_lookup{&sync_context, node_settings.etl(), node_settings.prune_mode.tx_index()};
         REQUIRE(stage_tx_lookup.forward(txn) == stagedsync::Stage::Result::kSuccess);
 
         db::PooledCursor lookup_table(txn, db::table::kTxLookup);
@@ -130,7 +130,7 @@ TEST_CASE("Stage Transaction Lookups") {
         // Execute stage forward
         NodeSettings node_settings = node::test_util::make_node_settings_from_temp_chain_data(context);
         stagedsync::SyncContext sync_context{};
-        stagedsync::TxLookup stage_tx_lookup(&node_settings, &sync_context);
+        stagedsync::TxLookup stage_tx_lookup{&sync_context, node_settings.etl(), node_settings.prune_mode.tx_index()};
         REQUIRE(stage_tx_lookup.forward(txn) == stagedsync::Stage::Result::kSuccess);
 
         // Only leave block 2 alive


### PR DESCRIPTION
Instead of passing all node_settings to each stage, each stage accepts only a subset that is needed.