### PR TITLE
tests: use controllable Erigon datadir 

### DIFF
--- a/.github/workflows/rpc-integration-tests.yml
+++ b/.github/workflows/rpc-integration-tests.yml
@@ -13,7 +13,7 @@ jobs:
   integration-test-suite:
     runs-on: self-hosted
     env:
-      ERIGON_DATA_DIR: /opt/erigon/datadir
+      ERIGON_DATA_DIR: /opt/erigon-versions/reference-version/datadir
       RPC_PAST_TEST_DIR: /opt/rpc-past-tests
       ERIGON_QA_PATH: /opt/erigon-qa
 

--- a/.github/workflows/rpc-performance-tests.yml
+++ b/.github/workflows/rpc-performance-tests.yml
@@ -8,7 +8,7 @@ jobs:
   performance-test-suite:
     runs-on: self-hosted
     env:
-      ERIGON_DATA_DIR: /opt/erigon/datadir
+      ERIGON_DATA_DIR: /opt/erigon-versions/reference-version/datadir
       RPC_PAST_TEST_DIR: /opt/rpc-past-tests
       ERIGON_QA_PATH: /opt/erigon-qa
 


### PR DESCRIPTION
On the self-hosted test runner machine, a software, controllable via REST interface, is capable of fetching different versions of the Erigon database for testing purposes. This PR utilizes the directory controlled by this software in the tests, enabling the ability to switch versions through manual user commands or via automation scripts.