### PR TITLE
rpcdaemon: enable fuzzer tests on GitHub Actions

### DIFF
--- a/.github/workflows/rpc-fuzzer-tests.yml
+++ b/.github/workflows/rpc-fuzzer-tests.yml
@@ -31,11 +31,11 @@ jobs:
 
       - name: Configure CMake
         working-directory: ${{runner.workspace}}/silkworm/build
-        run: CC=clang-15 CXX=clang++-15 cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=RelWithDebInfo -DSILKWORM_FUZZER=ON
+        run: CC=clang-15 CXX=clang++-15 cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCONAN_PROFILE=linux_x64_clang_13_release -DCMAKE_TOOLCHAIN_FILE=../project/cmake/toolchain/clang_libcxx.cmake -DSILKWORM_FUZZER=ON
 
       - name: Build Silkworm Fuzzer Test
         working-directory: ${{runner.workspace}}/silkworm/build
-        run: CC=clang-15 CXX=clang++-15 cmake --build . --config Release --target rpcdaemon_fuzzer_test -j 8
+        run: CC=clang-15 CXX=clang++-15 cmake --build . --target rpcdaemon_fuzzer_test -j 8
 
       - name: Prepare Corpus Directories
         working-directory: ${{runner.workspace}}/silkworm/build/cmd/test

--- a/.github/workflows/rpc-fuzzer-tests.yml
+++ b/.github/workflows/rpc-fuzzer-tests.yml
@@ -42,17 +42,17 @@ jobs:
       - name: Create Build Environment
         run: cmake -E make_directory ${{runner.workspace}}/silkworm/build
 
-      - name: Preinstall Conan packages
-        working-directory: ${{runner.workspace}}/silkworm
-        run: conan install --install-folder=build/conan --build=missing --profile=cmake/profiles/linux_x64_clang_13_release .
+      # - name: Preinstall Conan packages
+      #   working-directory: ${{runner.workspace}}/silkworm
+      #   run: conan install --install-folder=build/conan --build=missing --profile=cmake/profiles/linux_x64_clang_13_release .
 
       - name: Configure CMake
         working-directory: ${{runner.workspace}}/silkworm/build
-        run: CC=/lib/llvm-15/bin/clang CXX=/lib/llvm-15/bin/clang cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCONAN_PROFILE=linux_x64_clang_13_release -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain/clang_libcxx.cmake -DSILKWORM_FUZZER=ON
+        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCONAN_PROFILE=linux_x64_clang_13_release -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain/clang_libcxx.cmake -DSILKWORM_FUZZER=ON
 
       - name: Build Silkworm Fuzzer Test
         working-directory: ${{runner.workspace}}/silkworm/build
-        run: CC=/lib/llvm-15/bin/clang CXX=/lib/llvm-15/bin/clang cmake --build . --target rpcdaemon_fuzzer_test -j 8
+        run: cmake  --build . --target rpcdaemon_fuzzer_test -j 8
 
       - name: Prepare Corpus Directories
         working-directory: ${{runner.workspace}}/silkworm/build/cmd/test

--- a/.github/workflows/rpc-fuzzer-tests.yml
+++ b/.github/workflows/rpc-fuzzer-tests.yml
@@ -23,6 +23,9 @@ jobs:
           submodules: recursive
           fetch-depth: "1" # Fetch only the last commit, not the entire history
 
+      - name: Install Compiler (Clang 15)
+        run: sudo apt-get install -y libc++-15-dev libc++abi-15-dev clang-15
+
       - name: Clean Build Directory
         run: rm -rf ${{runner.workspace}}/silkworm/build
 
@@ -31,11 +34,11 @@ jobs:
 
       - name: Configure CMake
         working-directory: ${{runner.workspace}}/silkworm/build
-        run: CC=clang-15 CXX=clang++-15 cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCONAN_PROFILE=linux_x64_clang_13_release -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain/clang_libcxx.cmake -DSILKWORM_FUZZER=ON
+        run: CC=/lib/llvm-15/bin/clang CXX=/lib/llvm-15/bin/clang cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCONAN_PROFILE=linux_x64_clang_13_release -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain/clang_libcxx.cmake -DSILKWORM_FUZZER=ON
 
       - name: Build Silkworm Fuzzer Test
         working-directory: ${{runner.workspace}}/silkworm/build
