### PR TITLE
rpcdaemon: add config flag to toggle response dump in interface log

### DIFF
--- a/cmd/common/rpcdaemon_options.cpp
+++ b/cmd/common/rpcdaemon_options.cpp
@@ -86,6 +86,10 @@ static void add_options_interface_log(CLI::App& cli, const std::string& option_p
         ->description("Maximum size in megabytes of each interface log file for " + end_point_descr)
         ->check(CLI::Range(1, 1024))
         ->capture_default_str();
+
+    cli.add_flag("--" + option_prefix + ".log.dump_response", settings.dump_response)
+        ->description("Enable response dump in interface log for " + end_point_descr)
+        ->capture_default_str();
 }
 
 void add_rpcdaemon_options(CLI::App& cli, silkworm::rpc::DaemonSettings& settings) {

--- a/silkworm/rpc/common/interface_log.cpp
+++ b/silkworm/rpc/common/interface_log.cpp
@@ -30,6 +30,10 @@ class InterfaceLogImpl final {
         flush();
     }
 
+    [[nodiscard]] bool dump_response() const {
+        return dump_response_;
+    }
+
     [[nodiscard]] std::filesystem::path path() const {
         return file_path_;
     }
@@ -53,6 +57,7 @@ class InterfaceLogImpl final {
   private:
     std::string name_;
     bool auto_flush_;
+    bool dump_response_;
     std::filesystem::path file_path_;
     std::size_t max_file_size_;
     std::size_t max_files_;
@@ -63,6 +68,7 @@ class InterfaceLogImpl final {
 InterfaceLogImpl::InterfaceLogImpl(InterfaceLogSettings settings)
     : name_{std::move(settings.ifc_name)},
       auto_flush_{settings.auto_flush},
+      dump_response_{settings.dump_response},
       file_path_{settings.container_folder / std::filesystem::path{name_ + ".log"}},
       max_file_size_{settings.max_file_size_mb * kMebi},
       max_files_{settings.max_files},
@@ -96,7 +102,9 @@ void InterfaceLog::log_req(std::string_view msg) {
 }
 
 void InterfaceLog::log_rsp(std::string_view msg) {
-    p_impl_->log("RSP <- {}", msg);
+    if (p_impl_->dump_response()) {
+        p_impl_->log("RSP <- {}", msg);
+    }
 }
 
 void InterfaceLog::flush() {

--- a/silkworm/rpc/common/interface_log.hpp
+++ b/silkworm/rpc/common/interface_log.hpp
@@ -34,6 +34,7 @@ struct InterfaceLogSettings {
     std::size_t max_file_size_mb{1};
     std::size_t max_files{100};
     bool auto_flush{false};
+    bool dump_response{false};
 };
 
 class InterfaceLog final {

--- a/silkworm/rpc/common/interface_log_test.cpp
+++ b/silkworm/rpc/common/interface_log_test.cpp
@@ -27,7 +27,49 @@
 
 namespace silkworm::rpc {
 
-TEST_CASE("InterfaceLog basic", "[rpc][common][interface_log]") {
+TEST_CASE("InterfaceLog dump: full (req+rsp)", "[rpc][common][interface_log]") {
+    const auto tmp_dir{TemporaryDirectory::get_unique_temporary_path()};
+    InterfaceLogSettings settings{
+        .enabled = true,
+        .ifc_name = "eth_rpc",
+        .container_folder = tmp_dir,
+        .dump_response = true,
+    };
+    auto ifc_log{std::make_unique<InterfaceLog>(settings)};
+    REQUIRE(!ifc_log->path().empty());
+    ifc_log->log_req(R"({"json":"2.0"})");
+    ifc_log->log_rsp(R"({"json":"2.0"})");
+    std::ifstream log_ifstream{ifc_log->path().string()};
+
+    // Log file must be empty before flushing
+    CHECK(log_ifstream.get() == -1);
+    CHECK(log_ifstream.eof());
+    log_ifstream.clear();
+    log_ifstream.seekg(0);
+
+    SECTION("explicit flush") {
+        // InterfaceLog instance gets flushed here but remains alive until the end
+        ifc_log->flush();
+    }
+
+    SECTION("implicit flush") {
+        // InterfaceLog instance gets destroyed here and implicitly flushed
+        ifc_log.reset();
+    }
+
+    // First line must be the request
+    std::string content;
+    std::getline(log_ifstream, content);
+    CHECK(absl::StrContains(content, R"(REQ -> {"json":"2.0"})"));
+    // Second line must be the response
+    std::getline(log_ifstream, content);
+    CHECK(absl::StrContains(content, R"(RSP <- {"json":"2.0"})"));
+    // No other content is present
+    CHECK(log_ifstream.get() == -1);
+    CHECK(log_ifstream.eof());
+}
+
+TEST_CASE("InterfaceLog dump: default (only req)", "[rpc][common][interface_log]") {
     const auto tmp_dir{TemporaryDirectory::get_unique_temporary_path()};
     InterfaceLogSettings settings{
         .enabled = true,
@@ -60,9 +102,6 @@ TEST_CASE("InterfaceLog basic", "[rpc][common][interface_log]") {
     std::string content;
     std::getline(log_ifstream, content);
     CHECK(absl::StrContains(content, R"(REQ -> {"json":"2.0"})"));
-    // Second line must be the response
-    std::getline(log_ifstream, content);
-    CHECK(absl::StrContains(content, R"(RSP <- {"json":"2.0"})"));
     // No other content is present
     CHECK(log_ifstream.get() == -1);
     CHECK(log_ifstream.eof());


### PR DESCRIPTION
This PR introduces a configuration flag in RPC interface log to enable/disable the dump of any response (disabled by default).

Dumping the whole response can be useful for debugging some specific request/response pair, but makes the interface log content grow very fast, so it should be enabled carefully.

Command-line options to enable/disable the feature in each ETH/Engine endpoint are also added.