### PR TITLE
rpcdaemon: improve close of state-changes stream after server-side termination

### DIFF
--- a/silkworm/rpc/ethdb/kv/state_changes_stream_test.cpp
+++ b/silkworm/rpc/ethdb/kv/state_changes_stream_test.cpp
@@ -188,14 +188,14 @@ TEST_CASE_METHOD(StateChangesStreamTest, "StateChangesStream::close", "[rpc][eth
         // 2. AsyncReader<remote::StateChangeBatch>::Finish call succeeds w/ status cancelled
         EXPECT_CALL(*statechanges_reader_, Finish).WillOnce(test::finish_streaming_cancelled(grpc_context_));
 
-        // Execute the precondition: the stream must be running
+        // Execute the pre-condition: the stream must be running
         std::future<void> run_result;
         CHECK_NOTHROW(run_result = spawn(stream_.run()));
 
         // Execute the test: closing the stream should succeed
         CHECK_NOTHROW(stream_.close());
 
-        // Execute the postcondition: the running stream finishes
+        // Execute the post-condition: the running stream finishes
         CHECK_NOTHROW(run_result.get());
     }
     SECTION("while reading w/ error every 10ms") {
@@ -220,7 +220,7 @@ TEST_CASE_METHOD(StateChangesStreamTest, "StateChangesStream::close", "[rpc][eth
         EXPECT_CALL(*statechanges_reader_, Finish)
             .WillRepeatedly(test::finish_streaming_cancelled(grpc_context_));
 
-        // Execute the precondition: the stream must be running at least for 30ms
+        // Execute the pre-condition: the stream must be running at least for 30ms
         std::future<void> run_result;
         CHECK_NOTHROW(run_result = spawn(stream_.run()));
         sleep_for(30ms);
@@ -228,7 +228,7 @@ TEST_CASE_METHOD(StateChangesStreamTest, "StateChangesStream::close", "[rpc][eth
         // Execute the test: closing the stream should succeed
         CHECK_NOTHROW(stream_.close());
 
-        // Execute the postcondition: the running stream finishes
+        // Execute the post-condition: the running stream finishes
         CHECK_NOTHROW(run_result.get());
     }
 }

--- a/silkworm/rpc/grpc/server_streaming_rpc.hpp
+++ b/silkworm/rpc/grpc/server_streaming_rpc.hpp
@@ -141,7 +141,7 @@ class ServerStreamingRpc<PrepareAsync> {
             if (!ok) {
                 self_.status_ = grpc::Status{grpc::StatusCode::UNKNOWN, "unknown error in finish"};
             }
-            // Check OK status AND read failure to treat graceful close on server-side as operation aborted. Otherwise the user should
+            // Check OK status AND read failure to treat graceful close on server-side as operation aborted. Otherwise, the user should
             // try to detect such condition by filtering on "empty" (default-constructed) reply, which is not necessarily invalid.
             // It is legit using gRPC codes for application-level errors: https://grpc.github.io/grpc/core/md_doc_statuscodes.html
             if (self_.status_.ok() && self_.read_failed_) {
@@ -159,7 +159,7 @@ class ServerStreamingRpc<PrepareAsync> {
 
   public:
     explicit ServerStreamingRpc(Stub& stub, agrpc::GrpcContext& grpc_context)
-        : stub_(stub), grpc_context_(grpc_context), read_failed_{false} {
+        : stub_(stub), grpc_context_(grpc_context) {
     }
 
     template <typename CompletionToken = agrpc::DefaultCompletionToken>


### PR DESCRIPTION
This PR improves the close sequence of `StateChanges` streaming gRPC on client-side after the stream has been closed by server.

*Extras*
rpcdaemon: clean-up some code and comments