### PR TITLE
rpcdaemon: fix Windows build after PR 1898

### DIFF
--- a/silkworm/rpc/common/interface_log.cpp
+++ b/silkworm/rpc/common/interface_log.cpp
@@ -63,7 +63,7 @@ class InterfaceLogImpl final {
 InterfaceLogImpl::InterfaceLogImpl(InterfaceLogSettings settings)
     : name_{std::move(settings.ifc_name)},
       auto_flush_{settings.auto_flush},
-      file_path_{std::move(settings.container_folder) / std::filesystem::path{name_ + ".log"}},
+      file_path_{settings.container_folder / std::filesystem::path{name_ + ".log"}},
       max_file_size_{settings.max_file_size_mb * kMebi},
       max_files_{settings.max_files},
       rotating_sink_{std::make_shared<spdlog::sinks::rotating_file_sink_mt>(file_path_.string(), max_file_size_, max_files_)},

--- a/silkworm/rpc/common/interface_log.hpp
+++ b/silkworm/rpc/common/interface_log.hpp
@@ -30,7 +30,7 @@ class InterfaceLogImpl;
 struct InterfaceLogSettings {
     bool enabled{false};
     std::string ifc_name;
-    std::string container_folder{"logs/"};
+    std::filesystem::path container_folder{"logs/"};
     std::size_t max_file_size_mb{1};
     std::size_t max_files{100};
     bool auto_flush{false};

--- a/silkworm/rpc/common/interface_log_test.cpp
+++ b/silkworm/rpc/common/interface_log_test.cpp
@@ -32,7 +32,7 @@ TEST_CASE("InterfaceLog basic", "[rpc][common][interface_log]") {
     InterfaceLogSettings settings{
         .enabled = true,
         .ifc_name = "eth_rpc",
-        .container_folder = tmp_dir.string(),
+        .container_folder = tmp_dir,
     };
     auto ifc_log{std::make_unique<InterfaceLog>(settings)};
     REQUIRE(!ifc_log->path().empty());


### PR DESCRIPTION
This PR fixes the error in [Windows build](https://github.com/erigontech/silkworm/actions/runs/8221968635/job/22482956106) surfacing after #1898 by refactoring the `container_folder` type in `rpc::InterfaceLogSettings`.