### PR TITLE
perf_test_workflow: enable http compression on rpcdaemon startup

### DIFF
--- a/.github/workflows/rpc-performance-tests.yml
+++ b/.github/workflows/rpc-performance-tests.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Run Silkworm RpcDaemon
         working-directory: ${{runner.workspace}}/silkworm/build/cmd
         run: |
-          ./rpcdaemon --datadir $ERIGON_DATA_DIR --api admin,debug,eth,parity,erigon,trace,web3,txpool,ots,net --log.verbosity 1 --erigon_compatibility --jwt ./jwt.hex --skip_protocol_check &
+          ./rpcdaemon --datadir $ERIGON_DATA_DIR --api admin,debug,eth,parity,erigon,trace,web3,txpool,ots,net --log.verbosity 1 --erigon_compatibility --jwt ./jwt.hex --skip_protocol_check --http-compression &
           RPC_DAEMON_PID=$!
           echo "RPC_DAEMON_PID=$RPC_DAEMON_PID" >> $GITHUB_ENV
 

--- a/.github/workflows/rpc-performance-tests.yml
+++ b/.github/workflows/rpc-performance-tests.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Run Silkworm RpcDaemon
         working-directory: ${{runner.workspace}}/silkworm/build/cmd
         run: |
-          ./rpcdaemon --datadir $ERIGON_DATA_DIR --api admin,debug,eth,parity,erigon,trace,web3,txpool,ots,net --log.verbosity 1 --erigon_compatibility --jwt ./jwt.hex --skip_protocol_check --http-compression &
+          ./rpcdaemon --datadir $ERIGON_DATA_DIR --api admin,debug,eth,parity,erigon,trace,web3,txpool,ots,net --log.verbosity 1 --erigon_compatibility --jwt ./jwt.hex --skip_protocol_check &
           RPC_DAEMON_PID=$!
           echo "RPC_DAEMON_PID=$RPC_DAEMON_PID" >> $GITHUB_ENV
 
@@ -61,13 +61,13 @@ jobs:
           rm -rf ./reports/mainnet
           
           # Launch the RPC performance test runner
