### PR TITLE
snapshots: refactorings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -11,6 +11,7 @@ Checks: >
   -bugprone-unchecked-optional-access,
   -bugprone-unused-raii,
   cert-*,
+  -cert-dcl21-cpp,
   -cert-err58-cpp,
   -clang-analyzer-*,
   clang-diagnostic-*,

--- a/cmd/capi/execute.cpp
+++ b/cmd/capi/execute.cpp
@@ -158,12 +158,12 @@ std::vector<SilkwormChainSnapshot> collect_all_snapshots(const SnapshotRepositor
                 SilkwormHeadersSnapshot raw_headers_snapshot{
                     .segment{
                         .file_path = make_path(segment_file),
-                        .memory_address = header_snapshot->memory_file_address(),
-                        .memory_length = header_snapshot->memory_file_size()},
+                        .memory_address = header_snapshot->memory_file_region().data(),
+                        .memory_length = header_snapshot->memory_file_region().size()},
                     .header_hash_index{
                         .file_path = make_path(segment_file.index_file()),
-                        .memory_address = idx_header_hash->memory_file_address(),
-                        .memory_length = idx_header_hash->memory_file_size()}};
+                        .memory_address = idx_header_hash->memory_file_region().data(),
+                        .memory_length = idx_header_hash->memory_file_region().size()}};
                 headers_snapshot_sequence.push_back(raw_headers_snapshot);
             } break;
             case SnapshotType::bodies: {
@@ -172,12 +172,12 @@ std::vector<SilkwormChainSnapshot> collect_all_snapshots(const SnapshotRepositor
                 SilkwormBodiesSnapshot raw_bodies_snapshot{
                     .segment{
                         .file_path = make_path(segment_file),
-                        .memory_address = body_snapshot->memory_file_address(),
-                        .memory_length = body_snapshot->memory_file_size()},
+                        .memory_address = body_snapshot->memory_file_region().data(),
+                        .memory_length = body_snapshot->memory_file_region().size()},
                     .block_num_index{
                         .file_path = make_path(segment_file.index_file()),
-                        .memory_address = idx_body_number->memory_file_address(),
-                        .memory_length = idx_body_number->memory_file_size()}};
+                        .memory_address = idx_body_number->memory_file_region().data(),
+                        .memory_length = idx_body_number->memory_file_region().size()}};
                 bodies_snapshot_sequence.push_back(raw_bodies_snapshot);
             } break;
             case SnapshotType::transactions: {
@@ -187,16 +187,16 @@ std::vector<SilkwormChainSnapshot> collect_all_snapshots(const SnapshotRepositor
                 SilkwormTransactionsSnapshot raw_transactions_snapshot{
                     .segment{
                         .file_path = make_path(segment_file),
-                        .memory_address = tx_snapshot->memory_file_address(),
-                        .memory_length = tx_snapshot->memory_file_size()},
+                        .memory_address = tx_snapshot->memory_file_region().data(),
+                        .memory_length = tx_snapshot->memory_file_region().size()},
                     .tx_hash_index{
                         .file_path = make_path(segment_file.index_file()),
-                        .memory_address = idx_txn_hash->memory_file_address(),
-                        .memory_length = idx_txn_hash->memory_file_size()},
+                        .memory_address = idx_txn_hash->memory_file_region().data(),
+                        .memory_length = idx_txn_hash->memory_file_region().size()},
                     .tx_hash_2_block_index{
                         .file_path = make_path(segment_file.index_file_for_type(SnapshotType::transactions_to_block)),
-                        .memory_address = idx_txn_hash_2_block->memory_file_address(),
-                        .memory_length = idx_txn_hash_2_block->memory_file_size()}};
+                        .memory_address = idx_txn_hash_2_block->memory_file_region().data(),
+                        .memory_length = idx_txn_hash_2_block->memory_file_region().size()}};
                 transactions_snapshot_sequence.push_back(raw_transactions_snapshot);
             } break;
             default:
@@ -351,10 +351,11 @@ int build_indexes(SilkwormHandle handle, const BuildIndexesSettings& settings, c
             throw std::runtime_error("Snapshot not found in the repository:" + snapshot_name);
         }
 
-        auto mmf = new SilkwormMemoryMappedFile();
-        mmf->file_path = make_path(snapshot->path());
-        mmf->memory_address = snapshot->memory_file_address();
-        mmf->memory_length = snapshot->memory_file_size();
+        auto mmf = new SilkwormMemoryMappedFile{
+            .file_path = make_path(snapshot->path()),
+            .memory_address = snapshot->memory_file_region().data(),
+            .memory_length = snapshot->memory_file_region().size(),
+        };
         snapshots.push_back(mmf);
     }
 

--- a/cmd/dev/backend_kv_server.cpp
+++ b/cmd/dev/backend_kv_server.cpp
@@ -32,7 +32,7 @@
 #include <silkworm/core/types/address.hpp>
 #include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/db/access_layer.hpp>
-#include <silkworm/db/head_info.hpp>
+#include <silkworm/db/chain_head.hpp>
 #include <silkworm/db/mdbx/mdbx.hpp>
 #include <silkworm/infra/common/directories.hpp>
 #include <silkworm/infra/common/log.hpp>
