### PR TITLE
rpcdaemon: extract JSON-RPC handler out of transport

### DIFF
--- a/silkworm/rpc/commands/admin_api.hpp
+++ b/silkworm/rpc/commands/admin_api.hpp
@@ -41,6 +41,7 @@ class AdminRpcApi {
 
     AdminRpcApi(const AdminRpcApi&) = delete;
     AdminRpcApi& operator=(const AdminRpcApi&) = delete;
+    AdminRpcApi(AdminRpcApi&&) = default;
 
   protected:
     Task<void> handle_admin_node_info(const nlohmann::json& request, nlohmann::json& reply);

--- a/silkworm/rpc/commands/debug_api.cpp
+++ b/silkworm/rpc/commands/debug_api.cpp
@@ -298,7 +298,7 @@ Task<void> DebugRpcApi::handle_debug_account_at(const nlohmann::json& request, n
         const auto block_with_hash = co_await core::read_block_by_hash(*block_cache_, *chain_storage, block_hash);
         if (!block_with_hash) {
             const std::string error_msg = "block not found ";
-            SILK_ERROR << "handle_debug_account_at: core::read_block_by_hash: " << error_msg << request.dump();
+            SILK_TRACE << "handle_debug_account_at: core::read_block_by_hash: " << error_msg << request.dump();
             reply = make_json_error(request, -32000, error_msg);
             co_await tx->close();  // RAII not (yet) available with coroutines
             co_return;
@@ -308,7 +308,7 @@ Task<void> DebugRpcApi::handle_debug_account_at(const nlohmann::json& request, n
         auto block_number = block.header.number;
         const auto& transactions = block.transactions;
 
-        SILK_DEBUG << "Block number: " << block_number << " #tnx: " << transactions.size();
+        SILK_TRACE << "Block number: " << block_number << " #tnx: " << transactions.size();
 
         auto chain_config_ptr = co_await chain_storage->read_chain_config();
         ensure(chain_config_ptr.has_value(), "cannot read chain config");

--- a/silkworm/rpc/commands/debug_api.hpp
+++ b/silkworm/rpc/commands/debug_api.hpp
@@ -51,6 +51,7 @@ class DebugRpcApi {
 
     DebugRpcApi(const DebugRpcApi&) = delete;
     DebugRpcApi& operator=(const DebugRpcApi&) = delete;
+    DebugRpcApi(DebugRpcApi&&) = default;
 
   protected:
     Task<void> handle_debug_account_range(const nlohmann::json& request, nlohmann::json& reply);

--- a/silkworm/rpc/commands/engine_api.hpp
+++ b/silkworm/rpc/commands/engine_api.hpp
@@ -46,6 +46,7 @@ class EngineRpcApi {
 
     EngineRpcApi(const EngineRpcApi&) = delete;
     EngineRpcApi& operator=(const EngineRpcApi&) = delete;
+    EngineRpcApi(EngineRpcApi&&) = default;
 
   protected:
     Task<void> handle_engine_exchange_capabilities(const nlohmann::json& request, nlohmann::json& reply);

--- a/silkworm/rpc/commands/erigon_api.hpp
+++ b/silkworm/rpc/commands/erigon_api.hpp
@@ -46,6 +46,7 @@ class ErigonRpcApi {
 
     ErigonRpcApi(const ErigonRpcApi&) = delete;
     ErigonRpcApi& operator=(const ErigonRpcApi&) = delete;
+    ErigonRpcApi(ErigonRpcApi&&) = default;
 
   protected:
     Task<void> handle_erigon_block_number(const nlohmann::json& request, nlohmann::json& reply);

--- a/silkworm/rpc/commands/eth_api.hpp
+++ b/silkworm/rpc/commands/eth_api.hpp
@@ -64,6 +64,7 @@ class EthereumRpcApi {
 
     EthereumRpcApi(const EthereumRpcApi&) = delete;
     EthereumRpcApi& operator=(const EthereumRpcApi&) = delete;
+    EthereumRpcApi(EthereumRpcApi&&) = default;
 
   protected:
     Task<void> handle_eth_block_number(const nlohmann::json& request, nlohmann::json& reply);

--- a/silkworm/rpc/commands/net_api.hpp
+++ b/silkworm/rpc/commands/net_api.hpp
@@ -41,6 +41,7 @@ class NetRpcApi {
 
     NetRpcApi(const NetRpcApi&) = delete;
     NetRpcApi& operator=(const NetRpcApi&) = delete;
+    NetRpcApi(NetRpcApi&&) = default;
 
   protected:
     Task<void> handle_net_listening(const nlohmann::json& request, nlohmann::json& reply);

--- a/silkworm/rpc/commands/ots_api.hpp
+++ b/silkworm/rpc/commands/ots_api.hpp
@@ -193,6 +193,7 @@ class OtsRpcApi {
 
     OtsRpcApi(const OtsRpcApi&) = delete;
     OtsRpcApi& operator=(const OtsRpcApi&) = delete;
+    OtsRpcApi(OtsRpcApi&&) = default;
 
   protected:
     Task<void> handle_ots_get_api_level(const nlohmann::json& request, nlohmann::json& reply);

--- a/silkworm/rpc/commands/parity_api.hpp
+++ b/silkworm/rpc/commands/parity_api.hpp
@@ -44,6 +44,7 @@ class ParityRpcApi {
 
     ParityRpcApi(const ParityRpcApi&) = delete;
     ParityRpcApi& operator=(const ParityRpcApi&) = delete;
+    ParityRpcApi(ParityRpcApi&&) = default;
 
   protected:
     Task<void> handle_parity_get_block_receipts(const nlohmann::json& request, nlohmann::json& reply);

--- a/silkworm/rpc/commands/rpc_api.hpp
+++ b/silkworm/rpc/commands/rpc_api.hpp
@@ -70,6 +70,7 @@ class RpcApi : protected EthereumRpcApi,
 
     RpcApi(const RpcApi&) = delete;
     RpcApi& operator=(const RpcApi&) = delete;
+    RpcApi(RpcApi&&) = default;
 
     friend class RpcApiTable;
     friend class silkworm::rpc::json_rpc::RequestHandler;

--- a/silkworm/rpc/commands/rpc_api_table.hpp
+++ b/silkworm/rpc/commands/rpc_api_table.hpp
@@ -39,6 +39,7 @@ class RpcApiTable {
 
     RpcApiTable(const RpcApiTable&) = delete;
     RpcApiTable& operator=(const RpcApiTable&) = delete;
+    RpcApiTable(RpcApiTable&&) = default;
 
     [[nodiscard]] std::optional<HandleMethod> find_json_handler(const std::string& method) const;
     [[nodiscard]] std::optional<HandleMethodGlaze> find_json_glaze_handler(const std::string& method) const;

--- a/silkworm/rpc/commands/trace_api.hpp
+++ b/silkworm/rpc/commands/trace_api.hpp
@@ -52,6 +52,7 @@ class TraceRpcApi {
 
     TraceRpcApi(const TraceRpcApi&) = delete;
     TraceRpcApi& operator=(const TraceRpcApi&) = delete;
+    TraceRpcApi(TraceRpcApi&&) = default;
 
   protected:
     Task<void> handle_trace_call(const nlohmann::json& request, nlohmann::json& reply);

--- a/silkworm/rpc/commands/txpool_api.hpp
+++ b/silkworm/rpc/commands/txpool_api.hpp
@@ -41,6 +41,7 @@ class TxPoolRpcApi {
 
     TxPoolRpcApi(const TxPoolRpcApi&) = delete;
     TxPoolRpcApi& operator=(const TxPoolRpcApi&) = delete;
+    TxPoolRpcApi(TxPoolRpcApi&&) = default;
 
   protected:
     Task<void> handle_txpool_status(const nlohmann::json& request, nlohmann::json& reply);

--- a/silkworm/rpc/commands/web3_api.hpp
+++ b/silkworm/rpc/commands/web3_api.hpp
@@ -42,6 +42,7 @@ class Web3RpcApi {
 
     Web3RpcApi(const Web3RpcApi&) = delete;
     Web3RpcApi& operator=(const Web3RpcApi&) = delete;
+    Web3RpcApi(Web3RpcApi&&) = default;
 
   protected:
     Task<void> handle_web3_client_version(const nlohmann::json& request, nlohmann::json& reply);

--- a/silkworm/rpc/daemon.cpp
+++ b/silkworm/rpc/daemon.cpp
@@ -37,6 +37,7 @@
 #include <silkworm/rpc/ethdb/file/local_database.hpp>
 #include <silkworm/rpc/ethdb/kv/remote_database.hpp>
 #include <silkworm/rpc/http/jwt.hpp>
+#include <silkworm/rpc/json_rpc/request_handler.hpp>
 #include <silkworm/rpc/json_rpc/validator.hpp>
 
 namespace silkworm::rpc {

--- a/silkworm/rpc/http/connection.hpp
+++ b/silkworm/rpc/http/connection.hpp
@@ -32,7 +32,6 @@
 #include <silkworm/rpc/commands/rpc_api_table.hpp>
 #include <silkworm/rpc/common/constants.hpp>
 #include <silkworm/rpc/common/interface_log.hpp>
-#include <silkworm/rpc/json_rpc/request_handler.hpp>
 #include <silkworm/rpc/transport/request_handler.hpp>
 #include <silkworm/rpc/transport/stream_writer.hpp>
 #include <silkworm/rpc/ws/connection.hpp>

--- a/silkworm/rpc/http/server.cpp
+++ b/silkworm/rpc/http/server.cpp
@@ -83,7 +83,7 @@ Task<void> Server::run() {
         while (acceptor_.is_open()) {
             SILK_DEBUG << "Server::run accepting using io_context " << &this_executor << "...";
 
-            boost::asio::ip::tcp::socket socket{co_await ThisTask::executor};
+            boost::asio::ip::tcp::socket socket{this_executor};
             co_await acceptor_.async_accept(socket, boost::asio::use_awaitable);
             if (!acceptor_.is_open()) {
                 SILK_TRACE << "Server::run returning...";

--- a/silkworm/rpc/http/server.hpp
+++ b/silkworm/rpc/http/server.hpp
@@ -30,6 +30,7 @@
 #include <silkworm/rpc/commands/rpc_api_table.hpp>
 #include <silkworm/rpc/common/interface_log.hpp>
 #include <silkworm/rpc/json_rpc/request_handler.hpp>
+#include <silkworm/rpc/transport/request_handler.hpp>
 
 namespace silkworm::rpc::http {
 
@@ -41,15 +42,14 @@ class Server {
 
     // Construct the server to listen on the specified local TCP end-point
     Server(const std::string& end_point,
-           const std::string& api_spec,
+           RequestHandlerFactory&& handler_factory,
            boost::asio::io_context& io_context,
            boost::asio::thread_pool& workers,
            std::vector<std::string> allowed_origins,
            std::optional<std::string> jwt_secret,
            bool use_websocket,
            bool ws_compression,
-           bool http_compression,
-           InterfaceLogSettings ifc_log_settings = {});
+           bool http_compression);
 
     void start();
 
@@ -60,14 +60,8 @@ class Server {
 
     Task<void> run();
 
-    //! The JSON RPC API implementation
-    commands::RpcApi rpc_api_;
-
-    //! The repository of API request handlers
-    commands::RpcApiTable handler_table_;
-
-    //! The context used to perform asynchronous operations
-    boost::asio::io_context& io_context_;
+    //! The factory of RPC request handlers
+    RequestHandlerFactory handler_factory_;
 
     //! The acceptor used to listen for incoming TCP connections
     boost::asio::ip::tcp::acceptor acceptor_;
@@ -84,11 +78,8 @@ class Server {
     //! Flag indicating if WebSocket protocol compression will be used
     bool ws_compression_;
 
-    //! Flag indicating if Http protocol compression will be used
+    //! Flag indicating if HTTP protocol compression will be used
     bool http_compression_;
-
-    //! The interface logging configuration
-    InterfaceLogSettings ifc_log_settings_;
 
     //! The configured workers
     boost::asio::thread_pool& workers_;

--- a/silkworm/rpc/http/server.hpp
+++ b/silkworm/rpc/http/server.hpp
@@ -29,7 +29,6 @@
 #include <silkworm/infra/grpc/client/client_context_pool.hpp>
 #include <silkworm/rpc/commands/rpc_api_table.hpp>
 #include <silkworm/rpc/common/interface_log.hpp>
-#include <silkworm/rpc/json_rpc/request_handler.hpp>
 #include <silkworm/rpc/transport/request_handler.hpp>
 
 namespace silkworm::rpc::http {

--- a/silkworm/rpc/json/stream.hpp
+++ b/silkworm/rpc/json/stream.hpp
@@ -32,7 +32,7 @@
 #include <boost/asio/io_context.hpp>
 #include <nlohmann/json.hpp>
 
-#include <silkworm/rpc/common/writer.hpp>
+#include <silkworm/rpc/transport/stream_writer.hpp>
 
 namespace silkworm::rpc::json {
 

--- a/silkworm/rpc/json_rpc/request_handler.cpp
+++ b/silkworm/rpc/json_rpc/request_handler.cpp
@@ -24,8 +24,8 @@
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/rpc/commands/eth_api.hpp>
 #include <silkworm/rpc/common/clock_time.hpp>
-#include <silkworm/rpc/common/writer.hpp>
 #include <silkworm/rpc/protocol/errors.hpp>
+#include <silkworm/rpc/transport/stream_writer.hpp>
 
 namespace silkworm::rpc::json_rpc {
 

--- a/silkworm/rpc/json_rpc/request_handler.hpp
+++ b/silkworm/rpc/json_rpc/request_handler.hpp
@@ -31,12 +31,13 @@
 #include <silkworm/rpc/commands/rpc_api.hpp>
 #include <silkworm/rpc/commands/rpc_api_table.hpp>
 #include <silkworm/rpc/common/interface_log.hpp>
-#include <silkworm/rpc/common/writer.hpp>
 #include <silkworm/rpc/json_rpc/validator.hpp>
+#include <silkworm/rpc/transport/request_handler.hpp>
+#include <silkworm/rpc/transport/stream_writer.hpp>
 
 namespace silkworm::rpc::json_rpc {
 
-class RequestHandler {
+class RequestHandler : public rpc::RequestHandler {
   public:
     RequestHandler(StreamWriter* stream_writer,
                    commands::RpcApi& rpc_api,
@@ -47,7 +48,7 @@ class RequestHandler {
     RequestHandler(const RequestHandler&) = delete;
     RequestHandler& operator=(const RequestHandler&) = delete;
 
-    Task<std::optional<std::string>> handle(const std::string& request);
+    Task<std::optional<std::string>> handle(const std::string& request) override;
 
   protected:
     Task<bool> handle_request_and_create_reply(const nlohmann::json& request_json, std::string& response);

--- a/silkworm/rpc/test/api_test_database.hpp
+++ b/silkworm/rpc/test/api_test_database.hpp
@@ -39,11 +39,11 @@
 #include <silkworm/db/genesis.hpp>
 #include <silkworm/infra/test_util/log.hpp>
 #include <silkworm/rpc/common/constants.hpp>
-#include <silkworm/rpc/common/writer.hpp>
 #include <silkworm/rpc/ethdb/file/local_database.hpp>
 #include <silkworm/rpc/json_rpc/request_handler.hpp>
 #include <silkworm/rpc/json_rpc/validator.hpp>
 #include <silkworm/rpc/test/context_test_base.hpp>
+#include <silkworm/rpc/transport/stream_writer.hpp>
 
 namespace silkworm::rpc::test {
 

--- a/silkworm/rpc/transport/request_handler.hpp
+++ b/silkworm/rpc/transport/request_handler.hpp
@@ -1,0 +1,51 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+
+#include <silkworm/infra/concurrency/task.hpp>
+
+#include <absl/functional/any_invocable.h>
+
+#include "stream_writer.hpp"
+
+namespace silkworm::rpc {
+
+using Request = std::string;
+using Response = std::string;
+
+class RequestHandler {
+  public:
+    RequestHandler() = default;
+    virtual ~RequestHandler() = default;
+
+    RequestHandler(const RequestHandler&) = delete;
+    RequestHandler& operator=(const RequestHandler&) = delete;
+
+    virtual Task<std::optional<Response>> handle(const Request& request) = 0;
+};
+
+using RequestHandlerPtr = std::unique_ptr<RequestHandler>;
+
+//! We use \code absl::AnyInvocable waiting for \code std::move_only_function in C++23
+using RequestHandlerFactory = absl::AnyInvocable<RequestHandlerPtr(StreamWriter*)>;
+
+}  // namespace silkworm::rpc

--- a/silkworm/rpc/transport/stream_writer.hpp
+++ b/silkworm/rpc/transport/stream_writer.hpp
@@ -16,14 +16,11 @@
 
 #pragma once
 
-#include <deque>
-#include <memory>
+#include <cstddef>
 #include <string>
+#include <string_view>
 
 #include <silkworm/infra/concurrency/task.hpp>
-
-#include <boost/asio/ip/tcp.hpp>
-#include <boost/asio/write.hpp>
 
 namespace silkworm::rpc {
 

--- a/silkworm/rpc/transport/stream_writer_test.cpp
+++ b/silkworm/rpc/transport/stream_writer_test.cpp
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-#include "writer.hpp"
+#include "stream_writer.hpp"
 
 #include <iostream>
 

--- a/silkworm/rpc/ws/connection.hpp
+++ b/silkworm/rpc/ws/connection.hpp
@@ -30,7 +30,6 @@
 #include <boost/beast/websocket.hpp>
 
 #include <silkworm/rpc/commands/rpc_api_table.hpp>
-#include <silkworm/rpc/json_rpc/request_handler.hpp>
 #include <silkworm/rpc/transport/request_handler.hpp>
 #include <silkworm/rpc/transport/stream_writer.hpp>
 


### PR DESCRIPTION
This PR performs some refactoring to remove any dependency from `http` and `ws` modules to `json_rpc` module to avoid transport-level being dependent on presentation-level, which is kind of an anti-pattern. Namely, a new `transport` module is introduced which defines the `rpc::RequestHandler` interface and will contain both `http` and `ws` modules in the future.

This PR is the first one in a row.

*Extras*

- improve readability in `http::Server` run loop
- move `StreamWriter` from `common` to `transport`
- improve naming in `ws::Connection`
- demote some log traces