-        run: CC=clang-15 CXX=clang++-15 cmake --build . --target rpcdaemon_fuzzer_test -j 8
+        run: CC=/lib/llvm-15/bin/clang CXX=/lib/llvm-15/bin/clang cmake --build . --target rpcdaemon_fuzzer_test -j 8
 
       - name: Prepare Corpus Directories
         working-directory: ${{runner.workspace}}/silkworm/build/cmd/test

--- a/.github/workflows/rpc-fuzzer-tests.yml
+++ b/.github/workflows/rpc-fuzzer-tests.yml
@@ -25,6 +25,7 @@ jobs:
 
       # - name: Install Compiler (Clang 15)
       #   run: sudo apt-get install -y libc++-15-dev libc++abi-15-dev clang-15
+      
 
       - name: Clean Build Directory
         run: rm -rf ${{runner.workspace}}/silkworm/build

--- a/.github/workflows/rpc-fuzzer-tests.yml
+++ b/.github/workflows/rpc-fuzzer-tests.yml
@@ -23,9 +23,16 @@ jobs:
           submodules: recursive
           fetch-depth: "1" # Fetch only the last commit, not the entire history
 
-      # - name: Install Compiler (Clang 15)
-      #   run: sudo apt-get install -y libc++-15-dev libc++abi-15-dev clang-15
-      
+      - name: Install Compiler (Clang 15)
+        run: |
+          # Ensure the correct version of Clang is installed
+          sudo apt-get install -y libc++-15-dev libc++abi-15-dev clang-15
+
+          # Set the compiler paths
+          sudo ln -sfv /usr/bin/clang-15 /usr/bin/clang
+          sudo ln -sfv /usr/bin/clang++-15 /usr/bin/clang++
+          sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang 100
+          sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 100
 
       - name: Clean Build Directory
         run: rm -rf ${{runner.workspace}}/silkworm/build
@@ -86,9 +93,17 @@ jobs:
             cp crash-* $RPC_PAST_TEST_DIR/silkworm-fuzzer/crashes/
           fi
 
-      - name: Resume the Erigon instance dedicated to db maintenance
+      - name: Clean up
+        if: always()
         run: |
+          # Resume the Erigon instance dedicated to db maintenance
           python3 $ERIGON_QA_PATH/test_system/db-producer/resume_production.py || true
+
+          # Reset compiler paths
+          sudo update-alternatives --remove cc /usr/bin/clang
+          sudo update-alternatives --remove c++ /usr/bin/clang++
+          sudo rm -f /usr/bin/clang
+          sudo rm -f /usr/bin/clang++
 
       - name: Action for Success
         if: steps.test_step.outputs.TEST_RESULT == 'success'

--- a/.github/workflows/rpc-fuzzer-tests.yml
+++ b/.github/workflows/rpc-fuzzer-tests.yml
@@ -31,12 +31,11 @@ jobs:
 
       - name: Configure CMake
         working-directory: ${{runner.workspace}}/silkworm/build
-        run: |
-          cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCONAN_PROFILE=linux_x64_clang_13_release -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain/clang_libcxx.cmake -DSILKWORM_FUZZER=ON
+        run: CC=clang-15 CXX=clang++-15 cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=RelWithDebInfo -DSILKWORM_FUZZER=ON
 
       - name: Build Silkworm Fuzzer Test
         working-directory: ${{runner.workspace}}/silkworm/build
-        run: cmake --build . --config Release --target rpcdaemon_fuzzer_test -j 8
+        run: CC=clang-15 CXX=clang++-15 cmake --build . --config Release --target rpcdaemon_fuzzer_test -j 8
 
       - name: Prepare Corpus Directories
         working-directory: ${{runner.workspace}}/silkworm/build/cmd/test