-          python3 ./run_perf_tests.py -b mainnet -y eth_call -p pattern/mainnet/stress_test_eth_call_001_14M.tar -t 1:1,100:30,1000:20,10000:20,20000:20 -r 20 -s ${{runner.workspace}}/silkworm -g $ERIGON_DATA_DIR -m 2 -u
-          python3 ./run_perf_tests.py -b mainnet -y eth_getLogs -p pattern/mainnet/stress_test_eth_getLogs_15M.tar -t 1:1,100:30,1000:20,10000:20,20000:20 -r 20 -s ${{runner.workspace}}/silkworm -g $ERIGON_DATA_DIR -m 2 -u
-          python3 ./run_perf_tests.py -b mainnet -y eth_getBalance -p pattern/mainnet/stress_test_eth_getBalance_15M.tar -t 1:1,100:30,1000:20,10000:20,20000:20 -r 20 -s ${{runner.workspace}}/silkworm -g $ERIGON_DATA_DIR -m 2 -u
-          python3 ./run_perf_tests.py -b mainnet -y eth_getBlockByHash -p pattern/mainnet/stress_test_eth_getBlockByHash_14M.tar -t 1:1,100:30,1000:20,10000:20 -r 20 -s ${{runner.workspace}}/silkworm -g $ERIGON_DATA_DIR -m 2 -u
-          python3 ./run_perf_tests.py -b mainnet -y eth_getBlockByNumber -p pattern/mainnet/stress_test_eth_getBlockByNumber_13M.tar -t 1:1,100:30,1000:20,5000:20 -r 20 -s ${{runner.workspace}}/silkworm -g $ERIGON_DATA_DIR -m 2 -u
-          python3 ./run_perf_tests.py -b mainnet -y eth_getTransactionByHash -p pattern/mainnet/stress_test_eth_getTransactionByHash_13M.tar -t 1:1,100:30,1000:20,10000:20 -r 20 -s ${{runner.workspace}}/silkworm -g $ERIGON_DATA_DIR -m 2 -u
-          python3 ./run_perf_tests.py -b mainnet -y eth_getTransactionReceipt -p pattern/mainnet/stress_test_eth_getTransactionReceipt_14M.tar -t 1:1,100:30,1000:20,5000:20 -r 20 -s ${{runner.workspace}}/silkworm -g $ERIGON_DATA_DIR -m 2 -u
+          #python3 ./run_perf_tests.py -b mainnet -y eth_call -p pattern/mainnet/stress_test_eth_call_001_14M.tar -t 1:1,100:30,1000:20,10000:20,20000:20 -r 20 -s ${{runner.workspace}}/silkworm -g $ERIGON_DATA_DIR -m 2 -u
+          #python3 ./run_perf_tests.py -b mainnet -y eth_getLogs -p pattern/mainnet/stress_test_eth_getLogs_15M.tar -t 1:1,100:30,1000:20,10000:20,20000:20 -r 20 -s ${{runner.workspace}}/silkworm -g $ERIGON_DATA_DIR -m 2 -u
+          #python3 ./run_perf_tests.py -b mainnet -y eth_getBalance -p pattern/mainnet/stress_test_eth_getBalance_15M.tar -t 1:1,100:30,1000:20,10000:20,20000:20 -r 20 -s ${{runner.workspace}}/silkworm -g $ERIGON_DATA_DIR -m 2 -u
+          #python3 ./run_perf_tests.py -b mainnet -y eth_getBlockByHash -p pattern/mainnet/stress_test_eth_getBlockByHash_14M.tar -t 1:1,100:30,1000:20,10000:20 -r 20 -s ${{runner.workspace}}/silkworm -g $ERIGON_DATA_DIR -m 2 -u
+          #python3 ./run_perf_tests.py -b mainnet -y eth_getBlockByNumber -p pattern/mainnet/stress_test_eth_getBlockByNumber_13M.tar -t 1:1,100:30,1000:20,5000:20 -r 20 -s ${{runner.workspace}}/silkworm -g $ERIGON_DATA_DIR -m 2 -u
+          #python3 ./run_perf_tests.py -b mainnet -y eth_getTransactionByHash -p pattern/mainnet/stress_test_eth_getTransactionByHash_13M.tar -t 1:1,100:30,1000:20,10000:20 -r 20 -s ${{runner.workspace}}/silkworm -g $ERIGON_DATA_DIR -m 2 -u
+          #python3 ./run_perf_tests.py -b mainnet -y eth_getTransactionReceipt -p pattern/mainnet/stress_test_eth_getTransactionReceipt_14M.tar -t 1:1,100:30,1000:20,5000:20 -r 20 -s ${{runner.workspace}}/silkworm -g $ERIGON_DATA_DIR -m 2 -u
           
           # Capture test runner script exit status
           perf_exit_status=$?

--- a/.github/workflows/rpc-performance-tests.yml
+++ b/.github/workflows/rpc-performance-tests.yml
@@ -68,6 +68,7 @@ jobs:
           rm -rf ./reports/mainnet
           
           # Launch the RPC performance test runner
+          python3 ./run_perf_tests.py -b mainnet -y eth_call -p pattern/mainnet/stress_test_eth_call_001_14M.tar -t 1:1 -r 5 -s ${{runner.workspace}}/silkworm -g $ERIGON_DATA_DIR -m 2 -u
           #python3 ./run_perf_tests.py -b mainnet -y eth_call -p pattern/mainnet/stress_test_eth_call_001_14M.tar -t 1:1,100:30,1000:20,10000:20,20000:20 -r 20 -s ${{runner.workspace}}/silkworm -g $ERIGON_DATA_DIR -m 2 -u
           #python3 ./run_perf_tests.py -b mainnet -y eth_getLogs -p pattern/mainnet/stress_test_eth_getLogs_15M.tar -t 1:1,100:30,1000:20,10000:20,20000:20 -r 20 -s ${{runner.workspace}}/silkworm -g $ERIGON_DATA_DIR -m 2 -u
           #python3 ./run_perf_tests.py -b mainnet -y eth_getBalance -p pattern/mainnet/stress_test_eth_getBalance_15M.tar -t 1:1,100:30,1000:20,10000:20,20000:20 -r 20 -s ${{runner.workspace}}/silkworm -g $ERIGON_DATA_DIR -m 2 -u

