### PR TITLE
snapshots: less false-positives feature in recsplit

### DIFF
--- a/silkworm/db/snapshots/index.cpp
+++ b/silkworm/db/snapshots/index.cpp
@@ -135,7 +135,8 @@ void TransactionIndex::build() {
         .bucket_size = kBucketSize,
         .index_path = tx_idx_file.path(),
         .base_data_id = first_tx_id,
-        .double_enum_index = true};
+        .double_enum_index = true,
+        .less_false_positives = true};
     RecSplit8 tx_hash_rs{tx_hash_rs_settings, rec_split::seq_build_strategy(kOptimalBufferSize / 2)};
 
     const SnapshotPath tx2block_idx_file = segment_path_.index_file_for_type(SnapshotType::transactions_to_block);

--- a/silkworm/db/snapshots/index.hpp
+++ b/silkworm/db/snapshots/index.hpp
@@ -19,6 +19,7 @@
 #include <memory>
 #include <utility>
 
+#include <silkworm/infra/common/os.hpp>
 #include <silkworm/db/snapshots/path.hpp>
 #include <silkworm/db/snapshots/rec_split/rec_split.hpp>
 #include <silkworm/db/snapshots/seg/decompressor.hpp>
@@ -27,7 +28,7 @@ namespace silkworm::snapshots {
 
 class Index {
   public:
-    static constexpr uint64_t kPageSize{4096};
+    static inline const auto kPageSize{os::page_size()};
     static constexpr std::size_t kBucketSize{2'000};
 
     explicit Index(SnapshotPath segment_path, std::optional<MemoryMappedRegion> segment_region = {})

--- a/silkworm/db/snapshots/index.hpp
+++ b/silkworm/db/snapshots/index.hpp
@@ -19,10 +19,10 @@
 #include <memory>
 #include <utility>
 
-#include <silkworm/infra/common/os.hpp>
 #include <silkworm/db/snapshots/path.hpp>
 #include <silkworm/db/snapshots/rec_split/rec_split.hpp>
 #include <silkworm/db/snapshots/seg/decompressor.hpp>
+#include <silkworm/infra/common/os.hpp>
 
 namespace silkworm::snapshots {
 

--- a/silkworm/db/snapshots/rec_split/rec_split_par_test.cpp
+++ b/silkworm/db/snapshots/rec_split/rec_split_par_test.cpp
@@ -237,7 +237,7 @@ TEST_CASE("RecSplit8-Par: index lookup", "[silkworm][node][recsplit][ignore]") {
     RecSplit8 rs2{settings.index_path};
     for (size_t i{0}; i < settings.keys_count; ++i) {
         const std::string key{"key " + std::to_string(i)};
-        CHECK(rs2.lookup(key) == i * 17);
+        CHECK(rs2.lookup(key) == RecSplit8::LookupResult{i * 17, true});
     }
 }
 
@@ -259,8 +259,9 @@ TEST_CASE("RecSplit8-Par: double index lookup", "[silkworm][node][recsplit][igno
 
     RecSplit8 rs2{settings.index_path};
     for (size_t i{0}; i < settings.keys_count; ++i) {
-        const auto enumeration_index = rs2.lookup("key " + std::to_string(i));
+        const auto [enumeration_index, found] = rs2.lookup("key " + std::to_string(i));
         CHECK(enumeration_index == i);
+        CHECK(found);
         CHECK(rs2.ordinal_lookup(enumeration_index) == i * 17);
     }
 }

--- a/silkworm/db/snapshots/rec_split/rec_split_seq_test.cpp
+++ b/silkworm/db/snapshots/rec_split/rec_split_seq_test.cpp
@@ -233,7 +233,7 @@ TEST_CASE("RecSplit8: index lookup", "[silkworm][snapshots][recsplit][ignore]") 
     RecSplit8 rs2{settings.index_path};
     for (size_t i{0}; i < settings.keys_count; ++i) {
         const std::string key{"key " + std::to_string(i)};
-        CHECK(rs2.lookup(key) == i * 17);
+        CHECK((rs2.lookup(key) == RecSplit8::LookupResult{i * 17, true}));
     }
 }
 
@@ -254,8 +254,9 @@ TEST_CASE("RecSplit8: double index lookup", "[silkworm][snapshots][recsplit][ign
 
     RecSplit8 rs2{settings.index_path};
     for (size_t i{0}; i < settings.keys_count; ++i) {
-        const auto enumeration_index = rs2.lookup("key " + std::to_string(i));
+        const auto [enumeration_index, found] = rs2.lookup("key " + std::to_string(i));
         CHECK(enumeration_index == i);
+        CHECK(found);
         CHECK(rs2.ordinal_lookup(enumeration_index) == i * 17);
     }
 }

--- a/silkworm/db/snapshots/test_util/common.hpp
+++ b/silkworm/db/snapshots/test_util/common.hpp
@@ -104,7 +104,6 @@ struct SnapshotHeader {
 
 struct SnapshotBody {
     Bytes data;
-    SnapshotHeader* header{nullptr};
 
     void encode(Bytes& output) const {
         output.append(data.cbegin(), data.cend());


### PR DESCRIPTION
This PR introduces the `less false-positives` feature in our RecSplit implementation and activates such features for hash-to-offset index in transaction snapshots (see also https://github.com/ledgerwatch/erigon/pull/9515)

Depends on #1915 