### PR TITLE
qa-tests: always save the result

### DIFF
--- a/.github/workflows/rpc-integration-tests.yml
+++ b/.github/workflows/rpc-integration-tests.yml
@@ -110,7 +110,6 @@ jobs:
           path: ${{runner.workspace}}/rpc-tests/integration/mainnet/results/
 
       - name: Save test results
-        if: steps.test_step.outputs.TEST_RESULT != 'success'
         working-directory: ${{runner.workspace}}/silkworm
         env:
           TEST_RESULT: ${{ steps.test_step.outputs.TEST_RESULT }}


### PR DESCRIPTION
Currently, integration tests only save the result in the event of **failure**. 

However, with respect to the objective of making a **historical comparison** of test results, it is useful to know whether integration tests have run or not. 

Therefore, it is proposed to _always save the result_ of such tests, which is then a binary result: success or failure