--- a/.github/workflows/rpc-fuzzer-tests.yml
+++ b/.github/workflows/rpc-fuzzer-tests.yml
@@ -1,0 +1,95 @@
+name: QA - RPC Fuzzer Tests
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0'  # Runs every Sunday at 00:00 AM UTC
+  push: 
+    branches:
+      - fuzzer-github-actions
+  
+jobs:
+  integration-test-suite:
+    runs-on: self-hosted
+    env:
+      ERIGON_DATA_DIR: /opt/erigon-versions/reference-version/datadir
+      RPC_PAST_TEST_DIR: /opt/rpc-past-tests
+      ERIGON_QA_PATH: /opt/erigon-qa
+
+    steps:
+      - name: Checkout Silkworm Repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: "1" # Fetch only the last commit, not the entire history
+
+      - name: Clean Build Directory
+        run: rm -rf ${{runner.workspace}}/silkworm/build
+
+      - name: Create Build Environment
+        run: cmake -E make_directory ${{runner.workspace}}/silkworm/build
+
+      - name: Configure CMake
+        working-directory: ${{runner.workspace}}/silkworm/build
+        run: |
+          cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCONAN_PROFILE=linux_x64_clang_13_release -DCMAKE_TOOLCHAIN_FILE=../project/cmake/toolchain/clang_libcxx.cmake -DSILKWORM_FUZZER=ON
+
+      - name: Build Silkworm Fuzzer Test
+        working-directory: ${{runner.workspace}}/silkworm/build
+        run: cmake --build . --config Release --target rpcdaemon_fuzzer_test -j 8
+
+      - name: Prepare Corpus Directories
+        working-directory: ${{runner.workspace}}/silkworm/build/cmd/test
+        run: |
+          echo "Ensure persistent directories for fuzzing corpus are created"
+          mkdir -p $RPC_PAST_TEST_DIR/silkworm-fuzzer/corpus
+          mkdir -p $RPC_PAST_TEST_DIR/silkworm-fuzzer/crashes
+
+          echo "Create corpus artifacts from execution-api specification"
+          mkdir -p artifacts
+          for file in ../../../third_party/execution-apis/tests/*/*.io; do cp --backup=numbered "$file" artifacts; done
+          for file in artifacts/*; do sed -i '2,$d' "$file"; done
+          for file in artifacts/*; do sed -i 's/^>> //' "$file"; done
+
+      - name: Pause the Erigon instance dedicated to db maintenance
+        run: |
+          python3 $ERIGON_QA_PATH/test_system/db-producer/pause_production.py || true
+
+      - name: Execute Silkworm Fuzzer Test
+        working-directory: ${{runner.workspace}}/silkworm/build/cmd/test
+        id: test_step
+        run: |
+          set +e # Disable exit on error
+
+          ./rpcdaemon_fuzzer_test $RPC_PAST_TEST_DIR/silkworm-fuzzer/corpus artifacts -max_total_time=86400 -detect_leaks=0
+
+          # To enable running multiple tests in parallel, use the following command
+          # ./rpcdaemon_fuzzer_test $RPC_PAST_TEST_DIR/silkworm-fuzzer/corpus artifacts -max_total_time=86400 -detect_leaks=0 -jobs=8
+          
+          # Check test runner exit status
+          if [ $test_exit_status -eq 0 ]; then
+            echo "tests completed successfully"
+            echo
+            echo "TEST_RESULT=success" >> "$GITHUB_OUTPUT"
+          else
+            echo "error detected during tests"
+            echo "TEST_RESULT=failure" >> "$GITHUB_OUTPUT"
+            
+            # Save failed results to a directory with timestamp and commit hash
+            cp crash-* $RPC_PAST_TEST_DIR/silkworm-fuzzer/crashes/
+          fi
+
+      - name: Resume the Erigon instance dedicated to db maintenance
+        run: |
+          python3 $ERIGON_QA_PATH/test_system/db-producer/resume_production.py || true
+
+      - name: Action for Success
+        if: steps.test_step.outputs.TEST_RESULT == 'success'
+        run: echo "::notice::Tests completed successfully"
+
+      - name: Action for Failure
+        if: steps.test_step.outputs.TEST_RESULT != 'success'
+        run: |
+          echo "::error::Error detected during tests"
+          exit 1
+

--- a/.github/workflows/rpc-fuzzer-tests.yml
+++ b/.github/workflows/rpc-fuzzer-tests.yml
@@ -31,14 +31,10 @@ jobs:
           # sudo apt-get install -y libc++-15-dev libc++abi-15-dev clang-15
 
           # Set the compiler paths
-          # sudo ln -sfv /usr/bin/clang-15 /usr/bin/clang
-          # sudo ln -sfv /usr/bin/clang++-15 /usr/bin/clang++
-          # sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang 100
-          # sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 100
-          ln -sfv /usr/bin/clang-15 /usr/bin/clang
-          ln -sfv /usr/bin/clang++-15 /usr/bin/clang++
-          update-alternatives --install /usr/bin/cc cc /usr/bin/clang 100
-          update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 100
+          sudo ln -sfv /usr/bin/clang-15 /usr/bin/clang
+          sudo ln -sfv /usr/bin/clang++-15 /usr/bin/clang++
+          sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang 100
+          sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 100
 
       - name: Clean Build Directory
         run: rm -rf ${{runner.workspace}}/silkworm/build
@@ -106,14 +102,10 @@ jobs:
           python3 $ERIGON_QA_PATH/test_system/db-producer/resume_production.py || true
 
           # Reset compiler paths
-          # sudo update-alternatives --remove cc /usr/bin/clang
-          # sudo update-alternatives --remove c++ /usr/bin/clang++
-          # sudo rm -f /usr/bin/clang
-          # sudo rm -f /usr/bin/clang++
-          update-alternatives --remove cc /usr/bin/clang
-          update-alternatives --remove c++ /usr/bin/clang++
-          rm -f /usr/bin/clang
-          rm -f /usr/bin/clang++
+          sudo update-alternatives --remove cc /usr/bin/clang
+          sudo update-alternatives --remove c++ /usr/bin/clang++
+          sudo rm -f /usr/bin/clang
+          sudo rm -f /usr/bin/clang++
 
       - name: Action for Success
         if: steps.test_step.outputs.TEST_RESULT == 'success'

--- a/.github/workflows/rpc-fuzzer-tests.yml
+++ b/.github/workflows/rpc-fuzzer-tests.yml
@@ -26,6 +26,8 @@ jobs:
       - name: Install Compiler (Clang 15)
         run: |
           whoami
+          pwd
+          ls -a
 
           # Ensure the correct version of Clang is installed
           # sudo apt-get install -y libc++-15-dev libc++abi-15-dev clang-15
@@ -35,6 +37,8 @@ jobs:
           sudo ln -sfv /usr/bin/clang++-15 /usr/bin/clang++
           sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang 100
           sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 100
+          update-alternatives --query cc
+          update-alternatives --query c++
 
       - name: Clean Build Directory
         run: rm -rf ${{runner.workspace}}/silkworm/build
@@ -48,11 +52,11 @@ jobs:
 
       - name: Configure CMake
         working-directory: ${{runner.workspace}}/silkworm/build
-        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCONAN_PROFILE=linux_x64_clang_13_release -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain/clang_libcxx.cmake -DSILKWORM_FUZZER=ON
+        run: CC=clang-15 CXX=clang++-15 cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCONAN_PROFILE=linux_x64_clang_13_release -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain/clang_libcxx.cmake -DSILKWORM_FUZZER=ON
 
       - name: Build Silkworm Fuzzer Test
         working-directory: ${{runner.workspace}}/silkworm/build
-        run: cmake  --build . --target rpcdaemon_fuzzer_test -j 8
+        run: CC=clang-15 CXX=clang++-15 cmake  --build . --target rpcdaemon_fuzzer_test -j 8
 
       - name: Prepare Corpus Directories
         working-directory: ${{runner.workspace}}/silkworm/build/cmd/test

--- a/.github/workflows/rpc-fuzzer-tests.yml
+++ b/.github/workflows/rpc-fuzzer-tests.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Configure CMake
         working-directory: ${{runner.workspace}}/silkworm/build
-        run: CC=clang-15 CXX=clang++-15 cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCONAN_PROFILE=linux_x64_clang_13_release -DCMAKE_TOOLCHAIN_FILE=../project/cmake/toolchain/clang_libcxx.cmake -DSILKWORM_FUZZER=ON
+        run: CC=clang-15 CXX=clang++-15 cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCONAN_PROFILE=linux_x64_clang_13_release -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain/clang_libcxx.cmake -DSILKWORM_FUZZER=ON
 
       - name: Build Silkworm Fuzzer Test
         working-directory: ${{runner.workspace}}/silkworm/build

--- a/.github/workflows/rpc-fuzzer-tests.yml
+++ b/.github/workflows/rpc-fuzzer-tests.yml
@@ -23,8 +23,8 @@ jobs:
           submodules: recursive
           fetch-depth: "1" # Fetch only the last commit, not the entire history
 
-      - name: Install Compiler (Clang 15)
-        run: sudo apt-get install -y libc++-15-dev libc++abi-15-dev clang-15
+      # - name: Install Compiler (Clang 15)
+      #   run: sudo apt-get install -y libc++-15-dev libc++abi-15-dev clang-15
 
       - name: Clean Build Directory
         run: rm -rf ${{runner.workspace}}/silkworm/build

--- a/.github/workflows/rpc-fuzzer-tests.yml
+++ b/.github/workflows/rpc-fuzzer-tests.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Configure CMake
         working-directory: ${{runner.workspace}}/silkworm/build
         run: |
-          cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCONAN_PROFILE=linux_x64_clang_13_release -DCMAKE_TOOLCHAIN_FILE=../project/cmake/toolchain/clang_libcxx.cmake -DSILKWORM_FUZZER=ON
+          cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCONAN_PROFILE=linux_x64_clang_13_release -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain/clang_libcxx.cmake -DSILKWORM_FUZZER=ON
 
       - name: Build Silkworm Fuzzer Test
         working-directory: ${{runner.workspace}}/silkworm/build

--- a/.github/workflows/rpc-fuzzer-tests.yml
+++ b/.github/workflows/rpc-fuzzer-tests.yml
@@ -32,6 +32,10 @@ jobs:
       - name: Create Build Environment
         run: cmake -E make_directory ${{runner.workspace}}/silkworm/build
 
+      - name: Preinstall Conan packages
+        working-directory: ${{runner.workspace}}/silkworm
+        run: conan install --install-folder=build/conan --build=missing --profile=cmake/profiles/linux_x64_clang_13_release .
+
       - name: Configure CMake
         working-directory: ${{runner.workspace}}/silkworm/build
         run: CC=/lib/llvm-15/bin/clang CXX=/lib/llvm-15/bin/clang cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCONAN_PROFILE=linux_x64_clang_13_release -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain/clang_libcxx.cmake -DSILKWORM_FUZZER=ON

--- a/.github/workflows/rpc-fuzzer-tests.yml
+++ b/.github/workflows/rpc-fuzzer-tests.yml
@@ -84,15 +84,17 @@ jobs:
         if: always()
         working-directory: ${{runner.workspace}}/silkworm/build/cmd/test
         run: |
-          # Save failed results to a directory with timestamp and commit hash
-          cp crash-* $RPC_PAST_TEST_DIR/silkworm-fuzzer/crashes/
-
-          # Resume the Erigon instance dedicated to db maintenance
-          python3 $ERIGON_QA_PATH/test_system/db-producer/resume_production.py || true
-
           # Reset compiler paths
           sudo update-alternatives --remove cc /usr/bin/clang
           sudo update-alternatives --remove c++ /usr/bin/clang++
           sudo rm -f /usr/bin/clang
           sudo rm -f /usr/bin/clang++
+
+          # Save failed results to the crash directory (ignore errors)
+          cp crash-* $RPC_PAST_TEST_DIR/silkworm-fuzzer/crashes/ 2>/dev/null || :
+          cp leak-* $RPC_PAST_TEST_DIR/silkworm-fuzzer/crashes/ 2>/dev/null || :
+
+          # Resume the Erigon instance dedicated to db maintenance
+          python3 $ERIGON_QA_PATH/test_system/db-producer/resume_production.py || true
+
 

--- a/.github/workflows/rpc-fuzzer-tests.yml
+++ b/.github/workflows/rpc-fuzzer-tests.yml
@@ -9,7 +9,7 @@ on:
       - fuzzer-github-actions
   
 jobs:
-  integration-test-suite:
+  fuzzer-test-suite:
     runs-on: self-hosted
     env:
       ERIGON_DATA_DIR: /opt/erigon-versions/reference-version/datadir
@@ -25,14 +25,20 @@ jobs:
 
       - name: Install Compiler (Clang 15)
         run: |
+          whoami
+
           # Ensure the correct version of Clang is installed
-          sudo apt-get install -y libc++-15-dev libc++abi-15-dev clang-15
+          # sudo apt-get install -y libc++-15-dev libc++abi-15-dev clang-15
 
           # Set the compiler paths
-          sudo ln -sfv /usr/bin/clang-15 /usr/bin/clang
-          sudo ln -sfv /usr/bin/clang++-15 /usr/bin/clang++
-          sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang 100
-          sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 100
+          # sudo ln -sfv /usr/bin/clang-15 /usr/bin/clang
+          # sudo ln -sfv /usr/bin/clang++-15 /usr/bin/clang++
+          # sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang 100
+          # sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 100
+          ln -sfv /usr/bin/clang-15 /usr/bin/clang
+          ln -sfv /usr/bin/clang++-15 /usr/bin/clang++
+          update-alternatives --install /usr/bin/cc cc /usr/bin/clang 100
+          update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 100
 
       - name: Clean Build Directory
         run: rm -rf ${{runner.workspace}}/silkworm/build
@@ -100,10 +106,14 @@ jobs:
           python3 $ERIGON_QA_PATH/test_system/db-producer/resume_production.py || true
 
           # Reset compiler paths
-          sudo update-alternatives --remove cc /usr/bin/clang
-          sudo update-alternatives --remove c++ /usr/bin/clang++
-          sudo rm -f /usr/bin/clang
-          sudo rm -f /usr/bin/clang++
+          # sudo update-alternatives --remove cc /usr/bin/clang
+          # sudo update-alternatives --remove c++ /usr/bin/clang++
+          # sudo rm -f /usr/bin/clang
+          # sudo rm -f /usr/bin/clang++
+          update-alternatives --remove cc /usr/bin/clang
+          update-alternatives --remove c++ /usr/bin/clang++
+          rm -f /usr/bin/clang
+          rm -f /usr/bin/clang++
 
       - name: Action for Success
         if: steps.test_step.outputs.TEST_RESULT == 'success'

--- a/.github/workflows/rpc-fuzzer-tests.yml
+++ b/.github/workflows/rpc-fuzzer-tests.yml
@@ -12,31 +12,26 @@ jobs:
   fuzzer-test-suite:
     runs-on: self-hosted
     env:
-      ERIGON_DATA_DIR: /opt/erigon-versions/reference-version/datadir
       RPC_PAST_TEST_DIR: /opt/rpc-past-tests
       ERIGON_QA_PATH: /opt/erigon-qa
 
     steps:
       - name: Checkout Silkworm Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: "1" # Fetch only the last commit, not the entire history
 
       - name: Install Compiler (Clang 15)
         run: |
-          whoami
-          pwd
-          ls -a
-
           # Ensure the correct version of Clang is installed
           # sudo apt-get install -y libc++-15-dev libc++abi-15-dev clang-15
 
           # Set the compiler paths
           sudo ln -sfv /usr/bin/clang-15 /usr/bin/clang
           sudo ln -sfv /usr/bin/clang++-15 /usr/bin/clang++
-          sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang 100
-          sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 100
+          sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang 120
+          sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 120
           update-alternatives --query cc
           update-alternatives --query c++
 
@@ -46,6 +41,7 @@ jobs:
       - name: Create Build Environment
         run: cmake -E make_directory ${{runner.workspace}}/silkworm/build
 
+      # Temporarily disabled, try to enable it if issues with building Conan packages (e.g. Boost) arise
       # - name: Preinstall Conan packages
       #   working-directory: ${{runner.workspace}}/silkworm
       #   run: conan install --install-folder=build/conan --build=missing --profile=cmake/profiles/linux_x64_clang_13_release .
@@ -77,31 +73,20 @@ jobs:
 
       - name: Execute Silkworm Fuzzer Test
         working-directory: ${{runner.workspace}}/silkworm/build/cmd/test
-        id: test_step
         run: |
-          set +e # Disable exit on error
-
+          # Single thread execution
           ./rpcdaemon_fuzzer_test $RPC_PAST_TEST_DIR/silkworm-fuzzer/corpus artifacts -max_total_time=86400 -detect_leaks=0
 
-          # To enable running multiple tests in parallel, use the following command
+          # Multi-thread execution
           # ./rpcdaemon_fuzzer_test $RPC_PAST_TEST_DIR/silkworm-fuzzer/corpus artifacts -max_total_time=86400 -detect_leaks=0 -jobs=8
-          
-          # Check test runner exit status
-          if [ $test_exit_status -eq 0 ]; then
-            echo "tests completed successfully"
-            echo
-            echo "TEST_RESULT=success" >> "$GITHUB_OUTPUT"
-          else
-            echo "error detected during tests"
-            echo "TEST_RESULT=failure" >> "$GITHUB_OUTPUT"
-            
-            # Save failed results to a directory with timestamp and commit hash
-            cp crash-* $RPC_PAST_TEST_DIR/silkworm-fuzzer/crashes/
-          fi
 
-      - name: Clean up
+      - name: Tear Down
         if: always()
+        working-directory: ${{runner.workspace}}/silkworm/build/cmd/test
         run: |
+          # Save failed results to a directory with timestamp and commit hash
+          cp crash-* $RPC_PAST_TEST_DIR/silkworm-fuzzer/crashes/
+
           # Resume the Erigon instance dedicated to db maintenance
           python3 $ERIGON_QA_PATH/test_system/db-producer/resume_production.py || true
 
@@ -110,14 +95,4 @@ jobs:
           sudo update-alternatives --remove c++ /usr/bin/clang++
           sudo rm -f /usr/bin/clang
           sudo rm -f /usr/bin/clang++
-
-      - name: Action for Success
-        if: steps.test_step.outputs.TEST_RESULT == 'success'
-        run: echo "::notice::Tests completed successfully"
-
-      - name: Action for Failure
-        if: steps.test_step.outputs.TEST_RESULT != 'success'
-        run: |
-          echo "::error::Error detected during tests"
-          exit 1
 

--- a/.github/workflows/rpc-performance-tests.yml
+++ b/.github/workflows/rpc-performance-tests.yml
@@ -3,7 +3,7 @@ name: QA - RPC Performance Tests
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * *'  # Run every day at 00:00 AM UTC
+    - cron: '0 0 * * 1-6'  # Runs every day from Monday to Saturday at 00:00 AM UTC
 
 jobs:
   performance-test-suite:

--- a/cmake/toolchain/clang_libcxx.cmake
+++ b/cmake/toolchain/clang_libcxx.cmake
@@ -16,6 +16,8 @@
 
 include(${CMAKE_CURRENT_LIST_DIR}/cxx20.cmake)
 
+message(STATUS "CMAKE_CXX_COMPILER_ID: ${CMAKE_CXX_COMPILER_ID}")
+
 # coroutines support
 set(CMAKE_CXX_FLAGS
     "${CMAKE_CXX_FLAGS} -stdlib=libc++"

--- a/cmake/toolchain/clang_libcxx.cmake
+++ b/cmake/toolchain/clang_libcxx.cmake
@@ -16,8 +16,6 @@
 
 include(${CMAKE_CURRENT_LIST_DIR}/cxx20.cmake)
 
-message(STATUS "CMAKE_CXX_COMPILER_ID: ${CMAKE_CXX_COMPILER_ID}")
-
 # coroutines support
 set(CMAKE_CXX_FLAGS
     "${CMAKE_CXX_FLAGS} -stdlib=libc++"


### PR DESCRIPTION
This PR enables long-running fuzzer tests on GitHub Actions:
- Scheduled to run on Sundays for 24 hrs
- The workflow does minimal changes to the system to enable the Clang compilator, but these changes are reverted in the tear-down step
- Saves corpus to be reused by the next workflow run