### PR TITLE
rpcdaemon: extract awaitable async task run by executor

### DIFF
--- a/.github/workflows/rpc-performance-tests.yml
+++ b/.github/workflows/rpc-performance-tests.yml
@@ -1,6 +1,13 @@
 name: QA - RPC Performance Tests
 
 on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - opened
+      - ready_for_review
+      - synchronize
   schedule:
     - cron: '0 0 * * *'  # Run every day at 00:00 AM UTC
 

--- a/.github/workflows/rpc-performance-tests.yml
+++ b/.github/workflows/rpc-performance-tests.yml
@@ -1,13 +1,7 @@
 name: QA - RPC Performance Tests
 
 on:
-  pull_request:
-    branches:
-      - master
-    types:
-      - opened
-      - ready_for_review
-      - synchronize
+  workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'  # Run every day at 00:00 AM UTC
 

--- a/silkworm/rpc/common/async_task.hpp
+++ b/silkworm/rpc/common/async_task.hpp
@@ -1,0 +1,85 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <exception>
+#include <type_traits>
+#include <utility>
+
+#include <silkworm/infra/concurrency/task.hpp>
+
+#include <boost/asio/compose.hpp>
+#include <boost/asio/post.hpp>
+#include <boost/asio/this_coro.hpp>
+#include <boost/asio/use_awaitable.hpp>
+
+namespace silkworm::rpc {
+
+template <typename Executor, typename F, typename... Args>
+// NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward) because of https://github.com/llvm/llvm-project/issues/68105
+Task<std::invoke_result_t<F, Args...>> async_task(Executor runner, F&& fn, Args&&... args) {
+    auto this_executor = co_await ThisTask::executor;
+    co_return co_await boost::asio::async_compose<decltype(boost::asio::use_awaitable), void(std::exception_ptr, std::invoke_result_t<F, Args...>)>(
+        [&this_executor, &runner, fn = std::forward<F>(fn), ...args = std::forward<Args>(args)](auto& self) {
+            boost::asio::post(runner, [&, self = std::move(self)]() mutable {
+                try {
+                    auto result = std::invoke(fn, args...);
+                    boost::asio::post(this_executor, [result = std::move(result), self = std::move(self)]() mutable {
+                        if constexpr (std::is_void_v<std::invoke_result_t<F, Args...>>)
+                            self.complete({});
+                        else
+                            self.complete({}, result);
+                    });
+                } catch (...) {
+                    std::exception_ptr eptr = std::current_exception();
+                    boost::asio::post(this_executor, [eptr, self = std::move(self)]() mutable {
+                        if constexpr (std::is_void_v<std::invoke_result_t<F, Args...>>)
+                            self.complete(eptr);
+                        else
+                            self.complete(eptr, {});
+                    });
+                }
+            });
+        },
+        boost::asio::use_awaitable);
+}
+
+template <typename Executor, typename F, typename... Args>
+requires std::is_void_v<std::invoke_result_t<F, Args...>>
+// NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward) because of https://github.com/llvm/llvm-project/issues/68105
+Task<void> async_task(Executor runner, F&& fn, Args&&... args) {
+    auto this_executor = co_await ThisTask::executor;
+    co_return co_await boost::asio::async_compose<decltype(boost::asio::use_awaitable), void(std::exception_ptr)>(
+        [&this_executor, &runner, fn = std::forward<F>(fn), ...args = std::forward<Args>(args)](auto& self) {
+            boost::asio::post(runner, [&, self = std::move(self)]() mutable {
+                try {
+                    std::invoke(fn, args...);
+                    boost::asio::post(this_executor, [self = std::move(self)]() mutable {
+                        self.complete({});
+                    });
+                } catch (...) {
+                    std::exception_ptr eptr = std::current_exception();
+                    boost::asio::post(this_executor, [eptr, self = std::move(self)]() mutable {
+                        self.complete(eptr);
+                    });
+                }
+            });
+        },
+        boost::asio::use_awaitable);
+}
+
+}  // namespace silkworm::rpc

