### PR TITLE
mdbx-go: no_warn_duplicate_libraries

### DIFF
--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -88,12 +88,7 @@ elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES ".*Clang$")
   endif()
 
 else()
-
-  message(
-    WARNING
-      "${CMAKE_CXX_COMPILER_ID} is not tested. Should you stumble into any issue please report at https://github.com/torquem-ch/silkworm/issues"
-  )
-
+  message(WARNING "${CMAKE_CXX_COMPILER_ID} is not a supported compiler. Use at your own risk.")
 endif()
 
 if(SILKWORM_SANITIZE)

--- a/cmake/compiler_warnings.cmake
+++ b/cmake/compiler_warnings.cmake
@@ -21,9 +21,9 @@ if(MSVC)
   add_compile_options(/wd4068) # Silence warning C4068: unknown pragma
   add_compile_options(/wd5030) # Silence warning C5030: unknown gnu/clang attribute
   add_compile_options(/W4) # Display all other un-silenced warnings
-
   add_link_options(/ignore:4099)
-else()
+
+elseif((CMAKE_CXX_COMPILER_ID STREQUAL "GNU") OR ("${CMAKE_CXX_COMPILER_ID}" MATCHES ".*Clang$"))
   add_compile_options(-Werror -Wall -Wextra -pedantic)
   add_compile_options(-Wshadow -Wimplicit-fallthrough -Wunused)
   add_compile_options(-Wsign-compare -Wsign-conversion -Wdouble-promotion)
@@ -31,28 +31,31 @@ else()
   add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wnon-virtual-dtor>)
   add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Woverloaded-virtual>)
   add_compile_options(-Wtype-limits -Wformat=2)
-
   add_compile_options(-Wno-missing-field-initializers)
 
   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     add_compile_options(-Wduplicated-cond -Wduplicated-branches -Wlogical-op)
-
     add_compile_options(-Wno-attributes)
 
     if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12)
       # gcc 12 apparently has regressions in uninitialized diagnostics
       add_compile_options(-Wno-error=maybe-uninitialized)
     endif()
-  else()
-    # Clang
+
+  elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES ".*Clang$")
     add_compile_options(-Wconversion) # too much noise in gcc
 
     if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
       add_compile_definitions(_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS)
       add_compile_options(-Wthread-safety)
+    endif()
 
+    if((CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang") AND (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 15))
       # https://stackoverflow.com/questions/77164140/
       add_link_options(-Wl,-no_warn_duplicate_libraries)
     endif()
   endif()
+
+else()
+  message(WARNING "${CMAKE_CXX_COMPILER_ID} is not a supported compiler. Use at your own risk.")
 endif()

--- a/third_party/erigon-mdbx-go/CMakeLists.txt
+++ b/third_party/erigon-mdbx-go/CMakeLists.txt
@@ -17,3 +17,20 @@
 set(MDBX_ENABLE_TESTS OFF)
 add_subdirectory(mdbx-go/mdbxdist)
 target_compile_definitions(mdbx-static PUBLIC CONSTEXPR_ASSERT=assert)
+
+if(MDBX_BUILD_TOOLS)
+  foreach(
+    TOOL
+    mdbx_chk
+    mdbx_copy
+    mdbx_stat
+    mdbx_dump
+    mdbx_load
+    mdbx_drop
+  )
+    # https://stackoverflow.com/questions/77164140/
+    if(("${CMAKE_CXX_COMPILER_ID}" MATCHES ".*Clang$") AND (CMAKE_SYSTEM_NAME MATCHES "Darwin"))
+      target_link_options(${TOOL} PRIVATE -Wl,-no_warn_duplicate_libraries)
+    endif()
+  endforeach()
+endif()

--- a/third_party/erigon-mdbx-go/CMakeLists.txt
+++ b/third_party/erigon-mdbx-go/CMakeLists.txt
@@ -28,8 +28,9 @@ if(MDBX_BUILD_TOOLS)
     mdbx_load
     mdbx_drop
   )
-    # https://stackoverflow.com/questions/77164140/
-    if(("${CMAKE_CXX_COMPILER_ID}" MATCHES ".*Clang$") AND (CMAKE_SYSTEM_NAME MATCHES "Darwin"))
+
+    if((CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang") AND (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 15))
+      # https://stackoverflow.com/questions/77164140/
       target_link_options(${TOOL} PRIVATE -Wl,-no_warn_duplicate_libraries)
     endif()
   endforeach()


### PR DESCRIPTION
Happens when building all mdbx tools targets:
```
[5/5] Linking CXX executable third_party/erigon-mdbx-go/mdbx-go/mdbxdist/mdbx_chk
ld: warning: ignoring duplicate libraries: '-lc++', '-lc++abi'
```

https://stackoverflow.com/questions/77164140/