--- a/.github/workflows/rpc-performance-tests.yml
+++ b/.github/workflows/rpc-performance-tests.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout RPC Tests Repository & Install Requirements
         run: |
           rm -rf ${{runner.workspace}}/rpc-tests
-          git -c advice.detachedHead=false clone --depth 1 --branch v0.7.0 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
+          git -c advice.detachedHead=false clone --depth 1 --branch v0.7.1 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
           cd ${{runner.workspace}}/rpc-tests
           pip3 install -r requirements.txt
 

--- a/.github/workflows/rpc-performance-tests.yml
+++ b/.github/workflows/rpc-performance-tests.yml
@@ -1,6 +1,13 @@
 name: QA - RPC Performance Tests
 
 on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - opened
+      - ready_for_review
+      - synchronize
   schedule:
     - cron: '0 0 * * *'  # Run every day at 00:00 AM UTC
 
@@ -22,7 +29,7 @@ jobs:
       - name: Checkout RPC Tests Repository & Install Requirements
         run: |
           rm -rf ${{runner.workspace}}/rpc-tests
-          git -c advice.detachedHead=false clone --depth 1 --branch v0.1.0 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
+          git -c advice.detachedHead=false clone --depth 1 --branch v0.6.0 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
           cd ${{runner.workspace}}/rpc-tests
           pip3 install -r requirements.txt
 

--- a/.github/workflows/rpc-performance-tests.yml
+++ b/.github/workflows/rpc-performance-tests.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout RPC Tests Repository & Install Requirements
         run: |
           rm -rf ${{runner.workspace}}/rpc-tests
-          git -c advice.detachedHead=false clone --depth 1 --branch v0.6.0 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
+          git -c advice.detachedHead=false clone --depth 1 --branch v0.7.0 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
           cd ${{runner.workspace}}/rpc-tests
           pip3 install -r requirements.txt
 

--- a/.github/workflows/rpc-performance-tests.yml
+++ b/.github/workflows/rpc-performance-tests.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Run Silkworm RpcDaemon
         working-directory: ${{runner.workspace}}/silkworm/build/cmd
         run: |
-          ./rpcdaemon --datadir $ERIGON_DATA_DIR --api admin,debug,eth,parity,erigon,trace,web3,txpool,ots,net --log.verbosity 1 --erigon_compatibility --jwt ./jwt.hex --skip_protocol_check &
+          ./rpcdaemon --datadir $ERIGON_DATA_DIR --api admin,debug,eth,parity,erigon,trace,web3,txpool,ots,net --log.verbosity 1 --erigon_compatibility --jwt ./jwt.hex --skip_protocol_check --http-compression &
           RPC_DAEMON_PID=$!
           echo "RPC_DAEMON_PID=$RPC_DAEMON_PID" >> $GITHUB_ENV
 

--- a/.github/workflows/rpc-performance-tests.yml
+++ b/.github/workflows/rpc-performance-tests.yml
@@ -1,13 +1,6 @@
 name: QA - RPC Performance Tests
 
 on:
-  pull_request:
-    branches:
-      - master
-    types:
-      - opened
-      - ready_for_review
-      - synchronize
   schedule:
     - cron: '0 0 * * *'  # Run every day at 00:00 AM UTC
 
@@ -68,14 +61,13 @@ jobs:
           rm -rf ./reports/mainnet
           
           # Launch the RPC performance test runner
