### PR TITLE
capi: fix C99 compilation

### DIFF
--- a/cmd/capi/CMakeLists.txt
+++ b/cmd/capi/CMakeLists.txt
@@ -16,6 +16,7 @@
 
 find_package(Boost REQUIRED headers)
 
+# Target 'execute' is used to exercise the Silkworm C API library even if using C++ main
 add_executable(execute execute.cpp)
 
 set(PRIVATE_LIBS
@@ -29,3 +30,7 @@ set(PRIVATE_LIBS
 )
 
 target_link_libraries(execute PRIVATE ${PRIVATE_LIBS})
+
+# Target 'capi_main' is used to check that Silkworm C API header passes pure C compilation
+add_executable(capi_main main.c)
+target_link_libraries(capi_main PRIVATE silkworm_capi)

--- a/cmd/capi/main.c
+++ b/cmd/capi/main.c
@@ -1,0 +1,32 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include <stdio.h>
+
+#include <silkworm/capi/silkworm.h>
+
+int main(int argc, char* argv[]) {
+    (void)argc, (void)argv;
+#if defined(_MSC_VER)
+    printf("MSVC version: %d\n", _MSC_FULL_VER);
+#elif defined(__GNUC__) && !defined(__clang__)
+    printf("gcc version: %d.%d.%d\n", __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__);
+#else
+    printf("AppleClang version: %d.%d.%d\n", __clang_major__, __clang_minor__, __clang_patchlevel__);
+#endif
+    printf("C API silkworm_libmdbx_version: %s\n", silkworm_libmdbx_version());
+    return 0;
+}

--- a/silkworm/capi/silkworm.h
+++ b/silkworm/capi/silkworm.h
@@ -99,8 +99,8 @@ struct SilkwormChainSnapshot {
 #define SILKWORM_GIT_VERSION_SIZE 32
 
 //! Silkworm library logging level
-//! \note using anonymous enum seems the only way to obtain enum type in Cgo generated code
-typedef enum : uint8_t {
+//! \note using anonymous C99 enum is the most portable way to pass enum in Cgo
+typedef enum {  // NOLINT(performance-enum-size)
     SILKWORM_LOG_NONE,
     SILKWORM_LOG_CRITICAL,
     SILKWORM_LOG_ERROR,
@@ -153,7 +153,7 @@ SILKWORM_EXPORT int silkworm_add_snapshot(SilkwormHandle handle, struct Silkworm
  * \brief Get libmdbx version for compatibility checks.
  * \return A string in git describe format.
  */
-SILKWORM_EXPORT const char* silkworm_libmdbx_version() SILKWORM_NOEXCEPT;
+SILKWORM_EXPORT const char* silkworm_libmdbx_version(void) SILKWORM_NOEXCEPT;
 
 #define SILKWORM_RPC_SETTINGS_HOST_SIZE 128
 #define SILKWORM_RPC_SETTINGS_API_NAMESPACE_SPEC_SIZE 256


### PR DESCRIPTION
This PR fixes the pure C compilation of our C API header with strict compiler options in order to fix the errors surfaced in [Erigon CI](https://github.com/ledgerwatch/erigon/actions/runs/8760788201/job/24046312870?pr=10002).

A new pure C target named `capi_main` is also added to our build, so that we can hopefully gain early error detection and prevent any unexpected error at the end of the Erigon++ toolchain.