--- a/silkworm/rpc/common/async_task.hpp
+++ b/silkworm/rpc/common/async_task.hpp
@@ -34,7 +34,7 @@ template <typename Executor, typename F, typename... Args>
 Task<std::invoke_result_t<F, Args...>> async_task(Executor runner, F&& fn, Args&&... args) {
     auto this_executor = co_await ThisTask::executor;
     co_return co_await boost::asio::async_compose<decltype(boost::asio::use_awaitable), void(std::exception_ptr, std::invoke_result_t<F, Args...>)>(
-        [&this_executor, &runner, fn = std::forward<F>(fn), ...args = std::forward<Args>(args)](auto& self) {
+        [&this_executor, &runner, fn = std::forward<F>(fn), ... args = std::forward<Args>(args)](auto& self) {
             boost::asio::post(runner, [&, self = std::move(self)]() mutable {
                 try {
                     auto result = std::invoke(fn, args...);
@@ -59,12 +59,12 @@ Task<std::invoke_result_t<F, Args...>> async_task(Executor runner, F&& fn, Args&
 }
 
 template <typename Executor, typename F, typename... Args>
-requires std::is_void_v<std::invoke_result_t<F, Args...>>
+    requires std::is_void_v<std::invoke_result_t<F, Args...>>
 // NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward) because of https://github.com/llvm/llvm-project/issues/68105
 Task<void> async_task(Executor runner, F&& fn, Args&&... args) {
     auto this_executor = co_await ThisTask::executor;
     co_return co_await boost::asio::async_compose<decltype(boost::asio::use_awaitable), void(std::exception_ptr)>(
-        [&this_executor, &runner, fn = std::forward<F>(fn), ...args = std::forward<Args>(args)](auto& self) {
+        [&this_executor, &runner, fn = std::forward<F>(fn), ... args = std::forward<Args>(args)](auto& self) {
             boost::asio::post(runner, [&, self = std::move(self)]() mutable {
                 try {
                     std::invoke(fn, args...);

--- a/silkworm/rpc/common/async_task.hpp
+++ b/silkworm/rpc/common/async_task.hpp
@@ -51,8 +51,8 @@ template <typename Executor, typename F, typename... Args>
 Task<std::invoke_result_t<F, Args...>> async_task(Executor runner, F&& fn, Args&&... args) {
     auto this_executor = co_await ThisTask::executor;
     co_return co_await boost::asio::async_compose<decltype(boost::asio::use_awaitable), TaskCompletionHandler<F, Args...>>(
-        [&this_executor, &runner, fn = std::forward<F>(fn), ... args = std::forward<Args>(args)](auto& self) {
-            boost::asio::post(runner, [&, self = std::move(self)]() mutable {
+        [&this_executor, &runner, fn = std::forward<F>(fn), ... args = std::forward<Args>(args)](auto& self) mutable {
+            boost::asio::post(runner, [&, fn = std::forward<decltype(fn)>(fn), ... args = std::forward<Args>(args), self = std::move(self)]() mutable {
                 try {
                     if constexpr (std::is_void_v<std::invoke_result_t<F, Args...>>) {
                         std::invoke(fn, args...);

--- a/silkworm/rpc/common/async_task_benchmark.cpp
+++ b/silkworm/rpc/common/async_task_benchmark.cpp
@@ -14,12 +14,12 @@
    limitations under the License.
 */
 
-#include "async_task.hpp"
-
-#include <boost/asio/thread_pool.hpp>
 #include <benchmark/benchmark.h>
+#include <boost/asio/thread_pool.hpp>
 
 #include <silkworm/rpc/test/context_test_base.hpp>
+
+#include "async_task.hpp"
 
 namespace silkworm::rpc {
 

--- a/silkworm/rpc/common/async_task_benchmark.cpp
+++ b/silkworm/rpc/common/async_task_benchmark.cpp
@@ -1,0 +1,92 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "async_task.hpp"
+
+#include <boost/asio/thread_pool.hpp>
+#include <benchmark/benchmark.h>
+
+#include <silkworm/rpc/test/context_test_base.hpp>
+
+namespace silkworm::rpc {
+
+std::size_t recursive_factorial(std::size_t n) {
+    return n == 0 ? 1 : n * recursive_factorial(n - 1);
+}
+
+struct AsyncTaskBenchTest : test::ContextTestBase {
+};
+
+template <typename Executor>
+Task<std::size_t> async_compose_factorial(const Executor runner, const std::size_t number) {
+    const auto this_executor = co_await ThisTask::executor;
+    co_return co_await boost::asio::async_compose<decltype(boost::asio::use_awaitable), void(std::exception_ptr, std::size_t)>(
+        [&](auto& self) {
+            boost::asio::post(runner, [&, self = std::move(self)]() mutable {
+                try {
+                    const auto result = recursive_factorial(number);
+                    boost::asio::post(this_executor, [result, self = std::move(self)]() mutable {
+                        self.complete({}, result);
+                    });
+                } catch (...) {
+                    std::exception_ptr eptr = std::current_exception();
+                    boost::asio::post(this_executor, [eptr, self = std::move(self)]() mutable {
+                        self.complete(eptr, {});
+                    });
+                }
+            });
+        },
+        boost::asio::use_awaitable);
+}
+
+static void benchmark_async_compose(benchmark::State& state) {
+    const auto n = static_cast<std::size_t>(state.range(0));
+
+    boost::asio::thread_pool workers{};
+    AsyncTaskBenchTest test;
+    for ([[maybe_unused]] auto _ : state) {
+        const auto result = test.spawn_and_wait(async_compose_factorial(workers.get_executor(), n));
+        benchmark::DoNotOptimize(result);
+    }
+}
+
+BENCHMARK(benchmark_async_compose)->Arg(10);
+BENCHMARK(benchmark_async_compose)->Arg(100);
+BENCHMARK(benchmark_async_compose)->Arg(1'000);
+BENCHMARK(benchmark_async_compose)->Arg(10'000);
+
+template <typename Executor>
+Task<std::size_t> async_task_factorial(Executor runner, std::size_t number) {
+    co_return co_await async_task(runner, recursive_factorial, number);
+}
+
+static void benchmark_async_task(benchmark::State& state) {
+    const auto n = static_cast<std::size_t>(state.range(0));
+
+    boost::asio::thread_pool workers{};
+    AsyncTaskBenchTest test;
+    for ([[maybe_unused]] auto _ : state) {
+        const auto result = test.spawn_and_wait(async_task_factorial(workers.get_executor(), n));
+        benchmark::DoNotOptimize(result);
+    }
+}
+
+BENCHMARK(benchmark_async_task)->Arg(10);
+BENCHMARK(benchmark_async_task)->Arg(100);
+BENCHMARK(benchmark_async_task)->Arg(1'000);
+BENCHMARK(benchmark_async_task)->Arg(10'000);
+
+}  // namespace silkworm::rpc

--- a/silkworm/rpc/common/async_task_test.cpp
+++ b/silkworm/rpc/common/async_task_test.cpp
@@ -50,7 +50,6 @@ TEST_CASE_METHOD(AsyncTaskTest, "async_task: factorial", "[rpc][common][async_ta
     for (std::size_t i{0}; i < kTestData.size(); ++i) {
         const auto [n, r] = kTestData[i];
         SECTION("factorial " + std::to_string(n)) {
-            std::cout << n << "! = " << spawn_and_wait(async_factorial(workers.get_executor(), n)) << "\n";
             CHECK(spawn_and_wait(async_factorial(workers.get_executor(), n)) == r);
             CHECK(spawn_and_wait(async_task(workers.get_executor(), recursive_factorial, n)) == r);
         }

--- a/silkworm/rpc/common/async_task_test.cpp
+++ b/silkworm/rpc/common/async_task_test.cpp
@@ -1,0 +1,105 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "async_task.hpp"
+
+#include <string>
+#include <vector>
+
+#include <boost/asio/thread_pool.hpp>
+#include <catch2/catch.hpp>
+
+#include <silkworm/rpc/test/context_test_base.hpp>
+
+namespace silkworm::rpc {
+
+struct AsyncTaskTest : test::ContextTestBase {
+};
+
+const static std::vector<std::pair<std::size_t, std::size_t>> kTestData = {
+    {0, 1},
+    {1, 1},
+    {9, 362'880},
+    {10, 3'628'800},
+};
+
+std::size_t recursive_factorial(std::size_t n) {
+    return n == 0 ? 1 : n * recursive_factorial(n - 1);
+}
+
+template <typename Executor>
+Task<std::size_t> async_factorial(Executor runner, std::size_t number) {
+    co_return co_await async_task(runner, recursive_factorial, number);
+}
+
+TEST_CASE_METHOD(AsyncTaskTest, "async_task: factorial", "[rpc][common][async_task]") {
+    boost::asio::thread_pool workers;
+    for (std::size_t i{0}; i < kTestData.size(); ++i) {
+        const auto [n, r] = kTestData[i];
+        SECTION("factorial " + std::to_string(n)) {
+            std::cout << n << "! = " <<  spawn_and_wait(async_factorial(workers.get_executor(), n)) << "\n";
+            CHECK(spawn_and_wait(async_factorial(workers.get_executor(), n)) == r);
+            CHECK(spawn_and_wait(async_task(workers.get_executor(), recursive_factorial, n)) == r);
+        }
+    }
+}
+
+void raise_exception() {
+    throw std::runtime_error{""};
+}
+
+void raise_exception_with_args(int i) {
+    if (i > 0) {
+        throw std::runtime_error{""};
+    }
+}
+
+template <typename Executor>
+Task<void> async_raise_exception(Executor runner) {
+    co_await async_task(runner, raise_exception);
+    co_return;
+}
+
+template <typename Executor>
+Task<void> async_raise_exception_with_args(Executor runner, int i) {
+    co_await async_task(runner, raise_exception_with_args, i);
+    co_return;
+}
+
+template <typename Executor>
+Task<void> async_lambda_raise_exception(Executor runner) {
+    co_await async_task(runner, []() { throw std::runtime_error{""}; });
+    co_return;
+}
+
+template <typename Executor>
+Task<void> async_lambda_raise_exception_with_args(Executor runner, int i) {
+    co_await async_task(runner, [](auto ii) { if (ii > 0) throw std::runtime_error{""}; }, i);
+    co_return;
+}
+
+TEST_CASE_METHOD(AsyncTaskTest, "async_task: exception", "[rpc][common][async_task]") {
+    boost::asio::thread_pool workers;
+    CHECK_THROWS_AS(spawn_and_wait(async_task(workers.get_executor(), raise_exception)), std::runtime_error);
+    CHECK_THROWS_AS(spawn_and_wait(async_raise_exception(workers.get_executor())), std::runtime_error);
+    CHECK_THROWS_AS(spawn_and_wait(async_lambda_raise_exception(workers.get_executor())), std::runtime_error);
+
+    CHECK_THROWS_AS(spawn_and_wait(async_task(workers.get_executor(), raise_exception_with_args, 1)), std::runtime_error);
+    CHECK_THROWS_AS(spawn_and_wait(async_raise_exception_with_args(workers.get_executor(), 1)), std::runtime_error);
+    CHECK_THROWS_AS(spawn_and_wait(async_lambda_raise_exception_with_args(workers.get_executor(), 1)), std::runtime_error);
+}
+
+}  // namespace silkworm::rpc

--- a/silkworm/rpc/common/async_task_test.cpp
+++ b/silkworm/rpc/common/async_task_test.cpp
@@ -50,7 +50,7 @@ TEST_CASE_METHOD(AsyncTaskTest, "async_task: factorial", "[rpc][common][async_ta
     for (std::size_t i{0}; i < kTestData.size(); ++i) {
         const auto [n, r] = kTestData[i];
         SECTION("factorial " + std::to_string(n)) {
-            std::cout << n << "! = " <<  spawn_and_wait(async_factorial(workers.get_executor(), n)) << "\n";
+            std::cout << n << "! = " << spawn_and_wait(async_factorial(workers.get_executor(), n)) << "\n";
             CHECK(spawn_and_wait(async_factorial(workers.get_executor(), n)) == r);
             CHECK(spawn_and_wait(async_task(workers.get_executor(), recursive_factorial, n)) == r);
         }
@@ -87,7 +87,8 @@ Task<void> async_lambda_raise_exception(Executor runner) {
 
 template <typename Executor>
 Task<void> async_lambda_raise_exception_with_args(Executor runner, int i) {
-    co_await async_task(runner, [](auto ii) { if (ii > 0) throw std::runtime_error{""}; }, i);
+    co_await async_task(
+        runner, [](auto ii) { if (ii > 0) throw std::runtime_error{""}; }, i);
     co_return;
 }
 

--- a/silkworm/rpc/core/evm_debug_test.cpp
+++ b/silkworm/rpc/core/evm_debug_test.cpp
@@ -75,7 +75,7 @@ class TestDebugExecutor : DebugExecutor {
 };
 
 #ifndef SILKWORM_SANITIZE
-TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute precompiled") {
+/*TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute precompiled") {
     static Bytes kAccountHistoryKey1{*silkworm::from_hex("0a6bb546b9208cfab9e8fa2b9b2c042b18df703000000000009db707")};
     static Bytes kAccountHistoryKey2{*silkworm::from_hex("000000000000000000000000000000000000000900000000009db707")};
     static Bytes kAccountHistoryKey3{*silkworm::from_hex("000000000000000000000000000000000000000000000000009db707")};
@@ -163,7 +163,7 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute precompiled") {
             "structLogs":[]
         })"_json);
     }
-}
+}*/
 
 TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 1") {
     static Bytes kAccountHistoryKey1{*silkworm::from_hex("e0a2bd4258d2768837baa26a28fe71dc079f84c700000000005279a8")};

--- a/silkworm/rpc/core/evm_debug_test.cpp
+++ b/silkworm/rpc/core/evm_debug_test.cpp
@@ -75,7 +75,7 @@ class TestDebugExecutor : DebugExecutor {
 };
 
 #ifndef SILKWORM_SANITIZE
-/*TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute precompiled") {
+TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute precompiled") {
     static Bytes kAccountHistoryKey1{*silkworm::from_hex("0a6bb546b9208cfab9e8fa2b9b2c042b18df703000000000009db707")};
     static Bytes kAccountHistoryKey2{*silkworm::from_hex("000000000000000000000000000000000000000900000000009db707")};
     static Bytes kAccountHistoryKey3{*silkworm::from_hex("000000000000000000000000000000000000000000000000009db707")};
@@ -163,7 +163,7 @@ class TestDebugExecutor : DebugExecutor {
             "structLogs":[]
         })"_json);
     }
-}*/
+}
 
 TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 1") {
     static Bytes kAccountHistoryKey1{*silkworm::from_hex("e0a2bd4258d2768837baa26a28fe71dc079f84c700000000005279a8")};

--- a/silkworm/rpc/core/evm_debug_test.cpp
+++ b/silkworm/rpc/core/evm_debug_test.cpp
@@ -69,7 +69,7 @@ class TestDebugExecutor : DebugExecutor {
     TestDebugExecutor(const TestDebugExecutor&) = delete;
     TestDebugExecutor& operator=(const TestDebugExecutor&) = delete;
 
-    Task<void> execute(json::Stream& stream, const ChainStorage& storage, const silkworm::Block& block, const Call& call) {
+    Task<void> exec(json::Stream& stream, const ChainStorage& storage, const silkworm::Block& block, const Call& call) {
         return DebugExecutor::execute(stream, storage, block, call);
     }
 };
@@ -150,7 +150,7 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute precompiled") {
         const RemoteChainStorage storage{db_reader, backend.get()};
 
         stream.open_object();
-        spawn_and_wait(executor.execute(stream, storage, block, call));
+        spawn_and_wait(executor.exec(stream, storage, block, call));
         stream.close_object();
         spawn_and_wait(stream.close());
 
@@ -305,7 +305,7 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 1") {
         const RemoteChainStorage storage{db_reader, backend.get()};
 
         stream.open_object();
-        spawn_and_wait(executor.execute(stream, storage, block, call));
+        spawn_and_wait(executor.exec(stream, storage, block, call));
         stream.close_object();
         spawn_and_wait(stream.close());
 
@@ -368,7 +368,7 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 1") {
         const RemoteChainStorage storage{db_reader, backend.get()};
 
         stream.open_object();
-        spawn_and_wait(executor.execute(stream, storage, block, call));
+        spawn_and_wait(executor.exec(stream, storage, block, call));
         stream.close_object();
         spawn_and_wait(stream.close());
 
@@ -479,7 +479,7 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 1") {
         const RemoteChainStorage storage{db_reader, backend.get()};
 
         stream.open_object();
-        spawn_and_wait(executor.execute(stream, storage, block, call));
+        spawn_and_wait(executor.exec(stream, storage, block, call));
         stream.close_object();
         spawn_and_wait(stream.close());
 
@@ -581,7 +581,7 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 1") {
         const RemoteChainStorage storage{db_reader, backend.get()};
 
         stream.open_object();
-        spawn_and_wait(executor.execute(stream, storage, block, call));
+        spawn_and_wait(executor.exec(stream, storage, block, call));
         stream.close_object();
         spawn_and_wait(stream.close());
 
@@ -688,7 +688,7 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 1") {
         const RemoteChainStorage storage{db_reader, backend.get()};
 
         stream.open_object();
-        spawn_and_wait(executor.execute(stream, storage, block, call));
+        spawn_and_wait(executor.exec(stream, storage, block, call));
         stream.close_object();
         spawn_and_wait(stream.close());
 
@@ -796,7 +796,7 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 1") {
         const RemoteChainStorage storage{db_reader, backend.get()};
 
         stream.open_object();
-        spawn_and_wait(executor.execute(stream, storage, block, call));
+        spawn_and_wait(executor.exec(stream, storage, block, call));
         stream.close_object();
         spawn_and_wait(stream.close());
 
@@ -891,7 +891,7 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 1") {
         const RemoteChainStorage storage{db_reader, backend.get()};
 
         stream.open_object();
-        spawn_and_wait(executor.execute(stream, storage, block, call));
+        spawn_and_wait(executor.exec(stream, storage, block, call));
         stream.close_object();
         spawn_and_wait(stream.close());
 
@@ -1102,7 +1102,7 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 2") {
         const RemoteChainStorage storage{db_reader, backend.get()};
 
         stream.open_object();
-        spawn_and_wait(executor.execute(stream, storage, block, call));
+        spawn_and_wait(executor.exec(stream, storage, block, call));
         stream.close_object();
         spawn_and_wait(stream.close());
 
@@ -1263,7 +1263,7 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call with error") {
     const RemoteChainStorage storage{db_reader, backend.get()};
 
     stream.open_object();
-    spawn_and_wait(executor.execute(stream, storage, block, call));
+    spawn_and_wait(executor.exec(stream, storage, block, call));
     stream.close_object();
     spawn_and_wait(stream.close());
 

--- a/silkworm/rpc/core/evm_trace.cpp
+++ b/silkworm/rpc/core/evm_trace.cpp
@@ -22,13 +22,10 @@
 #include <stack>
 #include <string>
 
-#include <boost/asio/compose.hpp>
-#include <boost/asio/post.hpp>
 #include <boost/asio/use_awaitable.hpp>
 #include <evmc/hex.hpp>
 #include <evmc/instructions.h>
 #include <evmone/execution_state.hpp>
-#include <evmone/instructions.hpp>
 #include <intx/intx.hpp>
 
 #include <silkworm/core/common/endian.hpp>
@@ -39,9 +36,9 @@
 #include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/infra/common/ensure.hpp>
 #include <silkworm/infra/common/log.hpp>
+#include <silkworm/rpc/common/async_task.hpp>
 #include <silkworm/rpc/common/util.hpp>
 #include <silkworm/rpc/core/cached_chain.hpp>
-#include <silkworm/rpc/core/rawdb/chain.hpp>
 #include <silkworm/rpc/json/call.hpp>
 #include <silkworm/rpc/json/types.hpp>
 
@@ -1130,7 +1127,7 @@ void StateDiffTracer::on_reward_granted(const silkworm::CallResult& result, cons
             }
         }
     }
-};
+}
 
 void IntraBlockStateTracer::on_reward_granted(const silkworm::CallResult& result, const silkworm::IntraBlockState& intra_block_state) noexcept {
     SILK_DEBUG
@@ -1241,7 +1238,7 @@ Task<std::vector<Trace>> TraceCallExecutor::trace_block(const BlockWithHash& blo
 
         for (auto& ommer_reward : block_rewards.ommers) {
             RewardAction action;
-            action.author = block_with_hash.block.header.beneficiary; /* to be fix */
+            action.author = block_with_hash.block.header.beneficiary; /* to be fixed */
             action.reward_type = "block";
             action.value = ommer_reward;
 
@@ -1276,60 +1273,53 @@ Task<std::vector<TraceCallResult>> TraceCallExecutor::trace_block_transactions(c
     ensure(chain_config_ptr.has_value(), "cannot read chain config");
 
     auto current_executor = co_await boost::asio::this_coro::executor;
+    const auto call_result = co_await async_task(workers_.executor(), [&]() -> std::vector<TraceCallResult> {
+        auto state = tx_.create_state(current_executor, database_reader_, chain_storage_, block_number - 1);
+        IntraBlockState initial_ibs{*state};
 
-    const auto call_result = co_await boost::asio::async_compose<decltype(boost::asio::use_awaitable), void(std::vector<TraceCallResult>)>(
-        [&](auto& self) {
-            boost::asio::post(workers_, [&, self = std::move(self)]() mutable {
-                auto state = tx_.create_state(current_executor, database_reader_, chain_storage_, block_number - 1);
-                IntraBlockState initial_ibs{*state};
+        StateAddresses state_addresses(initial_ibs);
+        std::shared_ptr<EvmTracer> ibs_tracer = std::make_shared<trace::IntraBlockStateTracer>(state_addresses);
 
-                StateAddresses state_addresses(initial_ibs);
-                std::shared_ptr<EvmTracer> ibs_tracer = std::make_shared<trace::IntraBlockStateTracer>(state_addresses);
+        auto curr_state = tx_.create_state(current_executor, database_reader_, chain_storage_, block_number - 1);
+        EVMExecutor executor{*chain_config_ptr, workers_, curr_state};
 
-                auto curr_state = tx_.create_state(current_executor, database_reader_, chain_storage_, block_number - 1);
-                EVMExecutor executor{*chain_config_ptr, workers_, curr_state};
+        std::vector<TraceCallResult> trace_call_result(transactions.size());
+        for (std::uint64_t index = 0; index < transactions.size(); index++) {
+            const silkworm::Transaction& transaction{block.transactions[index]};
 
-                std::vector<TraceCallResult> trace_call_result(transactions.size());
-                for (std::uint64_t index = 0; index < transactions.size(); index++) {
-                    const silkworm::Transaction& transaction{block.transactions[index]};
+            auto& result = trace_call_result.at(index);
+            TraceCallTraces& traces = result.traces;
+            traces.transaction_hash = transaction.hash();
 
-                    auto& result = trace_call_result.at(index);
-                    TraceCallTraces& traces = result.traces;
-                    traces.transaction_hash = transaction.hash();
+            Tracers tracers;
+            if (config.vm_trace) {
+                traces.vm_trace.emplace();
+                std::shared_ptr<silkworm::EvmTracer> tracer = std::make_shared<trace::VmTraceTracer>(traces.vm_trace.value(), index);
+                tracers.push_back(tracer);
+            }
+            if (config.trace) {
+                std::shared_ptr<silkworm::EvmTracer> tracer = std::make_shared<trace::TraceTracer>(traces.trace, initial_ibs);
+                tracers.push_back(tracer);
+            }
+            if (config.state_diff) {
+                traces.state_diff.emplace();
 
-                    Tracers tracers;
-                    if (config.vm_trace) {
-                        traces.vm_trace.emplace();
-                        std::shared_ptr<silkworm::EvmTracer> tracer = std::make_shared<trace::VmTraceTracer>(traces.vm_trace.value(), index);
-                        tracers.push_back(tracer);
-                    }
-                    if (config.trace) {
-                        std::shared_ptr<silkworm::EvmTracer> tracer = std::make_shared<trace::TraceTracer>(traces.trace, initial_ibs);
-                        tracers.push_back(tracer);
-                    }
-                    if (config.state_diff) {
-                        traces.state_diff.emplace();
+                std::shared_ptr<silkworm::EvmTracer> tracer = std::make_shared<trace::StateDiffTracer>(traces.state_diff.value(), state_addresses);
+                tracers.push_back(tracer);
+            }
 
-                        std::shared_ptr<silkworm::EvmTracer> tracer = std::make_shared<trace::StateDiffTracer>(traces.state_diff.value(), state_addresses);
-                        tracers.push_back(tracer);
-                    }
+            tracers.push_back(ibs_tracer);
 
-                    tracers.push_back(ibs_tracer);
-
-                    auto execution_result = executor.call(block, transaction, tracers, /*refund=*/true, /*gas_bailout=*/true);
-                    if (execution_result.pre_check_error) {
-                        result.pre_check_error = execution_result.pre_check_error.value();
-                    } else {
-                        traces.output = "0x" + silkworm::to_hex(execution_result.data);
-                    }
-                    executor.reset();
-                }
-                boost::asio::post(current_executor, [trace_call_result, self = std::move(self)]() mutable {
-                    self.complete(trace_call_result);
-                });
-            });
-        },
-        boost::asio::use_awaitable);
+            auto execution_result = executor.call(block, transaction, tracers, /*refund=*/true, /*gas_bailout=*/true);
+            if (execution_result.pre_check_error) {
+                result.pre_check_error = execution_result.pre_check_error.value();
+            } else {
+                traces.output = "0x" + silkworm::to_hex(execution_result.data);
+            }
+            executor.reset();
+        }
+        return trace_call_result;
+    });
 
     co_return call_result;
 }
@@ -1350,63 +1340,57 @@ Task<TraceManyCallResult> TraceCallExecutor::trace_calls(const silkworm::Block& 
     ensure(chain_config_ptr.has_value(), "cannot read chain config");
 
     auto current_executor = co_await boost::asio::this_coro::executor;
-    const auto ret_result = co_await boost::asio::async_compose<decltype(boost::asio::use_awaitable), void(TraceManyCallResult)>(
-        [&](auto& self) {
-            boost::asio::post(workers_, [&, self = std::move(self)]() mutable {
-                auto state = tx_.create_state(current_executor, database_reader_, chain_storage_, block_number);
-                silkworm::IntraBlockState initial_ibs{*state};
-                StateAddresses state_addresses(initial_ibs);
+    const auto trace_calls_result = co_await async_task(workers_.executor(), [&]() -> TraceManyCallResult {
+        auto state = tx_.create_state(current_executor, database_reader_, chain_storage_, block_number);
+        silkworm::IntraBlockState initial_ibs{*state};
+        StateAddresses state_addresses(initial_ibs);
 
-                auto curr_state = tx_.create_state(current_executor, database_reader_, chain_storage_, block_number);
-                EVMExecutor executor{*chain_config_ptr, workers_, state};
+        auto curr_state = tx_.create_state(current_executor, database_reader_, chain_storage_, block_number);
+        EVMExecutor executor{*chain_config_ptr, workers_, state};
 
-                std::shared_ptr<silkworm::EvmTracer> ibs_tracer = std::make_shared<trace::IntraBlockStateTracer>(state_addresses);
+        std::shared_ptr<silkworm::EvmTracer> ibs_tracer = std::make_shared<trace::IntraBlockStateTracer>(state_addresses);
 
-                TraceManyCallResult result;
-                for (std::size_t index{0}; index < calls.size(); index++) {
-                    const auto& config = calls[index].trace_config;
+        TraceManyCallResult result;
+        for (std::size_t index{0}; index < calls.size(); index++) {
+            const auto& config = calls[index].trace_config;
 
-                    silkworm::Transaction transaction{calls[index].call.to_transaction()};
+            silkworm::Transaction transaction{calls[index].call.to_transaction()};
 
-                    Tracers tracers;
-                    TraceCallTraces traces;
-                    if (config.vm_trace) {
-                        traces.vm_trace.emplace();
-                        std::shared_ptr<silkworm::EvmTracer> tracer = std::make_shared<trace::VmTraceTracer>(traces.vm_trace.value(), index);
-                        tracers.push_back(tracer);
-                    }
-                    if (config.trace) {
-                        std::shared_ptr<silkworm::EvmTracer> tracer = std::make_shared<trace::TraceTracer>(traces.trace, initial_ibs);
-                        tracers.push_back(tracer);
-                    }
-                    if (config.state_diff) {
-                        traces.state_diff.emplace();
+            Tracers tracers;
+            TraceCallTraces traces;
+            if (config.vm_trace) {
+                traces.vm_trace.emplace();
+                std::shared_ptr<silkworm::EvmTracer> tracer = std::make_shared<trace::VmTraceTracer>(traces.vm_trace.value(), index);
+                tracers.push_back(tracer);
+            }
+            if (config.trace) {
+                std::shared_ptr<silkworm::EvmTracer> tracer = std::make_shared<trace::TraceTracer>(traces.trace, initial_ibs);
+                tracers.push_back(tracer);
+            }
+            if (config.state_diff) {
+                traces.state_diff.emplace();
 
-                        std::shared_ptr<silkworm::EvmTracer> tracer = std::make_shared<trace::StateDiffTracer>(traces.state_diff.value(), state_addresses);
-                        tracers.push_back(tracer);
-                    }
-                    tracers.push_back(ibs_tracer);
+                std::shared_ptr<silkworm::EvmTracer> tracer = std::make_shared<trace::StateDiffTracer>(traces.state_diff.value(), state_addresses);
+                tracers.push_back(tracer);
+            }
+            tracers.push_back(ibs_tracer);
 
-                    auto execution_result = executor.call(block, transaction, tracers, /*refund=*/true, /*gas_bailout=*/true);
+            auto execution_result = executor.call(block, transaction, tracers, /*refund=*/true, /*gas_bailout=*/true);
 
-                    if (execution_result.pre_check_error) {
-                        result.pre_check_error = "first run for txIndex " + std::to_string(index) + " error: " + execution_result.pre_check_error.value();
-                        result.traces.clear();
-                        break;
-                    }
-                    traces.output = "0x" + silkworm::to_hex(execution_result.data);
-                    result.traces.push_back(traces);
+            if (execution_result.pre_check_error) {
+                result.pre_check_error = "first run for txIndex " + std::to_string(index) + " error: " + execution_result.pre_check_error.value();
+                result.traces.clear();
+                break;
+            }
+            traces.output = "0x" + silkworm::to_hex(execution_result.data);
+            result.traces.push_back(traces);
 
-                    executor.reset();
-                }
-                boost::asio::post(current_executor, [result, self = std::move(self)]() mutable {
-                    self.complete(result);
-                });
-            });
-        },
-        boost::asio::use_awaitable);
+            executor.reset();
+        }
+        return result;
+    });
 
-    co_return ret_result;
+    co_return trace_calls_result;
 }
 
 Task<TraceDeployResult> TraceCallExecutor::trace_deploy_transaction(const silkworm::Block& block, const evmc::address& contract_address) {
@@ -1419,38 +1403,29 @@ Task<TraceDeployResult> TraceCallExecutor::trace_deploy_transaction(const silkwo
     ensure(chain_config_ptr.has_value(), "cannot read chain config");
 
     auto current_executor = co_await boost::asio::this_coro::executor;
+    const auto deploy_result = co_await async_task(workers_.executor(), [&]() -> TraceDeployResult {
+        auto state = tx_.create_state(current_executor, database_reader_, chain_storage_, block_number - 1);
+        silkworm::IntraBlockState initial_ibs{*state};
 
-    const auto deploy_result = co_await boost::asio::async_compose<decltype(boost::asio::use_awaitable), void(TraceDeployResult)>(
-        [&](auto& self) {
-            boost::asio::post(workers_, [&, self = std::move(self)]() mutable {
-                auto state = tx_.create_state(current_executor, database_reader_, chain_storage_, block_number - 1);
-                silkworm::IntraBlockState initial_ibs{*state};
+        auto curr_state = tx_.create_state(current_executor, database_reader_, chain_storage_, block_number - 1);
+        EVMExecutor executor{*chain_config_ptr, workers_, curr_state};
 
-                auto curr_state = tx_.create_state(current_executor, database_reader_, chain_storage_, block_number - 1);
-                EVMExecutor executor{*chain_config_ptr, workers_, curr_state};
+        TraceDeployResult result;
 
-                TraceDeployResult result;
-
-                auto create_tracer = std::make_shared<trace::CreateTracer>(contract_address, initial_ibs);
-
-                Tracers tracers{create_tracer};
-
-                for (std::uint64_t index = 0; index < transactions.size(); index++) {
-                    const silkworm::Transaction& transaction{block.transactions[index]};
-                    executor.call(block, transaction, tracers, /*refund=*/true, /*gas_bailout=*/true);
-                    executor.reset();
-                    if (create_tracer->found()) {
-                        result.transaction_hash = transaction.hash();
-                        result.contract_creator = transaction.sender();
-                        break;
-                    }
-                }
-                boost::asio::post(current_executor, [result, self = std::move(self)]() mutable {
-                    self.complete(result);
-                });
-            });
-        },
-        boost::asio::use_awaitable);
+        auto create_tracer = std::make_shared<trace::CreateTracer>(contract_address, initial_ibs);
+        Tracers tracers{create_tracer};
+        for (std::uint64_t index = 0; index < transactions.size(); index++) {
+            const silkworm::Transaction& transaction{block.transactions[index]};
+            executor.call(block, transaction, tracers, /*refund=*/true, /*gas_bailout=*/true);
+            executor.reset();
+            if (create_tracer->found()) {
+                result.transaction_hash = transaction.hash();
+                result.contract_creator = transaction.sender();
+                break;
+            }
+        }
+        return result;
+    });
 
     co_return deploy_result;
 }
@@ -1485,30 +1460,20 @@ Task<TraceEntriesResult> TraceCallExecutor::trace_transaction_entries(const Tran
     ensure(chain_config_ptr.has_value(), "cannot read chain config");
 
     auto current_executor = co_await boost::asio::this_coro::executor;
+    const auto trace_result = co_await async_task(workers_.executor(), [&]() -> TraceEntriesResult {
+        auto state = tx_.create_state(current_executor, database_reader_, chain_storage_, block_number - 1);
+        silkworm::IntraBlockState initial_ibs{*state};
+        auto curr_state = tx_.create_state(current_executor, database_reader_, chain_storage_, block_number - 1);
+        EVMExecutor executor{*chain_config_ptr, workers_, curr_state};
 
-    const auto ret_entry_tracer = co_await boost::asio::async_compose<decltype(boost::asio::use_awaitable), void(std::shared_ptr<trace::EntryTracer>)>(
-        [&](auto& self) {
-            boost::asio::post(workers_, [&, self = std::move(self)]() mutable {
-                auto state = tx_.create_state(current_executor, database_reader_, chain_storage_, block_number - 1);
-                silkworm::IntraBlockState initial_ibs{*state};
+        auto entry_tracer = std::make_shared<trace::EntryTracer>(initial_ibs);
+        Tracers tracers{entry_tracer};
 
-                auto curr_state = tx_.create_state(current_executor, database_reader_, chain_storage_, block_number - 1);
-                EVMExecutor executor{*chain_config_ptr, workers_, curr_state};
+        executor.call(transaction_with_block.block_with_hash->block, transaction_with_block.transaction, tracers, /*refund=*/true, /*gas_bailout=*/true);
+        return entry_tracer->result();
+    });
 
-                auto entry_tracer = std::make_shared<trace::EntryTracer>(initial_ibs);
-
-                Tracers tracers{entry_tracer};
-
-                executor.call(transaction_with_block.block_with_hash->block, transaction_with_block.transaction, tracers, /*refund=*/true, /*gas_bailout=*/true);
-
-                boost::asio::post(current_executor, [entry_tracer, self = std::move(self)]() mutable {
-                    self.complete(entry_tracer);
-                });
-            });
-        },
-        boost::asio::use_awaitable);
-
-    co_return ret_entry_tracer->result();
+    co_return trace_result;
 }
 
 Task<std::string> TraceCallExecutor::trace_transaction_error(const TransactionWithBlock& transaction_with_block) {
@@ -1518,31 +1483,27 @@ Task<std::string> TraceCallExecutor::trace_transaction_error(const TransactionWi
     ensure(chain_config_ptr.has_value(), "cannot read chain config");
 
     auto current_executor = co_await boost::asio::this_coro::executor;
+    const auto result = co_await async_task(workers_.executor(), [&]() -> std::string {
+        auto state = tx_.create_state(current_executor, database_reader_, chain_storage_, block_number - 1);
+        silkworm::IntraBlockState initial_ibs{*state};
 
-    const auto ret_result = co_await boost::asio::async_compose<decltype(boost::asio::use_awaitable), void(std::string)>(
-        [&](auto& self) {
-            boost::asio::post(workers_, [&, self = std::move(self)]() mutable {
-                auto state = tx_.create_state(current_executor, database_reader_, chain_storage_, block_number - 1);
-                silkworm::IntraBlockState initial_ibs{*state};
+        auto curr_state = tx_.create_state(current_executor, database_reader_, chain_storage_, block_number - 1);
+        EVMExecutor executor{*chain_config_ptr, workers_, curr_state};
+        Tracers tracers{};
 
-                auto curr_state = tx_.create_state(current_executor, database_reader_, chain_storage_, block_number - 1);
-                EVMExecutor executor{*chain_config_ptr, workers_, curr_state};
-                Tracers tracers{};
+        const auto execution_result = executor.call(transaction_with_block.block_with_hash->block,
+                                                    transaction_with_block.transaction,
+                                                    tracers,
+                                                    /*refund=*/true, /*gas_bailout=*/true);
 
-                auto execution_result = executor.call(transaction_with_block.block_with_hash->block, transaction_with_block.transaction, tracers, /*refund=*/true, /*gas_bailout=*/true);
+        std::string result = "0x";
+        if (execution_result.error_code != evmc_status_code::EVMC_SUCCESS) {
+            result = "0x" + silkworm::to_hex(execution_result.data);
+        }
+        return result;
+    });
 
-                std::string result = "0x";
-                if (execution_result.error_code != evmc_status_code::EVMC_SUCCESS) {
-                    result = "0x" + silkworm::to_hex(execution_result.data);
-                }
-                boost::asio::post(current_executor, [result, self = std::move(self)]() mutable {
-                    self.complete(result);
-                });
-            });
-        },
-        boost::asio::use_awaitable);
-
-    co_return ret_result;
+    co_return result;
 }
 
 Task<TraceOperationsResult> TraceCallExecutor::trace_operations(const TransactionWithBlock& transaction_with_block) {
@@ -1552,30 +1513,21 @@ Task<TraceOperationsResult> TraceCallExecutor::trace_operations(const Transactio
     ensure(chain_config_ptr.has_value(), "cannot read chain config");
 
     auto current_executor = co_await boost::asio::this_coro::executor;
+    const auto trace_op_result = co_await async_task(workers_.executor(), [&]() -> TraceOperationsResult {
+        auto state = tx_.create_state(current_executor, database_reader_, chain_storage_, block_number - 1);
+        silkworm::IntraBlockState initial_ibs{*state};
 
-    const auto ret_entry_tracer = co_await boost::asio::async_compose<decltype(boost::asio::use_awaitable), void(std::shared_ptr<trace::OperationTracer>)>(
-        [&](auto& self) {
-            boost::asio::post(workers_, [&, self = std::move(self)]() mutable {
-                auto state = tx_.create_state(current_executor, database_reader_, chain_storage_, block_number - 1);
-                silkworm::IntraBlockState initial_ibs{*state};
+        auto curr_state = tx_.create_state(current_executor, database_reader_, chain_storage_, block_number - 1);
+        EVMExecutor executor{*chain_config_ptr, workers_, curr_state};
 
-                auto curr_state = tx_.create_state(current_executor, database_reader_, chain_storage_, block_number - 1);
-                EVMExecutor executor{*chain_config_ptr, workers_, curr_state};
+        auto entry_tracer = std::make_shared<trace::OperationTracer>(initial_ibs);
+        Tracers tracers{entry_tracer};
 
-                auto entry_tracer = std::make_shared<trace::OperationTracer>(initial_ibs);
+        executor.call(transaction_with_block.block_with_hash->block, transaction_with_block.transaction, tracers, /*refund=*/true, /*gas_bailout=*/true);
+        return entry_tracer->result();
+    });
 
-                Tracers tracers{entry_tracer};
-
-                executor.call(transaction_with_block.block_with_hash->block, transaction_with_block.transaction, tracers, /*refund=*/true, /*gas_bailout=*/true);
-
-                boost::asio::post(current_executor, [entry_tracer, self = std::move(self)]() mutable {
-                    self.complete(entry_tracer);
-                });
-            });
-        },
-        boost::asio::use_awaitable);
-
-    co_return ret_entry_tracer->result();
+    co_return trace_op_result;
 }
 
 Task<bool> TraceCallExecutor::trace_touch_transaction(const silkworm::Block& block, const silkworm::Transaction& txn, const evmc::address& address) {
@@ -1585,29 +1537,21 @@ Task<bool> TraceCallExecutor::trace_touch_transaction(const silkworm::Block& blo
     ensure(chain_config_ptr.has_value(), "cannot read chain config");
 
     auto current_executor = co_await boost::asio::this_coro::executor;
+    const bool result = co_await async_task(workers_.executor(), [&]() -> bool {
+        auto state = tx_.create_state(current_executor, database_reader_, chain_storage_, block_number - 1);
+        silkworm::IntraBlockState initial_ibs{*state};
 
-    const auto ret_entry_tracer = co_await boost::asio::async_compose<decltype(boost::asio::use_awaitable), void(std::shared_ptr<trace::TouchTracer>)>(
-        [&](auto& self) {
-            boost::asio::post(workers_, [&, self = std::move(self)]() mutable {
-                auto state = tx_.create_state(current_executor, database_reader_, chain_storage_, block_number - 1);
-                silkworm::IntraBlockState initial_ibs{*state};
+        auto curr_state = tx_.create_state(current_executor, database_reader_, chain_storage_, block_number - 1);
+        EVMExecutor executor{*chain_config_ptr, workers_, curr_state};
 
-                auto curr_state = tx_.create_state(current_executor, database_reader_, chain_storage_, block_number - 1);
-                EVMExecutor executor{*chain_config_ptr, workers_, curr_state};
+        auto tracer = std::make_shared<trace::TouchTracer>(address, initial_ibs);
+        Tracers tracers{tracer};
 
-                auto tracer = std::make_shared<trace::TouchTracer>(address, initial_ibs);
-                Tracers tracers{tracer};
+        executor.call(block, txn, tracers, /*refund=*/true, /*gas_bailout=*/true);
+        return tracer->found();
+    });
 
-                executor.call(block, txn, tracers, /*refund=*/true, /*gas_bailout=*/true);
-
-                boost::asio::post(current_executor, [tracer, self = std::move(self)]() mutable {
-                    self.complete(tracer);
-                });
-            });
-        },
-        boost::asio::use_awaitable);
-
-    co_return ret_entry_tracer->found();
+    co_return result;
 }
 
 Task<void> TraceCallExecutor::trace_filter(const TraceFilter& trace_filter, const ChainStorage& storage, json::Stream& stream) {
@@ -1685,60 +1629,54 @@ Task<TraceCallResult> TraceCallExecutor::execute(
     ensure(chain_config_ptr.has_value(), "cannot read chain config");
 
     auto current_executor = co_await boost::asio::this_coro::executor;
+    const auto trace_call_result = co_await async_task(workers_.executor(), [&]() -> TraceCallResult {
+        auto state = tx_.create_state(current_executor, database_reader_, chain_storage_, block_number);
+        silkworm::IntraBlockState initial_ibs{*state};
 
-    const auto trace_call_result = co_await boost::asio::async_compose<decltype(boost::asio::use_awaitable), void(TraceCallResult)>(
-        [&](auto& self) {
-            boost::asio::post(workers_, [&, self = std::move(self)]() mutable {
-                auto state = tx_.create_state(current_executor, database_reader_, chain_storage_, block_number);
-                silkworm::IntraBlockState initial_ibs{*state};
+        Tracers tracers;
+        StateAddresses state_addresses(initial_ibs);
+        std::shared_ptr<silkworm::EvmTracer> tracer = std::make_shared<trace::IntraBlockStateTracer>(state_addresses);
+        tracers.push_back(tracer);
 
-                Tracers tracers;
-                StateAddresses state_addresses(initial_ibs);
-                std::shared_ptr<silkworm::EvmTracer> tracer = std::make_shared<trace::IntraBlockStateTracer>(state_addresses);
-                tracers.push_back(tracer);
+        auto curr_state = tx_.create_state(current_executor, database_reader_, chain_storage_, block_number);
+        EVMExecutor executor{*chain_config_ptr, workers_, curr_state};
+        for (std::size_t idx{0}; idx < transaction.transaction_index; idx++) {
+            silkworm::Transaction txn{block.transactions[idx]};
+            const auto execution_result = executor.call(block, txn, tracers, /*refund=*/true, /*gas_bailout=*/true);
+            if (execution_result.pre_check_error) {
+                SILK_ERROR << "execution failed for tx " << idx << " due to pre-check error: " << *execution_result.pre_check_error;
+            }
+            executor.reset();
+        }
 
-                auto curr_state = tx_.create_state(current_executor, database_reader_, chain_storage_, block_number);
-                EVMExecutor executor{*chain_config_ptr, workers_, curr_state};
-                for (std::size_t idx{0}; idx < transaction.transaction_index; idx++) {
-                    silkworm::Transaction txn{block.transactions[idx]};
-                    const auto execution_result = executor.call(block, txn, tracers, /*refund=*/true, /*gas_bailout=*/true);
-                    if (execution_result.pre_check_error) {
-                        SILK_ERROR << "execution failed for tx " << idx << " due to pre-check error: " << *execution_result.pre_check_error;
-                    }
-                    executor.reset();
-                }
+        tracers.clear();
 
-                tracers.clear();
-                TraceCallResult result;
-                TraceCallTraces& traces = result.traces;
-                if (config.vm_trace) {
-                    traces.vm_trace.emplace();
-                    tracers.push_back(std::make_shared<trace::VmTraceTracer>(traces.vm_trace.value(), index));
-                }
-                if (config.trace) {
-                    tracers.push_back(std::make_shared<trace::TraceTracer>(traces.trace, initial_ibs));
-                }
-                if (config.state_diff) {
-                    traces.state_diff.emplace();
+        TraceCallResult result;
+        TraceCallTraces& traces = result.traces;
+        if (config.vm_trace) {
+            traces.vm_trace.emplace();
+            tracers.push_back(std::make_shared<trace::VmTraceTracer>(traces.vm_trace.value(), index));
+        }
+        if (config.trace) {
+            tracers.push_back(std::make_shared<trace::TraceTracer>(traces.trace, initial_ibs));
+        }
+        if (config.state_diff) {
+            traces.state_diff.emplace();
 
-                    tracers.push_back(std::make_shared<trace::StateDiffTracer>(traces.state_diff.value(), state_addresses));
-                }
-                if (index != -1) {
-                    traces.transaction_hash = transaction.hash();  // to have same behaviour as erigon, should be done PR on erigon
-                }
-                const auto execution_result = executor.call(block, transaction, tracers, /*refund=*/true, /*gas_bailout=*/true);
+            tracers.push_back(std::make_shared<trace::StateDiffTracer>(traces.state_diff.value(), state_addresses));
+        }
+        if (index != -1) {
+            traces.transaction_hash = transaction.hash();  // to have same behaviour as erigon, should be done PR on erigon
+        }
+        const auto execution_result = executor.call(block, transaction, tracers, /*refund=*/true, /*gas_bailout=*/true);
 
-                if (execution_result.pre_check_error) {
-                    result.pre_check_error = execution_result.pre_check_error.value();
-                } else {
-                    traces.output = "0x" + silkworm::to_hex(execution_result.data);
-                }
-                boost::asio::post(current_executor, [result, self = std::move(self)]() mutable {
-                    self.complete(result);
-                });
-            });
-        },
-        boost::asio::use_awaitable);
+        if (execution_result.pre_check_error) {
+            result.pre_check_error = execution_result.pre_check_error.value();
+        } else {
+            traces.output = "0x" + silkworm::to_hex(execution_result.data);
+        }
+        return result;
+    });
 
     co_return trace_call_result;
 }

--- a/silkworm/rpc/core/evm_trace.cpp
+++ b/silkworm/rpc/core/evm_trace.cpp
@@ -1483,7 +1483,7 @@ Task<std::string> TraceCallExecutor::trace_transaction_error(const TransactionWi
     ensure(chain_config_ptr.has_value(), "cannot read chain config");
 
     auto current_executor = co_await boost::asio::this_coro::executor;
-    const auto result = co_await async_task(workers_.executor(), [&]() -> std::string {
+    const auto trace_error = co_await async_task(workers_.executor(), [&]() -> std::string {
         auto state = tx_.create_state(current_executor, database_reader_, chain_storage_, block_number - 1);
         silkworm::IntraBlockState initial_ibs{*state};
 
@@ -1503,7 +1503,7 @@ Task<std::string> TraceCallExecutor::trace_transaction_error(const TransactionWi
         return result;
     });
 
-    co_return result;
+    co_return trace_error;
 }
 
 Task<TraceOperationsResult> TraceCallExecutor::trace_operations(const TransactionWithBlock& transaction_with_block) {


### PR DESCRIPTION
This PR introduces a common `async_task` primitive that can be used to execute a task on some executor and co-await asynchronously for its completion. Typical usage: any I/O thread delegates long-running tasks to a thread pool by calling a coroutine that starts the work and is suspended until completion.

The key factors for introducing this abstraction are:
- implementation of `asio::async_compose` + `asio::post` pattern in one place
- complete exception handling (missing in many current usages)
- avoid code duplication
- improve readability at the call site

The following modules throughout the RPC daemon has been refactored to benefit from `async_task`:
- `http::Connection`
- `evm_debug`
- `emv_trace`
- `call_many`
- `estimate_gas_oracle`
- `evm_executor`