-          python3 ./run_perf_tests.py -b mainnet -y eth_call -p pattern/mainnet/stress_test_eth_call_001_14M.tar -t 1:1 -r 5 -s ${{runner.workspace}}/silkworm -g $ERIGON_DATA_DIR -m 2 -u
-          #python3 ./run_perf_tests.py -b mainnet -y eth_call -p pattern/mainnet/stress_test_eth_call_001_14M.tar -t 1:1,100:30,1000:20,10000:20,20000:20 -r 20 -s ${{runner.workspace}}/silkworm -g $ERIGON_DATA_DIR -m 2 -u
-          #python3 ./run_perf_tests.py -b mainnet -y eth_getLogs -p pattern/mainnet/stress_test_eth_getLogs_15M.tar -t 1:1,100:30,1000:20,10000:20,20000:20 -r 20 -s ${{runner.workspace}}/silkworm -g $ERIGON_DATA_DIR -m 2 -u
-          #python3 ./run_perf_tests.py -b mainnet -y eth_getBalance -p pattern/mainnet/stress_test_eth_getBalance_15M.tar -t 1:1,100:30,1000:20,10000:20,20000:20 -r 20 -s ${{runner.workspace}}/silkworm -g $ERIGON_DATA_DIR -m 2 -u
-          #python3 ./run_perf_tests.py -b mainnet -y eth_getBlockByHash -p pattern/mainnet/stress_test_eth_getBlockByHash_14M.tar -t 1:1,100:30,1000:20,10000:20 -r 20 -s ${{runner.workspace}}/silkworm -g $ERIGON_DATA_DIR -m 2 -u
-          #python3 ./run_perf_tests.py -b mainnet -y eth_getBlockByNumber -p pattern/mainnet/stress_test_eth_getBlockByNumber_13M.tar -t 1:1,100:30,1000:20,5000:20 -r 20 -s ${{runner.workspace}}/silkworm -g $ERIGON_DATA_DIR -m 2 -u
-          #python3 ./run_perf_tests.py -b mainnet -y eth_getTransactionByHash -p pattern/mainnet/stress_test_eth_getTransactionByHash_13M.tar -t 1:1,100:30,1000:20,10000:20 -r 20 -s ${{runner.workspace}}/silkworm -g $ERIGON_DATA_DIR -m 2 -u
-          #python3 ./run_perf_tests.py -b mainnet -y eth_getTransactionReceipt -p pattern/mainnet/stress_test_eth_getTransactionReceipt_14M.tar -t 1:1,100:30,1000:20,5000:20 -r 20 -s ${{runner.workspace}}/silkworm -g $ERIGON_DATA_DIR -m 2 -u
+          python3 ./run_perf_tests.py -b mainnet -y eth_call -p pattern/mainnet/stress_test_eth_call_001_14M.tar -t 1:1,100:30,1000:20,10000:20,20000:20 -r 20 -s ${{runner.workspace}}/silkworm -g $ERIGON_DATA_DIR -m 2 -u
+          python3 ./run_perf_tests.py -b mainnet -y eth_getLogs -p pattern/mainnet/stress_test_eth_getLogs_15M.tar -t 1:1,100:30,1000:20,10000:20,20000:20 -r 20 -s ${{runner.workspace}}/silkworm -g $ERIGON_DATA_DIR -m 2 -u
+          python3 ./run_perf_tests.py -b mainnet -y eth_getBalance -p pattern/mainnet/stress_test_eth_getBalance_15M.tar -t 1:1,100:30,1000:20,10000:20,20000:20 -r 20 -s ${{runner.workspace}}/silkworm -g $ERIGON_DATA_DIR -m 2 -u
+          python3 ./run_perf_tests.py -b mainnet -y eth_getBlockByHash -p pattern/mainnet/stress_test_eth_getBlockByHash_14M.tar -t 1:1,100:30,1000:20,10000:20 -r 20 -s ${{runner.workspace}}/silkworm -g $ERIGON_DATA_DIR -m 2 -u
+          python3 ./run_perf_tests.py -b mainnet -y eth_getBlockByNumber -p pattern/mainnet/stress_test_eth_getBlockByNumber_13M.tar -t 1:1,100:30,1000:20,5000:20 -r 20 -s ${{runner.workspace}}/silkworm -g $ERIGON_DATA_DIR -m 2 -u
+          python3 ./run_perf_tests.py -b mainnet -y eth_getTransactionByHash -p pattern/mainnet/stress_test_eth_getTransactionByHash_13M.tar -t 1:1,100:30,1000:20,10000:20 -r 20 -s ${{runner.workspace}}/silkworm -g $ERIGON_DATA_DIR -m 2 -u
+          python3 ./run_perf_tests.py -b mainnet -y eth_getTransactionReceipt -p pattern/mainnet/stress_test_eth_getTransactionReceipt_14M.tar -t 1:1,100:30,1000:20,5000:20 -r 20 -s ${{runner.workspace}}/silkworm -g $ERIGON_DATA_DIR -m 2 -u
           
           # Capture test runner script exit status
           perf_exit_status=$?


### PR DESCRIPTION
The vegeta pattern contains in the http header (accept-Encoding: gzip) therefore if the server is not launched with http-compression enabled, any request is refused with invalid media type
 