### PR TITLE
rpcdaemon: improve JWT handling in HTTP connection

### DIFF
--- a/silkworm/rpc/common/constants.hpp
+++ b/silkworm/rpc/common/constants.hpp
@@ -44,6 +44,4 @@ inline constexpr const char* kDefaultEth1ApiSpec{"admin,debug,eth,net,parity,eri
 inline constexpr const char* kDefaultEth2ApiSpec{"engine,eth"};
 inline constexpr const std::chrono::milliseconds kDefaultTimeout{10000};
 
-inline constexpr const std::size_t kHttpIncomingBufferSize{8192};
-
 }  // namespace silkworm

--- a/silkworm/rpc/http/connection.hpp
+++ b/silkworm/rpc/http/connection.hpp
@@ -39,6 +39,8 @@
 
 namespace silkworm::rpc::http {
 
+using RequestWithStringBody = boost::beast::http::request<boost::beast::http::string_body>;
+
 //! Represents a single connection from a client.
 class Connection : public StreamWriter {
   public:
@@ -65,23 +67,23 @@ class Connection : public StreamWriter {
     Task<void> close_stream() override;
     Task<std::size_t> write(std::string_view content, bool last) override;
 
-  private:
+  protected:
     //! Start the asynchronous read loop for the connection
     Task<void> read_loop();
 
     using AuthorizationError = std::string;
     using AuthorizationResult = tl::expected<void, AuthorizationError>;
-    AuthorizationResult is_request_authorized(const boost::beast::http::request<boost::beast::http::string_body>& req);
+    AuthorizationResult is_request_authorized(const RequestWithStringBody& req);
 
-    Task<void> handle_request(const boost::beast::http::request<boost::beast::http::string_body>& req);
-    Task<void> handle_actual_request(const boost::beast::http::request<boost::beast::http::string_body>& req);
-    Task<void> handle_preflight(const boost::beast::http::request<boost::beast::http::string_body>& req);
+    Task<void> handle_request(const RequestWithStringBody& req);
+    Task<void> handle_actual_request(const RequestWithStringBody& req);
+    Task<void> handle_preflight(const RequestWithStringBody& req);
 
     bool is_origin_allowed(const std::vector<std::string>& allowed_origins, const std::string& origin);
     bool is_method_allowed(boost::beast::http::verb method);
     bool is_accepted_content_type(const std::string& content_type);
 
-    Task<void> do_upgrade(const boost::beast::http::request<boost::beast::http::string_body>& req);
+    Task<void> do_upgrade(const RequestWithStringBody& req);
 
     template <class Body>
     void set_cors(boost::beast::http::response<Body>& res);

--- a/silkworm/rpc/http/connection_test.cpp
+++ b/silkworm/rpc/http/connection_test.cpp
@@ -18,10 +18,11 @@
 
 #include <boost/asio/thread_pool.hpp>
 #include <catch2/catch.hpp>
+#include <jwt-cpp/jwt.h>
+#include <jwt-cpp/traits/nlohmann-json/defaults.h>
 
 #include <silkworm/infra/grpc/client/client_context_pool.hpp>
 #include <silkworm/infra/test_util/log.hpp>
-#include <silkworm/rpc/commands/rpc_api_table.hpp>
 
 namespace silkworm::rpc::http {
 
@@ -30,21 +31,158 @@ namespace silkworm::rpc::http {
 // - write of size 1 thread T8 'grpc_global_tim' created by main thread
 // - previous write of size 1 by main thread
 #ifndef SILKWORM_SANITIZE
+
+class Connection_ForTest : public Connection {
+  public:
+    using Connection::Connection;
+    using Connection::is_request_authorized;
+};
+
 TEST_CASE("connection creation", "[rpc][http][connection]") {
     test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
 
     SECTION("field initialization") {
-        ClientContextPool context_pool{1};
-        context_pool.start();
-        boost::asio::thread_pool workers;
+        //ClientContextPool context_pool{1};
+        //context_pool.start();
+        //boost::asio::thread_pool workers;
         // Uncommenting the following lines you got stuck into llvm-cov problem:
         // error: cmd/unit_test: Failed to load coverage: Malformed coverage data
         /*
         commands::RpcApiTable handler_table{""};
         Connection conn{context_pool.next_context(), workers, handler_table};
         */
-        context_pool.stop();
-        context_pool.join();
+        //context_pool.stop();
+        //context_pool.join();
+
+        boost::asio::io_context ioc;
+        boost::asio::ip::tcp::socket socket{ioc};
+        socket.open(boost::asio::ip::tcp::v4());
+        RequestHandlerFactory handler_factory = [](auto*) -> RequestHandlerPtr { return nullptr; };
+        std::vector<std::string> allowed_origins;
+        std::optional<std::string> jwt_secret;
+        boost::asio::thread_pool workers;
+        Connection_ForTest conn{std::move(socket),
+                                handler_factory,
+                                allowed_origins,
+                                std::move(jwt_secret),
+                                false,
+                                false,
+                                false,
+                                workers};
+
+        RequestWithStringBody req;
+        const auto auth_result = conn.is_request_authorized(req);
+        CHECK(!auth_result);
+    }
+}
+
+static constexpr auto kSampleJWTKey{
+    "NTNv7j0TuYARvmNMmWXo6fKvM4o6nv/aUi9ryX38ZH+L1bkrnD1ObOQ8JAUmHCBq7Iy7otZcyAagBLHVKvvYaIpmMuxmARQ97jUVG16Jkpkp1wXO"
+    "PsrF9zwew6TpczyHkHgX5EuLg2MeBuiT/qJACs1J0apruOOJCg/gOtkjB4c="sv};
+static constexpr auto kSampleJWTBearer{
+    "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUs"
+    "ImlhdCI6MTcxMzUxNDQ3MCwiZXhwIjoxNzEzNTE4MDcwfQ.IBKIdE8Bcto9cwGSkr6mqylBLvfcPZZyDOyZMWYtEaQ"sv};
+
+static std::string create_and_sign_jwt_token(auto&& jwt_secret, bool include_issued_at = true) {
+    auto token_builder{jwt::create()};
+    if (include_issued_at) {
+        token_builder.set_issued_at(jwt::date::clock::now());
+    }
+    return token_builder.sign(jwt::algorithm::hs256{std::forward<decltype(jwt_secret)>(jwt_secret)});
+}
+
+static RequestWithStringBody create_request_with_authorization(std::string_view auth_value) {
+    RequestWithStringBody req;
+    req.insert(boost::beast::http::field::authorization, auth_value);
+    return req;
+}
+
+static RequestWithStringBody create_request_with_bearer_token(const std::string& jwt_token) {
+    return create_request_with_authorization("Bearer " + jwt_token);
+}
+
+TEST_CASE("is_request_authorized", "[rpc][http][connection]") {
+    test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
+    boost::asio::io_context ioc;
+    RequestHandlerFactory handler_factory = [](auto*) -> RequestHandlerPtr { return nullptr; };
+    std::vector<std::string> allowed_origins;
+    boost::asio::thread_pool workers;
+    auto make_connection = [&](auto&& j) -> Connection_ForTest {
+        boost::asio::ip::tcp::socket socket{ioc};
+        socket.open(boost::asio::ip::tcp::v4());
+        return {std::move(socket), handler_factory, allowed_origins, std::forward<decltype(j)>(j), false, false, false, workers};
+    };
+    std::optional<std::string> jwt_secret{kSampleJWTKey};
+    // Pass the expected JWT secret to the HTTP connection
+    Connection_ForTest connection{make_connection(*jwt_secret)};
+
+    SECTION("no HTTP Authorization header") {
+        const auto auth_result{connection.is_request_authorized(RequestWithStringBody{})};
+        CHECK(!auth_result);
+        CHECK(auth_result.error() == "missing token");
+    }
+
+    SECTION("empty HTTP Authorization header") {
+        RequestWithStringBody req;
+        req.insert(boost::beast::http::field::authorization, "");
+        const auto auth_result{connection.is_request_authorized(req)};
+        CHECK(!auth_result);
+        CHECK(auth_result.error() == "missing token");
+    }
+
+    SECTION("invalid Bearer token") {
+        RequestWithStringBody req{create_request_with_authorization("Bear")};
+        const auto auth_result{connection.is_request_authorized(req)};
+        CHECK(!auth_result);
+        CHECK(auth_result.error() == "missing token");
+    }
+
+    SECTION("invalid JWT token") {
+        RequestWithStringBody req = create_request_with_bearer_token("INVALID_TOKEN");
+        const auto auth_result{connection.is_request_authorized(req)};
+        CHECK(!auth_result);
+        CHECK(auth_result.error() == "invalid token");
+    }
+
+    SECTION("invalid JWT issued-at claim") {
+        // Create the HTTP request using a valid-but-too-old Bearer token
+        RequestWithStringBody req = create_request_with_authorization(kSampleJWTBearer);
+
+        const auto auth_result{connection.is_request_authorized(req)};
+        CHECK(!auth_result);
+        CHECK(auth_result.error() == "invalid issued-at claim");
+    }
+
+    SECTION("invalid JWT signature") {
+        // Create *now* a new JWT token and sign it using `another_jwt_secret`
+        std::optional<std::string> another_jwt_secret{"00112233"};
+        const auto jwt_token{create_and_sign_jwt_token(*another_jwt_secret)};
+        // Create the HTTP request using the JWT token
+        RequestWithStringBody req = create_request_with_bearer_token(jwt_token);
+
+        const auto auth_result{connection.is_request_authorized(req)};
+        CHECK(!auth_result);
+        CHECK(auth_result.error() == "invalid signature");
+    }
+
+    SECTION("missing JWT issued-at claim") {
+        // Create *now* a new JWT token w/o issued-at claim and sign it using the same `jwt_secret`
+        const auto jwt_token{create_and_sign_jwt_token(*jwt_secret, /*include_issued_at=*/false)};
+        // Create the HTTP request using the JWT token
+        RequestWithStringBody req = create_request_with_bearer_token(jwt_token);
+
+        const auto auth_result{connection.is_request_authorized(req)};
+        CHECK(!auth_result);
+        CHECK(auth_result.error() == "missing issued-at claim");
+    }
+
+    SECTION("valid JWT token") {
+        // Create *now* a new JWT token and sign it using the same `jwt_secret`
+        const auto jwt_token{create_and_sign_jwt_token(*jwt_secret)};
+        // Create the HTTP request using the JWT token
+        RequestWithStringBody req = create_request_with_bearer_token(jwt_token);
+
+        CHECK(connection.is_request_authorized(req));
     }
 }
 #endif  // SILKWORM_SANITIZE

--- a/silkworm/rpc/http/connection_test.cpp
+++ b/silkworm/rpc/http/connection_test.cpp
@@ -42,18 +42,6 @@ TEST_CASE("connection creation", "[rpc][http][connection]") {
     test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
 
     SECTION("field initialization") {
-        // ClientContextPool context_pool{1};
-        // context_pool.start();
-        // boost::asio::thread_pool workers;
-        //  Uncommenting the following lines you got stuck into llvm-cov problem:
-        //  error: cmd/unit_test: Failed to load coverage: Malformed coverage data
-        /*
-        commands::RpcApiTable handler_table{""};
-        Connection conn{context_pool.next_context(), workers, handler_table};
-        */
-        // context_pool.stop();
-        // context_pool.join();
-
         boost::asio::io_context ioc;
         boost::asio::ip::tcp::socket socket{ioc};
         socket.open(boost::asio::ip::tcp::v4());

--- a/silkworm/rpc/http/connection_test.cpp
+++ b/silkworm/rpc/http/connection_test.cpp
@@ -42,17 +42,17 @@ TEST_CASE("connection creation", "[rpc][http][connection]") {
     test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
 
     SECTION("field initialization") {
-        //ClientContextPool context_pool{1};
-        //context_pool.start();
-        //boost::asio::thread_pool workers;
-        // Uncommenting the following lines you got stuck into llvm-cov problem:
-        // error: cmd/unit_test: Failed to load coverage: Malformed coverage data
+        // ClientContextPool context_pool{1};
+        // context_pool.start();
+        // boost::asio::thread_pool workers;
+        //  Uncommenting the following lines you got stuck into llvm-cov problem:
+        //  error: cmd/unit_test: Failed to load coverage: Malformed coverage data
         /*
         commands::RpcApiTable handler_table{""};
         Connection conn{context_pool.next_context(), workers, handler_table};
         */
-        //context_pool.stop();
-        //context_pool.join();
+        // context_pool.stop();
+        // context_pool.join();
 
         boost::asio::io_context ioc;
         boost::asio::ip::tcp::socket socket{ioc};

--- a/silkworm/rpc/http/connection_test.cpp
+++ b/silkworm/rpc/http/connection_test.cpp
@@ -49,18 +49,14 @@ TEST_CASE("connection creation", "[rpc][http][connection]") {
         std::vector<std::string> allowed_origins;
         std::optional<std::string> jwt_secret;
         boost::asio::thread_pool workers;
-        Connection_ForTest conn{std::move(socket),
-                                handler_factory,
-                                allowed_origins,
-                                std::move(jwt_secret),
-                                false,
-                                false,
-                                false,
-                                workers};
-
-        RequestWithStringBody req;
-        const auto auth_result = conn.is_request_authorized(req);
-        CHECK(!auth_result);
+        CHECK_NOTHROW(Connection_ForTest{std::move(socket),
+                                         handler_factory,
+                                         allowed_origins,
+                                         std::move(jwt_secret),
+                                         false,
+                                         false,
+                                         false,
+                                         workers});
     }
 }
 


### PR DESCRIPTION
This PR refines the JSON Web token (JWT) support in HTTP connection by:

- adding unit tests
- implementing the optional check for `issued-at` claim [as specified in Execution APIs](https://github.com/ethereum/execution-apis/blob/main/src/engine/authentication.md#jwt-claims)
- fixing exception handling
- improving code readability (naming, comments)

*Extras*

Remove unused HTTP constant.