### PR TITLE
snapshots: index builder refactorings

### DIFF
--- a/cmd/dev/snapshots.cpp
+++ b/cmd/dev/snapshots.cpp
@@ -283,12 +283,12 @@ void create_index(const SnapSettings& settings, int repetitions) {
         for (int i{0}; i < repetitions; ++i) {
             switch (snap_file->type()) {
                 case SnapshotType::headers: {
-                    HeaderIndex index{*snap_file};
+                    auto index = HeaderIndex::make(*snap_file);
                     index.build();
                     break;
                 }
                 case SnapshotType::bodies: {
-                    BodyIndex index{*snap_file};
+                    auto index = BodyIndex::make(*snap_file);
                     index.build();
                     break;
                 }

--- a/cmd/dev/snapshots.cpp
+++ b/cmd/dev/snapshots.cpp
@@ -293,8 +293,12 @@ void create_index(const SnapSettings& settings, int repetitions) {
                     break;
                 }
                 case SnapshotType::transactions: {
-                    TransactionIndex index{*snap_file};
+                    auto bodies_segment_path = TransactionIndex1::bodies_segment_path(*snap_file);
+                    auto index = TransactionIndex1::make(bodies_segment_path, *snap_file);
                     index.build();
+
+                    TransactionToBlockIndex index_hash_to_block(bodies_segment_path, *snap_file);
+                    index_hash_to_block.build();
                     break;
                 }
                 default: {

--- a/cmd/dev/snapshots.cpp
+++ b/cmd/dev/snapshots.cpp
@@ -35,7 +35,7 @@
 #include <silkworm/db/snapshots/bittorrent/client.hpp>
 #include <silkworm/db/snapshots/body_index.hpp>
 #include <silkworm/db/snapshots/header_index.hpp>
-#include <silkworm/db/snapshots/index.hpp>
+#include <silkworm/db/snapshots/index_builder.hpp>
 #include <silkworm/db/snapshots/repository.hpp>
 #include <silkworm/db/snapshots/seg/seg_zip.hpp>
 #include <silkworm/db/snapshots/snapshot.hpp>
@@ -297,8 +297,8 @@ void create_index(const SnapSettings& settings, int repetitions) {
                     break;
                 }
                 case SnapshotType::transactions: {
-                    auto bodies_segment_path = TransactionIndex1::bodies_segment_path(*snap_file);
-                    auto index = TransactionIndex1::make(bodies_segment_path, *snap_file);
+                    auto bodies_segment_path = TransactionIndex::bodies_segment_path(*snap_file);
+                    auto index = TransactionIndex::make(bodies_segment_path, *snap_file);
                     index.build();
 
                     auto index_hash_to_block = TransactionToBlockIndex::make(bodies_segment_path, *snap_file);

--- a/cmd/dev/snapshots.cpp
+++ b/cmd/dev/snapshots.cpp
@@ -33,10 +33,14 @@
 #include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/db/snapshot_sync.hpp>
 #include <silkworm/db/snapshots/bittorrent/client.hpp>
+#include <silkworm/db/snapshots/body_index.hpp>
+#include <silkworm/db/snapshots/header_index.hpp>
 #include <silkworm/db/snapshots/index.hpp>
 #include <silkworm/db/snapshots/repository.hpp>
 #include <silkworm/db/snapshots/seg/seg_zip.hpp>
 #include <silkworm/db/snapshots/snapshot.hpp>
+#include <silkworm/db/snapshots/txn_index.hpp>
+#include <silkworm/db/snapshots/txn_to_block_index.hpp>
 #include <silkworm/infra/common/ensure.hpp>
 #include <silkworm/infra/common/log.hpp>
 
@@ -297,7 +301,7 @@ void create_index(const SnapSettings& settings, int repetitions) {
                     auto index = TransactionIndex1::make(bodies_segment_path, *snap_file);
                     index.build();
 
-                    TransactionToBlockIndex index_hash_to_block(bodies_segment_path, *snap_file);
+                    auto index_hash_to_block = TransactionToBlockIndex::make(bodies_segment_path, *snap_file);
                     index_hash_to_block.build();
                     break;
                 }

--- a/silkworm/capi/silkworm.cpp
+++ b/silkworm/capi/silkworm.cpp
@@ -19,6 +19,7 @@
 #include <charconv>
 #include <chrono>
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -268,10 +269,14 @@ SILKWORM_EXPORT int silkworm_build_recsplit_indexes(SilkwormHandle handle, struc
                 });
 
                 if (bodies_file < snapshots + len) {
-                    index = std::make_shared<snapshots::IndexBuilder>(snapshots::TransactionIndex::make(bodies_segment_path, *snapshot_path));
+                    auto bodies_segment_region = make_region(**bodies_file);
+
+                    index = std::make_shared<snapshots::IndexBuilder>(snapshots::TransactionIndex::make(
+                        bodies_segment_path, bodies_segment_region, *snapshot_path, snapshot_region));
                     needed_indexes.push_back(index);
 
-                    index = std::make_shared<snapshots::IndexBuilder>(snapshots::TransactionToBlockIndex::make(bodies_segment_path, *snapshot_path));
+                    index = std::make_shared<snapshots::IndexBuilder>(snapshots::TransactionToBlockIndex::make(
+                        bodies_segment_path, bodies_segment_region, *snapshot_path, snapshot_region));
                     needed_indexes.push_back(index);
                 }
                 break;

--- a/silkworm/capi/silkworm.cpp
+++ b/silkworm/capi/silkworm.cpp
@@ -248,11 +248,11 @@ SILKWORM_EXPORT int silkworm_build_recsplit_indexes(SilkwormHandle handle, struc
         std::shared_ptr<snapshots::Index> index;
         switch (snapshot_path->type()) {
             case snapshots::SnapshotType::headers: {
-                index = std::make_shared<snapshots::HeaderIndex>(*snapshot_path, snapshot_region);
+                index = std::make_shared<snapshots::Index>(snapshots::HeaderIndex::make(*snapshot_path, snapshot_region));
                 break;
             }
             case snapshots::SnapshotType::bodies: {
-                index = std::make_shared<snapshots::BodyIndex>(*snapshot_path, snapshot_region);
+                index = std::make_shared<snapshots::Index>(snapshots::BodyIndex::make(*snapshot_path, snapshot_region));
                 break;
             }
             case snapshots::SnapshotType::transactions: {

--- a/silkworm/capi/silkworm.cpp
+++ b/silkworm/capi/silkworm.cpp
@@ -33,7 +33,11 @@
 #include <silkworm/core/execution/execution.hpp>
 #include <silkworm/db/access_layer.hpp>
 #include <silkworm/db/buffer.hpp>
+#include <silkworm/db/snapshots/body_index.hpp>
+#include <silkworm/db/snapshots/header_index.hpp>
 #include <silkworm/db/snapshots/index.hpp>
+#include <silkworm/db/snapshots/txn_index.hpp>
+#include <silkworm/db/snapshots/txn_to_block_index.hpp>
 #include <silkworm/db/stages.hpp>
 #include <silkworm/infra/common/bounded_buffer.hpp>
 #include <silkworm/infra/common/directories.hpp>
@@ -267,7 +271,7 @@ SILKWORM_EXPORT int silkworm_build_recsplit_indexes(SilkwormHandle handle, struc
                     index = std::make_shared<snapshots::Index>(snapshots::TransactionIndex1::make(bodies_segment_path, *snapshot_path));
                     needed_indexes.push_back(index);
 
-                    index = std::make_shared<snapshots::TransactionToBlockIndex>(bodies_segment_path, *snapshot_path);
+                    index = std::make_shared<snapshots::IndexBuilder>(snapshots::TransactionToBlockIndex::make(bodies_segment_path, *snapshot_path));
                     needed_indexes.push_back(index);
                 }
                 break;

--- a/silkworm/capi/silkworm_test.cpp
+++ b/silkworm/capi/silkworm_test.cpp
@@ -642,12 +642,12 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_add_snapshot", "[silkworm][capi]") {
     snapshot_test::SampleTransactionSnapshotFile valid_tx_snapshot{};
     snapshot_test::SampleTransactionSnapshotPath tx_snapshot_path{valid_tx_snapshot.path()};
 
-    snapshots::HeaderIndex header_index{header_snapshot_path};
+    auto header_index = snapshots::HeaderIndex::make(header_snapshot_path);
     REQUIRE_NOTHROW(header_index.build());
     snapshots::HeaderSnapshot header_snapshot{header_snapshot_path};
     header_snapshot.reopen_segment();
     header_snapshot.reopen_index();
-    snapshots::BodyIndex body_index{body_snapshot_path};
+    auto body_index = snapshots::BodyIndex::make(body_snapshot_path);
     REQUIRE_NOTHROW(body_index.build());
     snapshots::BodySnapshot body_snapshot{body_snapshot_path};
     body_snapshot.reopen_segment();

--- a/silkworm/capi/silkworm_test.cpp
+++ b/silkworm/capi/silkworm_test.cpp
@@ -647,13 +647,17 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_add_snapshot", "[silkworm][capi]") {
     snapshots::HeaderSnapshot header_snapshot{header_snapshot_path};
     header_snapshot.reopen_segment();
     header_snapshot.reopen_index();
+
     auto body_index = snapshots::BodyIndex::make(body_snapshot_path);
     REQUIRE_NOTHROW(body_index.build());
     snapshots::BodySnapshot body_snapshot{body_snapshot_path};
     body_snapshot.reopen_segment();
     body_snapshot.reopen_index();
-    snapshots::TransactionIndex tx_index{tx_snapshot_path};
-    REQUIRE_NOTHROW(tx_index.build());
+
+    auto tx_index = snapshots::TransactionIndex1::make(body_snapshot_path, tx_snapshot_path);
+    tx_index.build();
+    snapshots::TransactionToBlockIndex tx_index_hash_to_block{body_snapshot_path, tx_snapshot_path};
+    tx_index_hash_to_block.build();
     snapshots::TransactionSnapshot tx_snapshot{tx_snapshot_path};
     tx_snapshot.reopen_segment();
     tx_snapshot.reopen_index();

--- a/silkworm/capi/silkworm_test.cpp
+++ b/silkworm/capi/silkworm_test.cpp
@@ -23,9 +23,13 @@
 
 #include <silkworm/core/trie/vector_root.hpp>
 #include <silkworm/db/mdbx/mdbx.hpp>
+#include <silkworm/db/snapshots/body_index.hpp>
+#include <silkworm/db/snapshots/header_index.hpp>
 #include <silkworm/db/snapshots/index.hpp>
 #include <silkworm/db/snapshots/snapshot.hpp>
 #include <silkworm/db/snapshots/test_util/common.hpp>
+#include <silkworm/db/snapshots/txn_index.hpp>
+#include <silkworm/db/snapshots/txn_to_block_index.hpp>
 #include <silkworm/infra/test_util/log.hpp>
 #include <silkworm/rpc/test/api_test_database.hpp>
 
@@ -656,7 +660,7 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_add_snapshot", "[silkworm][capi]") {
 
     auto tx_index = snapshots::TransactionIndex1::make(body_snapshot_path, tx_snapshot_path);
     tx_index.build();
-    snapshots::TransactionToBlockIndex tx_index_hash_to_block{body_snapshot_path, tx_snapshot_path};
+    auto tx_index_hash_to_block = snapshots::TransactionToBlockIndex::make(body_snapshot_path, tx_snapshot_path);
     tx_index_hash_to_block.build();
     snapshots::TransactionSnapshot tx_snapshot{tx_snapshot_path};
     tx_snapshot.reopen_segment();

--- a/silkworm/capi/silkworm_test.cpp
+++ b/silkworm/capi/silkworm_test.cpp
@@ -30,6 +30,7 @@
 #include <silkworm/db/snapshots/test_util/common.hpp>
 #include <silkworm/db/snapshots/txn_index.hpp>
 #include <silkworm/db/snapshots/txn_to_block_index.hpp>
+#include <silkworm/infra/common/directories.hpp>
 #include <silkworm/infra/test_util/log.hpp>
 #include <silkworm/rpc/test/api_test_database.hpp>
 
@@ -38,6 +39,8 @@ namespace silkworm {
 namespace snapshot_test = snapshots::test_util;
 
 struct CApiTest : public rpc::test::TestDatabaseContext {
+    TemporaryDirectory tmp_dir;
+
   private:
     // TODO(canepat) remove test_util::StreamSwap objects when C API settings include log level
     std::stringstream string_cout, string_cerr;
@@ -639,11 +642,11 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_execute_blocks_perpetual multiple bloc
 }
 
 TEST_CASE_METHOD(CApiTest, "CAPI silkworm_add_snapshot", "[silkworm][capi]") {
-    snapshot_test::SampleHeaderSnapshotFile valid_header_snapshot{};
+    snapshot_test::SampleHeaderSnapshotFile valid_header_snapshot{tmp_dir.path()};
     snapshot_test::SampleHeaderSnapshotPath header_snapshot_path{valid_header_snapshot.path()};
-    snapshot_test::SampleBodySnapshotFile valid_body_snapshot{};
+    snapshot_test::SampleBodySnapshotFile valid_body_snapshot{tmp_dir.path()};
     snapshot_test::SampleBodySnapshotPath body_snapshot_path{valid_body_snapshot.path()};
-    snapshot_test::SampleTransactionSnapshotFile valid_tx_snapshot{};
+    snapshot_test::SampleTransactionSnapshotFile valid_tx_snapshot{tmp_dir.path()};
     snapshot_test::SampleTransactionSnapshotPath tx_snapshot_path{valid_tx_snapshot.path()};
 
     auto header_index = snapshots::HeaderIndex::make(header_snapshot_path);

--- a/silkworm/capi/silkworm_test.cpp
+++ b/silkworm/capi/silkworm_test.cpp
@@ -25,7 +25,7 @@
 #include <silkworm/db/mdbx/mdbx.hpp>
 #include <silkworm/db/snapshots/body_index.hpp>
 #include <silkworm/db/snapshots/header_index.hpp>
-#include <silkworm/db/snapshots/index.hpp>
+#include <silkworm/db/snapshots/index_builder.hpp>
 #include <silkworm/db/snapshots/snapshot.hpp>
 #include <silkworm/db/snapshots/test_util/common.hpp>
 #include <silkworm/db/snapshots/txn_index.hpp>
@@ -658,7 +658,7 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_add_snapshot", "[silkworm][capi]") {
     body_snapshot.reopen_segment();
     body_snapshot.reopen_index();
 
-    auto tx_index = snapshots::TransactionIndex1::make(body_snapshot_path, tx_snapshot_path);
+    auto tx_index = snapshots::TransactionIndex::make(body_snapshot_path, tx_snapshot_path);
     tx_index.build();
     auto tx_index_hash_to_block = snapshots::TransactionToBlockIndex::make(body_snapshot_path, tx_snapshot_path);
     tx_index_hash_to_block.build();

--- a/silkworm/db/snapshot_sync.cpp
+++ b/silkworm/db/snapshot_sync.cpp
@@ -24,7 +24,7 @@
 #include <silkworm/core/types/hash.hpp>
 #include <silkworm/db/mdbx/etl_mdbx_collector.hpp>
 #include <silkworm/db/snapshots/config.hpp>
-#include <silkworm/db/snapshots/index.hpp>
+#include <silkworm/db/snapshots/index_builder.hpp>
 #include <silkworm/db/snapshots/path.hpp>
 #include <silkworm/db/stages.hpp>
 #include <silkworm/infra/common/ensure.hpp>

--- a/silkworm/db/snapshots/body_index.cpp
+++ b/silkworm/db/snapshots/body_index.cpp
@@ -1,0 +1,29 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "body_index.hpp"
+
+#include <silkworm/db/snapshots/seg/common/varint.hpp>
+
+namespace silkworm::snapshots {
+
+Bytes BodyIndex::KeyFactory::make(ByteView /*key_data*/, uint64_t i) {
+    Bytes uint64_buffer;
+    seg::varint::encode(uint64_buffer, i);
+    return uint64_buffer;
+}
+
+}  // namespace silkworm::snapshots

--- a/silkworm/db/snapshots/body_index.hpp
+++ b/silkworm/db/snapshots/body_index.hpp
@@ -1,0 +1,54 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+
+#include <silkworm/core/common/bytes.hpp>
+#include <silkworm/infra/common/memory_mapped_file.hpp>
+
+#include "index.hpp"
+#include "path.hpp"
+
+namespace silkworm::snapshots {
+
+class BodyIndex {
+  public:
+    static IndexBuilder make(SnapshotPath segment_path, std::optional<MemoryMappedRegion> segment_region = std::nullopt) {
+        auto descriptor = make_descriptor(segment_path);
+        auto query = std::make_unique<DecompressorIndexInputDataQuery>(std::move(segment_path), segment_region);
+        return IndexBuilder{std::move(descriptor), std::move(query)};
+    }
+
+    struct KeyFactory : IndexKeyFactory {
+        ~KeyFactory() override = default;
+        Bytes make(ByteView key_data, uint64_t i) override;
+    };
+
+  private:
+    static IndexDescriptor make_descriptor(const SnapshotPath& segment_path) {
+        return {
+            .index_file = segment_path.index_file(),
+            .key_factory = std::make_unique<KeyFactory>(),
+            .base_data_id = segment_path.block_from(),
+        };
+    }
+};
+
+}  // namespace silkworm::snapshots

--- a/silkworm/db/snapshots/body_index.hpp
+++ b/silkworm/db/snapshots/body_index.hpp
@@ -23,7 +23,7 @@
 #include <silkworm/core/common/bytes.hpp>
 #include <silkworm/infra/common/memory_mapped_file.hpp>
 
-#include "index.hpp"
+#include "index_builder.hpp"
 #include "path.hpp"
 
 namespace silkworm::snapshots {

--- a/silkworm/db/snapshots/header_index.cpp
+++ b/silkworm/db/snapshots/header_index.cpp
@@ -1,0 +1,35 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "header_index.hpp"
+
+#include <silkworm/core/common/util.hpp>
+#include <silkworm/infra/common/ensure.hpp>
+
+namespace silkworm::snapshots {
+
+Bytes HeaderIndex::KeyFactory::make(ByteView key_data, uint64_t i) {
+    auto word = key_data;
+    ensure(!word.empty(), [&]() { return "HeaderIndex: word empty i=" + std::to_string(i); });
+    const uint8_t first_hash_byte{word[0]};
+    const ByteView rlp_encoded_header{word.data() + 1, word.size() - 1};
+    const ethash::hash256 hash = keccak256(rlp_encoded_header);
+    ensure(hash.bytes[0] == first_hash_byte,
+           [&]() { return "HeaderIndex: invalid prefix=" + to_hex(first_hash_byte) + " hash=" + to_hex(hash.bytes); });
+    return Bytes{ByteView{hash.bytes}};
+}
+
+}  // namespace silkworm::snapshots

--- a/silkworm/db/snapshots/header_index.hpp
+++ b/silkworm/db/snapshots/header_index.hpp
@@ -1,0 +1,54 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+
+#include <silkworm/core/common/bytes.hpp>
+#include <silkworm/infra/common/memory_mapped_file.hpp>
+
+#include "index.hpp"
+#include "path.hpp"
+
+namespace silkworm::snapshots {
+
+class HeaderIndex {
+  public:
+    static IndexBuilder make(SnapshotPath segment_path, std::optional<MemoryMappedRegion> segment_region = std::nullopt) {
+        auto descriptor = make_descriptor(segment_path);
+        auto query = std::make_unique<DecompressorIndexInputDataQuery>(std::move(segment_path), segment_region);
+        return IndexBuilder{std::move(descriptor), std::move(query)};
+    }
+
+    struct KeyFactory : IndexKeyFactory {
+        ~KeyFactory() override = default;
+        Bytes make(ByteView key_data, uint64_t i) override;
+    };
+
+  private:
+    static IndexDescriptor make_descriptor(const SnapshotPath& segment_path) {
+        return {
+            .index_file = segment_path.index_file(),
+            .key_factory = std::make_unique<KeyFactory>(),
+            .base_data_id = segment_path.block_from(),
+        };
+    }
+};
+
+}  // namespace silkworm::snapshots

--- a/silkworm/db/snapshots/header_index.hpp
+++ b/silkworm/db/snapshots/header_index.hpp
@@ -23,7 +23,7 @@
 #include <silkworm/core/common/bytes.hpp>
 #include <silkworm/infra/common/memory_mapped_file.hpp>
 
-#include "index.hpp"
+#include "index_builder.hpp"
 #include "path.hpp"
 
 namespace silkworm::snapshots {

--- a/silkworm/db/snapshots/index.cpp
+++ b/silkworm/db/snapshots/index.cpp
@@ -16,20 +16,8 @@
 
 #include "index.hpp"
 
-#include <sstream>
-#include <stdexcept>
-
-#include <magic_enum.hpp>
-
-#include <silkworm/core/common/endian.hpp>
-#include <silkworm/core/common/util.hpp>
-#include <silkworm/core/types/block_body_for_storage.hpp>
-#include <silkworm/core/types/hash.hpp>
 #include <silkworm/db/snapshots/rec_split/rec_split.hpp>
 #include <silkworm/db/snapshots/rec_split/rec_split_seq.hpp>
-#include <silkworm/db/snapshots/seg/common/varint.hpp>
-#include <silkworm/db/snapshots/snapshot.hpp>
-#include <silkworm/infra/common/ensure.hpp>
 #include <silkworm/infra/common/log.hpp>
 
 namespace silkworm::snapshots {
@@ -37,153 +25,91 @@ namespace silkworm::snapshots {
 using RecSplitSettings = rec_split::RecSplitSettings;
 using RecSplit8 = rec_split::RecSplit8;
 
-void Index::build() {
-    SILK_TRACE << "Index::build path: " << segment_path_.path().string() << " start";
+IndexInputDataQuery::Iterator& IndexInputDataQuery::Iterator::operator++() {
+    auto next = query_->next_iterator(impl_);
+    impl_ = next.first;
+    entry_ = next.second;
+    return *this;
+}
 
+bool operator==(const IndexInputDataQuery::Iterator& lhs, const IndexInputDataQuery::Iterator& rhs) {
+    return (lhs.query_ == rhs.query_) &&
+           lhs.query_->equal_iterators(lhs.impl_, rhs.impl_);
+}
+
+static IndexInputDataQuery::Iterator::value_type decompressor_index_query_entry(seg::Decompressor::Iterator& it) {
+    return {
+        .key_data = *it,
+        .value = it.current_word_offset(),
+    };
+}
+
+IndexInputDataQuery::Iterator DecompressorIndexInputDataQuery::begin() {
+    auto decoder = std::make_shared<seg::Decompressor>(segment_path_.path(), segment_region_);
+    decoder->open();
+
+    auto impl_it = std::make_shared<IteratorImpl>(IteratorImpl{decoder, decoder->begin()});
+    return IndexInputDataQuery::Iterator{this, impl_it, decompressor_index_query_entry(impl_it->it)};
+}
+
+IndexInputDataQuery::Iterator DecompressorIndexInputDataQuery::end() {
+    auto decoder = std::make_shared<seg::Decompressor>(segment_path_.path(), segment_region_);
+
+    auto impl_it = std::make_shared<IteratorImpl>(IteratorImpl{{}, decoder->end()});
+    return IndexInputDataQuery::Iterator{this, impl_it, decompressor_index_query_entry(impl_it->it)};
+}
+
+std::size_t DecompressorIndexInputDataQuery::keys_count() {
     seg::Decompressor decoder{segment_path_.path(), segment_region_};
     decoder.open();
+    return decoder.words_count();
+}
 
-    const SnapshotPath index_file = segment_path_.index_file();
-    RecSplitSettings rec_split_settings{
-        .keys_count = decoder.words_count(),
-        .bucket_size = kBucketSize,
-        .index_path = index_file.path(),
-        .base_data_id = descriptor_.base_data_id,
-        .double_enum_index = true,
-        .less_false_positives = descriptor_.less_false_positives,
-    };
-    RecSplit8 rec_split1{rec_split_settings, rec_split::seq_build_strategy(descriptor_.etl_buffer_size)};
-
-    rec_split1.build_without_collisions([&](RecSplit8& rec_split) {
-        uint64_t i{0};
-        for (auto it = decoder.begin(); it != decoder.end(); ++it, ++i) {
-            auto& word = *it;
-            auto offset = it.current_word_offset();
-            rec_split.add_key(descriptor_.key_factory->make(word, i), offset);
+std::pair<std::shared_ptr<void>, IndexInputDataQuery::Iterator::value_type>
+DecompressorIndexInputDataQuery::next_iterator(std::shared_ptr<void> it_impl) {
+    auto& it_impl_ref = *reinterpret_cast<IteratorImpl*>(it_impl.get());
+    // check if not already at the end
+    if (it_impl_ref.decoder) {
+        ++it_impl_ref.it;
+        if (it_impl_ref.it == it_impl_ref.decoder->end()) {
+            it_impl_ref.decoder.reset();
         }
-    });
-
-    SILK_TRACE << "Index::build path: " << segment_path_.path().string() << " end";
-}
-
-Bytes HeaderIndex::KeyFactory::make(ByteView word, uint64_t i) {
-    ensure(!word.empty(), [&]() { return "HeaderIndex: word empty i=" + std::to_string(i); });
-    const uint8_t first_hash_byte{word[0]};
-    const ByteView rlp_encoded_header{word.data() + 1, word.size() - 1};
-    const ethash::hash256 hash = keccak256(rlp_encoded_header);
-    ensure(hash.bytes[0] == first_hash_byte,
-           [&]() { return "HeaderIndex: invalid prefix=" + to_hex(first_hash_byte) + " hash=" + to_hex(hash.bytes); });
-    return Bytes{ByteView{hash.bytes}};
-}
-
-Bytes BodyIndex::KeyFactory::make(ByteView /*word*/, uint64_t i) {
-    Bytes uint64_buffer;
-    seg::varint::encode(uint64_buffer, i);
-    return uint64_buffer;
-}
-
-static Hash tx_buffer_hash(ByteView tx_buffer, uint64_t tx_id) {
-    Hash tx_hash;
-
-    const bool is_system_tx{tx_buffer.empty()};
-    if (is_system_tx) {
-        // system-txs: hash:pad32(txnID)
-        endian::store_big_u64(tx_hash.bytes, tx_id);
-        return tx_hash;
     }
-
-    // Skip tx hash first byte plus address length for transaction decoding
-    constexpr int kTxFirstByteAndAddressLength{1 + kAddressLength};
-    if (tx_buffer.size() <= kTxFirstByteAndAddressLength) {
-        std::stringstream error;
-        error << " tx_buffer_hash cannot decode tx envelope: record " << to_hex(tx_buffer)
-              << " too short: " << tx_buffer.size()
-              << " tx_id: " << tx_id;
-        throw std::runtime_error{error.str()};
-    }
-    const ByteView tx_envelope{tx_buffer.substr(kTxFirstByteAndAddressLength)};
-    ByteView tx_envelope_view{tx_envelope};
-
-    rlp::Header tx_header;
-    TransactionType tx_type{};
-    auto decode_result = rlp::decode_transaction_header_and_type(tx_envelope_view, tx_header, tx_type);
-    if (!decode_result) {
-        std::stringstream error;
-        error << " tx_buffer_hash cannot decode tx envelope: " << to_hex(tx_envelope)
-              << " tx_id: " << tx_id
-              << " error: " << magic_enum::enum_name(decode_result.error());
-        throw std::runtime_error{error.str()};
-    }
-
-    const std::size_t tx_payload_offset = tx_type == TransactionType::kLegacy ? 0 : (tx_envelope.length() - tx_header.payload_length);
-    if (tx_buffer.size() <= kTxFirstByteAndAddressLength + tx_payload_offset) {
-        std::stringstream error;
-        error << " tx_buffer_hash cannot decode tx payload: record " << to_hex(tx_buffer)
-              << " too short: " << tx_buffer.size()
-              << " tx_id: " << tx_id;
-        throw std::runtime_error{error.str()};
-    }
-    const ByteView tx_payload{tx_buffer.substr(kTxFirstByteAndAddressLength + tx_payload_offset)};
-    const auto h256{keccak256(tx_payload)};
-    std::copy(std::begin(h256.bytes), std::begin(h256.bytes) + kHashLength, std::begin(tx_hash.bytes));
-
-    if (tx_id % 100'000 == 0) {
-        SILK_DEBUG << "tx_buffer_hash:"
-                   << " header.list: " << tx_header.list
-                   << " header.payload_length: " << tx_header.payload_length
-                   << " tx_id: " << tx_id;
-    }
-    SILK_TRACE << "tx_buffer_hash:"
-               << " type: " << int(tx_type)
-               << " tx_id: " << tx_id
-               << " payload: " << to_hex(tx_payload)
-               << " h256: " << to_hex(h256.bytes, kHashLength);
-
-    return tx_hash;
+    return {it_impl, decompressor_index_query_entry(it_impl_ref.it)};
 }
 
-SnapshotPath TransactionIndex1::bodies_segment_path(const SnapshotPath& segment_path) {
-    return SnapshotPath::from(
-        segment_path.path().parent_path(),
-        segment_path.version(),
-        segment_path.block_from(),
-        segment_path.block_to(),
-        SnapshotType::bodies);
+bool DecompressorIndexInputDataQuery::equal_iterators(
+    std::shared_ptr<void> lhs_it_impl,
+    std::shared_ptr<void> rhs_it_impl) const {
+    auto lhs = reinterpret_cast<IteratorImpl*>(lhs_it_impl.get());
+    auto rhs = reinterpret_cast<IteratorImpl*>(rhs_it_impl.get());
+    return (lhs->decoder == rhs->decoder) &&
+           (!lhs->decoder || (lhs->it == rhs->it));
 }
 
-std::pair<uint64_t, uint64_t> TransactionIndex1::compute_txs_amount(const SnapshotPath& bodies_segment_path) {
-    BodySnapshot bodies_snapshot{bodies_segment_path};
-    bodies_snapshot.reopen_segment();
-    return bodies_snapshot.compute_txs_amount();
-}
-
-void TransactionToBlockIndex::build() {
-    const SnapshotPath index_file = segment_path_.index_file_for_type(SnapshotType::transactions_to_block);
-    SILK_TRACE << "TransactionIndex::build path: " << index_file.path().string() << " start";
+void IndexBuilder::build() {
+    SILK_TRACE << "IndexBuilder::build path: " << descriptor_.index_file.path() << " start";
 
     RecSplitSettings rec_split_settings{
-        .keys_count = expected_tx_count_,
+        .keys_count = query_->keys_count(),
         .bucket_size = kBucketSize,
-        .index_path = index_file.path(),
+        .index_path = descriptor_.index_file.path(),
         .base_data_id = descriptor_.base_data_id,
-        .double_enum_index = false,
+        .double_enum_index = descriptor_.double_enum_index,
         .less_false_positives = descriptor_.less_false_positives,
     };
     RecSplit8 rec_split1{rec_split_settings, rec_split::seq_build_strategy(descriptor_.etl_buffer_size)};
 
     rec_split1.build_without_collisions([&](RecSplit8& rec_split) {
         uint64_t i{0};
-        for (auto& value : *query_) {
-            rec_split.add_key(descriptor_.key_factory->make(value.tx_buffer, i), value.block_number);
+        for (auto& entry : *query_) {
+            auto key = descriptor_.key_factory ? descriptor_.key_factory->make(entry.key_data, i) : Bytes{entry.key_data};
+            rec_split.add_key(key, entry.value);
             i++;
         }
     });
 
-    SILK_TRACE << "TransactionIndex::build path: " << segment_path_.path().string() << " end";
-}
-
-Bytes TransactionKeyFactory::make(ByteView word, uint64_t i) {
-    return Bytes{tx_buffer_hash(word, first_tx_id_ + i)};
+    SILK_TRACE << "IndexBuilder::build path: " << descriptor_.index_file.path() << " end";
 }
 
 }  // namespace silkworm::snapshots

--- a/silkworm/db/snapshots/index.cpp
+++ b/silkworm/db/snapshots/index.cpp
@@ -104,7 +104,7 @@ static Hash tx_buffer_hash(ByteView tx_buffer, uint64_t tx_id) {
               << " tx_id: " << tx_id;
         throw std::runtime_error{error.str()};
     }
-    const Bytes tx_envelope{tx_buffer.substr(kTxFirstByteAndAddressLength)};
+    const ByteView tx_envelope{tx_buffer.substr(kTxFirstByteAndAddressLength)};
     ByteView tx_envelope_view{tx_envelope};
 
     rlp::Header tx_header;
@@ -126,7 +126,7 @@ static Hash tx_buffer_hash(ByteView tx_buffer, uint64_t tx_id) {
               << " tx_id: " << tx_id;
         throw std::runtime_error{error.str()};
     }
-    const Bytes tx_payload{tx_buffer.substr(kTxFirstByteAndAddressLength + tx_payload_offset)};
+    const ByteView tx_payload{tx_buffer.substr(kTxFirstByteAndAddressLength + tx_payload_offset)};
     const auto h256{keccak256(tx_payload)};
     std::copy(std::begin(h256.bytes), std::begin(h256.bytes) + kHashLength, std::begin(tx_hash.bytes));
 

--- a/silkworm/db/snapshots/index.hpp
+++ b/silkworm/db/snapshots/index.hpp
@@ -48,7 +48,7 @@ class Index {
     virtual void build();
 
   protected:
-    virtual bool walk(rec_split::RecSplit8& rec_split, uint64_t i, uint64_t offset, ByteView word) = 0;
+    virtual Bytes make_key(ByteView word, uint64_t i) = 0;
 
     SnapshotPath segment_path_;
     std::optional<MemoryMappedRegion> segment_region_;
@@ -63,7 +63,7 @@ class HeaderIndex : public Index {
         : Index(std::move(segment_path), segment_region) {}
 
   protected:
-    bool walk(rec_split::RecSplit8& rec_split, uint64_t i, uint64_t offset, ByteView word) override;
+    Bytes make_key(ByteView word, uint64_t i) override;
 };
 
 class BodyIndex : public Index {
@@ -72,7 +72,7 @@ class BodyIndex : public Index {
         : Index(std::move(segment_path), segment_region) {}
 
   protected:
-    bool walk(rec_split::RecSplit8& rec_split, uint64_t i, uint64_t offset, ByteView word) override;
+    Bytes make_key(ByteView word, uint64_t i) override;
 };
 
 class TransactionIndex : public Index {
@@ -83,7 +83,7 @@ class TransactionIndex : public Index {
     void build() override;
 
   protected:
-    bool walk(rec_split::RecSplit8& rec_split, uint64_t i, uint64_t offset, ByteView word) override;
+    Bytes make_key(ByteView word, uint64_t i) override;
 
   private:
     SnapshotPath bodies_segment_path() const;

--- a/silkworm/db/snapshots/index_builder.cpp
+++ b/silkworm/db/snapshots/index_builder.cpp
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-#include "index.hpp"
+#include "index_builder.hpp"
 
 #include <silkworm/db/snapshots/rec_split/rec_split.hpp>
 #include <silkworm/db/snapshots/rec_split/rec_split_seq.hpp>

--- a/silkworm/db/snapshots/index_builder.hpp
+++ b/silkworm/db/snapshots/index_builder.hpp
@@ -130,7 +130,4 @@ struct IndexBuilder {
     std::unique_ptr<IndexInputDataQuery> query_;
 };
 
-// TODO: remove
-using Index = IndexBuilder;
-
 }  // namespace silkworm::snapshots

--- a/silkworm/db/snapshots/index_builder_test.cpp
+++ b/silkworm/db/snapshots/index_builder_test.cpp
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-#include "index.hpp"
+#include "index_builder.hpp"
 
 #include <catch2/catch.hpp>
 
@@ -60,7 +60,7 @@ TEST_CASE("TransactionIndex::build KO: empty snapshot", "[silkworm][snapshot][in
         auto txs_snapshot_path = *SnapshotPath::parse(txs_snapshot_file.path());
         auto bodies_snapshot_path = *SnapshotPath::parse(bodies_snapshot_file.path());
 
-        CHECK_THROWS_WITH(TransactionIndex1::make(bodies_snapshot_path, txs_snapshot_path).build(), StartsWith("empty body snapshot"));
+        CHECK_THROWS_WITH(TransactionIndex::make(bodies_snapshot_path, txs_snapshot_path).build(), StartsWith("empty body snapshot"));
         CHECK_THROWS_WITH(TransactionToBlockIndex::make(bodies_snapshot_path, txs_snapshot_path).build(), StartsWith("empty body snapshot"));
     }
 }
@@ -84,7 +84,7 @@ TEST_CASE("TransactionIndex::build KO: invalid snapshot", "[silkworm][snapshot][
         auto txs_snapshot_path = *SnapshotPath::parse(txs_snapshot_file.path());
         auto bodies_snapshot_path = *SnapshotPath::parse(bodies_snapshot_file.path());
 
-        CHECK_THROWS_WITH(TransactionIndex1::make(bodies_snapshot_path, txs_snapshot_path).build(), StartsWith("invalid zero word length"));
+        CHECK_THROWS_WITH(TransactionIndex::make(bodies_snapshot_path, txs_snapshot_path).build(), StartsWith("invalid zero word length"));
         CHECK_THROWS_WITH(TransactionToBlockIndex::make(bodies_snapshot_path, txs_snapshot_path).build(), StartsWith("invalid zero word length"));
     }
 
@@ -100,7 +100,7 @@ TEST_CASE("TransactionIndex::build KO: invalid snapshot", "[silkworm][snapshot][
         test::SampleTransactionSnapshotFile valid_txs_snapshot{};
         test::SampleTransactionSnapshotPath txs_snapshot_path{valid_txs_snapshot.path()};  // necessary to tweak the block numbers
 
-        CHECK_THROWS_WITH(TransactionIndex1::make(bodies_snapshot_path, txs_snapshot_path).build(), Contains("invalid: position depth"));
+        CHECK_THROWS_WITH(TransactionIndex::make(bodies_snapshot_path, txs_snapshot_path).build(), Contains("invalid: position depth"));
         CHECK_THROWS_WITH(TransactionToBlockIndex::make(bodies_snapshot_path, txs_snapshot_path).build(), Contains("invalid: position depth"));
     }
 
@@ -116,7 +116,7 @@ TEST_CASE("TransactionIndex::build KO: invalid snapshot", "[silkworm][snapshot][
         test::SampleTransactionSnapshotFile valid_txs_snapshot{};
         test::SampleTransactionSnapshotPath txs_snapshot_path{valid_txs_snapshot.path()};  // necessary to tweak the block numbers
 
-        CHECK_THROWS_WITH(TransactionIndex1::make(bodies_snapshot_path, txs_snapshot_path).build(), Contains("invalid: position read"));
+        CHECK_THROWS_WITH(TransactionIndex::make(bodies_snapshot_path, txs_snapshot_path).build(), Contains("invalid: position read"));
         CHECK_THROWS_WITH(TransactionToBlockIndex::make(bodies_snapshot_path, txs_snapshot_path).build(), Contains("invalid: position read"));
     }
 
@@ -132,7 +132,7 @@ TEST_CASE("TransactionIndex::build KO: invalid snapshot", "[silkworm][snapshot][
         test::SampleTransactionSnapshotFile valid_txs_snapshot{};
         test::SampleTransactionSnapshotPath txs_snapshot_path{valid_txs_snapshot.path()};  // necessary to tweak the block numbers
 
-        CHECK_THROWS_WITH(TransactionIndex1::make(bodies_snapshot_path, txs_snapshot_path).build(), Contains("invalid: position read"));
+        CHECK_THROWS_WITH(TransactionIndex::make(bodies_snapshot_path, txs_snapshot_path).build(), Contains("invalid: position read"));
         CHECK_THROWS_WITH(TransactionToBlockIndex::make(bodies_snapshot_path, txs_snapshot_path).build(), Contains("invalid: position read"));
     }
 
@@ -148,7 +148,7 @@ TEST_CASE("TransactionIndex::build KO: invalid snapshot", "[silkworm][snapshot][
         test::SampleTransactionSnapshotFile valid_txs_snapshot{};
         test::SampleTransactionSnapshotPath txs_snapshot_path{valid_txs_snapshot.path()};  // necessary to tweak the block numbers
 
-        CHECK_THROWS_AS(TransactionIndex1::make(bodies_snapshot_path, txs_snapshot_path).build(), DecodingException);
+        CHECK_THROWS_AS(TransactionIndex::make(bodies_snapshot_path, txs_snapshot_path).build(), DecodingException);
         CHECK_THROWS_AS(TransactionToBlockIndex::make(bodies_snapshot_path, txs_snapshot_path).build(), DecodingException);
     }
 
@@ -172,7 +172,7 @@ TEST_CASE("TransactionIndex::build KO: invalid snapshot", "[silkworm][snapshot][
         };
         test::SampleTransactionSnapshotPath txs_snapshot_path{invalid_txs_snapshot.path()};  // necessary to tweak the block numbers
 
-        auto tx_index = TransactionIndex1::make(bodies_snapshot_path, txs_snapshot_path);
+        auto tx_index = TransactionIndex::make(bodies_snapshot_path, txs_snapshot_path);
         CHECK_THROWS_WITH(tx_index.build(), StartsWith("keys expected"));
         auto tx_index_hash_to_block = TransactionToBlockIndex::make(bodies_snapshot_path, txs_snapshot_path);
         CHECK_THROWS_WITH(tx_index_hash_to_block.build(), Contains("tx count mismatch"));
@@ -186,7 +186,7 @@ TEST_CASE("TransactionIndex::build OK", "[silkworm][snapshot][index]") {
     test::SampleTransactionSnapshotFile valid_txs_snapshot{};
     test::SampleTransactionSnapshotPath txs_snapshot_path{valid_txs_snapshot.path()};  // necessary to tweak the block numbers
 
-    auto tx_index = TransactionIndex1::make(bodies_snapshot_path, txs_snapshot_path);
+    auto tx_index = TransactionIndex::make(bodies_snapshot_path, txs_snapshot_path);
     tx_index.build();
     auto tx_index_hash_to_block = TransactionToBlockIndex::make(bodies_snapshot_path, txs_snapshot_path);
     tx_index_hash_to_block.build();

--- a/silkworm/db/snapshots/index_test.cpp
+++ b/silkworm/db/snapshots/index_test.cpp
@@ -26,6 +26,7 @@ namespace silkworm::snapshots {
 
 namespace test = test_util;
 using silkworm::test_util::SetLogVerbosityGuard;
+using namespace Catch::Matchers;
 
 TEST_CASE("Index::Index", "[silkworm][snapshot][index]") {
     SetLogVerbosityGuard guard{log::Level::kNone};
@@ -51,8 +52,12 @@ TEST_CASE("TransactionIndex::build KO: empty snapshot", "[silkworm][snapshot][in
     SECTION("KO: empty body snapshot", "[.]") {
         test::TemporarySnapshotFile bodies_snapshot_file{kBodiesSnapshotFileName};
         test::TemporarySnapshotFile txs_snapshot_file{kTransactionsSnapshotFileName};
-        TransactionIndex tx_index{*SnapshotPath::parse(txs_snapshot_file.path().string())};
-        CHECK_THROWS_AS(tx_index.build(), std::runtime_error);
+
+        auto txs_snapshot_path = *SnapshotPath::parse(txs_snapshot_file.path());
+        auto bodies_snapshot_path = *SnapshotPath::parse(bodies_snapshot_file.path());
+
+        CHECK_THROWS_WITH(TransactionIndex1::make(bodies_snapshot_path, txs_snapshot_path).build(), StartsWith("empty body snapshot"));
+        CHECK_THROWS_WITH(TransactionToBlockIndex(bodies_snapshot_path, txs_snapshot_path).build(), StartsWith("empty body snapshot"));
     }
 }
 
@@ -71,8 +76,12 @@ TEST_CASE("TransactionIndex::build KO: invalid snapshot", "[silkworm][snapshot][
             test::SnapshotBody{
                 *from_hex("0000000000000000")}};
         test::TemporarySnapshotFile txs_snapshot_file{kTransactionsSnapshotFileName};
-        TransactionIndex tx_index{*SnapshotPath::parse(txs_snapshot_file.path().string())};
-        CHECK_THROWS_AS(tx_index.build(), std::runtime_error);
+
+        auto txs_snapshot_path = *SnapshotPath::parse(txs_snapshot_file.path());
+        auto bodies_snapshot_path = *SnapshotPath::parse(bodies_snapshot_file.path());
+
+        CHECK_THROWS_WITH(TransactionIndex1::make(bodies_snapshot_path, txs_snapshot_path).build(), StartsWith("invalid zero word length"));
+        CHECK_THROWS_WITH(TransactionToBlockIndex(bodies_snapshot_path, txs_snapshot_path).build(), StartsWith("invalid zero word length"));
     }
 
     SECTION("KO: invalid position depth") {
@@ -83,10 +92,12 @@ TEST_CASE("TransactionIndex::build KO: invalid snapshot", "[silkworm][snapshot][
             "04d980c001c6837004d980c001c6837004d980c001c6837004d980c001c68370"
             "04d980c001c6837004d980c001c6837004d980c001c6837004d980c001c68370"
             "04d980c001c6837004d980c001c6837004d901c0"};
+        test::SampleBodySnapshotPath bodies_snapshot_path{invalid_bodies_snapshot.path()};
         test::SampleTransactionSnapshotFile valid_txs_snapshot{};
         test::SampleTransactionSnapshotPath txs_snapshot_path{valid_txs_snapshot.path()};  // necessary to tweak the block numbers
-        TransactionIndex tx_index{txs_snapshot_path};
-        CHECK_THROWS_AS(tx_index.build(), std::runtime_error);
+
+        CHECK_THROWS_WITH(TransactionIndex1::make(bodies_snapshot_path, txs_snapshot_path).build(), Contains("invalid: position depth"));
+        CHECK_THROWS_WITH(TransactionToBlockIndex(bodies_snapshot_path, txs_snapshot_path).build(), Contains("invalid: position depth"));
     }
 
     SECTION("KO: invalid position value") {
@@ -97,10 +108,12 @@ TEST_CASE("TransactionIndex::build KO: invalid snapshot", "[silkworm][snapshot][
             "04d980c001c6837004d980c001c6837004d980c001c6837004d980c001c68370"
             "04d980c001c6837004d980c001c6837004d980c001c6837004d980c001c68370"
             "04d980c001c6837004d980c001c6837004d901c0"};
+        test::SampleBodySnapshotPath bodies_snapshot_path{invalid_bodies_snapshot.path()};
         test::SampleTransactionSnapshotFile valid_txs_snapshot{};
         test::SampleTransactionSnapshotPath txs_snapshot_path{valid_txs_snapshot.path()};  // necessary to tweak the block numbers
-        TransactionIndex tx_index{txs_snapshot_path};
-        CHECK_THROWS_AS(tx_index.build(), std::runtime_error);
+
+        CHECK_THROWS_WITH(TransactionIndex1::make(bodies_snapshot_path, txs_snapshot_path).build(), Contains("invalid: position read"));
+        CHECK_THROWS_WITH(TransactionToBlockIndex(bodies_snapshot_path, txs_snapshot_path).build(), Contains("invalid: position read"));
     }
 
     SECTION("KO: invalid positions count") {
@@ -111,10 +124,12 @@ TEST_CASE("TransactionIndex::build KO: invalid snapshot", "[silkworm][snapshot][
             "04d980c001c6837004d980c001c6837004d980c001c6837004d980c001c68370"
             "04d980c001c6837004d980c001c6837004d980c001c6837004d980c001c68370"
             "04d980c001c6837004d980c001c6837004d901c0"};
+        test::SampleBodySnapshotPath bodies_snapshot_path{invalid_bodies_snapshot.path()};
         test::SampleTransactionSnapshotFile valid_txs_snapshot{};
         test::SampleTransactionSnapshotPath txs_snapshot_path{valid_txs_snapshot.path()};  // necessary to tweak the block numbers
-        TransactionIndex tx_index{txs_snapshot_path};
-        CHECK_THROWS_AS(tx_index.build(), std::runtime_error);
+
+        CHECK_THROWS_WITH(TransactionIndex1::make(bodies_snapshot_path, txs_snapshot_path).build(), Contains("invalid: position read"));
+        CHECK_THROWS_WITH(TransactionToBlockIndex(bodies_snapshot_path, txs_snapshot_path).build(), Contains("invalid: position read"));
     }
 
     SECTION("KO: invalid RLP") {
@@ -125,14 +140,17 @@ TEST_CASE("TransactionIndex::build KO: invalid snapshot", "[silkworm][snapshot][
             "04d980c001c6837004d980c001c6837004d980c001c6837004d980c001c78370"  // {01, c7837004d980c0} <- c7 instead of c6
             "04d980c001c6837004d980c001c6837004d980c001c6837004d980c001c68370"
             "04d980c001c6837004d980c001c6837004d901c0"};
+        test::SampleBodySnapshotPath bodies_snapshot_path{invalid_bodies_snapshot.path()};
         test::SampleTransactionSnapshotFile valid_txs_snapshot{};
         test::SampleTransactionSnapshotPath txs_snapshot_path{valid_txs_snapshot.path()};  // necessary to tweak the block numbers
-        TransactionIndex tx_index{txs_snapshot_path};
-        CHECK_THROWS_AS(tx_index.build(), DecodingException);
+
+        CHECK_THROWS_AS(TransactionIndex1::make(bodies_snapshot_path, txs_snapshot_path).build(), DecodingException);
+        CHECK_THROWS_AS(TransactionToBlockIndex(bodies_snapshot_path, txs_snapshot_path).build(), DecodingException);
     }
 
     SECTION("KO: unexpected tx amount") {
         test::SampleBodySnapshotFile valid_bodies_snapshot{};
+        test::SampleBodySnapshotPath bodies_snapshot_path{valid_bodies_snapshot.path()};
         test::SampleTransactionSnapshotFile invalid_txs_snapshot{
             TemporaryDirectory::get_os_temporary_path(),
             "000000000000000C"                              // WC = 12
@@ -149,18 +167,25 @@ TEST_CASE("TransactionIndex::build KO: invalid snapshot", "[silkworm][snapshot][
             // 11 txs missing here...
         };
         test::SampleTransactionSnapshotPath txs_snapshot_path{invalid_txs_snapshot.path()};  // necessary to tweak the block numbers
-        TransactionIndex tx_index{txs_snapshot_path};
-        CHECK_THROWS_AS(tx_index.build(), std::logic_error);
+
+        auto tx_index = TransactionIndex1::make(bodies_snapshot_path, txs_snapshot_path);
+        CHECK_THROWS_WITH(tx_index.build(), StartsWith("keys expected"));
+        TransactionToBlockIndex tx_index_hash_to_block{bodies_snapshot_path, txs_snapshot_path};
+        CHECK_THROWS_WITH(tx_index_hash_to_block.build(), Contains("tx count mismatch"));
     }
 }
 
 TEST_CASE("TransactionIndex::build OK", "[silkworm][snapshot][index]") {
     SetLogVerbosityGuard guard{log::Level::kNone};
     test::SampleBodySnapshotFile valid_bodies_snapshot{};
+    test::SampleBodySnapshotPath bodies_snapshot_path{valid_bodies_snapshot.path()};
     test::SampleTransactionSnapshotFile valid_txs_snapshot{};
     test::SampleTransactionSnapshotPath txs_snapshot_path{valid_txs_snapshot.path()};  // necessary to tweak the block numbers
-    TransactionIndex tx_index{txs_snapshot_path};
-    CHECK_NOTHROW(tx_index.build());
+
+    auto tx_index = TransactionIndex1::make(bodies_snapshot_path, txs_snapshot_path);
+    tx_index.build();
+    TransactionToBlockIndex tx_index_hash_to_block{bodies_snapshot_path, txs_snapshot_path};
+    tx_index_hash_to_block.build();
 }
 
 }  // namespace silkworm::snapshots

--- a/silkworm/db/snapshots/index_test.cpp
+++ b/silkworm/db/snapshots/index_test.cpp
@@ -30,7 +30,7 @@ using silkworm::test_util::SetLogVerbosityGuard;
 TEST_CASE("Index::Index", "[silkworm][snapshot][index]") {
     SetLogVerbosityGuard guard{log::Level::kNone};
     test::TemporarySnapshotFile tmp_snapshot_file{"v1-014500-015000-headers.seg"};
-    HeaderIndex header_index{*SnapshotPath::parse(tmp_snapshot_file.path().string())};
+    auto header_index = HeaderIndex::make(*SnapshotPath::parse(tmp_snapshot_file.path().string()));
     CHECK_THROWS_AS(header_index.build(), std::logic_error);
 }
 
@@ -39,7 +39,7 @@ TEST_CASE("BodyIndex::build OK", "[silkworm][snapshot][index]") {
     SetLogVerbosityGuard guard{log::Level::kNone};
     test::SampleBodySnapshotFile valid_body_snapshot{};
     test::SampleBodySnapshotPath body_snapshot_path{valid_body_snapshot.path()};  // necessary to tweak the block numbers
-    BodyIndex body_index{body_snapshot_path};
+    auto body_index = BodyIndex::make(body_snapshot_path);
     CHECK_NOTHROW(body_index.build());
 }
 

--- a/silkworm/db/snapshots/index_test.cpp
+++ b/silkworm/db/snapshots/index_test.cpp
@@ -18,7 +18,11 @@
 
 #include <catch2/catch.hpp>
 
+#include <silkworm/db/snapshots/body_index.hpp>
+#include <silkworm/db/snapshots/header_index.hpp>
 #include <silkworm/db/snapshots/test_util/common.hpp>
+#include <silkworm/db/snapshots/txn_index.hpp>
+#include <silkworm/db/snapshots/txn_to_block_index.hpp>
 #include <silkworm/infra/common/decoding_exception.hpp>
 #include <silkworm/infra/test_util/log.hpp>
 
@@ -57,7 +61,7 @@ TEST_CASE("TransactionIndex::build KO: empty snapshot", "[silkworm][snapshot][in
         auto bodies_snapshot_path = *SnapshotPath::parse(bodies_snapshot_file.path());
 
         CHECK_THROWS_WITH(TransactionIndex1::make(bodies_snapshot_path, txs_snapshot_path).build(), StartsWith("empty body snapshot"));
-        CHECK_THROWS_WITH(TransactionToBlockIndex(bodies_snapshot_path, txs_snapshot_path).build(), StartsWith("empty body snapshot"));
+        CHECK_THROWS_WITH(TransactionToBlockIndex::make(bodies_snapshot_path, txs_snapshot_path).build(), StartsWith("empty body snapshot"));
     }
 }
 
@@ -81,7 +85,7 @@ TEST_CASE("TransactionIndex::build KO: invalid snapshot", "[silkworm][snapshot][
         auto bodies_snapshot_path = *SnapshotPath::parse(bodies_snapshot_file.path());
 
         CHECK_THROWS_WITH(TransactionIndex1::make(bodies_snapshot_path, txs_snapshot_path).build(), StartsWith("invalid zero word length"));
-        CHECK_THROWS_WITH(TransactionToBlockIndex(bodies_snapshot_path, txs_snapshot_path).build(), StartsWith("invalid zero word length"));
+        CHECK_THROWS_WITH(TransactionToBlockIndex::make(bodies_snapshot_path, txs_snapshot_path).build(), StartsWith("invalid zero word length"));
     }
 
     SECTION("KO: invalid position depth") {
@@ -97,7 +101,7 @@ TEST_CASE("TransactionIndex::build KO: invalid snapshot", "[silkworm][snapshot][
         test::SampleTransactionSnapshotPath txs_snapshot_path{valid_txs_snapshot.path()};  // necessary to tweak the block numbers
 
         CHECK_THROWS_WITH(TransactionIndex1::make(bodies_snapshot_path, txs_snapshot_path).build(), Contains("invalid: position depth"));
-        CHECK_THROWS_WITH(TransactionToBlockIndex(bodies_snapshot_path, txs_snapshot_path).build(), Contains("invalid: position depth"));
+        CHECK_THROWS_WITH(TransactionToBlockIndex::make(bodies_snapshot_path, txs_snapshot_path).build(), Contains("invalid: position depth"));
     }
 
     SECTION("KO: invalid position value") {
@@ -113,7 +117,7 @@ TEST_CASE("TransactionIndex::build KO: invalid snapshot", "[silkworm][snapshot][
         test::SampleTransactionSnapshotPath txs_snapshot_path{valid_txs_snapshot.path()};  // necessary to tweak the block numbers
 
         CHECK_THROWS_WITH(TransactionIndex1::make(bodies_snapshot_path, txs_snapshot_path).build(), Contains("invalid: position read"));
-        CHECK_THROWS_WITH(TransactionToBlockIndex(bodies_snapshot_path, txs_snapshot_path).build(), Contains("invalid: position read"));
+        CHECK_THROWS_WITH(TransactionToBlockIndex::make(bodies_snapshot_path, txs_snapshot_path).build(), Contains("invalid: position read"));
     }
 
     SECTION("KO: invalid positions count") {
@@ -129,7 +133,7 @@ TEST_CASE("TransactionIndex::build KO: invalid snapshot", "[silkworm][snapshot][
         test::SampleTransactionSnapshotPath txs_snapshot_path{valid_txs_snapshot.path()};  // necessary to tweak the block numbers
 
         CHECK_THROWS_WITH(TransactionIndex1::make(bodies_snapshot_path, txs_snapshot_path).build(), Contains("invalid: position read"));
-        CHECK_THROWS_WITH(TransactionToBlockIndex(bodies_snapshot_path, txs_snapshot_path).build(), Contains("invalid: position read"));
+        CHECK_THROWS_WITH(TransactionToBlockIndex::make(bodies_snapshot_path, txs_snapshot_path).build(), Contains("invalid: position read"));
     }
 
     SECTION("KO: invalid RLP") {
@@ -145,7 +149,7 @@ TEST_CASE("TransactionIndex::build KO: invalid snapshot", "[silkworm][snapshot][
         test::SampleTransactionSnapshotPath txs_snapshot_path{valid_txs_snapshot.path()};  // necessary to tweak the block numbers
 
         CHECK_THROWS_AS(TransactionIndex1::make(bodies_snapshot_path, txs_snapshot_path).build(), DecodingException);
-        CHECK_THROWS_AS(TransactionToBlockIndex(bodies_snapshot_path, txs_snapshot_path).build(), DecodingException);
+        CHECK_THROWS_AS(TransactionToBlockIndex::make(bodies_snapshot_path, txs_snapshot_path).build(), DecodingException);
     }
 
     SECTION("KO: unexpected tx amount") {
@@ -170,7 +174,7 @@ TEST_CASE("TransactionIndex::build KO: invalid snapshot", "[silkworm][snapshot][
 
         auto tx_index = TransactionIndex1::make(bodies_snapshot_path, txs_snapshot_path);
         CHECK_THROWS_WITH(tx_index.build(), StartsWith("keys expected"));
-        TransactionToBlockIndex tx_index_hash_to_block{bodies_snapshot_path, txs_snapshot_path};
+        auto tx_index_hash_to_block = TransactionToBlockIndex::make(bodies_snapshot_path, txs_snapshot_path);
         CHECK_THROWS_WITH(tx_index_hash_to_block.build(), Contains("tx count mismatch"));
     }
 }
@@ -184,7 +188,7 @@ TEST_CASE("TransactionIndex::build OK", "[silkworm][snapshot][index]") {
 
     auto tx_index = TransactionIndex1::make(bodies_snapshot_path, txs_snapshot_path);
     tx_index.build();
-    TransactionToBlockIndex tx_index_hash_to_block{bodies_snapshot_path, txs_snapshot_path};
+    auto tx_index_hash_to_block = TransactionToBlockIndex::make(bodies_snapshot_path, txs_snapshot_path);
     tx_index_hash_to_block.build();
 }
 

--- a/silkworm/db/snapshots/path.hpp
+++ b/silkworm/db/snapshots/path.hpp
@@ -110,6 +110,7 @@ class SnapshotPath {
     }
 
     friend bool operator<(const SnapshotPath& lhs, const SnapshotPath& rhs);
+    friend bool operator==(const SnapshotPath&, const SnapshotPath&) = default;
 
   protected:
     static std::filesystem::path build_filename(uint8_t version, BlockNum block_from, BlockNum block_to, SnapshotType type);

--- a/silkworm/db/snapshots/repository.cpp
+++ b/silkworm/db/snapshots/repository.cpp
@@ -208,11 +208,11 @@ std::vector<std::shared_ptr<Index>> SnapshotRepository::missing_indexes() const 
             std::shared_ptr<Index> index;
             switch (seg_file.type()) {
                 case SnapshotType::headers: {
-                    index = std::make_shared<HeaderIndex>(seg_file);
+                    index = std::make_shared<Index>(HeaderIndex::make(seg_file));
                     break;
                 }
                 case SnapshotType::bodies: {
-                    index = std::make_shared<BodyIndex>(seg_file);
+                    index = std::make_shared<Index>(BodyIndex::make(seg_file));
                     break;
                 }
                 case SnapshotType::transactions: {

--- a/silkworm/db/snapshots/repository.cpp
+++ b/silkworm/db/snapshots/repository.cpp
@@ -23,7 +23,7 @@
 #include <silkworm/core/common/assert.hpp>
 #include <silkworm/db/snapshots/body_index.hpp>
 #include <silkworm/db/snapshots/header_index.hpp>
-#include <silkworm/db/snapshots/index.hpp>
+#include <silkworm/db/snapshots/index_builder.hpp>
 #include <silkworm/db/snapshots/txn_index.hpp>
 #include <silkworm/db/snapshots/txn_to_block_index.hpp>
 #include <silkworm/infra/common/ensure.hpp>
@@ -203,13 +203,13 @@ std::optional<BlockNum> SnapshotRepository::find_block_number(Hash txn_hash) con
 
 std::vector<std::shared_ptr<IndexBuilder>> SnapshotRepository::missing_indexes() const {
     SnapshotPathList segment_files = get_segment_files();
-    std::vector<std::shared_ptr<Index>> missing_index_list;
+    std::vector<std::shared_ptr<IndexBuilder>> missing_index_list;
     missing_index_list.reserve(segment_files.size());
     for (const auto& seg_file : segment_files) {
         const auto index_file = seg_file.index_file();
         SILK_TRACE << "Segment file: " << seg_file.filename() << " has index: " << index_file.filename();
         if (!std::filesystem::exists(index_file.path())) {
-            std::shared_ptr<Index> index;
+            std::shared_ptr<IndexBuilder> index;
             switch (seg_file.type()) {
                 case SnapshotType::headers: {
                     index = std::make_shared<IndexBuilder>(HeaderIndex::make(seg_file));
@@ -222,9 +222,9 @@ std::vector<std::shared_ptr<IndexBuilder>> SnapshotRepository::missing_indexes()
                     break;
                 }
                 case SnapshotType::transactions: {
-                    auto bodies_segment_path = TransactionIndex1::bodies_segment_path(seg_file);
+                    auto bodies_segment_path = TransactionIndex::bodies_segment_path(seg_file);
                     if (std::find(segment_files.begin(), segment_files.end(), bodies_segment_path) != segment_files.end()) {
-                        index = std::make_shared<IndexBuilder>(TransactionIndex1::make(bodies_segment_path, seg_file));
+                        index = std::make_shared<IndexBuilder>(TransactionIndex::make(bodies_segment_path, seg_file));
                         missing_index_list.push_back(index);
 
                         index = std::make_shared<IndexBuilder>(TransactionToBlockIndex::make(bodies_segment_path, seg_file));

--- a/silkworm/db/snapshots/repository.hpp
+++ b/silkworm/db/snapshots/repository.hpp
@@ -31,7 +31,7 @@
 
 namespace silkworm::snapshots {
 
-class Index;
+struct IndexBuilder;
 
 template <typename T>
 concept ConcreteSnapshot = std::is_base_of<Snapshot, T>::value;
@@ -113,7 +113,7 @@ class SnapshotRepository {
     [[nodiscard]] const BodySnapshot* find_body_segment(BlockNum number) const;
     [[nodiscard]] const TransactionSnapshot* find_tx_segment(BlockNum number) const;
 
-    [[nodiscard]] std::vector<std::shared_ptr<Index>> missing_indexes() const;
+    [[nodiscard]] std::vector<std::shared_ptr<IndexBuilder>> missing_indexes() const;
 
     [[nodiscard]] BlockNum segment_max_block() const { return segment_max_block_; }
     [[nodiscard]] BlockNum idx_max_block() const { return idx_max_block_; }

--- a/silkworm/db/snapshots/repository_test.cpp
+++ b/silkworm/db/snapshots/repository_test.cpp
@@ -40,12 +40,11 @@ TEST_CASE("SnapshotRepository::SnapshotRepository", "[silkworm][node][snapshot]"
 
 TEST_CASE("SnapshotRepository::reopen_folder", "[silkworm][node][snapshot]") {
     SetLogVerbosityGuard guard{log::Level::kNone};
+    TemporaryDirectory tmp_dir;
 
-    const auto tmp_dir = TemporaryDirectory::get_unique_temporary_path();
-    std::filesystem::create_directories(tmp_dir);
-    test::TemporarySnapshotFile tmp_snapshot_1{tmp_dir, "v1-014500-015000-headers.seg"};
-    test::TemporarySnapshotFile tmp_snapshot_2{tmp_dir, "v1-011500-012000-bodies.seg"};
-    test::TemporarySnapshotFile tmp_snapshot_3{tmp_dir, "v1-015000-015500-transactions.seg"};
+    test::TemporarySnapshotFile tmp_snapshot_1{tmp_dir.path(), "v1-014500-015000-headers.seg"};
+    test::TemporarySnapshotFile tmp_snapshot_2{tmp_dir.path(), "v1-011500-012000-bodies.seg"};
+    test::TemporarySnapshotFile tmp_snapshot_3{tmp_dir.path(), "v1-015000-015500-transactions.seg"};
     SnapshotSettings settings{tmp_snapshot_1.path().parent_path()};
     SnapshotRepository repository{settings};
     CHECK_THROWS_AS(repository.reopen_folder(), std::logic_error);
@@ -57,9 +56,9 @@ TEST_CASE("SnapshotRepository::reopen_folder", "[silkworm][node][snapshot]") {
 
 TEST_CASE("SnapshotRepository::view", "[silkworm][node][snapshot]") {
     SetLogVerbosityGuard guard{log::Level::kNone};
-    const auto tmp_dir = TemporaryDirectory::get_unique_temporary_path();
-    std::filesystem::create_directories(tmp_dir);
-    SnapshotSettings settings{tmp_dir};
+    TemporaryDirectory tmp_dir;
+
+    SnapshotSettings settings{tmp_dir.path()};
     SnapshotRepository repository{settings};
     auto failing_walk = [](const auto&) { return false; };
     auto successful_walk = [](const auto&) { return true; };
@@ -81,9 +80,9 @@ TEST_CASE("SnapshotRepository::view", "[silkworm][node][snapshot]") {
     }
 
     SECTION("empty snapshots") {
-        test::TemporarySnapshotFile tmp_snapshot_1{tmp_dir, "v1-014500-015000-headers.seg"};
-        test::TemporarySnapshotFile tmp_snapshot_2{tmp_dir, "v1-011500-012000-bodies.seg"};
-        test::TemporarySnapshotFile tmp_snapshot_3{tmp_dir, "v1-015000-015500-transactions.seg"};
+        test::TemporarySnapshotFile tmp_snapshot_1{tmp_dir.path(), "v1-014500-015000-headers.seg"};
+        test::TemporarySnapshotFile tmp_snapshot_2{tmp_dir.path(), "v1-011500-012000-bodies.seg"};
+        test::TemporarySnapshotFile tmp_snapshot_3{tmp_dir.path(), "v1-015000-015500-transactions.seg"};
         CHECK_THROWS_AS(repository.reopen_folder(), std::logic_error);
 
         using ViewResult = SnapshotRepository::ViewResult;
@@ -100,9 +99,9 @@ TEST_CASE("SnapshotRepository::view", "[silkworm][node][snapshot]") {
     }
 
     SECTION("non-empty snapshots") {
-        test::HelloWorldSnapshotFile tmp_snapshot_1{tmp_dir, "v1-014500-015000-headers.seg"};
-        test::HelloWorldSnapshotFile tmp_snapshot_2{tmp_dir, "v1-011500-012000-bodies.seg"};
-        test::HelloWorldSnapshotFile tmp_snapshot_3{tmp_dir, "v1-015000-015500-transactions.seg"};
+        test::HelloWorldSnapshotFile tmp_snapshot_1{tmp_dir.path(), "v1-014500-015000-headers.seg"};
+        test::HelloWorldSnapshotFile tmp_snapshot_2{tmp_dir.path(), "v1-011500-012000-bodies.seg"};
+        test::HelloWorldSnapshotFile tmp_snapshot_3{tmp_dir.path(), "v1-015000-015500-transactions.seg"};
         repository.reopen_folder();
 
         using ViewResult = SnapshotRepository::ViewResult;
@@ -128,14 +127,13 @@ TEST_CASE("SnapshotRepository::view", "[silkworm][node][snapshot]") {
 
 TEST_CASE("SnapshotRepository::missing_block_ranges", "[silkworm][node][snapshot]") {
     SetLogVerbosityGuard guard{log::Level::kNone};
-    const auto tmp_dir = TemporaryDirectory::get_unique_temporary_path();
-    std::filesystem::create_directories(tmp_dir);
-    SnapshotSettings settings{tmp_dir};
+    TemporaryDirectory tmp_dir;
+    SnapshotSettings settings{tmp_dir.path()};
     SnapshotRepository repository{settings};
 
-    test::HelloWorldSnapshotFile tmp_snapshot_1{tmp_dir, "v1-014500-015000-headers.seg"};
-    test::HelloWorldSnapshotFile tmp_snapshot_2{tmp_dir, "v1-011500-012000-bodies.seg"};
-    test::HelloWorldSnapshotFile tmp_snapshot_3{tmp_dir, "v1-015000-015500-transactions.seg"};
+    test::HelloWorldSnapshotFile tmp_snapshot_1{tmp_dir.path(), "v1-014500-015000-headers.seg"};
+    test::HelloWorldSnapshotFile tmp_snapshot_2{tmp_dir.path(), "v1-011500-012000-bodies.seg"};
+    test::HelloWorldSnapshotFile tmp_snapshot_3{tmp_dir.path(), "v1-015000-015500-transactions.seg"};
     repository.reopen_folder();
     CHECK(repository.missing_block_ranges() == std::vector<BlockNumRange>{
                                                    BlockNumRange{0, 11'500'000},
@@ -144,16 +142,15 @@ TEST_CASE("SnapshotRepository::missing_block_ranges", "[silkworm][node][snapshot
 
 TEST_CASE("SnapshotRepository::find_segment", "[silkworm][node][snapshot]") {
     SetLogVerbosityGuard guard{log::Level::kNone};
-    const auto tmp_dir = TemporaryDirectory::get_unique_temporary_path();
-    std::filesystem::create_directories(tmp_dir);
-    SnapshotSettings settings{tmp_dir};
+    TemporaryDirectory tmp_dir;
+    SnapshotSettings settings{tmp_dir.path()};
     SnapshotRepository repository{settings};
 
     // These sample snapshot files just contain data for block range [1'500'012, 1'500'013], hence current snapshot
     // file name format is not sufficient to support them (see checks commented out below)
-    test::SampleHeaderSnapshotFile header_snapshot{tmp_dir};
-    test::SampleBodySnapshotFile body_snapshot{tmp_dir};
-    test::SampleTransactionSnapshotFile txn_snapshot{tmp_dir};
+    test::SampleHeaderSnapshotFile header_snapshot{tmp_dir.path()};
+    test::SampleBodySnapshotFile body_snapshot{tmp_dir.path()};
+    test::SampleTransactionSnapshotFile txn_snapshot{tmp_dir.path()};
 
     SECTION("header w/o index") {
         CHECK(repository.find_header_segment(1'500'011) == nullptr);
@@ -211,16 +208,15 @@ TEST_CASE("SnapshotRepository::find_segment", "[silkworm][node][snapshot]") {
 
 TEST_CASE("SnapshotRepository::find_block_number", "[silkworm][node][snapshot]") {
     SetLogVerbosityGuard guard{log::Level::kNone};
-    const auto tmp_dir = TemporaryDirectory::get_unique_temporary_path();
-    std::filesystem::create_directories(tmp_dir);
-    SnapshotSettings settings{tmp_dir};
+    TemporaryDirectory tmp_dir;
+    SnapshotSettings settings{tmp_dir.path()};
     SnapshotRepository repository{settings};
 
     // These sample snapshot files just contain data for block range [1'500'012, 1'500'013], hence current snapshot
     // file name format is not sufficient to support them (see checks commented out below)
-    test::SampleHeaderSnapshotFile header_snapshot{tmp_dir};
-    test::SampleBodySnapshotFile body_snapshot{tmp_dir};
-    test::SampleTransactionSnapshotFile txn_snapshot{tmp_dir};
+    test::SampleHeaderSnapshotFile header_snapshot{tmp_dir.path()};
+    test::SampleBodySnapshotFile body_snapshot{tmp_dir.path()};
+    test::SampleTransactionSnapshotFile txn_snapshot{tmp_dir.path()};
 
     test::SampleHeaderSnapshotPath header_snapshot_path{header_snapshot.path()};  // necessary to tweak the block numbers
     auto header_index = HeaderIndex::make(header_snapshot_path);

--- a/silkworm/db/snapshots/repository_test.cpp
+++ b/silkworm/db/snapshots/repository_test.cpp
@@ -20,7 +20,7 @@
 
 #include <silkworm/db/snapshots/body_index.hpp>
 #include <silkworm/db/snapshots/header_index.hpp>
-#include <silkworm/db/snapshots/index.hpp>
+#include <silkworm/db/snapshots/index_builder.hpp>
 #include <silkworm/db/snapshots/test_util/common.hpp>
 #include <silkworm/db/snapshots/txn_index.hpp>
 #include <silkworm/db/snapshots/txn_to_block_index.hpp>
@@ -181,7 +181,7 @@ TEST_CASE("SnapshotRepository::find_segment", "[silkworm][node][snapshot]") {
     auto body_index = BodyIndex::make(body_snapshot_path);
     REQUIRE_NOTHROW(body_index.build());
     test::SampleTransactionSnapshotPath txn_snapshot_path{txn_snapshot.path()};  // necessary to tweak the block numbers
-    REQUIRE_NOTHROW(TransactionIndex1::make(body_snapshot_path, txn_snapshot_path).build());
+    REQUIRE_NOTHROW(TransactionIndex::make(body_snapshot_path, txn_snapshot_path).build());
     REQUIRE_NOTHROW(TransactionToBlockIndex::make(body_snapshot_path, txn_snapshot_path).build());
 
     REQUIRE_NOTHROW(repository.reopen_folder());
@@ -229,7 +229,7 @@ TEST_CASE("SnapshotRepository::find_block_number", "[silkworm][node][snapshot]")
     auto body_index = BodyIndex::make(body_snapshot_path);
     REQUIRE_NOTHROW(body_index.build());
     test::SampleTransactionSnapshotPath txn_snapshot_path{txn_snapshot.path()};  // necessary to tweak the block numbers
-    REQUIRE_NOTHROW(TransactionIndex1::make(body_snapshot_path, txn_snapshot_path).build());
+    REQUIRE_NOTHROW(TransactionIndex::make(body_snapshot_path, txn_snapshot_path).build());
     REQUIRE_NOTHROW(TransactionToBlockIndex::make(body_snapshot_path, txn_snapshot_path).build());
 
     REQUIRE_NOTHROW(repository.reopen_folder());

--- a/silkworm/db/snapshots/repository_test.cpp
+++ b/silkworm/db/snapshots/repository_test.cpp
@@ -177,8 +177,8 @@ TEST_CASE("SnapshotRepository::find_segment", "[silkworm][node][snapshot]") {
     auto body_index = BodyIndex::make(body_snapshot_path);
     REQUIRE_NOTHROW(body_index.build());
     test::SampleTransactionSnapshotPath txn_snapshot_path{txn_snapshot.path()};  // necessary to tweak the block numbers
-    TransactionIndex txn_index{txn_snapshot_path};
-    REQUIRE_NOTHROW(txn_index.build());
+    REQUIRE_NOTHROW(TransactionIndex1::make(body_snapshot_path, txn_snapshot_path).build());
+    REQUIRE_NOTHROW(TransactionToBlockIndex(body_snapshot_path, txn_snapshot_path).build());
 
     REQUIRE_NOTHROW(repository.reopen_folder());
 
@@ -225,8 +225,8 @@ TEST_CASE("SnapshotRepository::find_block_number", "[silkworm][node][snapshot]")
     auto body_index = BodyIndex::make(body_snapshot_path);
     REQUIRE_NOTHROW(body_index.build());
     test::SampleTransactionSnapshotPath txn_snapshot_path{txn_snapshot.path()};  // necessary to tweak the block numbers
-    TransactionIndex txn_index{txn_snapshot_path};
-    REQUIRE_NOTHROW(txn_index.build());
+    REQUIRE_NOTHROW(TransactionIndex1::make(body_snapshot_path, txn_snapshot_path).build());
+    REQUIRE_NOTHROW(TransactionToBlockIndex(body_snapshot_path, txn_snapshot_path).build());
 
     REQUIRE_NOTHROW(repository.reopen_folder());
 

--- a/silkworm/db/snapshots/repository_test.cpp
+++ b/silkworm/db/snapshots/repository_test.cpp
@@ -18,8 +18,12 @@
 
 #include <catch2/catch.hpp>
 
+#include <silkworm/db/snapshots/body_index.hpp>
+#include <silkworm/db/snapshots/header_index.hpp>
 #include <silkworm/db/snapshots/index.hpp>
 #include <silkworm/db/snapshots/test_util/common.hpp>
+#include <silkworm/db/snapshots/txn_index.hpp>
+#include <silkworm/db/snapshots/txn_to_block_index.hpp>
 #include <silkworm/infra/common/directories.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/test_util/log.hpp>
@@ -178,7 +182,7 @@ TEST_CASE("SnapshotRepository::find_segment", "[silkworm][node][snapshot]") {
     REQUIRE_NOTHROW(body_index.build());
     test::SampleTransactionSnapshotPath txn_snapshot_path{txn_snapshot.path()};  // necessary to tweak the block numbers
     REQUIRE_NOTHROW(TransactionIndex1::make(body_snapshot_path, txn_snapshot_path).build());
-    REQUIRE_NOTHROW(TransactionToBlockIndex(body_snapshot_path, txn_snapshot_path).build());
+    REQUIRE_NOTHROW(TransactionToBlockIndex::make(body_snapshot_path, txn_snapshot_path).build());
 
     REQUIRE_NOTHROW(repository.reopen_folder());
 
@@ -226,7 +230,7 @@ TEST_CASE("SnapshotRepository::find_block_number", "[silkworm][node][snapshot]")
     REQUIRE_NOTHROW(body_index.build());
     test::SampleTransactionSnapshotPath txn_snapshot_path{txn_snapshot.path()};  // necessary to tweak the block numbers
     REQUIRE_NOTHROW(TransactionIndex1::make(body_snapshot_path, txn_snapshot_path).build());
-    REQUIRE_NOTHROW(TransactionToBlockIndex(body_snapshot_path, txn_snapshot_path).build());
+    REQUIRE_NOTHROW(TransactionToBlockIndex::make(body_snapshot_path, txn_snapshot_path).build());
 
     REQUIRE_NOTHROW(repository.reopen_folder());
 

--- a/silkworm/db/snapshots/repository_test.cpp
+++ b/silkworm/db/snapshots/repository_test.cpp
@@ -171,10 +171,10 @@ TEST_CASE("SnapshotRepository::find_segment", "[silkworm][node][snapshot]") {
     }
 
     test::SampleHeaderSnapshotPath header_snapshot_path{header_snapshot.path()};  // necessary to tweak the block numbers
-    HeaderIndex header_index{header_snapshot_path};
+    auto header_index = HeaderIndex::make(header_snapshot_path);
     REQUIRE_NOTHROW(header_index.build());
     test::SampleBodySnapshotPath body_snapshot_path{body_snapshot.path()};  // necessary to tweak the block numbers
-    BodyIndex body_index{body_snapshot_path};
+    auto body_index = BodyIndex::make(body_snapshot_path);
     REQUIRE_NOTHROW(body_index.build());
     test::SampleTransactionSnapshotPath txn_snapshot_path{txn_snapshot.path()};  // necessary to tweak the block numbers
     TransactionIndex txn_index{txn_snapshot_path};
@@ -219,10 +219,10 @@ TEST_CASE("SnapshotRepository::find_block_number", "[silkworm][node][snapshot]")
     test::SampleTransactionSnapshotFile txn_snapshot{tmp_dir};
 
     test::SampleHeaderSnapshotPath header_snapshot_path{header_snapshot.path()};  // necessary to tweak the block numbers
-    HeaderIndex header_index{header_snapshot_path};
+    auto header_index = HeaderIndex::make(header_snapshot_path);
     REQUIRE_NOTHROW(header_index.build());
     test::SampleBodySnapshotPath body_snapshot_path{body_snapshot.path()};  // necessary to tweak the block numbers
-    BodyIndex body_index{body_snapshot_path};
+    auto body_index = BodyIndex::make(body_snapshot_path);
     REQUIRE_NOTHROW(body_index.build());
     test::SampleTransactionSnapshotPath txn_snapshot_path{txn_snapshot.path()};  // necessary to tweak the block numbers
     TransactionIndex txn_index{txn_snapshot_path};

--- a/silkworm/db/snapshots/snapshot.cpp
+++ b/silkworm/db/snapshots/snapshot.cpp
@@ -37,10 +37,7 @@ inline std::string to_string(DecodingResult result) {
     return s;
 }
 
-Snapshot::Snapshot(SnapshotPath path)
-    : path_(std::move(path)), decoder_{path_.path()} {}
-
-Snapshot::Snapshot(SnapshotPath path, MemoryMappedRegion segment_region)
+Snapshot::Snapshot(SnapshotPath path, std::optional<MemoryMappedRegion> segment_region)
     : path_(std::move(path)), decoder_{path_.path(), segment_region} {}
 
 MemoryMappedRegion Snapshot::memory_file_region() const {
@@ -215,7 +212,8 @@ void HeaderSnapshot::close_index() {
     idx_header_hash_.reset();
 }
 
-BodySnapshot::BodySnapshot(SnapshotPath path) : Snapshot(std::move(path)) {}
+BodySnapshot::BodySnapshot(SnapshotPath path, std::optional<MemoryMappedRegion> segment_region)
+    : Snapshot(std::move(path), segment_region) {}
 
 BodySnapshot::BodySnapshot(SnapshotPath path, MappedBodiesSnapshot mapped)
     : Snapshot(std::move(path), mapped.segment), idx_body_number_region_{mapped.block_num_index} {}

--- a/silkworm/db/snapshots/snapshot.hpp
+++ b/silkworm/db/snapshots/snapshot.hpp
@@ -60,8 +60,7 @@ class Snapshot {
   public:
     static inline const auto kPageSize{os::page_size()};
 
-    explicit Snapshot(SnapshotPath path);
-    Snapshot(SnapshotPath path, MemoryMappedRegion segment_region);
+    explicit Snapshot(SnapshotPath path, std::optional<MemoryMappedRegion> segment_region = std::nullopt);
     virtual ~Snapshot() = default;
 
     [[nodiscard]] SnapshotPath path() const { return path_; }
@@ -137,7 +136,7 @@ using StoredBlockBody = BlockBodyForStorage;
 
 class BodySnapshot : public Snapshot {
   public:
-    explicit BodySnapshot(SnapshotPath path);
+    explicit BodySnapshot(SnapshotPath path, std::optional<MemoryMappedRegion> segment_region = std::nullopt);
     BodySnapshot(SnapshotPath path, MappedBodiesSnapshot mapped);
     ~BodySnapshot() override;
 

--- a/silkworm/db/snapshots/snapshot_benchmark.cpp
+++ b/silkworm/db/snapshots/snapshot_benchmark.cpp
@@ -78,7 +78,7 @@ static void build_header_index(benchmark::State& state) {
 
     for ([[maybe_unused]] auto _ : state) {
         test::SampleHeaderSnapshotPath header_snapshot_path{header_snapshot.path()};  // necessary to tweak the block numbers
-        snapshots::HeaderIndex header_index{header_snapshot_path};
+        auto header_index = snapshots::HeaderIndex::make(header_snapshot_path);
         header_index.build();
     }
 }
@@ -96,7 +96,7 @@ static void build_body_index(benchmark::State& state) {
 
     for ([[maybe_unused]] auto _ : state) {
         test::SampleBodySnapshotPath body_snapshot_path{body_snapshot.path()};  // necessary to tweak the block numbers
-        snapshots::BodyIndex body_index{body_snapshot_path};
+        auto body_index = snapshots::BodyIndex::make(body_snapshot_path);
         body_index.build();
     }
 }
@@ -115,7 +115,7 @@ static void build_tx_index(benchmark::State& state) {
 
     for ([[maybe_unused]] auto _ : state) {
         test::SampleBodySnapshotPath body_snapshot_path{body_snapshot.path()};  // necessary to tweak the block numbers
-        snapshots::BodyIndex body_index{body_snapshot_path};
+        auto body_index = snapshots::BodyIndex::make(body_snapshot_path);
         body_index.build();
 
         test::SampleTransactionSnapshotPath txn_snapshot_path{txn_snapshot.path()};  // necessary to tweak the block numbers
@@ -139,11 +139,11 @@ static void reopen_folder(benchmark::State& state) {
     test::SampleTransactionSnapshotFile txn_snapshot{tmp_dir};
 
     test::SampleHeaderSnapshotPath header_snapshot_path{header_snapshot.path()};  // necessary to tweak the block numbers
-    snapshots::HeaderIndex header_index{header_snapshot_path};
+    auto header_index = snapshots::HeaderIndex::make(header_snapshot_path);
     header_index.build();
 
     test::SampleBodySnapshotPath body_snapshot_path{body_snapshot.path()};  // necessary to tweak the block numbers
-    snapshots::BodyIndex body_index{body_snapshot_path};
+    auto body_index = snapshots::BodyIndex::make(body_snapshot_path);
     body_index.build();
 
     test::SampleTransactionSnapshotPath txn_snapshot_path{txn_snapshot.path()};  // necessary to tweak the block numbers

--- a/silkworm/db/snapshots/snapshot_benchmark.cpp
+++ b/silkworm/db/snapshots/snapshot_benchmark.cpp
@@ -17,9 +17,13 @@
 #include <benchmark/benchmark.h>
 
 #include <silkworm/core/common/util.hpp>
+#include <silkworm/db/snapshots/body_index.hpp>
+#include <silkworm/db/snapshots/header_index.hpp>
 #include <silkworm/db/snapshots/index.hpp>
 #include <silkworm/db/snapshots/seg/decompressor.hpp>
 #include <silkworm/db/snapshots/test_util/common.hpp>
+#include <silkworm/db/snapshots/txn_index.hpp>
+#include <silkworm/db/snapshots/txn_to_block_index.hpp>
 #include <silkworm/infra/common/directories.hpp>
 #include <silkworm/infra/test_util/log.hpp>
 #include <silkworm/infra/test_util/temporary_file.hpp>
@@ -121,7 +125,7 @@ static void build_tx_index(benchmark::State& state) {
         test::SampleTransactionSnapshotPath txn_snapshot_path{txn_snapshot.path()};  // necessary to tweak the block numbers
         auto tx_index = TransactionIndex1::make(body_snapshot_path, txn_snapshot_path);
         tx_index.build();
-        TransactionToBlockIndex tx_index_hash_to_block{body_snapshot_path, txn_snapshot_path};
+        auto tx_index_hash_to_block = TransactionToBlockIndex::make(body_snapshot_path, txn_snapshot_path);
         tx_index_hash_to_block.build();
     }
 }
@@ -151,7 +155,7 @@ static void reopen_folder(benchmark::State& state) {
     test::SampleTransactionSnapshotPath txn_snapshot_path{txn_snapshot.path()};  // necessary to tweak the block numbers
     auto tx_index = TransactionIndex1::make(body_snapshot_path, txn_snapshot_path);
     tx_index.build();
-    TransactionToBlockIndex tx_index_hash_to_block{body_snapshot_path, txn_snapshot_path};
+    auto tx_index_hash_to_block = TransactionToBlockIndex::make(body_snapshot_path, txn_snapshot_path);
     tx_index_hash_to_block.build();
 
     for ([[maybe_unused]] auto _ : state) {

--- a/silkworm/db/snapshots/snapshot_benchmark.cpp
+++ b/silkworm/db/snapshots/snapshot_benchmark.cpp
@@ -19,7 +19,7 @@
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/db/snapshots/body_index.hpp>
 #include <silkworm/db/snapshots/header_index.hpp>
-#include <silkworm/db/snapshots/index.hpp>
+#include <silkworm/db/snapshots/index_builder.hpp>
 #include <silkworm/db/snapshots/seg/decompressor.hpp>
 #include <silkworm/db/snapshots/test_util/common.hpp>
 #include <silkworm/db/snapshots/txn_index.hpp>
@@ -123,7 +123,7 @@ static void build_tx_index(benchmark::State& state) {
         body_index.build();
 
         test::SampleTransactionSnapshotPath txn_snapshot_path{txn_snapshot.path()};  // necessary to tweak the block numbers
-        auto tx_index = TransactionIndex1::make(body_snapshot_path, txn_snapshot_path);
+        auto tx_index = TransactionIndex::make(body_snapshot_path, txn_snapshot_path);
         tx_index.build();
         auto tx_index_hash_to_block = TransactionToBlockIndex::make(body_snapshot_path, txn_snapshot_path);
         tx_index_hash_to_block.build();
@@ -153,7 +153,7 @@ static void reopen_folder(benchmark::State& state) {
     body_index.build();
 
     test::SampleTransactionSnapshotPath txn_snapshot_path{txn_snapshot.path()};  // necessary to tweak the block numbers
-    auto tx_index = TransactionIndex1::make(body_snapshot_path, txn_snapshot_path);
+    auto tx_index = TransactionIndex::make(body_snapshot_path, txn_snapshot_path);
     tx_index.build();
     auto tx_index_hash_to_block = TransactionToBlockIndex::make(body_snapshot_path, txn_snapshot_path);
     tx_index_hash_to_block.build();

--- a/silkworm/db/snapshots/snapshot_benchmark.cpp
+++ b/silkworm/db/snapshots/snapshot_benchmark.cpp
@@ -119,8 +119,10 @@ static void build_tx_index(benchmark::State& state) {
         body_index.build();
 
         test::SampleTransactionSnapshotPath txn_snapshot_path{txn_snapshot.path()};  // necessary to tweak the block numbers
-        snapshots::TransactionIndex txn_index{txn_snapshot_path};
-        txn_index.build();
+        auto tx_index = TransactionIndex1::make(body_snapshot_path, txn_snapshot_path);
+        tx_index.build();
+        TransactionToBlockIndex tx_index_hash_to_block{body_snapshot_path, txn_snapshot_path};
+        tx_index_hash_to_block.build();
     }
 }
 BENCHMARK(build_tx_index);
@@ -147,8 +149,10 @@ static void reopen_folder(benchmark::State& state) {
     body_index.build();
 
     test::SampleTransactionSnapshotPath txn_snapshot_path{txn_snapshot.path()};  // necessary to tweak the block numbers
-    snapshots::TransactionIndex txn_index{txn_snapshot_path};
-    txn_index.build();
+    auto tx_index = TransactionIndex1::make(body_snapshot_path, txn_snapshot_path);
+    tx_index.build();
+    TransactionToBlockIndex tx_index_hash_to_block{body_snapshot_path, txn_snapshot_path};
+    tx_index_hash_to_block.build();
 
     for ([[maybe_unused]] auto _ : state) {
         repository.reopen_folder();

--- a/silkworm/db/snapshots/snapshot_benchmark.cpp
+++ b/silkworm/db/snapshots/snapshot_benchmark.cpp
@@ -69,16 +69,15 @@ static void open_snapshot(benchmark::State& state) {
 BENCHMARK(open_snapshot);
 
 static void build_header_index(benchmark::State& state) {
-    const auto tmp_dir = TemporaryDirectory::get_unique_temporary_path();
-    std::filesystem::create_directories(tmp_dir);
-    snapshots::SnapshotSettings settings{tmp_dir};
+    TemporaryDirectory tmp_dir;
+    snapshots::SnapshotSettings settings{tmp_dir.path()};
     snapshots::SnapshotRepository repository{settings};
 
     // These sample snapshot files just contain data for block range [1'500'012, 1'500'013], hence current snapshot
     // file name format is not sufficient to support them (see checks commented out below)
-    test::SampleHeaderSnapshotFile header_snapshot{tmp_dir};
-    test::SampleBodySnapshotFile body_snapshot{tmp_dir};
-    test::SampleTransactionSnapshotFile txn_snapshot{tmp_dir};
+    test::SampleHeaderSnapshotFile header_snapshot{tmp_dir.path()};
+    test::SampleBodySnapshotFile body_snapshot{tmp_dir.path()};
+    test::SampleTransactionSnapshotFile txn_snapshot{tmp_dir.path()};
 
     for ([[maybe_unused]] auto _ : state) {
         test::SampleHeaderSnapshotPath header_snapshot_path{header_snapshot.path()};  // necessary to tweak the block numbers
@@ -89,14 +88,13 @@ static void build_header_index(benchmark::State& state) {
 BENCHMARK(build_header_index);
 
 static void build_body_index(benchmark::State& state) {
-    const auto tmp_dir = TemporaryDirectory::get_unique_temporary_path();
-    std::filesystem::create_directories(tmp_dir);
-    snapshots::SnapshotSettings settings{tmp_dir};
+    TemporaryDirectory tmp_dir;
+    snapshots::SnapshotSettings settings{tmp_dir.path()};
     snapshots::SnapshotRepository repository{settings};
 
     // These sample snapshot files just contain data for block range [1'500'012, 1'500'013], hence current snapshot
     // file name format is not sufficient to support them (see checks commented out below)
-    test::SampleBodySnapshotFile body_snapshot{tmp_dir};
+    test::SampleBodySnapshotFile body_snapshot{tmp_dir.path()};
 
     for ([[maybe_unused]] auto _ : state) {
         test::SampleBodySnapshotPath body_snapshot_path{body_snapshot.path()};  // necessary to tweak the block numbers
@@ -107,15 +105,14 @@ static void build_body_index(benchmark::State& state) {
 BENCHMARK(build_body_index);
 
 static void build_tx_index(benchmark::State& state) {
-    const auto tmp_dir = TemporaryDirectory::get_unique_temporary_path();
-    std::filesystem::create_directories(tmp_dir);
-    snapshots::SnapshotSettings settings{tmp_dir};
+    TemporaryDirectory tmp_dir;
+    snapshots::SnapshotSettings settings{tmp_dir.path()};
     snapshots::SnapshotRepository repository{settings};
 
     // These sample snapshot files just contain data for block range [1'500'012, 1'500'013], hence current snapshot
     // file name format is not sufficient to support them (see checks commented out below)
-    test::SampleBodySnapshotFile body_snapshot{tmp_dir};
-    test::SampleTransactionSnapshotFile txn_snapshot{tmp_dir};
+    test::SampleBodySnapshotFile body_snapshot{tmp_dir.path()};
+    test::SampleTransactionSnapshotFile txn_snapshot{tmp_dir.path()};
 
     for ([[maybe_unused]] auto _ : state) {
         test::SampleBodySnapshotPath body_snapshot_path{body_snapshot.path()};  // necessary to tweak the block numbers
@@ -133,16 +130,15 @@ BENCHMARK(build_tx_index);
 
 static void reopen_folder(benchmark::State& state) {
     SetLogVerbosityGuard guard{log::Level::kNone};
-    const auto tmp_dir = TemporaryDirectory::get_unique_temporary_path();
-    std::filesystem::create_directories(tmp_dir);
-    snapshots::SnapshotSettings settings{tmp_dir};
+    TemporaryDirectory tmp_dir;
+    snapshots::SnapshotSettings settings{tmp_dir.path()};
     snapshots::SnapshotRepository repository{settings};
 
     // These sample snapshot files just contain data for block range [1'500'012, 1'500'013], hence current snapshot
     // file name format is not sufficient to support them (see checks commented out below)
-    test::SampleHeaderSnapshotFile header_snapshot{tmp_dir};
-    test::SampleBodySnapshotFile body_snapshot{tmp_dir};
-    test::SampleTransactionSnapshotFile txn_snapshot{tmp_dir};
+    test::SampleHeaderSnapshotFile header_snapshot{tmp_dir.path()};
+    test::SampleBodySnapshotFile body_snapshot{tmp_dir.path()};
+    test::SampleTransactionSnapshotFile txn_snapshot{tmp_dir.path()};
 
     test::SampleHeaderSnapshotPath header_snapshot_path{header_snapshot.path()};  // necessary to tweak the block numbers
     auto header_index = snapshots::HeaderIndex::make(header_snapshot_path);

--- a/silkworm/db/snapshots/snapshot_test.cpp
+++ b/silkworm/db/snapshots/snapshot_test.cpp
@@ -131,7 +131,7 @@ TEST_CASE("HeaderSnapshot::header_by_number OK", "[silkworm][node][snapshot][ind
     SetLogVerbosityGuard guard{log::Level::kNone};
     test::SampleHeaderSnapshotFile valid_header_snapshot{};                             // contains headers for [1'500'012, 1'500'013]
     test::SampleHeaderSnapshotPath header_snapshot_path{valid_header_snapshot.path()};  // necessary to tweak the block numbers
-    HeaderIndex header_index{header_snapshot_path};
+    auto header_index = HeaderIndex::make(header_snapshot_path);
     REQUIRE_NOTHROW(header_index.build());
 
     HeaderSnapshot header_snapshot{header_snapshot_path};
@@ -169,7 +169,7 @@ TEST_CASE("BodySnapshot::body_by_number OK", "[silkworm][node][snapshot][index]"
     SetLogVerbosityGuard guard{log::Level::kNone};
     test::SampleBodySnapshotFile valid_body_snapshot{};                           // contains bodies for [1'500'012, 1'500'013]
     test::SampleBodySnapshotPath body_snapshot_path{valid_body_snapshot.path()};  // necessary to tweak the block numbers
-    BodyIndex body_index{body_snapshot_path};
+    auto body_index = BodyIndex::make(body_snapshot_path);
     REQUIRE_NOTHROW(body_index.build());
 
     BodySnapshot body_snapshot{body_snapshot_path};
@@ -414,7 +414,7 @@ TEST_CASE("HeaderSnapshot::reopen_index regeneration", "[silkworm][node][snapsho
     SetLogVerbosityGuard guard{log::Level::kNone};
     test::SampleHeaderSnapshotFile sample_header_snapshot{};
     test::SampleHeaderSnapshotPath header_snapshot_path{sample_header_snapshot.path()};
-    HeaderIndex header_index{header_snapshot_path};
+    auto header_index = HeaderIndex::make(header_snapshot_path);
     REQUIRE_NOTHROW(header_index.build());
 
     HeaderSnapshot header_snapshot{header_snapshot_path};
@@ -436,7 +436,7 @@ TEST_CASE("BodySnapshot::reopen_index regeneration", "[silkworm][node][snapshot]
     SetLogVerbosityGuard guard{log::Level::kNone};
     test::SampleBodySnapshotFile sample_body_snapshot{};
     test::SampleBodySnapshotPath body_snapshot_path{sample_body_snapshot.path()};
-    BodyIndex body_index{body_snapshot_path};
+    auto body_index = BodyIndex::make(body_snapshot_path);
     REQUIRE_NOTHROW(body_index.build());
 
     BodySnapshot body_snapshot{body_snapshot_path};

--- a/silkworm/db/snapshots/snapshot_test.cpp
+++ b/silkworm/db/snapshots/snapshot_test.cpp
@@ -23,7 +23,7 @@
 
 #include <silkworm/db/snapshots/body_index.hpp>
 #include <silkworm/db/snapshots/header_index.hpp>
-#include <silkworm/db/snapshots/index.hpp>
+#include <silkworm/db/snapshots/index_builder.hpp>
 #include <silkworm/db/snapshots/test_util/common.hpp>
 #include <silkworm/db/snapshots/txn_index.hpp>
 #include <silkworm/db/snapshots/txn_to_block_index.hpp>
@@ -198,7 +198,7 @@ TEST_CASE("TransactionSnapshot::txn_by_id OK", "[silkworm][node][snapshot][index
     test::SampleBodySnapshotPath body_snapshot_path{body_snapshot.path()};
     test::SampleTransactionSnapshotFile valid_tx_snapshot{};                         // contains txs for [1'500'012, 1'500'013]
     test::SampleTransactionSnapshotPath tx_snapshot_path{valid_tx_snapshot.path()};  // necessary to tweak the block numbers
-    auto tx_index = TransactionIndex1::make(body_snapshot_path, tx_snapshot_path);
+    auto tx_index = TransactionIndex::make(body_snapshot_path, tx_snapshot_path);
     CHECK_NOTHROW(tx_index.build());
 
     TransactionSnapshot tx_snapshot{tx_snapshot_path};
@@ -220,7 +220,7 @@ TEST_CASE("TransactionSnapshot::block_num_by_txn_hash OK", "[silkworm][node][sna
     test::SampleBodySnapshotPath body_snapshot_path{body_snapshot.path()};
     test::SampleTransactionSnapshotFile valid_tx_snapshot{};                         // contains txs for [1'500'012, 1'500'013]
     test::SampleTransactionSnapshotPath tx_snapshot_path{valid_tx_snapshot.path()};  // necessary to tweak the block numbers
-    auto tx_index = TransactionIndex1::make(body_snapshot_path, tx_snapshot_path);
+    auto tx_index = TransactionIndex::make(body_snapshot_path, tx_snapshot_path);
     REQUIRE_NOTHROW(tx_index.build());
     auto tx_index_hash_to_block = TransactionToBlockIndex::make(body_snapshot_path, tx_snapshot_path);
     REQUIRE_NOTHROW(tx_index_hash_to_block.build());
@@ -256,7 +256,7 @@ TEST_CASE("TransactionSnapshot::txn_range OK", "[silkworm][node][snapshot][index
     test::SampleBodySnapshotPath body_snapshot_path{body_snapshot.path()};
     test::SampleTransactionSnapshotFile valid_tx_snapshot{};                         // contains txs for [1'500'012, 1'500'013]
     test::SampleTransactionSnapshotPath tx_snapshot_path{valid_tx_snapshot.path()};  // necessary to tweak the block numbers
-    auto tx_index = TransactionIndex1::make(body_snapshot_path, tx_snapshot_path);
+    auto tx_index = TransactionIndex::make(body_snapshot_path, tx_snapshot_path);
     REQUIRE_NOTHROW(tx_index.build());
 
     TransactionSnapshot tx_snapshot{tx_snapshot_path};
@@ -292,7 +292,7 @@ TEST_CASE("TransactionSnapshot::txn_rlp_range OK", "[silkworm][node][snapshot][i
     test::SampleBodySnapshotPath body_snapshot_path{body_snapshot.path()};
     test::SampleTransactionSnapshotFile valid_tx_snapshot{};                         // contains txs for [1'500'012, 1'500'013]
     test::SampleTransactionSnapshotPath tx_snapshot_path{valid_tx_snapshot.path()};  // necessary to tweak the block numbers
-    auto tx_index = TransactionIndex1::make(body_snapshot_path, tx_snapshot_path);
+    auto tx_index = TransactionIndex::make(body_snapshot_path, tx_snapshot_path);
     REQUIRE_NOTHROW(tx_index.build());
 
     TransactionSnapshot tx_snapshot{tx_snapshot_path};
@@ -474,7 +474,7 @@ TEST_CASE("TransactionSnapshot::reopen_index regeneration", "[silkworm][node][sn
     test::SampleBodySnapshotPath body_snapshot_path{body_snapshot.path()};
     test::SampleTransactionSnapshotFile sample_tx_snapshot{};
     test::SampleTransactionSnapshotPath tx_snapshot_path{sample_tx_snapshot.path()};
-    auto tx_index = TransactionIndex1::make(body_snapshot_path, tx_snapshot_path);
+    auto tx_index = TransactionIndex::make(body_snapshot_path, tx_snapshot_path);
     REQUIRE_NOTHROW(tx_index.build());
 
     TransactionSnapshot tx_snapshot{tx_snapshot_path};

--- a/silkworm/db/snapshots/snapshot_test.cpp
+++ b/silkworm/db/snapshots/snapshot_test.cpp
@@ -21,8 +21,12 @@
 
 #include <catch2/catch.hpp>
 
+#include <silkworm/db/snapshots/body_index.hpp>
+#include <silkworm/db/snapshots/header_index.hpp>
 #include <silkworm/db/snapshots/index.hpp>
 #include <silkworm/db/snapshots/test_util/common.hpp>
+#include <silkworm/db/snapshots/txn_index.hpp>
+#include <silkworm/db/snapshots/txn_to_block_index.hpp>
 #include <silkworm/infra/common/directories.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/test_util/log.hpp>
@@ -218,7 +222,7 @@ TEST_CASE("TransactionSnapshot::block_num_by_txn_hash OK", "[silkworm][node][sna
     test::SampleTransactionSnapshotPath tx_snapshot_path{valid_tx_snapshot.path()};  // necessary to tweak the block numbers
     auto tx_index = TransactionIndex1::make(body_snapshot_path, tx_snapshot_path);
     REQUIRE_NOTHROW(tx_index.build());
-    TransactionToBlockIndex tx_index_hash_to_block{body_snapshot_path, tx_snapshot_path};
+    auto tx_index_hash_to_block = TransactionToBlockIndex::make(body_snapshot_path, tx_snapshot_path);
     REQUIRE_NOTHROW(tx_index_hash_to_block.build());
 
     TransactionSnapshot tx_snapshot{tx_snapshot_path};

--- a/silkworm/db/snapshots/snapshot_test.cpp
+++ b/silkworm/db/snapshots/snapshot_test.cpp
@@ -190,10 +190,12 @@ TEST_CASE("BodySnapshot::body_by_number OK", "[silkworm][node][snapshot][index]"
 // https://etherscan.io/block/1500013
 TEST_CASE("TransactionSnapshot::txn_by_id OK", "[silkworm][node][snapshot][index]") {
     SetLogVerbosityGuard guard{log::Level::kNone};
+    test::SampleBodySnapshotFile body_snapshot;
+    test::SampleBodySnapshotPath body_snapshot_path{body_snapshot.path()};
     test::SampleTransactionSnapshotFile valid_tx_snapshot{};                         // contains txs for [1'500'012, 1'500'013]
     test::SampleTransactionSnapshotPath tx_snapshot_path{valid_tx_snapshot.path()};  // necessary to tweak the block numbers
-    TransactionIndex tx_index{tx_snapshot_path};
-    REQUIRE_NOTHROW(tx_index.build());
+    auto tx_index = TransactionIndex1::make(body_snapshot_path, tx_snapshot_path);
+    CHECK_NOTHROW(tx_index.build());
 
     TransactionSnapshot tx_snapshot{tx_snapshot_path};
     tx_snapshot.reopen_segment();
@@ -210,10 +212,14 @@ TEST_CASE("TransactionSnapshot::txn_by_id OK", "[silkworm][node][snapshot][index
 // https://etherscan.io/block/1500012
 TEST_CASE("TransactionSnapshot::block_num_by_txn_hash OK", "[silkworm][node][snapshot][index]") {
     SetLogVerbosityGuard guard{log::Level::kNone};
+    test::SampleBodySnapshotFile body_snapshot;
+    test::SampleBodySnapshotPath body_snapshot_path{body_snapshot.path()};
     test::SampleTransactionSnapshotFile valid_tx_snapshot{};                         // contains txs for [1'500'012, 1'500'013]
     test::SampleTransactionSnapshotPath tx_snapshot_path{valid_tx_snapshot.path()};  // necessary to tweak the block numbers
-    TransactionIndex tx_index{tx_snapshot_path};
+    auto tx_index = TransactionIndex1::make(body_snapshot_path, tx_snapshot_path);
     REQUIRE_NOTHROW(tx_index.build());
+    TransactionToBlockIndex tx_index_hash_to_block{body_snapshot_path, tx_snapshot_path};
+    REQUIRE_NOTHROW(tx_index_hash_to_block.build());
 
     TransactionSnapshot tx_snapshot{tx_snapshot_path};
     tx_snapshot.reopen_segment();
@@ -242,9 +248,11 @@ TEST_CASE("TransactionSnapshot::block_num_by_txn_hash OK", "[silkworm][node][sna
 // https://etherscan.io/block/1500012
 TEST_CASE("TransactionSnapshot::txn_range OK", "[silkworm][node][snapshot][index]") {
     SetLogVerbosityGuard guard{log::Level::kNone};
+    test::SampleBodySnapshotFile body_snapshot;
+    test::SampleBodySnapshotPath body_snapshot_path{body_snapshot.path()};
     test::SampleTransactionSnapshotFile valid_tx_snapshot{};                         // contains txs for [1'500'012, 1'500'013]
     test::SampleTransactionSnapshotPath tx_snapshot_path{valid_tx_snapshot.path()};  // necessary to tweak the block numbers
-    TransactionIndex tx_index{tx_snapshot_path};
+    auto tx_index = TransactionIndex1::make(body_snapshot_path, tx_snapshot_path);
     REQUIRE_NOTHROW(tx_index.build());
 
     TransactionSnapshot tx_snapshot{tx_snapshot_path};
@@ -276,9 +284,11 @@ TEST_CASE("TransactionSnapshot::txn_range OK", "[silkworm][node][snapshot][index
 
 TEST_CASE("TransactionSnapshot::txn_rlp_range OK", "[silkworm][node][snapshot][index]") {
     SetLogVerbosityGuard guard{log::Level::kNone};
+    test::SampleBodySnapshotFile body_snapshot;
+    test::SampleBodySnapshotPath body_snapshot_path{body_snapshot.path()};
     test::SampleTransactionSnapshotFile valid_tx_snapshot{};                         // contains txs for [1'500'012, 1'500'013]
     test::SampleTransactionSnapshotPath tx_snapshot_path{valid_tx_snapshot.path()};  // necessary to tweak the block numbers
-    TransactionIndex tx_index{tx_snapshot_path};
+    auto tx_index = TransactionIndex1::make(body_snapshot_path, tx_snapshot_path);
     REQUIRE_NOTHROW(tx_index.build());
 
     TransactionSnapshot tx_snapshot{tx_snapshot_path};
@@ -456,9 +466,11 @@ TEST_CASE("BodySnapshot::reopen_index regeneration", "[silkworm][node][snapshot]
 
 TEST_CASE("TransactionSnapshot::reopen_index regeneration", "[silkworm][node][snapshot][index]") {
     SetLogVerbosityGuard guard{log::Level::kNone};
+    test::SampleBodySnapshotFile body_snapshot;
+    test::SampleBodySnapshotPath body_snapshot_path{body_snapshot.path()};
     test::SampleTransactionSnapshotFile sample_tx_snapshot{};
     test::SampleTransactionSnapshotPath tx_snapshot_path{sample_tx_snapshot.path()};
-    TransactionIndex tx_index{tx_snapshot_path};
+    auto tx_index = TransactionIndex1::make(body_snapshot_path, tx_snapshot_path);
     REQUIRE_NOTHROW(tx_index.build());
 
     TransactionSnapshot tx_snapshot{tx_snapshot_path};

--- a/silkworm/db/snapshots/snapshot_test.cpp
+++ b/silkworm/db/snapshots/snapshot_test.cpp
@@ -41,8 +41,8 @@ static const SnapshotPath kValidHeadersSegmentPath{*SnapshotPath::parse("v1-0145
 
 class SnapshotPath_ForTest : public SnapshotPath {
   public:
-    SnapshotPath_ForTest(BlockNum block_from, BlockNum block_to)
-        : SnapshotPath(SnapshotPath::from(TemporaryDirectory::get_os_temporary_path(),
+    SnapshotPath_ForTest(const std::filesystem::path& tmp_dir, BlockNum block_from, BlockNum block_to)
+        : SnapshotPath(SnapshotPath::from(tmp_dir,
                                           kSnapshotV1,
                                           block_from,
                                           block_to,
@@ -53,7 +53,8 @@ class Snapshot_ForTest : public Snapshot {
   public:
     explicit Snapshot_ForTest(SnapshotPath path) : Snapshot(std::move(path)) {}
     explicit Snapshot_ForTest(std::filesystem::path path) : Snapshot(*SnapshotPath::parse(std::move(path))) {}
-    Snapshot_ForTest(BlockNum block_from, BlockNum block_to) : Snapshot(SnapshotPath_ForTest{block_from, block_to}) {}
+    Snapshot_ForTest(const std::filesystem::path& tmp_dir, BlockNum block_from, BlockNum block_to)
+        : Snapshot(SnapshotPath_ForTest{tmp_dir, block_from, block_to}) {}
     ~Snapshot_ForTest() override { close(); }
 
     void reopen_index() override {}
@@ -75,13 +76,14 @@ static auto move_last_write_time(const std::filesystem::path& p, const std::chro
 }
 
 TEST_CASE("Snapshot::Snapshot", "[silkworm][node][snapshot][snapshot]") {
+    TemporaryDirectory tmp_dir;
     SECTION("valid") {
         std::vector<std::pair<BlockNum, BlockNum>> block_ranges{
             {0, 1},
             {1'000, 1'000},
             {1'000, 2'000}};
         for (const auto& [block_from, block_to] : block_ranges) {
-            Snapshot_ForTest snapshot{block_from, block_to};
+            Snapshot_ForTest snapshot{tmp_dir.path(), block_from, block_to};
             CHECK(!snapshot.fs_path().empty());
             CHECK(snapshot.block_from() == block_from);
             CHECK(snapshot.block_to() == block_to);
@@ -93,21 +95,23 @@ TEST_CASE("Snapshot::Snapshot", "[silkworm][node][snapshot][snapshot]") {
         std::vector<std::pair<BlockNum, BlockNum>> block_ranges{
             {1'000, 999}};
         for (const auto& [block_from, block_to] : block_ranges) {
-            CHECK_THROWS_AS(Snapshot_ForTest(block_from, block_to), std::logic_error);
+            CHECK_THROWS_AS(Snapshot_ForTest(tmp_dir.path(), block_from, block_to), std::logic_error);
         }
     }
 }
 
 TEST_CASE("Snapshot::reopen_segment", "[silkworm][node][snapshot][snapshot]") {
     SetLogVerbosityGuard guard{log::Level::kNone};
-    test::TemporarySnapshotFile tmp_snapshot_file{kValidHeadersSegmentPath.filename(), test::SnapshotHeader{}};
+    TemporaryDirectory tmp_dir;
+    test::TemporarySnapshotFile tmp_snapshot_file{tmp_dir.path(), kValidHeadersSegmentPath.filename(), test::SnapshotHeader{}};
     Snapshot_ForTest snapshot{tmp_snapshot_file.path()};
     snapshot.reopen_segment();
 }
 
 TEST_CASE("Snapshot::for_each_item", "[silkworm][node][snapshot][snapshot]") {
     SetLogVerbosityGuard guard{log::Level::kNone};
-    test::HelloWorldSnapshotFile hello_world_snapshot_file{kValidHeadersSegmentPath.filename()};
+    TemporaryDirectory tmp_dir;
+    test::HelloWorldSnapshotFile hello_world_snapshot_file{tmp_dir.path(), kValidHeadersSegmentPath.filename()};
     seg::Decompressor decoder{hello_world_snapshot_file.path()};
     Snapshot_ForTest tmp_snapshot{hello_world_snapshot_file.path()};
     tmp_snapshot.reopen_segment();
@@ -123,7 +127,8 @@ TEST_CASE("Snapshot::for_each_item", "[silkworm][node][snapshot][snapshot]") {
 
 TEST_CASE("Snapshot::close", "[silkworm][node][snapshot][snapshot]") {
     SetLogVerbosityGuard guard{log::Level::kNone};
-    test::HelloWorldSnapshotFile hello_world_snapshot_file{kValidHeadersSegmentPath.filename()};
+    TemporaryDirectory tmp_dir;
+    test::HelloWorldSnapshotFile hello_world_snapshot_file{tmp_dir.path(), kValidHeadersSegmentPath.filename()};
     seg::Decompressor decoder{hello_world_snapshot_file.path()};
     Snapshot_ForTest tmp_snapshot{hello_world_snapshot_file.path()};
     tmp_snapshot.reopen_segment();
@@ -133,7 +138,8 @@ TEST_CASE("Snapshot::close", "[silkworm][node][snapshot][snapshot]") {
 // https://etherscan.io/block/1500013
 TEST_CASE("HeaderSnapshot::header_by_number OK", "[silkworm][node][snapshot][index]") {
     SetLogVerbosityGuard guard{log::Level::kNone};
-    test::SampleHeaderSnapshotFile valid_header_snapshot{};                             // contains headers for [1'500'012, 1'500'013]
+    TemporaryDirectory tmp_dir;
+    test::SampleHeaderSnapshotFile valid_header_snapshot{tmp_dir.path()};               // contains headers for [1'500'012, 1'500'013]
     test::SampleHeaderSnapshotPath header_snapshot_path{valid_header_snapshot.path()};  // necessary to tweak the block numbers
     auto header_index = HeaderIndex::make(header_snapshot_path);
     REQUIRE_NOTHROW(header_index.build());
@@ -171,7 +177,8 @@ TEST_CASE("HeaderSnapshot::header_by_number OK", "[silkworm][node][snapshot][ind
 // https://etherscan.io/block/1500013
 TEST_CASE("BodySnapshot::body_by_number OK", "[silkworm][node][snapshot][index]") {
     SetLogVerbosityGuard guard{log::Level::kNone};
-    test::SampleBodySnapshotFile valid_body_snapshot{};                           // contains bodies for [1'500'012, 1'500'013]
+    TemporaryDirectory tmp_dir;
+    test::SampleBodySnapshotFile valid_body_snapshot{tmp_dir.path()};             // contains bodies for [1'500'012, 1'500'013]
     test::SampleBodySnapshotPath body_snapshot_path{valid_body_snapshot.path()};  // necessary to tweak the block numbers
     auto body_index = BodyIndex::make(body_snapshot_path);
     REQUIRE_NOTHROW(body_index.build());
@@ -194,9 +201,10 @@ TEST_CASE("BodySnapshot::body_by_number OK", "[silkworm][node][snapshot][index]"
 // https://etherscan.io/block/1500013
 TEST_CASE("TransactionSnapshot::txn_by_id OK", "[silkworm][node][snapshot][index]") {
     SetLogVerbosityGuard guard{log::Level::kNone};
-    test::SampleBodySnapshotFile body_snapshot;
+    TemporaryDirectory tmp_dir;
+    test::SampleBodySnapshotFile body_snapshot{tmp_dir.path()};
     test::SampleBodySnapshotPath body_snapshot_path{body_snapshot.path()};
-    test::SampleTransactionSnapshotFile valid_tx_snapshot{};                         // contains txs for [1'500'012, 1'500'013]
+    test::SampleTransactionSnapshotFile valid_tx_snapshot{tmp_dir.path()};           // contains txs for [1'500'012, 1'500'013]
     test::SampleTransactionSnapshotPath tx_snapshot_path{valid_tx_snapshot.path()};  // necessary to tweak the block numbers
     auto tx_index = TransactionIndex::make(body_snapshot_path, tx_snapshot_path);
     CHECK_NOTHROW(tx_index.build());
@@ -216,9 +224,10 @@ TEST_CASE("TransactionSnapshot::txn_by_id OK", "[silkworm][node][snapshot][index
 // https://etherscan.io/block/1500012
 TEST_CASE("TransactionSnapshot::block_num_by_txn_hash OK", "[silkworm][node][snapshot][index]") {
     SetLogVerbosityGuard guard{log::Level::kNone};
-    test::SampleBodySnapshotFile body_snapshot;
+    TemporaryDirectory tmp_dir;
+    test::SampleBodySnapshotFile body_snapshot{tmp_dir.path()};
     test::SampleBodySnapshotPath body_snapshot_path{body_snapshot.path()};
-    test::SampleTransactionSnapshotFile valid_tx_snapshot{};                         // contains txs for [1'500'012, 1'500'013]
+    test::SampleTransactionSnapshotFile valid_tx_snapshot{tmp_dir.path()};           // contains txs for [1'500'012, 1'500'013]
     test::SampleTransactionSnapshotPath tx_snapshot_path{valid_tx_snapshot.path()};  // necessary to tweak the block numbers
     auto tx_index = TransactionIndex::make(body_snapshot_path, tx_snapshot_path);
     REQUIRE_NOTHROW(tx_index.build());
@@ -252,9 +261,10 @@ TEST_CASE("TransactionSnapshot::block_num_by_txn_hash OK", "[silkworm][node][sna
 // https://etherscan.io/block/1500012
 TEST_CASE("TransactionSnapshot::txn_range OK", "[silkworm][node][snapshot][index]") {
     SetLogVerbosityGuard guard{log::Level::kNone};
-    test::SampleBodySnapshotFile body_snapshot;
+    TemporaryDirectory tmp_dir;
+    test::SampleBodySnapshotFile body_snapshot{tmp_dir.path()};
     test::SampleBodySnapshotPath body_snapshot_path{body_snapshot.path()};
-    test::SampleTransactionSnapshotFile valid_tx_snapshot{};                         // contains txs for [1'500'012, 1'500'013]
+    test::SampleTransactionSnapshotFile valid_tx_snapshot{tmp_dir.path()};           // contains txs for [1'500'012, 1'500'013]
     test::SampleTransactionSnapshotPath tx_snapshot_path{valid_tx_snapshot.path()};  // necessary to tweak the block numbers
     auto tx_index = TransactionIndex::make(body_snapshot_path, tx_snapshot_path);
     REQUIRE_NOTHROW(tx_index.build());
@@ -288,9 +298,10 @@ TEST_CASE("TransactionSnapshot::txn_range OK", "[silkworm][node][snapshot][index
 
 TEST_CASE("TransactionSnapshot::txn_rlp_range OK", "[silkworm][node][snapshot][index]") {
     SetLogVerbosityGuard guard{log::Level::kNone};
-    test::SampleBodySnapshotFile body_snapshot;
+    TemporaryDirectory tmp_dir;
+    test::SampleBodySnapshotFile body_snapshot{tmp_dir.path()};
     test::SampleBodySnapshotPath body_snapshot_path{body_snapshot.path()};
-    test::SampleTransactionSnapshotFile valid_tx_snapshot{};                         // contains txs for [1'500'012, 1'500'013]
+    test::SampleTransactionSnapshotFile valid_tx_snapshot{tmp_dir.path()};           // contains txs for [1'500'012, 1'500'013]
     test::SampleTransactionSnapshotPath tx_snapshot_path{valid_tx_snapshot.path()};  // necessary to tweak the block numbers
     auto tx_index = TransactionIndex::make(body_snapshot_path, tx_snapshot_path);
     REQUIRE_NOTHROW(tx_index.build());
@@ -426,7 +437,8 @@ TEST_CASE("TransactionSnapshot::slice_tx_payload", "[silkworm][node][snapshot]")
 
 TEST_CASE("HeaderSnapshot::reopen_index regeneration", "[silkworm][node][snapshot][index]") {
     SetLogVerbosityGuard guard{log::Level::kNone};
-    test::SampleHeaderSnapshotFile sample_header_snapshot{};
+    TemporaryDirectory tmp_dir;
+    test::SampleHeaderSnapshotFile sample_header_snapshot{tmp_dir.path()};
     test::SampleHeaderSnapshotPath header_snapshot_path{sample_header_snapshot.path()};
     auto header_index = HeaderIndex::make(header_snapshot_path);
     REQUIRE_NOTHROW(header_index.build());
@@ -448,7 +460,8 @@ TEST_CASE("HeaderSnapshot::reopen_index regeneration", "[silkworm][node][snapsho
 
 TEST_CASE("BodySnapshot::reopen_index regeneration", "[silkworm][node][snapshot][index]") {
     SetLogVerbosityGuard guard{log::Level::kNone};
-    test::SampleBodySnapshotFile sample_body_snapshot{};
+    TemporaryDirectory tmp_dir;
+    test::SampleBodySnapshotFile sample_body_snapshot{tmp_dir.path()};
     test::SampleBodySnapshotPath body_snapshot_path{sample_body_snapshot.path()};
     auto body_index = BodyIndex::make(body_snapshot_path);
     REQUIRE_NOTHROW(body_index.build());
@@ -470,9 +483,10 @@ TEST_CASE("BodySnapshot::reopen_index regeneration", "[silkworm][node][snapshot]
 
 TEST_CASE("TransactionSnapshot::reopen_index regeneration", "[silkworm][node][snapshot][index]") {
     SetLogVerbosityGuard guard{log::Level::kNone};
-    test::SampleBodySnapshotFile body_snapshot;
+    TemporaryDirectory tmp_dir;
+    test::SampleBodySnapshotFile body_snapshot{tmp_dir.path()};
     test::SampleBodySnapshotPath body_snapshot_path{body_snapshot.path()};
-    test::SampleTransactionSnapshotFile sample_tx_snapshot{};
+    test::SampleTransactionSnapshotFile sample_tx_snapshot{tmp_dir.path()};
     test::SampleTransactionSnapshotPath tx_snapshot_path{sample_tx_snapshot.path()};
     auto tx_index = TransactionIndex::make(body_snapshot_path, tx_snapshot_path);
     REQUIRE_NOTHROW(tx_index.build());

--- a/silkworm/db/snapshots/test_util/common.hpp
+++ b/silkworm/db/snapshots/test_util/common.hpp
@@ -113,15 +113,9 @@ struct SnapshotBody {
 //! Temporary snapshot file
 class TemporarySnapshotFile {
   public:
-    explicit TemporarySnapshotFile(const SnapshotHeader& header, const SnapshotBody& body = {}) {
-        Bytes data{};
-        header.encode(data);
-        body.encode(data);
-        file_.write(data);
-    }
     TemporarySnapshotFile(const std::filesystem::path& tmp_dir,
                           const std::string& filename,
-                          const SnapshotHeader& header,
+                          const SnapshotHeader& header = {},
                           const SnapshotBody& body = {})
         : file_(tmp_dir, filename) {
         Bytes data{};
@@ -129,18 +123,11 @@ class TemporarySnapshotFile {
         body.encode(data);
         file_.write(data);
     }
-    TemporarySnapshotFile(const std::filesystem::path& tmp_dir, const std::string& filename)
-        : TemporarySnapshotFile(tmp_dir, filename, {}, {}) {}
-    TemporarySnapshotFile(const std::string& filename, ByteView data)
-        : TemporarySnapshotFile(TemporaryDirectory::get_os_temporary_path(), filename, data) {}
+
     TemporarySnapshotFile(const std::filesystem::path& tmp_dir, const std::string& filename, ByteView data)
         : file_(tmp_dir, filename) {
         file_.write(data);
     }
-    TemporarySnapshotFile(const std::string& filename, const SnapshotHeader& header, const SnapshotBody& body = {})
-        : TemporarySnapshotFile(TemporaryDirectory::get_os_temporary_path(), filename, header, body) {}
-    explicit TemporarySnapshotFile(const std::string& filename)
-        : TemporarySnapshotFile(TemporaryDirectory::get_os_temporary_path(), filename, {}, {}) {}
 
     const std::filesystem::path& path() const { return file_.path(); }
 
@@ -151,9 +138,6 @@ class TemporarySnapshotFile {
 //! HelloWorld snapshot file: it contains just one word: "hello, world" w/o any patterns
 class HelloWorldSnapshotFile : public TemporarySnapshotFile {
   public:
-    explicit HelloWorldSnapshotFile() : TemporarySnapshotFile{kHeader, kBody} {}
-    explicit HelloWorldSnapshotFile(const std::string& filename)
-        : TemporarySnapshotFile{filename, kHeader, kBody} {}
     explicit HelloWorldSnapshotFile(const std::filesystem::path& tmp_dir, const std::string& filename)
         : TemporarySnapshotFile{tmp_dir, filename, kHeader, kBody} {}
 
@@ -187,10 +171,6 @@ class HelloWorldSnapshotFile : public TemporarySnapshotFile {
 class SampleHeaderSnapshotFile : public TemporarySnapshotFile {
   public:
     inline static constexpr const char* kHeadersSnapshotFileName{"v1-001500-001500-headers.seg"};
-
-    //! This ctor lets you pass any snapshot content and is used to produce broken snapshots
-    explicit SampleHeaderSnapshotFile(std::string_view hex)
-        : TemporarySnapshotFile{kHeadersSnapshotFileName, *from_hex(hex)} {}
 
     //! This ctor lets you pass any snapshot content and is used to produce broken snapshots
     SampleHeaderSnapshotFile(const std::filesystem::path& tmp_dir, std::string_view hex)
@@ -227,20 +207,12 @@ class SampleHeaderSnapshotFile : public TemporarySnapshotFile {
               "1FAD3D458F3E8316E36D8347E7C4825208845733A90798D78301040084476574"
               "6887676F312E352E31856C696E7578A0799895E28A837BBDF28B8ECF5FC0E625"
               "1398ECB0FFC7FF5BBB457C21B14CE982888698762012B46FEF") {}
-
-    //! This empty ctor captures the correct sample snapshot content once for all
-    explicit SampleHeaderSnapshotFile()
-        : SampleHeaderSnapshotFile{TemporaryDirectory::get_os_temporary_path()} {}
 };
 
 //! Sample Bodies snapshot file: it contains the mainnet block bodies in range [1'500'012, 1'500'013]
 class SampleBodySnapshotFile : public TemporarySnapshotFile {
   public:
     inline static constexpr const char* kBodiesSnapshotFileName{"v1-001500-001500-bodies.seg"};
-
-    //! This ctor lets you pass any snapshot content and is used to produce broken snapshots
-    explicit SampleBodySnapshotFile(std::string_view hex)
-        : TemporarySnapshotFile{kBodiesSnapshotFileName, *from_hex(hex)} {}
 
     //! This ctor lets you pass any snapshot content and is used to produce broken snapshots
     SampleBodySnapshotFile(const std::filesystem::path& tmp_dir, std::string_view hex)
@@ -276,20 +248,12 @@ class SampleBodySnapshotFile : public TemporarySnapshotFile {
               "98D783010400844765746887676F312E352E31856C696E7578A028FB78C93A8C"
               "6BF6B9A353BD3566DE6861EAAC19C0ED1B663CBAAEE0CFE6E70A88C7E9D99815"
               "48460F") {}
-
-    //! This empty ctor captures the correct sample snapshot content once for all
-    explicit SampleBodySnapshotFile()
-        : SampleBodySnapshotFile{TemporaryDirectory::get_os_temporary_path()} {}
 };
 
 //! Sample Transactions snapshot file: it contains the mainnet block transactions in range [1'500'012, 1'500'013]
 class SampleTransactionSnapshotFile : public TemporarySnapshotFile {
   public:
     inline static constexpr const char* kTransactionsSnapshotFileName{"v1-001500-001500-transactions.seg"};
-
-    //! This ctor lets you pass any snapshot content and is used to produce broken snapshots
-    explicit SampleTransactionSnapshotFile(std::string_view hex)
-        : TemporarySnapshotFile{kTransactionsSnapshotFileName, *from_hex(hex)} {}
 
     //! This ctor lets you pass any snapshot content and is used to produce broken snapshots
     SampleTransactionSnapshotFile(const std::filesystem::path& tmp_dir, std::string_view hex)
@@ -372,10 +336,6 @@ class SampleTransactionSnapshotFile : public TemporarySnapshotFile {
               "0679FA90B5A028A6D676D77923B19506C7AAAE5F1DC2F2244855AABB6672401C"
               "1B55B0D844FF"  // Txn position 0 block 1'500'013 END
               "03") {}
-
-    //! This empty ctor captures the correct sample snapshot content once for all
-    explicit SampleTransactionSnapshotFile()
-        : SampleTransactionSnapshotFile{TemporaryDirectory::get_os_temporary_path()} {}
 };
 
 class SampleSnapshotPath : public SnapshotPath {

--- a/silkworm/db/snapshots/txn_hash.cpp
+++ b/silkworm/db/snapshots/txn_hash.cpp
@@ -1,0 +1,92 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "txn_hash.hpp"
+
+#include <algorithm>
+#include <sstream>
+#include <stdexcept>
+
+#include <magic_enum.hpp>
+
+#include <silkworm/core/common/endian.hpp>
+#include <silkworm/core/common/util.hpp>
+#include <silkworm/core/types/transaction.hpp>
+#include <silkworm/infra/common/log.hpp>
+
+namespace silkworm::snapshots {
+
+Hash tx_buffer_hash(ByteView tx_buffer, uint64_t tx_id) {
+    Hash tx_hash;
+
+    const bool is_system_tx{tx_buffer.empty()};
+    if (is_system_tx) {
+        // system-txs: hash:pad32(txnID)
+        endian::store_big_u64(tx_hash.bytes, tx_id);
+        return tx_hash;
+    }
+
+    // Skip tx hash first byte plus address length for transaction decoding
+    constexpr int kTxFirstByteAndAddressLength{1 + kAddressLength};
+    if (tx_buffer.size() <= kTxFirstByteAndAddressLength) {
+        std::stringstream error;
+        error << " tx_buffer_hash cannot decode tx envelope: record " << to_hex(tx_buffer)
+              << " too short: " << tx_buffer.size()
+              << " tx_id: " << tx_id;
+        throw std::runtime_error{error.str()};
+    }
+    const ByteView tx_envelope{tx_buffer.substr(kTxFirstByteAndAddressLength)};
+    ByteView tx_envelope_view{tx_envelope};
+
+    rlp::Header tx_header;
+    TransactionType tx_type{};
+    auto decode_result = rlp::decode_transaction_header_and_type(tx_envelope_view, tx_header, tx_type);
+    if (!decode_result) {
+        std::stringstream error;
+        error << " tx_buffer_hash cannot decode tx envelope: " << to_hex(tx_envelope)
+              << " tx_id: " << tx_id
+              << " error: " << magic_enum::enum_name(decode_result.error());
+        throw std::runtime_error{error.str()};
+    }
+
+    const std::size_t tx_payload_offset = tx_type == TransactionType::kLegacy ? 0 : (tx_envelope.length() - tx_header.payload_length);
+    if (tx_buffer.size() <= kTxFirstByteAndAddressLength + tx_payload_offset) {
+        std::stringstream error;
+        error << " tx_buffer_hash cannot decode tx payload: record " << to_hex(tx_buffer)
+              << " too short: " << tx_buffer.size()
+              << " tx_id: " << tx_id;
+        throw std::runtime_error{error.str()};
+    }
+    const ByteView tx_payload{tx_buffer.substr(kTxFirstByteAndAddressLength + tx_payload_offset)};
+    const auto h256{keccak256(tx_payload)};
+    std::copy(std::begin(h256.bytes), std::begin(h256.bytes) + kHashLength, std::begin(tx_hash.bytes));
+
+    if (tx_id % 100'000 == 0) {
+        SILK_DEBUG << "tx_buffer_hash:"
+                   << " header.list: " << tx_header.list
+                   << " header.payload_length: " << tx_header.payload_length
+                   << " tx_id: " << tx_id;
+    }
+    SILK_TRACE << "tx_buffer_hash:"
+               << " type: " << int(tx_type)
+               << " tx_id: " << tx_id
+               << " payload: " << to_hex(tx_payload)
+               << " h256: " << to_hex(h256.bytes, kHashLength);
+
+    return tx_hash;
+}
+
+}  // namespace silkworm::snapshots

--- a/silkworm/db/snapshots/txn_hash.hpp
+++ b/silkworm/db/snapshots/txn_hash.hpp
@@ -1,0 +1,28 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <cstdint>
+
+#include <silkworm/core/common/bytes.hpp>
+#include <silkworm/core/types/hash.hpp>
+
+namespace silkworm::snapshots {
+
+Hash tx_buffer_hash(ByteView tx_buffer, uint64_t tx_id);
+
+}  // namespace silkworm::snapshots

--- a/silkworm/db/snapshots/txn_index.cpp
+++ b/silkworm/db/snapshots/txn_index.cpp
@@ -34,8 +34,10 @@ SnapshotPath TransactionIndex::bodies_segment_path(const SnapshotPath& segment_p
         SnapshotType::bodies);
 }
 
-std::pair<uint64_t, uint64_t> TransactionIndex::compute_txs_amount(const SnapshotPath& bodies_segment_path) {
-    BodySnapshot bodies_snapshot{bodies_segment_path};
+std::pair<uint64_t, uint64_t> TransactionIndex::compute_txs_amount(
+    SnapshotPath bodies_segment_path,
+    std::optional<MemoryMappedRegion> bodies_segment_region) {
+    BodySnapshot bodies_snapshot{std::move(bodies_segment_path), bodies_segment_region};
     bodies_snapshot.reopen_segment();
     return bodies_snapshot.compute_txs_amount();
 }

--- a/silkworm/db/snapshots/txn_index.cpp
+++ b/silkworm/db/snapshots/txn_index.cpp
@@ -25,7 +25,7 @@ Bytes TransactionKeyFactory::make(ByteView key_data, uint64_t i) {
     return Bytes{tx_buffer_hash(key_data, first_tx_id_ + i)};
 }
 
-SnapshotPath TransactionIndex1::bodies_segment_path(const SnapshotPath& segment_path) {
+SnapshotPath TransactionIndex::bodies_segment_path(const SnapshotPath& segment_path) {
     return SnapshotPath::from(
         segment_path.path().parent_path(),
         segment_path.version(),
@@ -34,7 +34,7 @@ SnapshotPath TransactionIndex1::bodies_segment_path(const SnapshotPath& segment_
         SnapshotType::bodies);
 }
 
-std::pair<uint64_t, uint64_t> TransactionIndex1::compute_txs_amount(const SnapshotPath& bodies_segment_path) {
+std::pair<uint64_t, uint64_t> TransactionIndex::compute_txs_amount(const SnapshotPath& bodies_segment_path) {
     BodySnapshot bodies_snapshot{bodies_segment_path};
     bodies_snapshot.reopen_segment();
     return bodies_snapshot.compute_txs_amount();

--- a/silkworm/db/snapshots/txn_index.cpp
+++ b/silkworm/db/snapshots/txn_index.cpp
@@ -1,0 +1,43 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "txn_index.hpp"
+
+#include "snapshot.hpp"
+#include "txn_hash.hpp"
+
+namespace silkworm::snapshots {
+
+Bytes TransactionKeyFactory::make(ByteView key_data, uint64_t i) {
+    return Bytes{tx_buffer_hash(key_data, first_tx_id_ + i)};
+}
+
+SnapshotPath TransactionIndex1::bodies_segment_path(const SnapshotPath& segment_path) {
+    return SnapshotPath::from(
+        segment_path.path().parent_path(),
+        segment_path.version(),
+        segment_path.block_from(),
+        segment_path.block_to(),
+        SnapshotType::bodies);
+}
+
+std::pair<uint64_t, uint64_t> TransactionIndex1::compute_txs_amount(const SnapshotPath& bodies_segment_path) {
+    BodySnapshot bodies_snapshot{bodies_segment_path};
+    bodies_snapshot.reopen_segment();
+    return bodies_snapshot.compute_txs_amount();
+}
+
+}  // namespace silkworm::snapshots

--- a/silkworm/db/snapshots/txn_index.hpp
+++ b/silkworm/db/snapshots/txn_index.hpp
@@ -24,7 +24,7 @@
 #include <silkworm/db/etl/collector.hpp>
 #include <silkworm/infra/common/memory_mapped_file.hpp>
 
-#include "index.hpp"
+#include "index_builder.hpp"
 #include "path.hpp"
 
 namespace silkworm::snapshots {
@@ -39,7 +39,7 @@ struct TransactionKeyFactory : IndexKeyFactory {
     uint64_t first_tx_id_;
 };
 
-class TransactionIndex1 {
+class TransactionIndex {
   public:
     static IndexBuilder make(const SnapshotPath& bodies_segment_path, SnapshotPath segment_path, std::optional<MemoryMappedRegion> segment_region = std::nullopt) {
         auto txs_amount = compute_txs_amount(bodies_segment_path);

--- a/silkworm/db/snapshots/txn_index.hpp
+++ b/silkworm/db/snapshots/txn_index.hpp
@@ -1,0 +1,66 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+
+#include <silkworm/core/common/bytes.hpp>
+#include <silkworm/db/etl/collector.hpp>
+#include <silkworm/infra/common/memory_mapped_file.hpp>
+
+#include "index.hpp"
+#include "path.hpp"
+
+namespace silkworm::snapshots {
+
+struct TransactionKeyFactory : IndexKeyFactory {
+    TransactionKeyFactory(uint64_t first_tx_id) : first_tx_id_(first_tx_id) {}
+    ~TransactionKeyFactory() override = default;
+
+    Bytes make(ByteView key_data, uint64_t i) override;
+
+  private:
+    uint64_t first_tx_id_;
+};
+
+class TransactionIndex1 {
+  public:
+    static IndexBuilder make(const SnapshotPath& bodies_segment_path, SnapshotPath segment_path, std::optional<MemoryMappedRegion> segment_region = std::nullopt) {
+        auto txs_amount = compute_txs_amount(bodies_segment_path);
+        auto descriptor = make_descriptor(segment_path, txs_amount.first);
+        auto query = std::make_unique<DecompressorIndexInputDataQuery>(std::move(segment_path), segment_region);
+        return IndexBuilder{std::move(descriptor), std::move(query)};
+    }
+
+    static SnapshotPath bodies_segment_path(const SnapshotPath& segment_path);
+    static std::pair<uint64_t, uint64_t> compute_txs_amount(const SnapshotPath& bodies_segment_path);
+
+  private:
+    static IndexDescriptor make_descriptor(const SnapshotPath& segment_path, uint64_t first_tx_id) {
+        return {
+            .index_file = segment_path.index_file(),
+            .key_factory = std::make_unique<TransactionKeyFactory>(first_tx_id),
+            .base_data_id = first_tx_id,
+            .less_false_positives = true,
+            .etl_buffer_size = db::etl::kOptimalBufferSize / 2,
+        };
+    }
+};
+
+}  // namespace silkworm::snapshots

--- a/silkworm/db/snapshots/txn_index.hpp
+++ b/silkworm/db/snapshots/txn_index.hpp
@@ -41,15 +41,29 @@ struct TransactionKeyFactory : IndexKeyFactory {
 
 class TransactionIndex {
   public:
-    static IndexBuilder make(const SnapshotPath& bodies_segment_path, SnapshotPath segment_path, std::optional<MemoryMappedRegion> segment_region = std::nullopt) {
-        auto txs_amount = compute_txs_amount(bodies_segment_path);
+    static IndexBuilder make(
+        SnapshotPath bodies_segment_path,
+        SnapshotPath segment_path) {
+        return make(
+            std::move(bodies_segment_path), std::nullopt,
+            std::move(segment_path), std::nullopt);
+    }
+
+    static IndexBuilder make(
+        SnapshotPath bodies_segment_path,
+        std::optional<MemoryMappedRegion> bodies_segment_region,
+        SnapshotPath segment_path,
+        std::optional<MemoryMappedRegion> segment_region) {
+        auto txs_amount = compute_txs_amount(std::move(bodies_segment_path), bodies_segment_region);
         auto descriptor = make_descriptor(segment_path, txs_amount.first);
         auto query = std::make_unique<DecompressorIndexInputDataQuery>(std::move(segment_path), segment_region);
         return IndexBuilder{std::move(descriptor), std::move(query)};
     }
 
     static SnapshotPath bodies_segment_path(const SnapshotPath& segment_path);
-    static std::pair<uint64_t, uint64_t> compute_txs_amount(const SnapshotPath& bodies_segment_path);
+    static std::pair<uint64_t, uint64_t> compute_txs_amount(
+        SnapshotPath bodies_segment_path,
+        std::optional<MemoryMappedRegion> bodies_segment_region);
 
   private:
     static IndexDescriptor make_descriptor(const SnapshotPath& segment_path, uint64_t first_tx_id) {

--- a/silkworm/db/snapshots/txn_to_block_index.cpp
+++ b/silkworm/db/snapshots/txn_to_block_index.cpp
@@ -1,0 +1,82 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "txn_to_block_index.hpp"
+
+#include "txs_and_bodies_query.hpp"
+
+namespace silkworm::snapshots {
+
+static IndexInputDataQuery::Iterator::value_type query_entry(TxsAndBodiesQuery::Iterator& it) {
+    return {
+        .key_data = it->tx_buffer,
+        .value = it->block_number,
+    };
+}
+
+IndexInputDataQuery::Iterator TransactionToBlockIndexInputDataQuery::begin() {
+    auto impl_it = std::make_shared<TxsAndBodiesQuery::Iterator>(query_.begin());
+    return IndexInputDataQuery::Iterator{this, impl_it, query_entry(*impl_it)};
+}
+
+IndexInputDataQuery::Iterator TransactionToBlockIndexInputDataQuery::end() {
+    auto impl_it = std::make_shared<TxsAndBodiesQuery::Iterator>(query_.end());
+    return IndexInputDataQuery::Iterator{this, impl_it, query_entry(*impl_it)};
+}
+
+std::size_t TransactionToBlockIndexInputDataQuery::keys_count() {
+    return query_.expected_tx_count();
+}
+
+std::pair<std::shared_ptr<void>, IndexInputDataQuery::Iterator::value_type>
+TransactionToBlockIndexInputDataQuery::next_iterator(std::shared_ptr<void> it_impl) {
+    auto& it_impl_ref = *reinterpret_cast<TxsAndBodiesQuery::Iterator*>(it_impl.get());
+    ++it_impl_ref;
+    return {it_impl, query_entry(it_impl_ref)};
+}
+
+bool TransactionToBlockIndexInputDataQuery::equal_iterators(
+    std::shared_ptr<void> lhs_it_impl,
+    std::shared_ptr<void> rhs_it_impl) const {
+    auto lhs = reinterpret_cast<TxsAndBodiesQuery::Iterator*>(lhs_it_impl.get());
+    auto rhs = reinterpret_cast<TxsAndBodiesQuery::Iterator*>(rhs_it_impl.get());
+    return (*lhs == *rhs);
+}
+
+IndexBuilder TransactionToBlockIndex::make(
+    const SnapshotPath& bodies_segment_path,
+    SnapshotPath segment_path,
+    std::optional<MemoryMappedRegion> segment_region) {
+    auto txs_amount = TransactionIndex1::compute_txs_amount(bodies_segment_path);
+    const uint64_t first_tx_id = txs_amount.first;
+    const uint64_t expected_tx_count = txs_amount.second;
+
+    auto descriptor = make_descriptor(segment_path, first_tx_id);
+
+    TxsAndBodiesQuery data_query{
+        std::move(segment_path),
+        segment_region,
+        bodies_segment_path,
+        std::nullopt,
+        first_tx_id,
+        expected_tx_count,
+    };
+
+    auto query = std::make_unique<TransactionToBlockIndexInputDataQuery>(std::move(data_query));
+    return IndexBuilder{std::move(descriptor), std::move(query)};
+}
+
+}  // namespace silkworm::snapshots

--- a/silkworm/db/snapshots/txn_to_block_index.cpp
+++ b/silkworm/db/snapshots/txn_to_block_index.cpp
@@ -57,10 +57,11 @@ bool TransactionToBlockIndexInputDataQuery::equal_iterators(
 }
 
 IndexBuilder TransactionToBlockIndex::make(
-    const SnapshotPath& bodies_segment_path,
+    SnapshotPath bodies_segment_path,
+    std::optional<MemoryMappedRegion> bodies_segment_region,
     SnapshotPath segment_path,
     std::optional<MemoryMappedRegion> segment_region) {
-    auto txs_amount = TransactionIndex::compute_txs_amount(bodies_segment_path);
+    auto txs_amount = TransactionIndex::compute_txs_amount(bodies_segment_path, bodies_segment_region);
     const uint64_t first_tx_id = txs_amount.first;
     const uint64_t expected_tx_count = txs_amount.second;
 
@@ -69,8 +70,8 @@ IndexBuilder TransactionToBlockIndex::make(
     TxsAndBodiesQuery data_query{
         std::move(segment_path),
         segment_region,
-        bodies_segment_path,
-        std::nullopt,
+        std::move(bodies_segment_path),
+        bodies_segment_region,
         first_tx_id,
         expected_tx_count,
     };

--- a/silkworm/db/snapshots/txn_to_block_index.cpp
+++ b/silkworm/db/snapshots/txn_to_block_index.cpp
@@ -60,7 +60,7 @@ IndexBuilder TransactionToBlockIndex::make(
     const SnapshotPath& bodies_segment_path,
     SnapshotPath segment_path,
     std::optional<MemoryMappedRegion> segment_region) {
-    auto txs_amount = TransactionIndex1::compute_txs_amount(bodies_segment_path);
+    auto txs_amount = TransactionIndex::compute_txs_amount(bodies_segment_path);
     const uint64_t first_tx_id = txs_amount.first;
     const uint64_t expected_tx_count = txs_amount.second;
 

--- a/silkworm/db/snapshots/txn_to_block_index.hpp
+++ b/silkworm/db/snapshots/txn_to_block_index.hpp
@@ -23,7 +23,7 @@
 #include <silkworm/db/etl/collector.hpp>
 #include <silkworm/infra/common/memory_mapped_file.hpp>
 
-#include "index.hpp"
+#include "index_builder.hpp"
 #include "path.hpp"
 #include "txn_index.hpp"
 #include "txs_and_bodies_query.hpp"

--- a/silkworm/db/snapshots/txn_to_block_index.hpp
+++ b/silkworm/db/snapshots/txn_to_block_index.hpp
@@ -48,9 +48,18 @@ class TransactionToBlockIndexInputDataQuery : public IndexInputDataQuery {
 class TransactionToBlockIndex {
   public:
     static IndexBuilder make(
-        const SnapshotPath& bodies_segment_path,
+        SnapshotPath bodies_segment_path,
+        SnapshotPath segment_path) {
+        return make(
+            std::move(bodies_segment_path), std::nullopt,
+            std::move(segment_path), std::nullopt);
+    }
+
+    static IndexBuilder make(
+        SnapshotPath bodies_segment_path,
+        std::optional<MemoryMappedRegion> bodies_segment_region,
         SnapshotPath segment_path,
-        std::optional<MemoryMappedRegion> segment_region = std::nullopt);
+        std::optional<MemoryMappedRegion> segment_region);
 
   private:
     static IndexDescriptor make_descriptor(const SnapshotPath& segment_path, uint64_t first_tx_id) {

--- a/silkworm/db/snapshots/txn_to_block_index.hpp
+++ b/silkworm/db/snapshots/txn_to_block_index.hpp
@@ -1,0 +1,67 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+
+#include <silkworm/db/etl/collector.hpp>
+#include <silkworm/infra/common/memory_mapped_file.hpp>
+
+#include "index.hpp"
+#include "path.hpp"
+#include "txn_index.hpp"
+#include "txs_and_bodies_query.hpp"
+
+namespace silkworm::snapshots {
+
+class TransactionToBlockIndexInputDataQuery : public IndexInputDataQuery {
+  public:
+    TransactionToBlockIndexInputDataQuery(TxsAndBodiesQuery query)
+        : query_(std::move(query)) {}
+
+    Iterator begin() override;
+    Iterator end() override;
+    std::size_t keys_count() override;
+    std::pair<std::shared_ptr<void>, Iterator::value_type> next_iterator(std::shared_ptr<void> it_impl) override;
+    bool equal_iterators(std::shared_ptr<void> lhs_it_impl, std::shared_ptr<void> rhs_it_impl) const override;
+
+  private:
+    TxsAndBodiesQuery query_;
+};
+
+class TransactionToBlockIndex {
+  public:
+    static IndexBuilder make(
+        const SnapshotPath& bodies_segment_path,
+        SnapshotPath segment_path,
+        std::optional<MemoryMappedRegion> segment_region = std::nullopt);
+
+  private:
+    static IndexDescriptor make_descriptor(const SnapshotPath& segment_path, uint64_t first_tx_id) {
+        return {
+            .index_file = segment_path.index_file_for_type(SnapshotType::transactions_to_block),
+            .key_factory = std::make_unique<TransactionKeyFactory>(first_tx_id),
+            .base_data_id = segment_path.block_from(),
+            .double_enum_index = false,
+            .etl_buffer_size = db::etl::kOptimalBufferSize / 2,
+        };
+    }
+};
+
+}  // namespace silkworm::snapshots

--- a/silkworm/db/snapshots/txs_and_bodies_query.cpp
+++ b/silkworm/db/snapshots/txs_and_bodies_query.cpp
@@ -1,0 +1,166 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "txs_and_bodies_query.hpp"
+
+#include <limits>
+#include <sstream>
+#include <stdexcept>
+
+#include <magic_enum.hpp>
+
+namespace silkworm::snapshots {
+
+TxsAndBodiesQuery::Iterator::Iterator(
+    std::shared_ptr<seg::Decompressor> txs_decoder,
+    seg::Decompressor::Iterator tx_it,
+    std::shared_ptr<seg::Decompressor> bodies_decoder,
+    seg::Decompressor::Iterator body_it,
+    BlockNum first_block_number,
+    uint64_t first_tx_id,
+    uint64_t expected_tx_count,
+    std::string log_title)
+    : txs_decoder_(std::move(txs_decoder)),
+      tx_it_(std::move(tx_it)),
+      bodies_decoder_(std::move(bodies_decoder)),
+      body_it_(std::move(body_it)),
+      first_tx_id_(first_tx_id),
+      expected_tx_count_(expected_tx_count),
+      log_title_(std::move(log_title)) {
+    value_.block_number = first_block_number;
+    value_.body_rlp = *body_it_;
+    if (!value_.body_rlp.empty()) {
+        decode_body_rlp(value_.body_rlp, value_.body);
+    }
+    value_.tx_buffer = *tx_it_;
+}
+
+void TxsAndBodiesQuery::Iterator::skip_bodies_until_tx_id(uint64_t tx_id) {
+    while (!(tx_id < value_.body.base_txn_id + value_.body.txn_count)) {
+        ++body_it_;
+        if (body_it_ == bodies_decoder_->end()) {
+            throw std::runtime_error{log_title_ + " not enough bodies"};
+        }
+        value_.block_number++;
+        value_.body_rlp = *body_it_;
+        decode_body_rlp(value_.body_rlp, value_.body);
+    }
+}
+
+TxsAndBodiesQuery::Iterator& TxsAndBodiesQuery::Iterator::operator++() {
+    // check if already at the end
+    if (!txs_decoder_) {
+        return *this;
+    }
+
+    ++tx_it_;
+    ++i_;
+
+    if (tx_it_ != txs_decoder_->end()) {
+        value_.tx_buffer = *tx_it_;
+        skip_bodies_until_tx_id(first_tx_id_ + i_);
+    } else {
+        if (i_ != expected_tx_count_) {
+            std::stringstream error;
+            error << log_title_
+                  << " tx count mismatch: expected=" + std::to_string(expected_tx_count_)
+                  << " got=" << std::to_string(i_);
+            throw std::runtime_error{error.str()};
+        }
+
+        // reset to match the end iterator
+        body_it_ = bodies_decoder_->end();
+        txs_decoder_.reset();
+        bodies_decoder_.reset();
+        value_ = {};
+        value_.block_number = std::numeric_limits<uint64_t>::max();
+    }
+
+    return *this;
+}
+
+bool operator==(const TxsAndBodiesQuery::Iterator& lhs, const TxsAndBodiesQuery::Iterator& rhs) {
+    return (lhs.txs_decoder_ == rhs.txs_decoder_) &&
+           (!lhs.txs_decoder_ || (lhs.tx_it_ == rhs.tx_it_)) &&
+           (lhs.bodies_decoder_ == rhs.bodies_decoder_) &&
+           (!lhs.bodies_decoder_ || (lhs.body_it_ == rhs.body_it_));
+}
+
+void TxsAndBodiesQuery::Iterator::decode_body_rlp(ByteView body_rlp, BlockBodyForStorage& body) {
+    auto decode_result = decode_stored_block_body(body_rlp, body);
+    if (!decode_result) {
+        std::stringstream error;
+        error << log_title_
+              << " cannot decode block " << value_.block_number
+              << " body: " << to_hex(body_rlp)
+              << " i: " << i_
+              << " error: " << magic_enum::enum_name(decode_result.error());
+        throw std::runtime_error{error.str()};
+    }
+}
+
+TxsAndBodiesQuery::Iterator TxsAndBodiesQuery::begin() {
+    std::string log_title = "TxsAndBodiesQuery for: " + txs_segment_path_.path().string();
+
+    auto txs_decoder = std::make_shared<seg::Decompressor>(txs_segment_path_.path(), txs_segment_region_);
+    txs_decoder->open();
+
+    const auto tx_count = txs_decoder->words_count();
+    if (tx_count != expected_tx_count_) {
+        std::stringstream error;
+        error << log_title
+              << " tx count mismatch: expected=" << std::to_string(expected_tx_count_)
+              << " got=" << std::to_string(tx_count);
+        throw std::runtime_error{error.str()};
+    }
+
+    auto bodies_decoder = std::make_shared<seg::Decompressor>(bodies_segment_path_.path(), bodies_segment_region_);
+    bodies_decoder->open();
+
+    TxsAndBodiesQuery::Iterator it{
+        txs_decoder,
+        txs_decoder->begin(),
+        bodies_decoder,
+        bodies_decoder->begin(),
+        bodies_segment_path_.block_from(),
+        first_tx_id_,
+        expected_tx_count_,
+        log_title,
+    };
+
+    if (it->body_rlp.empty()) {
+        throw std::runtime_error{log_title + " no bodies"};
+    }
+
+    return it;
+}
+
+TxsAndBodiesQuery::Iterator TxsAndBodiesQuery::end() {
+    auto txs_decoder = std::make_shared<seg::Decompressor>(txs_segment_path_.path(), txs_segment_region_);
+    auto bodies_decoder = std::make_shared<seg::Decompressor>(bodies_segment_path_.path(), bodies_segment_region_);
+    return Iterator{
+        {},
+        txs_decoder->end(),
+        {},
+        bodies_decoder->end(),
+        std::numeric_limits<uint64_t>::max(),
+        first_tx_id_,
+        expected_tx_count_,
+        "TxsAndBodiesQuery::end",
+    };
+}
+
+}  // namespace silkworm::snapshots

--- a/silkworm/db/snapshots/txs_and_bodies_query.hpp
+++ b/silkworm/db/snapshots/txs_and_bodies_query.hpp
@@ -1,0 +1,111 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include <silkworm/core/common/base.hpp>
+#include <silkworm/core/common/bytes.hpp>
+#include <silkworm/core/types/block_body_for_storage.hpp>
+#include <silkworm/db/snapshots/seg/decompressor.hpp>
+#include <silkworm/infra/common/memory_mapped_file.hpp>
+
+#include "path.hpp"
+
+namespace silkworm::snapshots {
+
+class TxsAndBodiesQuery {
+  public:
+    class Iterator {
+      public:
+        Iterator(
+            std::shared_ptr<seg::Decompressor> txs_decoder,
+            seg::Decompressor::Iterator tx_it,
+            std::shared_ptr<seg::Decompressor> bodies_decoder,
+            seg::Decompressor::Iterator body_it,
+            BlockNum first_block_number,
+            uint64_t first_tx_id,
+            uint64_t expected_tx_count,
+            std::string log_title);
+
+        struct value_type {
+            BlockNum block_number{};
+            ByteView body_rlp;
+            BlockBodyForStorage body;
+            ByteView tx_buffer;
+        };
+
+        using iterator_category = std::input_iterator_tag;
+        using difference_type = void;
+        using pointer = value_type*;
+        using reference = value_type&;
+
+        reference operator*() { return value_; }
+        pointer operator->() { return &value_; }
+
+        Iterator operator++(int) { return std::exchange(*this, ++Iterator{*this}); }
+        Iterator& operator++();
+
+        friend bool operator!=(const Iterator& lhs, const Iterator& rhs) = default;
+        friend bool operator==(const Iterator& lhs, const Iterator& rhs);
+
+      private:
+        void skip_bodies_until_tx_id(uint64_t tx_id);
+        void decode_body_rlp(ByteView body_rlp, BlockBodyForStorage& body);
+
+        std::shared_ptr<seg::Decompressor> txs_decoder_;
+        seg::Decompressor::Iterator tx_it_;
+        std::shared_ptr<seg::Decompressor> bodies_decoder_;
+        seg::Decompressor::Iterator body_it_;
+        uint64_t i_{};
+        value_type value_;
+        uint64_t first_tx_id_;
+        uint64_t expected_tx_count_;
+        std::string log_title_;
+    };
+
+    TxsAndBodiesQuery(
+        SnapshotPath txs_segment_path,
+        std::optional<MemoryMappedRegion> txs_segment_region,
+        SnapshotPath bodies_segment_path,
+        std::optional<MemoryMappedRegion> bodies_segment_region,
+        uint64_t first_tx_id,
+        uint64_t expected_tx_count)
+        : txs_segment_path_(std::move(txs_segment_path)),
+          txs_segment_region_(std::move(txs_segment_region)),
+          bodies_segment_path_(std::move(bodies_segment_path)),
+          bodies_segment_region_(std::move(bodies_segment_region)),
+          first_tx_id_(first_tx_id),
+          expected_tx_count_(expected_tx_count) {}
+
+    Iterator begin();
+    Iterator end();
+
+  private:
+    SnapshotPath txs_segment_path_;
+    std::optional<MemoryMappedRegion> txs_segment_region_;
+    SnapshotPath bodies_segment_path_;
+    std::optional<MemoryMappedRegion> bodies_segment_region_;
+    uint64_t first_tx_id_;
+    uint64_t expected_tx_count_;
+};
+
+}  // namespace silkworm::snapshots

--- a/silkworm/db/snapshots/txs_and_bodies_query.hpp
+++ b/silkworm/db/snapshots/txs_and_bodies_query.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cstdint>
+#include <iterator>
 #include <memory>
 #include <optional>
 #include <string>
@@ -98,6 +99,8 @@ class TxsAndBodiesQuery {
 
     Iterator begin();
     Iterator end();
+
+    uint64_t expected_tx_count() { return expected_tx_count_; }
 
   private:
     SnapshotPath txs_segment_path_;


### PR DESCRIPTION
The same IndexBuilder is used for all indexes. It needs a descriptor (with settings) and a query (with input data). There are 2 types of index input data queries:
1. DecompressorIndexInputDataQuery reads a snapshot (based on seg::Decompressor::Iterator) and produces key = word, value = offset.
2. TransactionToBlockIndexInputDataQuery reads a TxsAndBodiesQuery and produces key = tx word, value = block_number. TxsAndBodiesQuery is a query that JOINs bodies + txs.

Each target index is configured in its own dedicated file. TransactionToBlockIndex is separated from the TransactionIndex. 

Transaction indexes require a bodies_segment_path to be provided. capi also passes a bodies_segment_region.

Avoid get_os_temporary_path in tests: the tests were interfering with each other.

