### PR TITLE
rpcdaemon: fix interface log settings for Engine RPC end-point

### DIFF
--- a/cmd/common/rpcdaemon_options.cpp
+++ b/cmd/common/rpcdaemon_options.cpp
@@ -73,16 +73,16 @@ struct ApiSpecValidator : public CLI::Validator {
 
 static void add_options_interface_log(CLI::App& cli, const std::string& option_prefix, const std::string& end_point_descr,
                                       rpc::InterfaceLogSettings& settings) {
-    cli.add_flag("--" + option_prefix + ".enabled", settings.enabled)
+    cli.add_flag("--" + option_prefix + ".log.enabled", settings.enabled)
         ->description("Enable interface log files for " + end_point_descr)
         ->capture_default_str();
 
-    cli.add_option("--" + option_prefix + ".max_files", settings.max_files)
+    cli.add_option("--" + option_prefix + ".log.max_files", settings.max_files)
         ->description("Maximum number of distinct interface log files for " + end_point_descr)
         ->check(CLI::Range(1, 500))
         ->capture_default_str();
 
-    cli.add_option("--" + option_prefix + ".max_file_size", settings.max_file_size_mb)
+    cli.add_option("--" + option_prefix + ".log.max_file_size", settings.max_file_size_mb)
         ->description("Maximum size in megabytes of each interface log file for " + end_point_descr)
         ->check(CLI::Range(1, 1024))
         ->capture_default_str();

--- a/cmd/silkworm.cpp
+++ b/cmd/silkworm.cpp
@@ -306,6 +306,7 @@ int main(int argc, char* argv[]) {
         // ChainSync: the chain synchronization process based on the consensus protocol
         chainsync::EngineRpcSettings rpc_settings{
             .engine_end_point = settings.rpcdaemon_settings.engine_end_point,
+            .engine_ifc_log_settings = settings.rpcdaemon_settings.engine_ifc_log_settings,
             .private_api_addr = settings.rpcdaemon_settings.private_api_addr,
             .log_verbosity = settings.log_settings.log_verbosity,
             .wait_mode = settings.rpcdaemon_settings.context_pool_settings.wait_mode,

--- a/silkworm/rpc/daemon.cpp
+++ b/silkworm/rpc/daemon.cpp
@@ -305,13 +305,20 @@ void Daemon::start() {
             end_point, api_spec, ioc, worker_pool_, settings_.cors_domain, std::move(jwt_secret),
             settings_.use_websocket, settings_.ws_compression, std::move(ilog_settings));
     };
+    auto set_container_folder = [](InterfaceLogSettings& ilog_settings, const std::filesystem::path& datadir) {
+        ilog_settings.container_folder = datadir / ilog_settings.container_folder;
+    };
 
-    // Put the interface logs into the data folder in case we run with local data
-    if (settings_.datadir) {
-        std::filesystem::path logs_folder{*settings_.datadir / "logs"};
-        settings_.eth_ifc_log_settings.container_folder = logs_folder.string();
-        settings_.engine_ifc_log_settings.container_folder = logs_folder.string();
+    // Put the interface logs into the data folder
+    std::filesystem::path data_folder{};
+    if (chaindata_env_) {
+        data_folder = chaindata_env_->get_path().parent_path();
     }
+    if (settings_.datadir) {
+        data_folder = *settings_.datadir;
+    }
+    set_container_folder(settings_.eth_ifc_log_settings, data_folder);
+    set_container_folder(settings_.engine_ifc_log_settings, data_folder);
 
     // Create and start the configured RPC services for each execution context
     for (std::size_t i{0}; i < settings_.context_pool_settings.num_contexts; ++i) {

--- a/silkworm/sync/sync.cpp
+++ b/silkworm/sync/sync.cpp
@@ -39,6 +39,7 @@ Sync::Sync(const boost::asio::any_io_executor& executor,
             .log_settings = {
                 .log_verbosity = rpc_settings.log_verbosity,
             },
+            .engine_ifc_log_settings = rpc_settings.engine_ifc_log_settings,
             .context_pool_settings{
                 .num_contexts = 1,                             // single-client so just one scheduler is OK
                 .wait_mode = concurrency::WaitMode::blocking,  // single-client so no need to play w/ strategies

--- a/silkworm/sync/sync.hpp
+++ b/silkworm/sync/sync.hpp
@@ -28,6 +28,7 @@
 #include <silkworm/infra/grpc/client/client_context_pool.hpp>
 #include <silkworm/node/db/mdbx.hpp>
 #include <silkworm/node/stagedsync/client.hpp>
+#include <silkworm/rpc/common/interface_log.hpp>
 #include <silkworm/rpc/daemon.hpp>
 #include <silkworm/sentry/api/common/sentry_client.hpp>
 
@@ -39,6 +40,7 @@ namespace silkworm::chainsync {
 
 struct EngineRpcSettings {
     std::string engine_end_point{kDefaultEngineEndPoint};
+    rpc::InterfaceLogSettings engine_ifc_log_settings{.ifc_name = "engine_rpc_api"};
     std::string private_api_addr{kDefaultPrivateApiAddr};
     log::Level log_verbosity{log::Level::kInfo};
     concurrency::WaitMode wait_mode{concurrency::WaitMode::blocking};


### PR DESCRIPTION
This PR propagates correctly the interface log settings for the Engine RPC end-point to the `rpc::Daemon` module both in standalone and embedded mode.

Moreover, the following small changes are also included:
- put interface logs inside chaindata sub-folder (instead of working directory)
- better names for interface log settings, i.e. `--eth.log.*` or `--engine.log.*`