@@ -116,10 +116,10 @@ std::shared_ptr<silkworm::sentry::api::SentryClient> make_sentry_client(
     db::ROAccess db_access) {
     std::shared_ptr<silkworm::sentry::api::SentryClient> sentry_client;
 
-    auto head_info_provider = [db_access = std::move(db_access)]() {
-        return db::read_head_info(db_access);
+    auto chain_head_provider = [db_access = std::move(db_access)]() {
+        return db::read_chain_head(db_access);
     };
-    silkworm::sentry::eth::StatusDataProvider eth_status_data_provider{std::move(head_info_provider), node_settings.chain_config.value()};
+    silkworm::sentry::eth::StatusDataProvider eth_status_data_provider{std::move(chain_head_provider), node_settings.chain_config.value()};
 
     if (node_settings.remote_sentry_addresses.empty()) {
         assert(false);

--- a/cmd/silkworm.cpp
+++ b/cmd/silkworm.cpp
@@ -29,7 +29,7 @@
 #include <boost/asio/use_future.hpp>
 
 #include <silkworm/buildinfo.h>
-#include <silkworm/db/head_info.hpp>
+#include <silkworm/db/chain_head.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/concurrency/awaitable_wait_for_all.hpp>
 #include <silkworm/infra/concurrency/awaitable_wait_for_one.hpp>
@@ -278,10 +278,10 @@ int main(int argc, char* argv[]) {
         settings.sentry_settings.data_dir_path = node_settings.data_directory->path();
         settings.sentry_settings.network_id = node_settings.network_id;
 
-        auto head_info_provider = [db_access = db::ROAccess{chaindata_db}] {
-            return db::read_head_info(db_access);
+        auto chain_head_provider = [db_access = db::ROAccess{chaindata_db}] {
+            return db::read_chain_head(db_access);
         };
-        sentry::eth::StatusDataProvider eth_status_data_provider{std::move(head_info_provider), node_settings.chain_config.value()};
+        sentry::eth::StatusDataProvider eth_status_data_provider{std::move(chain_head_provider), node_settings.chain_config.value()};
 
         auto [sentry_client, sentry_server] = sentry::SentryClientFactory::make_sentry(
             std::move(settings.sentry_settings),

--- a/silkworm/capi/silkworm_test.cpp
+++ b/silkworm/capi/silkworm_test.cpp
@@ -426,42 +426,42 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_add_snapshot", "[silkworm][capi]") {
     SilkwormHeadersSnapshot valid_shs{
         .segment = SilkwormMemoryMappedFile{
             .file_path = header_snapshot_path_string.c_str(),
-            .memory_address = header_snapshot.memory_file_address(),
-            .memory_length = header_snapshot.memory_file_size(),
+            .memory_address = header_snapshot.memory_file_region().data(),
+            .memory_length = header_snapshot.memory_file_region().size(),
         },
         .header_hash_index = SilkwormMemoryMappedFile{
             .file_path = header_index_path_string.c_str(),
-            .memory_address = header_snapshot.idx_header_hash()->memory_file_address(),
-            .memory_length = header_snapshot.idx_header_hash()->memory_file_size(),
+            .memory_address = header_snapshot.idx_header_hash()->memory_file_region().data(),
+            .memory_length = header_snapshot.idx_header_hash()->memory_file_region().size(),
         },
     };
     SilkwormBodiesSnapshot valid_sbs{
         .segment = SilkwormMemoryMappedFile{
             .file_path = body_snapshot_path_string.c_str(),
-            .memory_address = body_snapshot.memory_file_address(),
-            .memory_length = body_snapshot.memory_file_size(),
+            .memory_address = body_snapshot.memory_file_region().data(),
+            .memory_length = body_snapshot.memory_file_region().size(),
         },
         .block_num_index = SilkwormMemoryMappedFile{
             .file_path = body_index_path_string.c_str(),
-            .memory_address = body_snapshot.idx_body_number()->memory_file_address(),
-            .memory_length = body_snapshot.idx_body_number()->memory_file_size(),
+            .memory_address = body_snapshot.idx_body_number()->memory_file_region().data(),
+            .memory_length = body_snapshot.idx_body_number()->memory_file_region().size(),
         },
     };
     SilkwormTransactionsSnapshot valid_sts{
         .segment = SilkwormMemoryMappedFile{
             .file_path = tx_snapshot_path_string.c_str(),
-            .memory_address = tx_snapshot.memory_file_address(),
-            .memory_length = tx_snapshot.memory_file_size(),
+            .memory_address = tx_snapshot.memory_file_region().data(),
+            .memory_length = tx_snapshot.memory_file_region().size(),
         },
         .tx_hash_index = SilkwormMemoryMappedFile{
             .file_path = tx_hash_index_path_string.c_str(),
-            .memory_address = tx_snapshot.idx_txn_hash()->memory_file_address(),
-            .memory_length = tx_snapshot.idx_txn_hash()->memory_file_size(),
+            .memory_address = tx_snapshot.idx_txn_hash()->memory_file_region().data(),
+            .memory_length = tx_snapshot.idx_txn_hash()->memory_file_region().size(),
         },
         .tx_hash_2_block_index = SilkwormMemoryMappedFile{
             .file_path = tx_hash2block_index_path_string.c_str(),
-            .memory_address = tx_snapshot.idx_txn_hash_2_block()->memory_file_address(),
-            .memory_length = tx_snapshot.idx_txn_hash_2_block()->memory_file_size(),
+            .memory_address = tx_snapshot.idx_txn_hash_2_block()->memory_file_region().data(),
+            .memory_length = tx_snapshot.idx_txn_hash_2_block()->memory_file_region().size(),
         },
     };
 

--- a/silkworm/core/types/block.cpp
+++ b/silkworm/core/types/block.cpp
@@ -26,8 +26,6 @@
 
 namespace silkworm {
 
-BlockNum height(const BlockId& b) { return b.number; }
-
 evmc::bytes32 BlockHeader::hash(bool for_sealing, bool exclude_extra_data_sig) const {
     Bytes rlp;
     rlp::encode(rlp, *this, for_sealing, exclude_extra_data_sig);

--- a/silkworm/core/types/block.hpp
+++ b/silkworm/core/types/block.hpp
@@ -36,19 +36,6 @@ namespace silkworm {
 
 using TotalDifficulty = intx::uint256;
 
-struct BlockId {  // TODO(canepat) rename BlockNumberAndHash
-    BlockNum number{};
-    Hash hash;
-};
-
-BlockNum height(const BlockId& b);
-
-struct ChainHead {
-    BlockNum height{};
-    Hash hash;
-    TotalDifficulty total_difficulty{};
-};
-
 struct BlockHeader {
     using NonceType = std::array<uint8_t, 8>;
 
@@ -123,26 +110,5 @@ namespace rlp {
     DecodingResult decode(ByteView& from, BlockHeader& to, Leftover mode = Leftover::kProhibit) noexcept;
     DecodingResult decode(ByteView& from, Block& to, Leftover mode = Leftover::kProhibit) noexcept;
 }  // namespace rlp
-
-// Comparison operator ==
-inline bool operator==(const BlockId& a, const BlockId& b) {
-    return a.number == b.number && a.hash == b.hash;
-}
-
-inline bool operator==(const ChainHead& a, const BlockId& b) {
-    return a.height == b.number && a.hash == b.hash;
-}
-
-inline bool operator==(const BlockId& a, const ChainHead& b) {
-    return a.number == b.height && a.hash == b.hash;
-}
-
-inline bool operator==(const ChainHead& a, const ChainHead& b) {
-    return a.height == b.height && a.hash == b.hash && a.total_difficulty == b.total_difficulty;
-}
-
-inline BlockId to_BlockId(const ChainHead& head) {
-    return {.number = head.height, .hash = head.hash};
-}
 
 }  // namespace silkworm

--- a/silkworm/core/types/block_id.hpp
+++ b/silkworm/core/types/block_id.hpp
@@ -16,12 +16,17 @@
 
 #pragma once
 
-#include <silkworm/core/types/head_info.hpp>
-#include <silkworm/db/mdbx/mdbx.hpp>
+#include <silkworm/core/common/base.hpp>
+#include <silkworm/core/types/hash.hpp>
 
-namespace silkworm::db {
+namespace silkworm {
 
-HeadInfo read_head_info(ROTxn& txn);
-HeadInfo read_head_info(db::ROAccess db_access);
+// TODO(canepat) rename BlockNumberAndHash
+struct BlockId {
+    BlockNum number{};
+    Hash hash;
 
-}  // namespace silkworm::db
+    friend bool operator==(const BlockId&, const BlockId&) = default;
+};
+
+}  // namespace silkworm

--- a/silkworm/core/types/chain_head.hpp
+++ b/silkworm/core/types/chain_head.hpp
@@ -20,14 +20,29 @@
 
 #include <silkworm/core/common/base.hpp>
 
+#include "block_id.hpp"
 #include "hash.hpp"
 
 namespace silkworm {
 
-struct HeadInfo {
-    BlockNum block_num{0};
+struct ChainHead {
+    BlockNum height{0};
     Hash hash;
     intx::uint256 total_difficulty;
+
+    friend bool operator==(const ChainHead&, const ChainHead&) = default;
 };
+
+inline bool operator==(const ChainHead& a, const BlockId& b) {
+    return a.height == b.number && a.hash == b.hash;
+}
+
+inline bool operator==(const BlockId& a, const ChainHead& b) {
+    return a.number == b.height && a.hash == b.hash;
+}
+
+inline BlockId to_BlockId(const ChainHead& head) {
+    return {.number = head.height, .hash = head.hash};
+}
 
 }  // namespace silkworm

--- a/silkworm/db/chain_head.hpp
+++ b/silkworm/db/chain_head.hpp
@@ -1,0 +1,27 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <silkworm/core/types/chain_head.hpp>
+#include <silkworm/db/mdbx/mdbx.hpp>
+
+namespace silkworm::db {
+
+ChainHead read_chain_head(ROTxn& txn);
+ChainHead read_chain_head(db::ROAccess db_access);
+
+}  // namespace silkworm::db

--- a/silkworm/db/snapshots/index.cpp
+++ b/silkworm/db/snapshots/index.cpp
@@ -74,14 +74,14 @@ bool HeaderIndex::walk(RecSplit8& rec_split, uint64_t i, uint64_t offset, ByteVi
     const ethash::hash256 hash = keccak256(rlp_encoded_header);
     ensure(hash.bytes[0] == first_hash_byte,
            [&]() { return "HeaderIndex: invalid prefix=" + to_hex(first_hash_byte) + " hash=" + to_hex(hash.bytes); });
-    rec_split.add_key(hash.bytes, kHashLength, offset);
+    rec_split.add_key(ByteView{hash.bytes}, offset);
     return true;
 }
 
 bool BodyIndex::walk(RecSplit8& rec_split, uint64_t i, uint64_t offset, ByteView /*word*/) {
     Bytes uint64_buffer;
     seg::varint::encode(uint64_buffer, i);
-    rec_split.add_key(uint64_buffer.data(), uint64_buffer.size(), offset);
+    rec_split.add_key(uint64_buffer, offset);
     return true;
 }
 
@@ -262,7 +262,7 @@ void TransactionIndex::build() {
                         throw std::runtime_error{error.str()};
                     }
 
-                    tx_hash_to_block_rs.add_key(tx_hash.bytes, kHashLength, block_number);
+                    tx_hash_to_block_rs.add_key(tx_hash, block_number);
                     i++;
                 }
 
@@ -291,7 +291,7 @@ bool TransactionIndex::walk(RecSplit8& rec_split, uint64_t i, uint64_t offset, B
         throw std::runtime_error{error.str()};
     }
 
-    rec_split.add_key(tx_hash.bytes, kHashLength, offset);
+    rec_split.add_key(tx_hash, offset);
     return true;
 }
 

--- a/silkworm/db/snapshots/index.hpp
+++ b/silkworm/db/snapshots/index.hpp
@@ -19,6 +19,7 @@
 #include <memory>
 #include <utility>
 
+#include <silkworm/db/etl/collector.hpp>
 #include <silkworm/db/snapshots/path.hpp>
 #include <silkworm/db/snapshots/rec_split/rec_split.hpp>
 #include <silkworm/db/snapshots/seg/decompressor.hpp>
@@ -31,8 +32,15 @@ class Index {
     static inline const auto kPageSize{os::page_size()};
     static constexpr std::size_t kBucketSize{2'000};
 
-    explicit Index(SnapshotPath segment_path, std::optional<MemoryMappedRegion> segment_region = {})
-        : segment_path_(std::move(segment_path)), segment_region_{segment_region} {}
+    explicit Index(
+        SnapshotPath segment_path,
+        std::optional<MemoryMappedRegion> segment_region = std::nullopt,
+        size_t etl_buffer_size = db::etl::kOptimalBufferSize)
+        : segment_path_(std::move(segment_path)),
+          segment_region_(segment_region),
+          base_data_id_(path().block_from()),
+          less_false_positives_(false),
+          etl_buffer_size_(etl_buffer_size) {}
     virtual ~Index() = default;
 
     [[nodiscard]] SnapshotPath path() const { return segment_path_.index_file(); }
@@ -44,6 +52,9 @@ class Index {
 
     SnapshotPath segment_path_;
     std::optional<MemoryMappedRegion> segment_region_;
+    uint64_t base_data_id_;
+    bool less_false_positives_;
+    size_t etl_buffer_size_;
 };
 
 class HeaderIndex : public Index {
@@ -73,6 +84,11 @@ class TransactionIndex : public Index {
 
   protected:
     bool walk(rec_split::RecSplit8& rec_split, uint64_t i, uint64_t offset, ByteView word) override;
+
+  private:
+    SnapshotPath bodies_segment_path() const;
+    std::pair<uint64_t, uint64_t> compute_txs_amount();
+    uint64_t read_tx_count();
 };
 
 }  // namespace silkworm::snapshots

--- a/silkworm/db/snapshots/index_test.cpp
+++ b/silkworm/db/snapshots/index_test.cpp
@@ -150,7 +150,7 @@ TEST_CASE("TransactionIndex::build KO: invalid snapshot", "[silkworm][snapshot][
         };
         test::SampleTransactionSnapshotPath txs_snapshot_path{invalid_txs_snapshot.path()};  // necessary to tweak the block numbers
         TransactionIndex tx_index{txs_snapshot_path};
-        CHECK_THROWS_AS(tx_index.build(), std::runtime_error);
+        CHECK_THROWS_AS(tx_index.build(), std::logic_error);
     }
 }
 

--- a/silkworm/db/snapshots/seg/seg_zip.cpp
+++ b/silkworm/db/snapshots/seg/seg_zip.cpp
@@ -49,15 +49,9 @@ void seg_unzip(const std::filesystem::path& path) {
     out_path.replace_extension("idt");
     RawWordsStream words{out_path, RawWordsStream::OpenMode::kCreate, 1_Mebi};
 
-    decompressor.read_ahead([&](Decompressor::Iterator it) -> bool {
-        Bytes word;
-        while (it.has_next()) {
-            word.clear();
-            it.next(word);
-            words.write_word(word);
-        }
-        return true;
-    });
+    for (auto& word : decompressor) {
+        words.write_word(word);
+    }
 }
 
 }  // namespace silkworm::snapshots::seg

--- a/silkworm/db/snapshots/snapshot.cpp
+++ b/silkworm/db/snapshots/snapshot.cpp
@@ -43,16 +43,10 @@ Snapshot::Snapshot(SnapshotPath path)
 Snapshot::Snapshot(SnapshotPath path, MemoryMappedRegion segment_region)
     : path_(std::move(path)), decoder_{path_.path(), segment_region} {}
 
-uint8_t* Snapshot::memory_file_address() const {
+MemoryMappedRegion Snapshot::memory_file_region() const {
     const auto memory_file{decoder_.memory_file()};
-    if (!memory_file) return nullptr;
-    return memory_file->address();
-}
-
-std::size_t Snapshot::memory_file_size() const {
-    const auto memory_file{decoder_.memory_file()};
-    if (!memory_file) return 0;
-    return memory_file->length();
+    if (!memory_file) return MemoryMappedRegion{};
+    return memory_file->region();
 }
 
 void Snapshot::reopen_segment() {

--- a/silkworm/db/snapshots/snapshot.hpp
+++ b/silkworm/db/snapshots/snapshot.hpp
@@ -73,8 +73,7 @@ class Snapshot {
     [[nodiscard]] bool empty() const { return item_count() == 0; }
     [[nodiscard]] std::size_t item_count() const { return decoder_.words_count(); }
 
-    [[nodiscard]] uint8_t* memory_file_address() const;
-    [[nodiscard]] std::size_t memory_file_size() const;
+    [[nodiscard]] MemoryMappedRegion memory_file_region() const;
 
     void reopen_segment();
     virtual void reopen_index() = 0;

--- a/silkworm/db/snapshots/snapshot_decompressor_test.cpp
+++ b/silkworm/db/snapshots/snapshot_decompressor_test.cpp
@@ -229,7 +229,7 @@ TEST_CASE("Decompressor::Decompressor from memory", "[silkworm][node][seg][decom
     SetLogVerbosityGuard guard{log::Level::kNone};
     test::TemporarySnapshotFile tmp_snapshot{create_nonempty_snapshot_file()};
     MemoryMappedFile mmf{tmp_snapshot.path()};
-    Decompressor decoder_from_memory{tmp_snapshot.path(), MemoryMappedRegion{mmf.address(), mmf.length()}};
+    Decompressor decoder_from_memory{tmp_snapshot.path(), mmf.region()};
     CHECK(!decoder_from_memory.is_open());
     CHECK(decoder_from_memory.compressed_path() == tmp_snapshot.path());
     CHECK(decoder_from_memory.words_count() == 0);

--- a/silkworm/db/snapshots/snapshot_decompressor_test.cpp
+++ b/silkworm/db/snapshots/snapshot_decompressor_test.cpp
@@ -329,21 +329,15 @@ TEST_CASE("Decompressor::open valid files", "[silkworm][node][seg][decompressor]
     }
 }
 
-TEST_CASE("Decompressor::read_ahead", "[silkworm][node][seg][decompressor]") {
+TEST_CASE("Decompressor::begin", "[silkworm][node][seg][decompressor]") {
     SetLogVerbosityGuard guard{log::Level::kNone};
     test::TemporarySnapshotFile tmp_snapshot{create_nonempty_snapshot_file()};
     Decompressor decoder{tmp_snapshot.path()};
     CHECK_NOTHROW(decoder.open());
 
-    for (const bool b : std::vector<bool>{true, false}) {
-        SECTION("check returned value: " + std::to_string(b)) {
-            CHECK_NOTHROW(decoder.read_ahead([=](auto) -> bool { return b; }) == b);
-        }
-    }
-
     SECTION("failure after close") {
         decoder.close();
-        CHECK_THROWS_AS(decoder.read_ahead([](auto) -> bool { return false; }), std::logic_error);
+        CHECK_THROWS_AS(decoder.begin(), std::logic_error);
     }
 }
 
@@ -372,48 +366,24 @@ TEST_CASE("Iterator::Iterator empty data", "[silkworm][node][seg][decompressor]"
     CHECK_NOTHROW(decoder.open());
 
     SECTION("data_size") {
-        const auto read_function = [](const auto it) -> bool {
-            CHECK(it.data_size() == 0);
-            return true;
-        };
-        CHECK_NOTHROW(decoder.read_ahead(read_function));
+        CHECK(decoder.make_iterator().data_size() == 0);
     }
     SECTION("has_next") {
-        const auto read_function = [](const auto it) -> bool {
-            CHECK_FALSE(it.has_next());
-            return true;
-        };
-        CHECK_NOTHROW(decoder.read_ahead(read_function));
+        CHECK_FALSE(decoder.make_iterator().has_next());
     }
     SECTION("next") {
-        const auto read_function = [](auto it) -> bool {
-            silkworm::Bytes buffer{};
-            CHECK_THROWS_AS(it.next(buffer), std::runtime_error);
-            return true;
-        };
-        CHECK_NOTHROW(decoder.read_ahead(read_function));
+        silkworm::Bytes buffer;
+        CHECK_THROWS_AS(decoder.make_iterator().next(buffer), std::runtime_error);
     }
     SECTION("next_uncompressed") {
-        const auto read_function = [](auto it) -> bool {
-            silkworm::Bytes buffer{};
-            CHECK_THROWS_AS(it.next_uncompressed(buffer), std::runtime_error);
-            return true;
-        };
-        CHECK_NOTHROW(decoder.read_ahead(read_function));
+        silkworm::Bytes buffer;
+        CHECK_THROWS_AS(decoder.make_iterator().next_uncompressed(buffer), std::runtime_error);
     }
     SECTION("skip") {
-        const auto read_function = [](auto it) -> bool {
-            CHECK_THROWS_AS(it.skip(), std::runtime_error);
-            return true;
-        };
-        CHECK_NOTHROW(decoder.read_ahead(read_function));
+        CHECK_THROWS_AS(decoder.make_iterator().skip(), std::runtime_error);
     }
     SECTION("skip_uncompressed") {
-        const auto read_function = [](auto it) -> bool {
-            CHECK_THROWS_AS(it.skip_uncompressed(), std::runtime_error);
-            return true;
-        };
-        CHECK_NOTHROW(decoder.read_ahead(read_function));
+        CHECK_THROWS_AS(decoder.make_iterator().skip_uncompressed(), std::runtime_error);
     }
 }
 
@@ -456,8 +426,9 @@ TEST_CASE("Decompressor: lorem ipsum next_uncompressed", "[silkworm][node][seg][
     Decompressor decoder{tmp_file.path()};
     CHECK_NOTHROW(decoder.open());
 
-    auto test_function = [&](auto it) {
+    {
         std::size_t i{0};
+        auto it = decoder.make_iterator();
         while (it.has_next() && i < kLoremIpsumWords.size()) {
             if (i % 2 == 0) {
                 it.skip_uncompressed();
@@ -472,14 +443,7 @@ TEST_CASE("Decompressor: lorem ipsum next_uncompressed", "[silkworm][node][seg][
         }
         CHECK_FALSE(it.has_next());
         CHECK(i == kLoremIpsumWords.size());
-        return true;
-    };
-    // Apply function using Decompressor::read_ahead
-    decoder.read_ahead(test_function);
-
-    // Obtain an iterator and manually apply function
-    auto it = decoder.make_iterator();
-    CHECK(test_function(it));
+    }
 }
 
 TEST_CASE("Decompressor: lorem ipsum next", "[silkworm][node][seg][decompressor]") {
@@ -489,8 +453,9 @@ TEST_CASE("Decompressor: lorem ipsum next", "[silkworm][node][seg][decompressor]
     Decompressor decoder{tmp_file.path()};
     CHECK_NOTHROW(decoder.open());
 
-    auto test_function = [&](auto it) {
+    {
         std::size_t i{0};
+        auto it = decoder.make_iterator();
         while (it.has_next() && i < kLoremIpsumWords.size()) {
             if (i % 2 == 0) {
                 it.skip();
@@ -505,14 +470,7 @@ TEST_CASE("Decompressor: lorem ipsum next", "[silkworm][node][seg][decompressor]
         }
         CHECK_FALSE(it.has_next());
         CHECK(i == kLoremIpsumWords.size());
-        return true;
-    };
-    // Apply function using Decompressor::read_ahead
-    decoder.read_ahead(test_function);
-
-    // Obtain an iterator and manually apply function
-    auto it = decoder.make_iterator();
-    CHECK(test_function(it));
+    }
 }
 
 TEST_CASE("Decompressor: lorem ipsum has_prefix", "[silkworm][node][seg][decompressor]") {
@@ -522,8 +480,9 @@ TEST_CASE("Decompressor: lorem ipsum has_prefix", "[silkworm][node][seg][decompr
     Decompressor decoder{tmp_file.path()};
     CHECK_NOTHROW(decoder.open());
 
-    auto test_function = [&](auto it) {
+    {
         std::size_t i{0};
+        auto it = decoder.make_iterator();
         while (it.has_next() && i < kLoremIpsumWords.size()) {
             const std::string word_plus_index{kLoremIpsumWords[i] + " " + std::to_string(i)};
             const Bytes expected_word{word_plus_index.cbegin(), word_plus_index.cend()};
@@ -537,14 +496,7 @@ TEST_CASE("Decompressor: lorem ipsum has_prefix", "[silkworm][node][seg][decompr
             ++i;
         }
         CHECK(i == kLoremIpsumWords.size());
-        return true;
-    };
-    // Apply function using Decompressor::read_ahead
-    decoder.read_ahead(test_function);
-
-    // Obtain an iterator and manually apply function
-    auto it = decoder.make_iterator();
-    CHECK(test_function(it));
+    }
 }
 
 }  // namespace silkworm::snapshots

--- a/silkworm/infra/common/memory_mapped_file.cpp
+++ b/silkworm/infra/common/memory_mapped_file.cpp
@@ -43,10 +43,9 @@ MemoryMappedFile::MemoryMappedFile(std::filesystem::path path, std::optional<Mem
     ensure(std::filesystem::is_regular_file(path_), [&]() { return "MemoryMappedFile: " + path_.string() + " is not regular file"; });
 
     if (region) {
-        ensure(region->address != nullptr, "MemoryMappedFile: address is null");
-        ensure(region->length > 0, "MemoryMappedFile: length is zero");
-        address_ = region->address;
-        length_ = region->length;
+        ensure(region->data() != nullptr, "MemoryMappedFile: address is null");
+        ensure(!region->empty(), "MemoryMappedFile: length is zero");
+        region_ = *region;
     } else {
         map_existing(read_only);
     }
@@ -84,9 +83,10 @@ void MemoryMappedFile::map_existing(bool read_only) {
 
     [[maybe_unused]] auto _ = gsl::finally([fd]() { if (INVALID_HANDLE_VALUE != fd) ::CloseHandle(fd); });
 
-    length_ = std::filesystem::file_size(path_);
+    auto size = std::filesystem::file_size(path_);
+    auto address = static_cast<uint8_t*>(mmap(fd, size, read_only));
+    region_ = {address, size};
 
-    address_ = static_cast<uint8_t*>(mmap(fd, read_only));
     fd = INVALID_HANDLE_VALUE;
 }
 
@@ -99,7 +99,7 @@ void MemoryMappedFile::advise_random() {
 void MemoryMappedFile::advise_sequential() {
 }
 
-void* MemoryMappedFile::mmap(FileDescriptor fd, bool read_only) {
+void* MemoryMappedFile::mmap(FileDescriptor fd, size_t size, bool read_only) {
     DWORD protection = static_cast<DWORD>(read_only ? PAGE_READONLY : PAGE_READWRITE);
 
     mapping_ = ::CreateFileMapping(fd, nullptr, protection, 0, 0, nullptr);  // note: no size specified to avoid MapViewOfFile failure
@@ -108,7 +108,7 @@ void* MemoryMappedFile::mmap(FileDescriptor fd, bool read_only) {
     }
 
     DWORD desired_access = static_cast<DWORD>(read_only ? FILE_MAP_READ : FILE_MAP_ALL_ACCESS);
-    void* memory = (LPTSTR)::MapViewOfFile(mapping_, desired_access, 0, static_cast<DWORD>(0), length_);
+    void* memory = (LPTSTR)::MapViewOfFile(mapping_, desired_access, 0, static_cast<DWORD>(0), size);
 
     if (memory == nullptr) {
         throw std::runtime_error{"MapViewOfFile failed for: " + path_.string() + " error: " + std::to_string(GetLastError())};
@@ -142,9 +142,9 @@ void MemoryMappedFile::map_existing(bool read_only) {
     }
     [[maybe_unused]] auto _ = gsl::finally([fd]() { ::close(fd); });
 
-    length_ = std::filesystem::file_size(path_);
-
-    address_ = static_cast<uint8_t*>(mmap(fd, read_only));
+    auto size = std::filesystem::file_size(path_);
+    auto address = static_cast<uint8_t*>(mmap(fd, size, read_only));
+    region_ = {address, size};
 }
 
 void MemoryMappedFile::advise_normal() {
@@ -159,10 +159,10 @@ void MemoryMappedFile::advise_sequential() {
     advise(MADV_SEQUENTIAL);
 }
 
-void* MemoryMappedFile::mmap(FileDescriptor fd, bool read_only) {
+void* MemoryMappedFile::mmap(FileDescriptor fd, size_t size, bool read_only) {
     int flags = MAP_SHARED;
 
-    const auto address = ::mmap(nullptr, length_, read_only ? PROT_READ : (PROT_READ | PROT_WRITE), flags, fd, 0);
+    const auto address = ::mmap(nullptr, size, read_only ? PROT_READ : (PROT_READ | PROT_WRITE), flags, fd, 0);
     if (address == MAP_FAILED) {
         throw std::runtime_error{"mmap failed for: " + path_.string() + " error: " + safe_strerror(errno)};
     }
@@ -171,8 +171,8 @@ void* MemoryMappedFile::mmap(FileDescriptor fd, bool read_only) {
 }
 
 void MemoryMappedFile::unmap() {
-    if (address_ != nullptr) {
-        const int result = ::munmap(address_, length_);
+    if (region_.data() != nullptr) {
+        const int result = ::munmap(region_.data(), region_.size());
         if (result == -1) {
             throw std::runtime_error{"munmap failed for: " + path_.string() + " error: " + safe_strerror(errno)};
         }
@@ -180,7 +180,7 @@ void MemoryMappedFile::unmap() {
 }
 
 void MemoryMappedFile::advise(int advice) {
-    const int result = ::madvise(address_, length_, advice);
+    const int result = ::madvise(region_.data(), region_.size(), advice);
     if (result == -1) {
         // Ignore not implemented in kernel error because it still works (from Erigon)
         if (errno != ENOSYS) {

--- a/silkworm/infra/common/memory_mapped_file.cpp
+++ b/silkworm/infra/common/memory_mapped_file.cpp
@@ -90,13 +90,13 @@ void MemoryMappedFile::map_existing(bool read_only) {
     fd = INVALID_HANDLE_VALUE;
 }
 
-void MemoryMappedFile::advise_normal() {
+void MemoryMappedFile::advise_normal() const {
 }
 
-void MemoryMappedFile::advise_random() {
+void MemoryMappedFile::advise_random() const {
 }
 
-void MemoryMappedFile::advise_sequential() {
+void MemoryMappedFile::advise_sequential() const {
 }
 
 void* MemoryMappedFile::mmap(FileDescriptor fd, size_t size, bool read_only) {
@@ -147,15 +147,15 @@ void MemoryMappedFile::map_existing(bool read_only) {
     region_ = {address, size};
 }
 
-void MemoryMappedFile::advise_normal() {
+void MemoryMappedFile::advise_normal() const {
     advise(MADV_NORMAL);
 }
 
-void MemoryMappedFile::advise_random() {
+void MemoryMappedFile::advise_random() const {
     advise(MADV_RANDOM);
 }
 
-void MemoryMappedFile::advise_sequential() {
+void MemoryMappedFile::advise_sequential() const {
     advise(MADV_SEQUENTIAL);
 }
 
@@ -179,7 +179,7 @@ void MemoryMappedFile::unmap() {
     }
 }
 
-void MemoryMappedFile::advise(int advice) {
+void MemoryMappedFile::advise(int advice) const {
     const int result = ::madvise(region_.data(), region_.size(), advice);
     if (result == -1) {
         // Ignore not implemented in kernel error because it still works (from Erigon)

--- a/silkworm/infra/common/memory_mapped_file.hpp
+++ b/silkworm/infra/common/memory_mapped_file.hpp
@@ -101,9 +101,9 @@ class MemoryMappedFile {
         return std::filesystem::last_write_time(path_);
     }
 
-    void advise_normal();
-    void advise_random();
-    void advise_sequential();
+    void advise_normal() const;
+    void advise_random() const;
+    void advise_sequential() const;
 
   private:
     void map_existing(bool read_only);
@@ -126,7 +126,7 @@ class MemoryMappedFile {
     HANDLE file_ = nullptr;
     HANDLE mapping_ = nullptr;
 #else
-    void advise(int advice);
+    void advise(int advice) const;
 #endif
 };
 

--- a/silkworm/infra/common/memory_mapped_file.hpp
+++ b/silkworm/infra/common/memory_mapped_file.hpp
@@ -47,6 +47,7 @@
 #include <filesystem>
 #include <istream>
 #include <optional>
+#include <span>
 #include <streambuf>
 #include <tuple>
 
@@ -69,10 +70,7 @@ using FileDescriptor = HANDLE;
 using FileDescriptor = int;
 #endif
 
-struct MemoryMappedRegion {
-    uint8_t* address{nullptr};
-    std::size_t length{0};
-};
+using MemoryMappedRegion = std::span<uint8_t>;
 
 class MemoryMappedFile {
   public:
@@ -91,12 +89,12 @@ class MemoryMappedFile {
         return path_;
     }
 
-    [[nodiscard]] uint8_t* address() const {
-        return address_;
+    [[nodiscard]] MemoryMappedRegion region() const {
+        return region_;
     }
 
-    [[nodiscard]] std::size_t length() const {
-        return length_;
+    [[nodiscard]] size_t size() const {
+        return region_.size();
     }
 
     [[nodiscard]] std::filesystem::file_time_type last_write_time() const {
@@ -110,17 +108,14 @@ class MemoryMappedFile {
   private:
     void map_existing(bool read_only);
 
-    void* mmap(FileDescriptor fd, bool read_only);
+    void* mmap(FileDescriptor fd, size_t size, bool read_only);
     void unmap();
 
     //! The path to the file
     std::filesystem::path path_;
 
     //! The address of the mapped area
-    uint8_t* address_{nullptr};
-
-    //! The file size
-    std::size_t length_{0};
+    MemoryMappedRegion region_;
 
     //! Flag indicating if memory-mapping is managed internally or not
     bool managed_;
@@ -136,17 +131,15 @@ class MemoryMappedFile {
 };
 
 struct MemoryMappedStreamBuf : std::streambuf {
-    MemoryMappedStreamBuf(char const* base, std::size_t size) {
-        char* p{const_cast<char*>(base)};  // NOLINT(cppcoreguidelines-pro-type-const-cast)
-        this->setg(p, p, p + size);
+    MemoryMappedStreamBuf(MemoryMappedRegion region) {
+        auto p = reinterpret_cast<char*>(region.data());
+        this->setg(p, p, p + region.size());
     }
 };
 
 struct MemoryMappedInputStream : virtual MemoryMappedStreamBuf, std::istream {
-    MemoryMappedInputStream(char const* base, std::size_t size)
-        : MemoryMappedStreamBuf(base, size), std::istream(static_cast<std::streambuf*>(this)) {}
-    MemoryMappedInputStream(unsigned char const* base, std::size_t size)
-        : MemoryMappedInputStream(reinterpret_cast<char const*>(base), size) {}
+    MemoryMappedInputStream(MemoryMappedRegion region)
+        : MemoryMappedStreamBuf(region), std::istream(static_cast<std::streambuf*>(this)) {}
 };
 
 }  // namespace silkworm

--- a/silkworm/infra/common/memory_mapped_file_benchmark.cpp
+++ b/silkworm/infra/common/memory_mapped_file_benchmark.cpp
@@ -69,9 +69,7 @@ static void benchmark_checksum_memory_mapped_file(benchmark::State& state) {
         silkworm::MemoryMappedFile mapped_file{tmp_file_path};
         mapped_file.advise_sequential();
         int checksum{0};
-        std::size_t count{0};
-        for (auto it{mapped_file.address()}; count < mapped_file.length(); ++it, ++count) {
-            const auto byte{*it};
+        for (auto byte : mapped_file.region()) {
             checksum += byte;
         }
         benchmark::DoNotOptimize(checksum);

--- a/silkworm/node/stagedsync/client.hpp
+++ b/silkworm/node/stagedsync/client.hpp
@@ -21,6 +21,7 @@
 #include <boost/asio/io_context.hpp>
 
 #include <silkworm/core/types/block.hpp>
+#include <silkworm/core/types/block_id.hpp>
 #include <silkworm/node/stagedsync/types.hpp>
 
 namespace silkworm::execution {

--- a/silkworm/node/stagedsync/forks/canonical_chain.hpp
+++ b/silkworm/node/stagedsync/forks/canonical_chain.hpp
@@ -24,6 +24,7 @@
 
 #include <silkworm/core/common/lru_cache.hpp>
 #include <silkworm/core/types/block.hpp>
+#include <silkworm/core/types/block_id.hpp>
 #include <silkworm/db/access_layer.hpp>
 #include <silkworm/db/stage.hpp>
 #include <silkworm/node/stagedsync/execution_pipeline.hpp>

--- a/silkworm/sentry/common/random.hpp
+++ b/silkworm/sentry/common/random.hpp
@@ -55,7 +55,7 @@ std::list<T*> random_list_items(std::list<T>& l, size_t max_count) {
 
         BackInsertPtrIterator& operator*() { return *this; }
         BackInsertPtrIterator& operator++() { return *this; }
-        BackInsertPtrIterator operator++(int) { return *this; }  // NOLINT(cert-dcl21-cpp)
+        BackInsertPtrIterator operator++(int) { return *this; }
 
       private:
         std::list<T*>* container_;

--- a/silkworm/sentry/eth/status_data_provider.hpp
+++ b/silkworm/sentry/eth/status_data_provider.hpp
@@ -21,7 +21,7 @@
 #include <silkworm/infra/concurrency/task.hpp>
 
 #include <silkworm/core/chain/config.hpp>
-#include <silkworm/core/types/head_info.hpp>
+#include <silkworm/core/types/chain_head.hpp>
 
 #include "status_data.hpp"
 
@@ -30,9 +30,9 @@ namespace silkworm::sentry::eth {
 class StatusDataProvider {
   public:
     StatusDataProvider(
-        std::function<HeadInfo()> head_info_provider,
+        std::function<ChainHead()> chain_head_provider,
         const ChainConfig& chain_config)
-        : head_info_provider_(std::move(head_info_provider)),
+        : chain_head_provider_(std::move(chain_head_provider)),
           chain_config_(chain_config) {}
 
     using StatusData = silkworm::sentry::eth::StatusData;
@@ -43,11 +43,11 @@ class StatusDataProvider {
 
   private:
     static StatusData make_status_data(
-        HeadInfo head_info,
+        ChainHead chain_head,
         uint8_t eth_version,
         const ChainConfig& chain_config);
 
-    std::function<HeadInfo()> head_info_provider_;
+    std::function<ChainHead()> chain_head_provider_;
     const ChainConfig& chain_config_;
 };
 

--- a/silkworm/sync/internals/chain_fork_view.hpp
+++ b/silkworm/sync/internals/chain_fork_view.hpp
@@ -20,6 +20,7 @@
 
 #include <silkworm/core/common/lru_cache.hpp>
 #include <silkworm/core/types/block.hpp>
+#include <silkworm/core/types/chain_head.hpp>
 #include <silkworm/sync/internals/types.hpp>
 
 namespace silkworm::chainsync {

--- a/silkworm/sync/internals/header_chain_plus_exec_test.cpp
+++ b/silkworm/sync/internals/header_chain_plus_exec_test.cpp
@@ -92,7 +92,7 @@ TEST_CASE("Headers receiving and saving") {
     auto& tx = exec_engine.main_chain_.tx();  // mdbx refuses to open a ROTxn when there is a RWTxn in the same thread
 
     auto head = exec_engine.last_fork_choice();
-    REQUIRE(height(head) == 0);
+    REQUIRE(head.number == 0);
 
     std::vector<BlockHeader> last_headers = exec_engine.get_last_headers(1);
     REQUIRE(last_headers.size() == 1);

--- a/silkworm/sync/sync_pow.cpp
+++ b/silkworm/sync/sync_pow.cpp
@@ -51,9 +51,9 @@ PoWSync::NewHeight PoWSync::resume() {  // find the point (head) where we left o
     auto last_fcu = sync_wait(in(exec_engine_), exec_engine_.last_fork_choice());  // previously was get_canonical_head()
     auto block_progress = sync_wait(in(exec_engine_), exec_engine_.block_progress());
 
-    ensure_invariant(height(last_fcu) <= block_progress, "canonical head beyond block progress");
+    ensure_invariant(last_fcu.number <= block_progress, "canonical head beyond block progress");
 
-    if (block_progress == height(last_fcu)) {
+    if (block_progress == last_fcu.number) {
         // if fcu and header progress match than we have the actual canonical, we only need to do a forward sync...
         ensure_invariant(last_fcu == chain_fork_view_.head(), "last fcu misaligned with canonical head");
         chain_fork_view_.reset_head({last_fcu.number, last_fcu.hash,


### PR DESCRIPTION
* MemoryMappedRegion: use span
* Decompressor::Iterator as input_iterator
* refactor tx_buffer_hash calculation
* fix sys tx hash (https://github.com/ledgerwatch/erigon/pull/9727)
* build tx indexes separately (doesn't affect perf)
* refactor RecSplit.build_without_collisions
* RecSplit.add_key: use ByteView instead of ptr+len
