### PR TITLE
db: fix block number values in HeaderNumber table after snapshot sync

### DIFF
--- a/cmd/dev/snapshots.cpp
+++ b/cmd/dev/snapshots.cpp
@@ -709,7 +709,7 @@ void lookup_transaction(const SnapSettings& settings) {
 void sync(const SnapSettings& settings) {
     std::chrono::time_point start{std::chrono::steady_clock::now()};
     SnapshotRepository snapshot_repository{settings};
-    node::SnapshotSync snapshot_sync{&snapshot_repository, kMainnetConfig};
+    db::SnapshotSync snapshot_sync{&snapshot_repository, kMainnetConfig};
     std::vector<std::string> snapshot_file_names;
     if (settings.snapshot_file_name) {
         snapshot_file_names.push_back(*settings.snapshot_file_name);

--- a/silkworm/db/snapshot_sync.cpp
+++ b/silkworm/db/snapshot_sync.cpp
@@ -32,7 +32,7 @@
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/concurrency/thread_pool.hpp>
 
-namespace silkworm::node {
+namespace silkworm::db {
 
 //! Interval between successive checks for either completion or stop requested
 static constexpr std::chrono::seconds kCheckCompletionInterval{1};
@@ -253,7 +253,7 @@ void SnapshotSync::update_block_headers(db::RWTxn& txn, BlockNum max_block_avail
 
         // Collect entries for later loading kHeaderNumbers table
         Bytes block_hash_bytes{block_hash.bytes, kHashLength};
-        Bytes encoded_block_number{sizeof(uint64_t), '\0'};
+        Bytes encoded_block_number(sizeof(BlockNum), '\0');
         endian::store_big_u64(encoded_block_number.data(), block_number);
         hash2bn_collector.collect({std::move(block_hash_bytes), std::move(encoded_block_number)});
 
@@ -334,4 +334,4 @@ void SnapshotSync::update_block_senders(db::RWTxn& txn, BlockNum max_block_avail
     SILK_INFO << "SnapshotSync: database Senders stage progress updated [" << stage_progress << "]";
 }
 
-}  // namespace silkworm::node
+}  // namespace silkworm::db

--- a/silkworm/db/snapshot_sync.hpp
+++ b/silkworm/db/snapshot_sync.hpp
@@ -27,7 +27,7 @@
 #include <silkworm/db/snapshots/settings.hpp>
 #include <silkworm/infra/concurrency/stoppable.hpp>
 
-namespace silkworm::node {
+namespace silkworm::db {
 
 class SnapshotSync : public Stoppable {
   public:
@@ -54,4 +54,4 @@ class SnapshotSync : public Stoppable {
     std::thread client_thread_;
 };
 
-}  // namespace silkworm::node
+}  // namespace silkworm::db

--- a/silkworm/db/snapshot_sync.hpp
+++ b/silkworm/db/snapshot_sync.hpp
@@ -39,7 +39,7 @@ class SnapshotSync : public Stoppable {
     bool download_and_index_snapshots(db::RWTxn& txn);
     bool download_snapshots(const std::vector<std::string>& snapshot_file_names);
 
-  private:
+  protected:
     void build_missing_indexes();
     void update_database(db::RWTxn& txn, BlockNum max_block_available);
     void update_block_headers(db::RWTxn& txn, BlockNum max_block_available);

--- a/silkworm/db/snapshot_sync_test.cpp
+++ b/silkworm/db/snapshot_sync_test.cpp
@@ -21,9 +21,9 @@
 #include <silkworm/core/chain/config.hpp>
 #include <silkworm/db/snapshots/body_index.hpp>
 #include <silkworm/db/snapshots/header_index.hpp>
+#include <silkworm/db/snapshots/test_util/common.hpp>
 #include <silkworm/db/snapshots/txn_index.hpp>
 #include <silkworm/db/snapshots/txn_to_block_index.hpp>
-#include <silkworm/db/snapshots/test_util/common.hpp>
 #include <silkworm/db/test_util/temp_chain_data.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/test_util/log.hpp>
@@ -84,13 +84,13 @@ TEST_CASE("SnapshotSync::download_and_index_snapshots", "[db][snapshot][sync]") 
 }
 
 struct SnapshotSync_ForTest : public SnapshotSync {
-    using SnapshotSync::SnapshotSync;
     using SnapshotSync::build_missing_indexes;
-    using SnapshotSync::update_database;
-    using SnapshotSync::update_block_headers;
+    using SnapshotSync::SnapshotSync;
     using SnapshotSync::update_block_bodies;
     using SnapshotSync::update_block_hashes;
+    using SnapshotSync::update_block_headers;
     using SnapshotSync::update_block_senders;
+    using SnapshotSync::update_database;
 };
 
 TEST_CASE("SnapshotSync::update_block_headers", "[db][snapshot][sync]") {

--- a/silkworm/db/snapshot_sync_test.cpp
+++ b/silkworm/db/snapshot_sync_test.cpp
@@ -24,18 +24,19 @@
 #include <silkworm/infra/test_util/log.hpp>
 #include <silkworm/infra/test_util/temporary_file.hpp>
 
-namespace silkworm::node {
+namespace silkworm::db {
 
 using namespace snapshots;
+using namespace silkworm::test_util;
 
 TEST_CASE("SnapshotSync::SnapshotSync", "[silkworm][snapshot][sync]") {
-    test_util::SetLogVerbosityGuard guard{log::Level::kNone};
+    SetLogVerbosityGuard guard{log::Level::kNone};
     SnapshotRepository repository{SnapshotSettings{}};
     CHECK_NOTHROW(SnapshotSync{&repository, kMainnetConfig});
 }
 
 TEST_CASE("SnapshotSync::download_and_index_snapshots", "[silkworm][snapshot][sync]") {
-    test_util::SetLogVerbosityGuard guard{log::Level::kNone};
+    SetLogVerbosityGuard guard{log::Level::kNone};
     db::test_util::TempChainData context;
     const auto tmp_dir{TemporaryDirectory::get_unique_temporary_path()};
     bittorrent::BitTorrentSettings bittorrent_settings{
@@ -77,4 +78,4 @@ TEST_CASE("SnapshotSync::download_and_index_snapshots", "[silkworm][snapshot][sy
     }
 }
 
-}  // namespace silkworm::node
+}  // namespace silkworm::db

--- a/silkworm/db/snapshot_sync_test.cpp
+++ b/silkworm/db/snapshot_sync_test.cpp
@@ -19,6 +19,11 @@
 #include <catch2/catch.hpp>
 
 #include <silkworm/core/chain/config.hpp>
+#include <silkworm/db/snapshots/body_index.hpp>
+#include <silkworm/db/snapshots/header_index.hpp>
+#include <silkworm/db/snapshots/txn_index.hpp>
+#include <silkworm/db/snapshots/txn_to_block_index.hpp>
+#include <silkworm/db/snapshots/test_util/common.hpp>
 #include <silkworm/db/test_util/temp_chain_data.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/test_util/log.hpp>
@@ -29,13 +34,13 @@ namespace silkworm::db {
 using namespace snapshots;
 using namespace silkworm::test_util;
 
-TEST_CASE("SnapshotSync::SnapshotSync", "[silkworm][snapshot][sync]") {
+TEST_CASE("SnapshotSync::SnapshotSync", "[db][snapshot][sync]") {
     SetLogVerbosityGuard guard{log::Level::kNone};
     SnapshotRepository repository{SnapshotSettings{}};
     CHECK_NOTHROW(SnapshotSync{&repository, kMainnetConfig});
 }
 
-TEST_CASE("SnapshotSync::download_and_index_snapshots", "[silkworm][snapshot][sync]") {
+TEST_CASE("SnapshotSync::download_and_index_snapshots", "[db][snapshot][sync]") {
     SetLogVerbosityGuard guard{log::Level::kNone};
     db::test_util::TempChainData context;
     const auto tmp_dir{TemporaryDirectory::get_unique_temporary_path()};
@@ -76,6 +81,79 @@ TEST_CASE("SnapshotSync::download_and_index_snapshots", "[silkworm][snapshot][sy
         SnapshotSync sync{&repository, kMainnetConfig};
         CHECK(sync.download_and_index_snapshots(context.rw_txn()));
     }
+}
+
+struct SnapshotSync_ForTest : public SnapshotSync {
+    using SnapshotSync::SnapshotSync;
+    using SnapshotSync::build_missing_indexes;
+    using SnapshotSync::update_database;
+    using SnapshotSync::update_block_headers;
+    using SnapshotSync::update_block_bodies;
+    using SnapshotSync::update_block_hashes;
+    using SnapshotSync::update_block_senders;
+};
+
+TEST_CASE("SnapshotSync::update_block_headers", "[db][snapshot][sync]") {
+    SetLogVerbosityGuard guard{log::Level::kNone};
+    TemporaryDirectory tmp_dir;
+    SnapshotSettings settings{tmp_dir.path()};
+    SnapshotRepository repository{settings};
+    db::test_util::TempChainData tmp_db;
+
+    // Create a sample Header snapshot+index
+    snapshots::test_util::SampleHeaderSnapshotFile header_snapshot_file{tmp_dir.path()};
+    snapshots::test_util::SampleHeaderSnapshotPath header_snapshot_path{header_snapshot_file.path()};
+    snapshots::Snapshot header_snapshot{header_snapshot_path};
+    REQUIRE_NOTHROW(snapshots::HeaderIndex::make(header_snapshot_path).build());
+    snapshots::Index idx_header_hash{header_snapshot_path.index_file()};
+
+    // Create a sample Body snapshot+index
+    snapshots::test_util::SampleBodySnapshotFile body_snapshot_file{tmp_dir.path()};
+    snapshots::test_util::SampleBodySnapshotPath body_snapshot_path{body_snapshot_file.path()};
+    snapshots::Snapshot body_snapshot{body_snapshot_path};
+    REQUIRE_NOTHROW(snapshots::BodyIndex::make(body_snapshot_path).build());
+    snapshots::Index idx_body_number{body_snapshot_path.index_file()};
+
+    // Create a sample Transaction snapshot+indexes
+    snapshots::test_util::SampleTransactionSnapshotFile txn_snapshot_file{tmp_dir.path()};
+    snapshots::test_util::SampleTransactionSnapshotPath txn_snapshot_path{txn_snapshot_file.path()};
+    snapshots::Snapshot txn_snapshot{txn_snapshot_path};
+    REQUIRE_NOTHROW(snapshots::TransactionIndex::make(body_snapshot_path, txn_snapshot_path).build());
+    REQUIRE_NOTHROW(snapshots::TransactionToBlockIndex::make(body_snapshot_path, txn_snapshot_path).build());
+    snapshots::Index idx_txn_hash{txn_snapshot_path.index_file_for_type(snapshots::SnapshotType::transactions)};
+    snapshots::Index idx_txn_hash_2_block{txn_snapshot_path.index_file_for_type(snapshots::SnapshotType::transactions_to_block)};
+
+    // Add a sample Snapshot bundle to the repository
+    snapshots::SnapshotBundle bundle{
+        .header_snapshot = std::move(header_snapshot),
+        .idx_header_hash = std::move(idx_header_hash),
+
+        .body_snapshot = std::move(body_snapshot),
+        .idx_body_number = std::move(idx_body_number),
+
+        .txn_snapshot = std::move(txn_snapshot),
+        .idx_txn_hash = std::move(idx_txn_hash),
+        .idx_txn_hash_2_block = std::move(idx_txn_hash_2_block),
+    };
+    repository.add_snapshot_bundle(std::move(bundle));
+
+    // Update the block headers in the database according to the repository content
+    SnapshotSync_ForTest snapshot_sync{&repository, kMainnetConfig};
+    CHECK_NOTHROW(snapshot_sync.update_block_headers(tmp_db.rw_txn(), repository.max_block_available()));
+
+    // Expect that the database is correctly populated (N.B. cannot check Difficulty table because of sample snapshots)
+    auto block_is_in_header_numbers = [&](Hash block_hash, BlockNum expected_block_number) {
+        const auto block_number = db::read_block_number(tmp_db.rw_txn(), block_hash);
+        return block_number == expected_block_number;
+    };
+    auto block_is_canonical = [&](BlockNum block_number, Hash expected_block_hash) {
+        const auto canonical_block_hash = db::read_canonical_hash(tmp_db.rw_txn(), block_number);
+        return canonical_block_hash == expected_block_hash;
+    };
+
+    const Hash block_1500013_hash{0xbef48d7de01f2d7ea1a7e4d1ed401f73d6d0257a364f6770b25ba51a123ac35f_bytes32};
+    CHECK(block_is_in_header_numbers(block_1500013_hash, 1'500'013));
+    CHECK(block_is_canonical(1'500'013, block_1500013_hash));
 }
 
 }  // namespace silkworm::db

--- a/silkworm/node/node.cpp
+++ b/silkworm/node/node.cpp
@@ -109,7 +109,7 @@ void NodeImpl::setup_snapshots() {
         db::RWTxnManaged rw_txn{chaindata_db_};
 
         // Snapshot sync - download chain from peers using snapshot files
-        SnapshotSync snapshot_sync{&snapshot_repository_, settings_.chain_config.value()};
+        db::SnapshotSync snapshot_sync{&snapshot_repository_, settings_.chain_config.value()};
         snapshot_sync.download_and_index_snapshots(rw_txn);
 
         rw_txn.commit_and_stop();


### PR DESCRIPTION
This PR fixes a [wrong initialisation](https://quuxplusone.github.io/blog/2019/02/18/knightmare-of-initialization/) of the encoding buffer for block numbers, used to fill the content of `HeaderNumber` table at the end of snapshot synchronisation process.

*Extras*
Change namespace for `SnapshotSync` to `silkworm::db`