### PR TITLE
cmake: use absolute path when applying exclude regex

### DIFF
--- a/cmake/common/targets.cmake
+++ b/cmake/common/targets.cmake
@@ -18,7 +18,7 @@ find_package(Catch2 REQUIRED)
 
 macro(list_filter VAR EXCLUDE_REGEX)
   foreach(R IN LISTS ${EXCLUDE_REGEX})
-    list(FILTER ${VAR} EXCLUDE REGEX "${R}")
+    list(FILTER ${VAR} EXCLUDE REGEX "{SILKWORM_SRC_DIR}/${R}")
   endforeach()
 endmacro()
 

--- a/cmake/common/targets.cmake
+++ b/cmake/common/targets.cmake
@@ -18,7 +18,7 @@ find_package(Catch2 REQUIRED)
 
 macro(list_filter VAR EXCLUDE_REGEX)
   foreach(R IN LISTS ${EXCLUDE_REGEX})
-    list(FILTER ${VAR} EXCLUDE REGEX "{SILKWORM_SRC_DIR}/${R}")
+    list(FILTER ${VAR} EXCLUDE REGEX "${SILKWORM_SRC_DIR}/${R}")
   endforeach()
 endmacro()
 

--- a/silkworm/node/CMakeLists.txt
+++ b/silkworm/node/CMakeLists.txt
@@ -54,5 +54,5 @@ silkworm_library(
   silkworm_node
   PUBLIC ${SILKWORM_NODE_PUBLIC_LIBS}
   PRIVATE ${SILKWORM_NODE_PRIVATE_LIBS}
-  EXCLUDE_REGEX "db"
+  EXCLUDE_REGEX "node/db"
 )

--- a/silkworm/node/db/CMakeLists.txt
+++ b/silkworm/node/db/CMakeLists.txt
@@ -47,5 +47,5 @@ silkworm_library(
   silkworm_db
   PUBLIC ${LIBS_PUBLIC}
   PRIVATE ${LIBS_PRIVATE}
-  EXCLUDE_REGEX "db/etl"
+  EXCLUDE_REGEX "node/db/etl"
 )


### PR DESCRIPTION
After #1885 I started to experience linking errors on my machine for targets `snapshots` and `db_toolbox`. The problem was caused by library `silkworm_node` being empty, which in turn was due to a combination of two things:
- one of my Silkworm repo stays in external disk and contains `db` folder in parent path (i.e. `/db/silkworm/...`)
- the exclude regex application in `silkworm_library` CMake function excluded all source files for such weird path

I've added `SILKWORM_SRC_DIR` in each exclude regex token to filter using absolute paths.