### PR TITLE
db: replace HeadInfo with ChainHead

### DIFF
--- a/cmd/dev/backend_kv_server.cpp
+++ b/cmd/dev/backend_kv_server.cpp
@@ -32,7 +32,7 @@
 #include <silkworm/core/types/address.hpp>
 #include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/db/access_layer.hpp>
-#include <silkworm/db/head_info.hpp>
+#include <silkworm/db/chain_head.hpp>
 #include <silkworm/db/mdbx/mdbx.hpp>
 #include <silkworm/infra/common/directories.hpp>
 #include <silkworm/infra/common/log.hpp>
@@ -116,10 +116,10 @@ std::shared_ptr<silkworm::sentry::api::SentryClient> make_sentry_client(
     db::ROAccess db_access) {
     std::shared_ptr<silkworm::sentry::api::SentryClient> sentry_client;
 
-    auto head_info_provider = [db_access = std::move(db_access)]() {
-        return db::read_head_info(db_access);
+    auto chain_head_provider = [db_access = std::move(db_access)]() {
+        return db::read_chain_head(db_access);
     };
-    silkworm::sentry::eth::StatusDataProvider eth_status_data_provider{std::move(head_info_provider), node_settings.chain_config.value()};
+    silkworm::sentry::eth::StatusDataProvider eth_status_data_provider{std::move(chain_head_provider), node_settings.chain_config.value()};
 
     if (node_settings.remote_sentry_addresses.empty()) {
         assert(false);

--- a/cmd/silkworm.cpp
+++ b/cmd/silkworm.cpp
@@ -29,7 +29,7 @@
 #include <boost/asio/use_future.hpp>
 
 #include <silkworm/buildinfo.h>
-#include <silkworm/db/head_info.hpp>
+#include <silkworm/db/chain_head.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/concurrency/awaitable_wait_for_all.hpp>
 #include <silkworm/infra/concurrency/awaitable_wait_for_one.hpp>
@@ -278,10 +278,10 @@ int main(int argc, char* argv[]) {
         settings.sentry_settings.data_dir_path = node_settings.data_directory->path();
         settings.sentry_settings.network_id = node_settings.network_id;
 
-        auto head_info_provider = [db_access = db::ROAccess{chaindata_db}] {
-            return db::read_head_info(db_access);
+        auto chain_head_provider = [db_access = db::ROAccess{chaindata_db}] {
+            return db::read_chain_head(db_access);
         };
-        sentry::eth::StatusDataProvider eth_status_data_provider{std::move(head_info_provider), node_settings.chain_config.value()};
+        sentry::eth::StatusDataProvider eth_status_data_provider{std::move(chain_head_provider), node_settings.chain_config.value()};
 
         auto [sentry_client, sentry_server] = sentry::SentryClientFactory::make_sentry(
             std::move(settings.sentry_settings),

--- a/silkworm/core/types/block.cpp
+++ b/silkworm/core/types/block.cpp
@@ -26,8 +26,6 @@
 
 namespace silkworm {
 
-BlockNum height(const BlockId& b) { return b.number; }
-
 evmc::bytes32 BlockHeader::hash(bool for_sealing, bool exclude_extra_data_sig) const {
     Bytes rlp;
     rlp::encode(rlp, *this, for_sealing, exclude_extra_data_sig);

--- a/silkworm/core/types/block.hpp
+++ b/silkworm/core/types/block.hpp
@@ -36,19 +36,6 @@ namespace silkworm {
 
 using TotalDifficulty = intx::uint256;
 
-struct BlockId {  // TODO(canepat) rename BlockNumberAndHash
-    BlockNum number{};
-    Hash hash;
-};
-
-BlockNum height(const BlockId& b);
-
-struct ChainHead {
-    BlockNum height{};
-    Hash hash;
-    TotalDifficulty total_difficulty{};
-};
-
 struct BlockHeader {
     using NonceType = std::array<uint8_t, 8>;
 
@@ -123,26 +110,5 @@ namespace rlp {
     DecodingResult decode(ByteView& from, BlockHeader& to, Leftover mode = Leftover::kProhibit) noexcept;
     DecodingResult decode(ByteView& from, Block& to, Leftover mode = Leftover::kProhibit) noexcept;
 }  // namespace rlp
-
-// Comparison operator ==
-inline bool operator==(const BlockId& a, const BlockId& b) {
-    return a.number == b.number && a.hash == b.hash;
-}
-
-inline bool operator==(const ChainHead& a, const BlockId& b) {
-    return a.height == b.number && a.hash == b.hash;
-}
-
-inline bool operator==(const BlockId& a, const ChainHead& b) {
-    return a.number == b.height && a.hash == b.hash;
-}
-
-inline bool operator==(const ChainHead& a, const ChainHead& b) {
-    return a.height == b.height && a.hash == b.hash && a.total_difficulty == b.total_difficulty;
-}
-
-inline BlockId to_BlockId(const ChainHead& head) {
-    return {.number = head.height, .hash = head.hash};
-}
 
 }  // namespace silkworm

--- a/silkworm/core/types/block_id.hpp
+++ b/silkworm/core/types/block_id.hpp
@@ -16,12 +16,17 @@
 
 #pragma once
 
-#include <silkworm/core/types/head_info.hpp>
-#include <silkworm/db/mdbx/mdbx.hpp>
+#include <silkworm/core/common/base.hpp>
+#include <silkworm/core/types/hash.hpp>
 
-namespace silkworm::db {
+namespace silkworm {
 
-HeadInfo read_head_info(ROTxn& txn);
-HeadInfo read_head_info(db::ROAccess db_access);
+// TODO(canepat) rename BlockNumberAndHash
+struct BlockId {
+    BlockNum number{};
+    Hash hash;
 
-}  // namespace silkworm::db
+    friend bool operator==(const BlockId&, const BlockId&) = default;
+};
+
+}  // namespace silkworm

--- a/silkworm/core/types/chain_head.hpp
+++ b/silkworm/core/types/chain_head.hpp
@@ -20,14 +20,29 @@
 
 #include <silkworm/core/common/base.hpp>
 
+#include "block_id.hpp"
 #include "hash.hpp"
 
 namespace silkworm {
 
-struct HeadInfo {
-    BlockNum block_num{0};
+struct ChainHead {
+    BlockNum height{0};
     Hash hash;
     intx::uint256 total_difficulty;
+
+    friend bool operator==(const ChainHead&, const ChainHead&) = default;
 };
+
+inline bool operator==(const ChainHead& a, const BlockId& b) {
+    return a.height == b.number && a.hash == b.hash;
+}
+
+inline bool operator==(const BlockId& a, const ChainHead& b) {
+    return a.number == b.height && a.hash == b.hash;
+}
+
+inline BlockId to_BlockId(const ChainHead& head) {
+    return {.number = head.height, .hash = head.hash};
+}
 
 }  // namespace silkworm

--- a/silkworm/db/chain_head.hpp
+++ b/silkworm/db/chain_head.hpp
@@ -1,0 +1,27 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <silkworm/core/types/chain_head.hpp>
+#include <silkworm/db/mdbx/mdbx.hpp>
+
+namespace silkworm::db {
+
+ChainHead read_chain_head(ROTxn& txn);
+ChainHead read_chain_head(db::ROAccess db_access);
+
+}  // namespace silkworm::db

--- a/silkworm/node/stagedsync/client.hpp
+++ b/silkworm/node/stagedsync/client.hpp
@@ -21,6 +21,7 @@
 #include <boost/asio/io_context.hpp>
 
 #include <silkworm/core/types/block.hpp>
+#include <silkworm/core/types/block_id.hpp>
 #include <silkworm/node/stagedsync/types.hpp>
 
 namespace silkworm::execution {

--- a/silkworm/node/stagedsync/forks/canonical_chain.hpp
+++ b/silkworm/node/stagedsync/forks/canonical_chain.hpp
@@ -24,6 +24,7 @@
 
 #include <silkworm/core/common/lru_cache.hpp>
 #include <silkworm/core/types/block.hpp>
+#include <silkworm/core/types/block_id.hpp>
 #include <silkworm/db/access_layer.hpp>
 #include <silkworm/db/stage.hpp>
 #include <silkworm/node/stagedsync/execution_pipeline.hpp>

--- a/silkworm/sentry/eth/status_data_provider.hpp
+++ b/silkworm/sentry/eth/status_data_provider.hpp
@@ -21,7 +21,7 @@
 #include <silkworm/infra/concurrency/task.hpp>
 
 #include <silkworm/core/chain/config.hpp>
-#include <silkworm/core/types/head_info.hpp>
+#include <silkworm/core/types/chain_head.hpp>
 
 #include "status_data.hpp"
 
@@ -30,9 +30,9 @@ namespace silkworm::sentry::eth {
 class StatusDataProvider {
   public:
     StatusDataProvider(
-        std::function<HeadInfo()> head_info_provider,
+        std::function<ChainHead()> chain_head_provider,
         const ChainConfig& chain_config)
-        : head_info_provider_(std::move(head_info_provider)),
+        : chain_head_provider_(std::move(chain_head_provider)),
           chain_config_(chain_config) {}
 
     using StatusData = silkworm::sentry::eth::StatusData;
@@ -43,11 +43,11 @@ class StatusDataProvider {
 
   private:
     static StatusData make_status_data(
-        HeadInfo head_info,
+        ChainHead chain_head,
         uint8_t eth_version,
         const ChainConfig& chain_config);
 
-    std::function<HeadInfo()> head_info_provider_;
+    std::function<ChainHead()> chain_head_provider_;
     const ChainConfig& chain_config_;
 };
 

--- a/silkworm/sync/internals/chain_fork_view.hpp
+++ b/silkworm/sync/internals/chain_fork_view.hpp
@@ -20,6 +20,7 @@
 
 #include <silkworm/core/common/lru_cache.hpp>
 #include <silkworm/core/types/block.hpp>
+#include <silkworm/core/types/chain_head.hpp>
 #include <silkworm/sync/internals/types.hpp>
 
 namespace silkworm::chainsync {

--- a/silkworm/sync/internals/header_chain_plus_exec_test.cpp
+++ b/silkworm/sync/internals/header_chain_plus_exec_test.cpp
@@ -92,7 +92,7 @@ TEST_CASE("Headers receiving and saving") {
     auto& tx = exec_engine.main_chain_.tx();  // mdbx refuses to open a ROTxn when there is a RWTxn in the same thread
 
     auto head = exec_engine.last_fork_choice();
-    REQUIRE(height(head) == 0);
+    REQUIRE(head.number == 0);
 
     std::vector<BlockHeader> last_headers = exec_engine.get_last_headers(1);
     REQUIRE(last_headers.size() == 1);

--- a/silkworm/sync/sync_pow.cpp
+++ b/silkworm/sync/sync_pow.cpp
@@ -51,9 +51,9 @@ PoWSync::NewHeight PoWSync::resume() {  // find the point (head) where we left o
     auto last_fcu = sync_wait(in(exec_engine_), exec_engine_.last_fork_choice());  // previously was get_canonical_head()
     auto block_progress = sync_wait(in(exec_engine_), exec_engine_.block_progress());
 
-    ensure_invariant(height(last_fcu) <= block_progress, "canonical head beyond block progress");
+    ensure_invariant(last_fcu.number <= block_progress, "canonical head beyond block progress");
 
-    if (block_progress == height(last_fcu)) {
+    if (block_progress == last_fcu.number) {
         // if fcu and header progress match than we have the actual canonical, we only need to do a forward sync...
         ensure_invariant(last_fcu == chain_fork_view_.head(), "last fcu misaligned with canonical head");
         chain_fork_view_.reset_head({last_fcu.number, last_fcu.hash,


### PR DESCRIPTION
HeadInfo was identical to an existing ChainHead type. Let's use it instead of defining a new type.
