### PR TITLE
capi: export RpcDaemon configuration settings

### DIFF
--- a/cmd/capi/execute.cpp
+++ b/cmd/capi/execute.cpp
@@ -396,7 +396,8 @@ int start_rpcdaemon(SilkwormHandle handle, const rpc::DaemonSettings& /*settings
         .exclusive = true};
     ::mdbx::env_managed env{silkworm::db::open_env(config)};
 
-    const int status_code{silkworm_start_rpcdaemon(handle, &*env)};
+    SilkwormRpcSettings settings{};
+    const int status_code{silkworm_start_rpcdaemon(handle, &*env, &settings)};
     if (status_code != SILKWORM_OK) {
         SILK_ERROR << "silkworm_start_rpcdaemon failed [code=" << std::to_string(status_code) << "]";
     }

--- a/silkworm/capi/common.cpp
+++ b/silkworm/capi/common.cpp
@@ -18,9 +18,49 @@
 
 #include <cstring>
 
-std::filesystem::path make_path(const char data_dir_path[SILKWORM_PATH_SIZE]) {
+namespace log = silkworm::log;
+
+//! Build Silkworm log level from its C representation
+static log::Level make_log_level(const SilkwormLogLevel c_log_level) {
+    log::Level verbosity{};
+    switch (c_log_level) {
+        case SilkwormLogLevel::NONE:
+            verbosity = log::Level::kNone;
+            break;
+        case SilkwormLogLevel::CRITICAL:
+            verbosity = log::Level::kCritical;
+            break;
+        case SilkwormLogLevel::ERROR:
+            verbosity = log::Level::kError;
+            break;
+        case SilkwormLogLevel::WARNING:
+            verbosity = log::Level::kWarning;
+            break;
+        case SilkwormLogLevel::INFO:
+            verbosity = log::Level::kInfo;
+            break;
+        case SilkwormLogLevel::DEBUG:
+            verbosity = log::Level::kDebug;
+            break;
+        case SilkwormLogLevel::TRACE:
+            verbosity = log::Level::kTrace;
+            break;
+    }
+    return verbosity;
+}
+
+std::filesystem::path parse_path(const char data_dir_path[SILKWORM_PATH_SIZE]) {
     // Treat as char8_t so that filesystem::path assumes UTF-8 encoding of the input path
     auto begin = reinterpret_cast<const char8_t*>(data_dir_path);
     size_t len = strnlen(data_dir_path, SILKWORM_PATH_SIZE);
     return std::filesystem::path{begin, begin + len};
+}
+
+log::Settings make_log_settings(const SilkwormLogLevel c_log_level) {
+    return {
+        .log_utc = false,       // display local time
+        .log_timezone = false,  // no timezone ID
+        .log_trim = true,       // compact rendering (i.e. no whitespaces)
+        .log_verbosity = make_log_level(c_log_level),
+    };
 }

--- a/silkworm/capi/common.cpp
+++ b/silkworm/capi/common.cpp
@@ -1,0 +1,26 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "common.hpp"
+
+#include <cstring>
+
+std::filesystem::path make_path(const char data_dir_path[SILKWORM_PATH_SIZE]) {
+    // Treat as char8_t so that filesystem::path assumes UTF-8 encoding of the input path
+    auto begin = reinterpret_cast<const char8_t*>(data_dir_path);
+    size_t len = strnlen(data_dir_path, SILKWORM_PATH_SIZE);
+    return std::filesystem::path{begin, begin + len};
+}

--- a/silkworm/capi/common.hpp
+++ b/silkworm/capi/common.hpp
@@ -18,7 +18,12 @@
 
 #include <filesystem>
 
+#include <silkworm/infra/common/log.hpp>
+
 #include "silkworm.h"
 
 //! Build a file system path from its C null-terminated upper-bounded representation
-std::filesystem::path make_path(const char path[SILKWORM_PATH_SIZE]);
+std::filesystem::path parse_path(const char path[SILKWORM_PATH_SIZE]);
+
+//! Build log configuration matching Erigon log format w/ custom verbosity level
+silkworm::log::Settings make_log_settings(SilkwormLogLevel c_log_level);

--- a/silkworm/capi/common.hpp
+++ b/silkworm/capi/common.hpp
@@ -1,0 +1,24 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <filesystem>
+
+#include "silkworm.h"
+
+//! Build a file system path from its C null-terminated upper-bounded representation
+std::filesystem::path make_path(const char path[SILKWORM_PATH_SIZE]);

--- a/silkworm/capi/instance.hpp
+++ b/silkworm/capi/instance.hpp
@@ -24,9 +24,11 @@
 
 #include <silkworm/db/snapshots/repository.hpp>
 #include <silkworm/infra/concurrency/context_pool_settings.hpp>
+#include <silkworm/infra/common/log.hpp>
 #include <silkworm/rpc/daemon.hpp>
 
 struct SilkwormInstance {
+    silkworm::log::Settings log_settings;
     silkworm::concurrency::ContextPoolSettings context_pool_settings;
     std::filesystem::path data_dir_path;
     std::unique_ptr<silkworm::snapshots::SnapshotRepository> snapshot_repository;

--- a/silkworm/capi/instance.hpp
+++ b/silkworm/capi/instance.hpp
@@ -23,8 +23,8 @@
 #include <boost/asio/cancellation_signal.hpp>
 
 #include <silkworm/db/snapshots/repository.hpp>
-#include <silkworm/infra/concurrency/context_pool_settings.hpp>
 #include <silkworm/infra/common/log.hpp>
+#include <silkworm/infra/concurrency/context_pool_settings.hpp>
 #include <silkworm/rpc/daemon.hpp>
 
 struct SilkwormInstance {

--- a/silkworm/capi/rpcdaemon.cpp
+++ b/silkworm/capi/rpcdaemon.cpp
@@ -121,7 +121,12 @@ SILKWORM_EXPORT int silkworm_start_rpcdaemon(SilkwormHandle handle, MDBX_env* en
     }
 
     SILK_INFO << "[Silkworm RPC] Starting ETH API at " << daemon_settings.eth_end_point;
-    handle->rpcdaemon->start();
+    try {
+        handle->rpcdaemon->start();
+    } catch (const std::exception& ex) {
+        SILK_ERROR << "[Silkworm RPC] Cannot start RPC daemon due to: " << ex.what();
+        return SILKWORM_INTERNAL_ERROR;
+    }
 
     return SILKWORM_OK;
 }
@@ -134,11 +139,16 @@ SILKWORM_EXPORT int silkworm_stop_rpcdaemon(SilkwormHandle handle) SILKWORM_NOEX
         return SILKWORM_OK;
     }
 
-    handle->rpcdaemon->stop();
-    SILK_INFO << "[Silkworm RPC] Exiting...";
-    handle->rpcdaemon->join();
-    SILK_INFO << "[Silkworm RPC] Stopped";
-    handle->rpcdaemon.reset();
+    try {
+        handle->rpcdaemon->stop();
+        SILK_INFO << "[Silkworm RPC] Exiting...";
+        handle->rpcdaemon->join();
+        SILK_INFO << "[Silkworm RPC] Stopped";
+        handle->rpcdaemon.reset();
+    } catch (const std::exception& ex) {
+        SILK_ERROR << "[Silkworm RPC] Cannot stop RPC daemon due to: " << ex.what();
+        return SILKWORM_INTERNAL_ERROR;
+    }
 
     return SILKWORM_OK;
 }

--- a/silkworm/capi/rpcdaemon.cpp
+++ b/silkworm/capi/rpcdaemon.cpp
@@ -26,15 +26,13 @@ using namespace silkworm::rpc;
 using silkworm::concurrency::ContextPoolSettings;
 
 //! Build interface log settings for ETH JSON-RPC from their C representation
-static InterfaceLogSettings make_eth_ifc_log_settings(const struct SilkwormRpcInterfaceLogSettings* settings) {
+static InterfaceLogSettings make_eth_ifc_log_settings(const struct SilkwormRpcInterfaceLogSettings settings) {
     InterfaceLogSettings eth_ifc_log_settings{.ifc_name = "eth_rpc_api"};
-    if (settings) {
-        eth_ifc_log_settings.enabled = settings->enabled;
-        eth_ifc_log_settings.container_folder = parse_path(settings->container_folder);
-        eth_ifc_log_settings.max_file_size_mb = settings->max_file_size_mb;
-        eth_ifc_log_settings.max_files = settings->max_files;
-        eth_ifc_log_settings.dump_response = settings->dump_response;
-    }
+    eth_ifc_log_settings.enabled = settings.enabled;
+    eth_ifc_log_settings.container_folder = parse_path(settings.container_folder);
+    eth_ifc_log_settings.max_file_size_mb = settings.max_file_size_mb;
+    eth_ifc_log_settings.max_files = settings.max_files;
+    eth_ifc_log_settings.dump_response = settings.dump_response;
     return eth_ifc_log_settings;
 }
 

--- a/silkworm/capi/rpcdaemon.cpp
+++ b/silkworm/capi/rpcdaemon.cpp
@@ -79,6 +79,7 @@ static DaemonSettings make_daemon_settings(SilkwormHandle handle, const struct S
         .num_workers = settings.num_workers > 0 ? settings.num_workers : kDefaultNumWorkers,
         .cors_domain = parse_cors_domains(settings.cors_domains),
         .jwt_secret_file = jwt_path.empty() ? std::nullopt : std::make_optional(jwt_path.string()),
+        .skip_protocol_check = settings.skip_internal_protocol_check,
         .erigon_json_rpc_compatibility = settings.erigon_json_rpc_compatibility,
         .use_websocket = settings.ws_enabled,
         .ws_compression = settings.ws_compression,

--- a/silkworm/capi/rpcdaemon.cpp
+++ b/silkworm/capi/rpcdaemon.cpp
@@ -1,0 +1,145 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include <silkworm/infra/common/log.hpp>
+#include <silkworm/rpc/settings.hpp>
+
+#include "common.hpp"
+#include "instance.hpp"
+#include "silkworm.h"
+
+using namespace silkworm;
+using namespace silkworm::rpc;
+using silkworm::concurrency::ContextPoolSettings;
+
+//! Build interface log settings for ETH JSON-RPC from their C representation
+static InterfaceLogSettings make_eth_ifc_log_settings(const struct SilkwormRpcInterfaceLogSettings* settings) {
+    InterfaceLogSettings eth_ifc_log_settings{.ifc_name = "eth_rpc_api"};
+    if (settings) {
+        eth_ifc_log_settings.enabled = settings->enabled;
+        eth_ifc_log_settings.container_folder = make_path(settings->container_folder);
+        eth_ifc_log_settings.max_file_size_mb = settings->max_file_size_mb;
+        eth_ifc_log_settings.max_files = settings->max_files;
+        eth_ifc_log_settings.dump_response = settings->dump_response;
+    }
+    return eth_ifc_log_settings;
+}
+
+//! Build JSON-RPC endpoint from C settings
+static std::string parse_end_point(const char (&c_host)[SILKWORM_RPC_SETTINGS_HOST_SIZE], int port, const std::string& default_end_point) {
+    auto host = std::string{c_host};
+    if (host.empty() && port == 0) {
+        return kDefaultEth1EndPoint;
+    }
+    const auto semicolon_position{default_end_point.find(':')};
+    SILKWORM_ASSERT(semicolon_position != std::string::npos);
+    if (host.empty()) {
+        host = default_end_point.substr(0, semicolon_position);
+    }
+    if (port == 0) {
+        port = std::stoi(default_end_point.substr(semicolon_position + 1));
+    }
+    std::string eth_end_point{host + ":" + std::to_string(port)};
+    return eth_end_point;
+}
+
+//! Build list of CORS domains from their C representation
+static std::vector<std::string> parse_cors_domains(
+    const char (&c_cors_domains)[SILKWORM_RPC_SETTINGS_CORS_DOMAINS_MAX][SILKWORM_RPC_SETTINGS_CORS_DOMAIN_SIZE]) {
+    std::vector<std::string> cors_domains;
+    for (const auto& c_domain : c_cors_domains) {
+        std::string_view domain_str = c_domain;
+        if (domain_str.empty()) break;
+        cors_domains.emplace_back(domain_str);
+    }
+    return cors_domains;
+}
+
+//! Build whole RPC daemon settings from their C representation
+static DaemonSettings make_daemon_settings(SilkwormHandle handle, const struct SilkwormRpcSettings& settings) {
+    const auto jwt_path{make_path(settings.jwt_file_path)};
+    return {
+        .log_settings = handle->log_settings,
+        .eth_ifc_log_settings = make_eth_ifc_log_settings(settings.eth_if_log_settings),
+        .context_pool_settings = handle->context_pool_settings,
+        .eth_end_point = parse_end_point(settings.eth_api_host, settings.eth_api_port, kDefaultEth1EndPoint),
+        .engine_end_point = "",  // disable end-point for Engine RPC API
+        .eth_api_spec = std::string{settings.eth_api_spec},
+        .num_workers = settings.num_workers > 0 ? settings.num_workers : kDefaultNumWorkers,
+        .cors_domain = parse_cors_domains(settings.cors_domains),
+        .jwt_secret_file = jwt_path.empty() ? std::nullopt : std::make_optional(jwt_path.string()),
+        .erigon_json_rpc_compatibility = settings.erigon_json_rpc_compatibility,
+        .use_websocket = settings.ws_enabled,
+        .ws_compression = settings.ws_compression,
+        .http_compression = settings.http_compression,
+    };
+}
+
+SILKWORM_EXPORT int silkworm_start_rpcdaemon(SilkwormHandle handle, MDBX_env* env, const struct SilkwormRpcSettings* settings) SILKWORM_NOEXCEPT {
+    if (!handle) {
+        return SILKWORM_INVALID_HANDLE;
+    }
+    if (handle->rpcdaemon) {
+        return SILKWORM_SERVICE_ALREADY_STARTED;
+    }
+    if (!env) {
+        return SILKWORM_INVALID_MDBX_ENV;
+    }
+    if (!settings) {
+        return SILKWORM_INVALID_SETTINGS;
+    }
+
+    auto daemon_settings = make_daemon_settings(handle, *settings);
+    db::EnvUnmanaged unmanaged_env{env};
+
+    // Create the one-and-only Silkrpc daemon
+    handle->rpcdaemon = std::make_unique<rpc::Daemon>(daemon_settings, std::make_optional<mdbx::env>(unmanaged_env));
+
+    // Check protocol version compatibility with Core Services
+    if (!daemon_settings.skip_protocol_check) {
+        SILK_INFO << "[Silkworm RPC] Checking protocol version compatibility with core services...";
+
+        const auto checklist = handle->rpcdaemon->run_checklist();
+        for (const auto& protocol_check : checklist.protocol_checklist) {
+            SILK_INFO << protocol_check.result;
+        }
+        checklist.success_or_throw();
+    } else {
+        SILK_TRACE << "[Silkworm RPC] Skip protocol version compatibility check with core services";
+    }
+
+    SILK_INFO << "[Silkworm RPC] Starting ETH API at " << daemon_settings.eth_end_point;
+    handle->rpcdaemon->start();
+
+    return SILKWORM_OK;
+}
+
+SILKWORM_EXPORT int silkworm_stop_rpcdaemon(SilkwormHandle handle) SILKWORM_NOEXCEPT {
+    if (!handle) {
+        return SILKWORM_INVALID_HANDLE;
+    }
+    if (!handle->rpcdaemon) {
+        return SILKWORM_OK;
+    }
+
+    handle->rpcdaemon->stop();
+    SILK_INFO << "[Silkworm RPC] Exiting...";
+    handle->rpcdaemon->join();
+    SILK_INFO << "[Silkworm RPC] Stopped";
+    handle->rpcdaemon.reset();
+
+    return SILKWORM_OK;
+}

--- a/silkworm/capi/rpcdaemon.cpp
+++ b/silkworm/capi/rpcdaemon.cpp
@@ -30,7 +30,7 @@ static InterfaceLogSettings make_eth_ifc_log_settings(const struct SilkwormRpcIn
     InterfaceLogSettings eth_ifc_log_settings{.ifc_name = "eth_rpc_api"};
     if (settings) {
         eth_ifc_log_settings.enabled = settings->enabled;
-        eth_ifc_log_settings.container_folder = make_path(settings->container_folder);
+        eth_ifc_log_settings.container_folder = parse_path(settings->container_folder);
         eth_ifc_log_settings.max_file_size_mb = settings->max_file_size_mb;
         eth_ifc_log_settings.max_files = settings->max_files;
         eth_ifc_log_settings.dump_response = settings->dump_response;
@@ -70,7 +70,7 @@ static std::vector<std::string> parse_cors_domains(
 
 //! Build whole RPC daemon settings from their C representation
 static DaemonSettings make_daemon_settings(SilkwormHandle handle, const struct SilkwormRpcSettings& settings) {
-    const auto jwt_path{make_path(settings.jwt_file_path)};
+    const auto jwt_path{parse_path(settings.jwt_file_path)};
     return {
         .log_settings = handle->log_settings,
         .eth_ifc_log_settings = make_eth_ifc_log_settings(settings.eth_if_log_settings),

--- a/silkworm/capi/silkworm.cpp
+++ b/silkworm/capi/silkworm.cpp
@@ -42,7 +42,6 @@
 #include <silkworm/db/stages.hpp>
 #include <silkworm/infra/common/bounded_buffer.hpp>
 #include <silkworm/infra/common/directories.hpp>
-#include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/common/stopwatch.hpp>
 #include <silkworm/infra/concurrency/context_pool_settings.hpp>
 #include <silkworm/infra/concurrency/signal_handler.hpp>
@@ -53,45 +52,6 @@
 
 using namespace std::chrono_literals;
 using namespace silkworm;
-
-//! Create Silkworm log level from its C representation
-static log::Level make_log_level(const SilkwormLogLevel c_log_level) {
-    log::Level verbosity{};
-    switch (c_log_level) {
-        case SilkwormLogLevel::NONE:
-            verbosity = log::Level::kNone;
-            break;
-        case SilkwormLogLevel::CRITICAL:
-            verbosity = log::Level::kCritical;
-            break;
-        case SilkwormLogLevel::ERROR:
-            verbosity = log::Level::kError;
-            break;
-        case SilkwormLogLevel::WARNING:
-            verbosity = log::Level::kWarning;
-            break;
-        case SilkwormLogLevel::INFO:
-            verbosity = log::Level::kInfo;
-            break;
-        case SilkwormLogLevel::DEBUG:
-            verbosity = log::Level::kDebug;
-            break;
-        case SilkwormLogLevel::TRACE:
-            verbosity = log::Level::kTrace;
-            break;
-    }
-    return verbosity;
-}
-
-//! Build log configuration matching Erigon log format w/ custom verbosity level
-static log::Settings make_log_settings(const SilkwormLogLevel c_log_level) {
-    return {
-        .log_utc = false,       // display local time
-        .log_timezone = false,  // no timezone ID
-        .log_trim = true,       // compact rendering (i.e. no whitespaces)
-        .log_verbosity = make_log_level(c_log_level),
-    };
-}
 
 static MemoryMappedRegion make_region(const SilkwormMemoryMappedFile& mmf) {
     return {mmf.memory_address, mmf.memory_length};
@@ -253,7 +213,7 @@ SILKWORM_EXPORT int silkworm_init(SilkwormHandle* handle, const struct SilkwormS
         .context_pool_settings = {
             .num_contexts = settings->num_contexts > 0 ? settings->num_contexts : concurrency::kDefaultNumContexts,
         },
-        .data_dir_path = make_path(settings->data_dir_path),
+        .data_dir_path = parse_path(settings->data_dir_path),
         .snapshot_repository = std::move(snapshot_repository),
         .rpcdaemon = {},
         .sentry_thread = {},

--- a/silkworm/capi/silkworm.h
+++ b/silkworm/capi/silkworm.h
@@ -193,6 +193,8 @@ struct SilkwormRpcSettings {
     bool ws_compression;
     //! Flag indicating if compression of HTTP messages is supported
     bool http_compression;
+    //! Flag indicating if version check on internal gRPC protocols should be skipped
+    bool skip_internal_protocol_check;
 };
 
 /**

--- a/silkworm/capi/silkworm.h
+++ b/silkworm/capi/silkworm.h
@@ -98,7 +98,23 @@ struct SilkwormChainSnapshot {
 #define SILKWORM_PATH_SIZE 260
 #define SILKWORM_GIT_VERSION_SIZE 32
 
+//! Silkworm library logging level
+enum SilkwormLogLevel : uint8_t {
+    NONE,
+    CRITICAL,
+    ERROR,
+    WARNING,
+    INFO,
+    DEBUG,
+    TRACE
+};
+
+//! Silkworm library general configuration options
 struct SilkwormSettings {
+    //! Log verbosity level
+    enum SilkwormLogLevel log_verbosity;
+    //! Number of I/O contexts to use in concurrency mode
+    uint32_t num_contexts;
     //! Data directory path in UTF-8.
     char data_dir_path[SILKWORM_PATH_SIZE];
     //! libmdbx version string in git describe format.
@@ -138,13 +154,54 @@ SILKWORM_EXPORT int silkworm_add_snapshot(SilkwormHandle handle, struct Silkworm
  */
 SILKWORM_EXPORT const char* silkworm_libmdbx_version() SILKWORM_NOEXCEPT;
 
+#define SILKWORM_RPC_SETTINGS_HOST_SIZE 128
+#define SILKWORM_RPC_SETTINGS_API_NAMESPACE_SPEC_SIZE 256
+#define SILKWORM_RPC_SETTINGS_CORS_DOMAINS_MAX 20
+#define SILKWORM_RPC_SETTINGS_CORS_DOMAIN_SIZE 256
+
+//! Silkworm RPC interface log options
+struct SilkwormRpcInterfaceLogSettings {
+    bool enabled;
+    char container_folder[SILKWORM_PATH_SIZE];
+    uint16_t max_file_size_mb;
+    uint16_t max_files;
+    bool dump_response;
+};
+
+//! Silkworm RPC configuration options
+struct SilkwormRpcSettings {
+    //! Configuration options for interface log of ETH JSON-RPC end-point
+    struct SilkwormRpcInterfaceLogSettings* eth_if_log_settings;
+    //! Host address for ETH JSON-RPC end-point
+    char eth_api_host[SILKWORM_RPC_SETTINGS_HOST_SIZE];
+    //! Listening port number for ETH JSON-RPC end-point
+    uint16_t eth_api_port;
+    //! ETH JSON-RPC namespace specification (comma-separated list of API namespaces)
+    char eth_api_spec[SILKWORM_RPC_SETTINGS_API_NAMESPACE_SPEC_SIZE];
+    //! Number of threads in worker pool (for long-run tasks)
+    uint32_t num_workers;
+    //! Array of CORS domains
+    char cors_domains[SILKWORM_RPC_SETTINGS_CORS_DOMAINS_MAX][SILKWORM_RPC_SETTINGS_CORS_DOMAIN_SIZE];
+    //! Path to the JWT file in UTF-8.
+    char jwt_file_path[SILKWORM_PATH_SIZE];
+    //! Flag indicating if JSON-RPC strict compatibility w/ Erigon is supported
+    bool erigon_json_rpc_compatibility;
+    //! Flag indicating if WebSocket support is enabled
+    bool ws_enabled;
+    //! Flag indicating if compression of WebSocket messages is supported
+    bool ws_compression;
+    //! Flag indicating if compression of HTTP messages is supported
+    bool http_compression;
+};
+
 /**
  * \brief Start Silkworm RPC daemon.
- * \param[in] handle A valid Silkworm instance handle, got with silkworm_init.Must not be zero.
+ * \param[in] handle A valid Silkworm instance handle, got with silkworm_init. Must not be zero.
  * \param[in] env An valid MDBX environment. Must not be zero.
+ * \param[in] settings The RPC daemon configuration settings. Must not be zero.
  * \return SILKWORM_OK (=0) on success, a non-zero error value on failure.
  */
-SILKWORM_EXPORT int silkworm_start_rpcdaemon(SilkwormHandle handle, MDBX_env* env) SILKWORM_NOEXCEPT;
+SILKWORM_EXPORT int silkworm_start_rpcdaemon(SilkwormHandle handle, MDBX_env* env, const struct SilkwormRpcSettings* settings) SILKWORM_NOEXCEPT;
 
 /**
  * \brief Stop Silkworm RPC daemon and wait for its termination.
@@ -159,6 +216,7 @@ SILKWORM_EXPORT int silkworm_stop_rpcdaemon(SilkwormHandle handle) SILKWORM_NOEX
 #define SILKWORM_SENTRY_SETTINGS_PEERS_MAX 128
 #define SILKWORM_SENTRY_SETTINGS_PEER_URL_SIZE 200
 
+//! Silkworm Sentry configuration options
 struct SilkwormSentrySettings {
     char client_id[SILKWORM_SENTRY_SETTINGS_CLIENT_ID_SIZE];
     uint16_t api_port;

--- a/silkworm/capi/silkworm.h
+++ b/silkworm/capi/silkworm.h
@@ -99,7 +99,8 @@ struct SilkwormChainSnapshot {
 #define SILKWORM_GIT_VERSION_SIZE 32
 
 //! Silkworm library logging level
-enum SilkwormLogLevel : uint8_t {
+//! \note using anonymous enum seems the only way to obtain enum type in Cgo generated code
+typedef enum : uint8_t {
     NONE,
     CRITICAL,
     ERROR,
@@ -107,12 +108,12 @@ enum SilkwormLogLevel : uint8_t {
     INFO,
     DEBUG,
     TRACE
-};
+} SilkwormLogLevel;
 
 //! Silkworm library general configuration options
 struct SilkwormSettings {
     //! Log verbosity level
-    enum SilkwormLogLevel log_verbosity;
+    SilkwormLogLevel log_verbosity;
     //! Number of I/O contexts to use in concurrency mode
     uint32_t num_contexts;
     //! Data directory path in UTF-8.
@@ -171,7 +172,7 @@ struct SilkwormRpcInterfaceLogSettings {
 //! Silkworm RPC configuration options
 struct SilkwormRpcSettings {
     //! Configuration options for interface log of ETH JSON-RPC end-point
-    struct SilkwormRpcInterfaceLogSettings* eth_if_log_settings;
+    struct SilkwormRpcInterfaceLogSettings eth_if_log_settings;
     //! Host address for ETH JSON-RPC end-point
     char eth_api_host[SILKWORM_RPC_SETTINGS_HOST_SIZE];
     //! Listening port number for ETH JSON-RPC end-point

--- a/silkworm/capi/silkworm_test.cpp
+++ b/silkworm/capi/silkworm_test.cpp
@@ -807,7 +807,7 @@ static SilkwormRpcSettings make_rpc_settings() {
     (void)std::snprintf(settings.eth_api_host, SILKWORM_RPC_SETTINGS_HOST_SIZE, "localhost");
     (void)std::snprintf(settings.eth_api_spec, SILKWORM_RPC_SETTINGS_API_NAMESPACE_SPEC_SIZE, "eth,ots");
     for (auto& domain : settings.cors_domains) {
-        (void)std::snprintf(domain, SILKWORM_RPC_SETTINGS_CORS_DOMAIN_SIZE, "");
+        domain[0] = 0;
     }
     (void)std::snprintf(settings.cors_domains[0], SILKWORM_RPC_SETTINGS_CORS_DOMAIN_SIZE, "*");
     (void)std::snprintf(settings.jwt_file_path, SILKWORM_PATH_SIZE, "jwt.hex");

--- a/silkworm/capi/silkworm_test.cpp
+++ b/silkworm/capi/silkworm_test.cpp
@@ -790,8 +790,8 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_start_rpcdaemon", "[silkworm][capi]") 
     SECTION("invalid handle") {
         // We purposely do not call silkworm_init to provide a null handle
         SilkwormHandle handle{nullptr};
-        SilkwormRpcSettings settings{};
-        CHECK(silkworm_start_rpcdaemon(handle, db, &settings) == SILKWORM_INVALID_HANDLE);
+        SilkwormRpcSettings rpc_settings{};
+        CHECK(silkworm_start_rpcdaemon(handle, db, &rpc_settings) == SILKWORM_INVALID_HANDLE);
     }
 
     // Use Silkworm as a library with silkworm_init/silkworm_fini automated by RAII
@@ -803,8 +803,8 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_start_rpcdaemon", "[silkworm][capi]") 
 
     SECTION("default settings") {
         // We must skip internal protocol check here (would block because gRPC server not present)
-        SilkwormRpcSettings settings{.skip_internal_protocol_check = true};
-        CHECK(silkworm_lib.start_rpcdaemon(db, &settings) == SILKWORM_OK);
+        SilkwormRpcSettings rpc_settings{.skip_internal_protocol_check = true};
+        CHECK(silkworm_lib.start_rpcdaemon(db, &rpc_settings) == SILKWORM_OK);
     }
 }
 
@@ -824,8 +824,8 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_stop_rpcdaemon", "[silkworm][capi]") {
 
     SECTION("already started") {
         // We must skip internal protocol check here (would block because gRPC server not present)
-        SilkwormRpcSettings settings{.skip_internal_protocol_check = true};
-        REQUIRE(silkworm_lib.start_rpcdaemon(db, &settings) == SILKWORM_OK);
+        SilkwormRpcSettings rpc_settings{.skip_internal_protocol_check = true};
+        REQUIRE(silkworm_lib.start_rpcdaemon(db, &rpc_settings) == SILKWORM_OK);
         CHECK(silkworm_lib.stop_rpcdaemon() == SILKWORM_OK);
     }
 }

--- a/silkworm/infra/concurrency/context_pool_settings.hpp
+++ b/silkworm/infra/concurrency/context_pool_settings.hpp
@@ -20,10 +20,13 @@
 
 namespace silkworm::concurrency {
 
+//! Default number of threads to use for I/O tasks
+inline const auto kDefaultNumContexts{std::thread::hardware_concurrency() / 2};
+
 //! The configuration settings for \refitem ContextPool
 struct ContextPoolSettings {
-    uint32_t num_contexts{std::thread::hardware_concurrency() / 2};  // The number of execution contexts to activate
-    WaitMode wait_mode{WaitMode::blocking};                          // The waiting strategy when context has no work
+    uint32_t num_contexts{kDefaultNumContexts};  // The number of execution contexts to activate
+    WaitMode wait_mode{WaitMode::blocking};      // The waiting strategy when context has no work
 };
 
 }  // namespace silkworm::concurrency

--- a/silkworm/rpc/common/worker_pool.hpp
+++ b/silkworm/rpc/common/worker_pool.hpp
@@ -1,0 +1,31 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <thread>
+
+#include <boost/asio/thread_pool.hpp>
+
+namespace silkworm::rpc {
+
+//! Default number of threads in worker pool (i.e. dedicated to heavier tasks)
+inline const auto kDefaultNumWorkers{std::thread::hardware_concurrency() / 2};
+
+// TODO(canepat) replace boost::asio::thread_pool with WorkerPool
+// using WorkerPool = boost::asio::thread_pool;
+
+}  // namespace silkworm::rpc

--- a/silkworm/rpc/settings.hpp
+++ b/silkworm/rpc/settings.hpp
@@ -24,6 +24,7 @@
 #include <silkworm/infra/concurrency/context_pool_settings.hpp>
 #include <silkworm/rpc/common/constants.hpp>
 #include <silkworm/rpc/common/interface_log.hpp>
+#include <silkworm/rpc/common/worker_pool.hpp>
 
 namespace silkworm::rpc {
 
@@ -37,7 +38,7 @@ struct DaemonSettings {
     std::string engine_end_point{kDefaultEngineEndPoint};
     std::string eth_api_spec{kDefaultEth1ApiSpec};
     std::string private_api_addr{kDefaultPrivateApiAddr};
-    uint32_t num_workers{std::thread::hardware_concurrency() / 2};
+    uint32_t num_workers{kDefaultNumWorkers};
     std::vector<std::string> cors_domain;
     std::optional<std::string> jwt_secret_file;
     bool skip_protocol_check{false};


### PR DESCRIPTION
This PR exports our Silkworm RPC Daemon configuration settings in the C API interface. The following options can be customised (all of them are opt-in, default values provide a meaningful configuration):
- number of I/O execution contexts to use in concurrency mode
- configuration options for interface log of Execution JSON-RPC end-point
- host address for Execution JSON-RPC end-point
- listening port number for Execution JSON-RPC end-point
- API namespace specification (comma-separated list of API namespaces)
- number of threads in worker pool (for long-run tasks)
- list of CORS domains
- path to the JWT file in UTF-8
- flag indicating if JSON-RPC strict compatibility w/ Erigon is supported
- flag indicating if WebSocket support is enabled
- flag indicating if compression of WebSocket messages is supported
- flag indicating if compression of HTTP messages is supported

**Extras**

This PR also adds the logging verbosity level as Silkworm instance global setting. This is necessary to make Silkworm emit logs with the same verbosity as the C API client code, if needed.