### PR TITLE
ci: remove Fuzzer test runner from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -461,16 +461,3 @@ workflows:
           name: linux-clang-fuzzer
       - linux-clang-tidy
       - linux-wasm-build
-  
-  fuzzer:
-    triggers:
-      - schedule:
-          cron: "0 0 * * 6"
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
-      - linux-clang-fuzzer:
-          name: linux-clang-run-fuzzer
-          run_tests: true


### PR DESCRIPTION
This PR removes the periodic execution of Fuzzer tests from CircleCI, given that we moved it to Github Action self-hosted runner.