### PR TITLE
db: missing length errors in access layer

### DIFF
--- a/silkworm/db/access_layer_test.cpp
+++ b/silkworm/db/access_layer_test.cpp
@@ -900,8 +900,8 @@ TEST_CASE("write and read body w/ withdrawals", "[db][access_layer]") {
     CHECK(body_out == body_in);
 }
 
-using testing::InvokeWithoutArgs;
 using testing::_;
+using testing::InvokeWithoutArgs;
 
 static void expect_mock_ro_cursor(test_util::MockROTxn& mock_ro_txn, test_util::MockROCursor* mock_ro_cursor) {
     EXPECT_CALL(mock_ro_txn, ro_cursor(_))

--- a/silkworm/db/access_layer_test.cpp
+++ b/silkworm/db/access_layer_test.cpp
@@ -920,13 +920,15 @@ struct AccessLayerTest {
     test_util::MockROCursor* mock_ro_cursor = new test_util::MockROCursor;
 };
 
-static const Hash kBlockHash;  // empty but it doesn't matter for the tests
-static const ::mdbx::slice kValidBlockHashSlice{kBlockHash.bytes, kHashLength};
-static const ::mdbx::slice kInvalidBlockHashSlice{kBlockHash.bytes, 30};
+static constexpr Hash kBlockHash;  // empty but it doesn't matter for the tests
+static constexpr ::mdbx::slice kValidBlockHashSlice{kBlockHash.bytes, kHashLength};
+static constexpr ::mdbx::slice kInvalidBlockHashSlice{kBlockHash.bytes, 30};
+static const Bytes kValidEncodedBlockNumber{*from_hex("0000000000000002")};
+static const Bytes kInvalidEncodedBlockNumber{*from_hex("0002")};
 
 TEST_CASE_METHOD(AccessLayerTest, "read_block_number", "[db][access_layer]") {
-    const ::mdbx::slice valid_block_number_slice{*from_hex("0000000000000002")};
-    const ::mdbx::slice invalid_block_number_slice{*from_hex("0002")};
+    const ::mdbx::slice valid_block_number_slice{kValidEncodedBlockNumber};
+    const ::mdbx::slice invalid_block_number_slice{kInvalidEncodedBlockNumber};
 
     SECTION("valid block number") {
         EXPECT_CALL(*mock_ro_cursor, find(kValidBlockHashSlice, false))
@@ -952,12 +954,12 @@ TEST_CASE_METHOD(AccessLayerTest, "read_block_number", "[db][access_layer]") {
 }
 
 TEST_CASE_METHOD(AccessLayerTest, "read_canonical_head", "[db][access_layer]") {
-    const ::mdbx::slice valid_block_number_slice{*from_hex("0000000000000002")};
-    const ::mdbx::slice invalid_block_number_slice{*from_hex("0002")};
+    const ::mdbx::slice valid_block_number_slice{kValidEncodedBlockNumber};
+    const ::mdbx::slice invalid_block_number_slice{kInvalidEncodedBlockNumber};
 
     SECTION("valid canonical head") {
         EXPECT_CALL(*mock_ro_cursor, to_last())
-            .WillOnce(InvokeWithoutArgs([&]() mutable -> CursorResult {
+            .WillOnce(InvokeWithoutArgs([=]() mutable -> CursorResult {
                 return CursorResult{valid_block_number_slice, kValidBlockHashSlice, /*.done=*/true};
             }));
         CHECK(read_canonical_head(mock_ro_txn) == std::tuple<BlockNum, Hash>{2, kBlockHash});
@@ -971,14 +973,14 @@ TEST_CASE_METHOD(AccessLayerTest, "read_canonical_head", "[db][access_layer]") {
     }
     SECTION("invalid key size") {
         EXPECT_CALL(*mock_ro_cursor, to_last())
-            .WillOnce(InvokeWithoutArgs([&]() mutable -> CursorResult {
+            .WillOnce(InvokeWithoutArgs([=]() mutable -> CursorResult {
                 return CursorResult{invalid_block_number_slice, kValidBlockHashSlice, /*.done=*/true};
             }));
         CHECK_THROWS_AS(read_canonical_head(mock_ro_txn), std::length_error);
     }
     SECTION("invalid value size") {
         EXPECT_CALL(*mock_ro_cursor, to_last())
-            .WillOnce(InvokeWithoutArgs([&]() mutable -> CursorResult {
+            .WillOnce(InvokeWithoutArgs([=]() mutable -> CursorResult {
                 return CursorResult{valid_block_number_slice, kInvalidBlockHashSlice, /*.done=*/true};
             }));
         CHECK_THROWS_AS(read_canonical_head(mock_ro_txn), std::length_error);
@@ -987,11 +989,12 @@ TEST_CASE_METHOD(AccessLayerTest, "read_canonical_head", "[db][access_layer]") {
 
 TEST_CASE_METHOD(AccessLayerTest, "read_canonical_header_hash", "[db][access_layer]") {
     BlockNum block_number{2};
-    const ::mdbx::slice block_key_slice{to_slice(block_key(block_number))};
+    const auto block_number_key{block_key(block_number)};
+    const ::mdbx::slice block_key_slice{to_slice(block_number_key)};
 
     SECTION("valid canonical header hash") {
         EXPECT_CALL(*mock_ro_cursor, find(block_key_slice, false))
-            .WillOnce(InvokeWithoutArgs([&]() mutable -> CursorResult {
+            .WillOnce(InvokeWithoutArgs([=]() mutable -> CursorResult {
                 return CursorResult{block_key_slice, kValidBlockHashSlice, /*.done=*/true};
             }));
         CHECK(read_canonical_header_hash(mock_ro_txn, block_number) == kBlockHash);
@@ -1005,7 +1008,7 @@ TEST_CASE_METHOD(AccessLayerTest, "read_canonical_header_hash", "[db][access_lay
     }
     SECTION("invalid value size") {
         EXPECT_CALL(*mock_ro_cursor, find(block_key_slice, false))
-            .WillOnce(InvokeWithoutArgs([&]() mutable -> CursorResult {
+            .WillOnce(InvokeWithoutArgs([=]() mutable -> CursorResult {
                 return CursorResult{block_key_slice, kInvalidBlockHashSlice, /*.done=*/true};
             }));
         CHECK_THROWS_AS(read_canonical_header_hash(mock_ro_txn, block_number), std::length_error);
@@ -1014,7 +1017,8 @@ TEST_CASE_METHOD(AccessLayerTest, "read_canonical_header_hash", "[db][access_lay
 
 TEST_CASE_METHOD(AccessLayerTest, "read_block_by_number", "[db][access_layer]") {
     BlockNum block_number{2};
-    const ::mdbx::slice block_key_slice{to_slice(block_key(block_number))};
+    const auto block_number_key{block_key(block_number)};
+    const ::mdbx::slice block_key_slice{to_slice(block_number_key)};
     Block block;
 
     SECTION("data not found") {
@@ -1026,7 +1030,7 @@ TEST_CASE_METHOD(AccessLayerTest, "read_block_by_number", "[db][access_layer]") 
     }
     SECTION("invalid value size") {
         EXPECT_CALL(*mock_ro_cursor, find(block_key_slice, false))
-            .WillOnce(InvokeWithoutArgs([&]() mutable -> CursorResult {
+            .WillOnce(InvokeWithoutArgs([=]() mutable -> CursorResult {
                 return CursorResult{block_key_slice, kInvalidBlockHashSlice, true};
             }));
         CHECK_THROWS_AS(read_block_by_number(mock_ro_txn, block_number, /*read_senders=*/false, block), std::length_error);

--- a/silkworm/db/mdbx/mdbx.hpp
+++ b/silkworm/db/mdbx/mdbx.hpp
@@ -218,6 +218,7 @@ class ROTxn {
   protected:
     explicit ROTxn(::mdbx::txn& txn_ref) : txn_ref_{txn_ref} {}
 
+  private:
     ::mdbx::txn& txn_ref_;
 };
 

--- a/silkworm/db/test_util/mock_cursor.hpp
+++ b/silkworm/db/test_util/mock_cursor.hpp
@@ -50,8 +50,6 @@ class MockROCursor : public ROCursor {
     MOCK_METHOD((bool), eof, (), (const));
     MOCK_METHOD((bool), on_first, (), (const));
     MOCK_METHOD((bool), on_last, (), (const));
-
-    //CursorResult find(const Slice&) override { return CursorResult{{}, {}, false}; }
 };
 
 }  // namespace silkworm::db::test_util

--- a/silkworm/db/test_util/mock_cursor.hpp
+++ b/silkworm/db/test_util/mock_cursor.hpp
@@ -24,32 +24,32 @@ namespace silkworm::db::test_util {
 
 class MockROCursor : public ROCursor {
   public:
-    MOCK_METHOD((void), bind, (ROTxn&, const MapConfig&));
-    MOCK_METHOD((size_t), size, (), (const));
+    MOCK_METHOD((void), bind, (ROTxn&, const MapConfig&), (override));
+    MOCK_METHOD((size_t), size, (), (const, override));
     MOCK_METHOD((bool), empty, (), (const));
-    MOCK_METHOD((bool), is_multi_value, (), (const));
-    MOCK_METHOD((bool), is_dangling, (), (const));
-    MOCK_METHOD((::mdbx::map_handle), map, (), (const));
-    MOCK_METHOD((CursorResult), to_first, ());
-    MOCK_METHOD((CursorResult), to_first, (bool));
-    MOCK_METHOD((CursorResult), to_previous, ());
-    MOCK_METHOD((CursorResult), to_previous, (bool));
-    MOCK_METHOD((CursorResult), current, (), (const));
-    MOCK_METHOD((CursorResult), current, (bool), (const));
-    MOCK_METHOD((CursorResult), to_next, ());
-    MOCK_METHOD((CursorResult), to_next, (bool));
-    MOCK_METHOD((CursorResult), to_last, ());
-    MOCK_METHOD((CursorResult), to_last, (bool));
-    MOCK_METHOD((CursorResult), find, (const Slice&));
-    MOCK_METHOD((CursorResult), find, (const Slice&, bool));
-    MOCK_METHOD((CursorResult), lower_bound, (const Slice&));
-    MOCK_METHOD((CursorResult), lower_bound, (const Slice&, bool));
-    MOCK_METHOD((MoveResult), move, (MoveOperation, bool));
-    MOCK_METHOD((MoveResult), move, (MoveOperation, const Slice&, bool));
-    MOCK_METHOD((bool), seek, (const Slice&));
-    MOCK_METHOD((bool), eof, (), (const));
-    MOCK_METHOD((bool), on_first, (), (const));
-    MOCK_METHOD((bool), on_last, (), (const));
+    MOCK_METHOD((bool), is_multi_value, (), (const, override));
+    MOCK_METHOD((bool), is_dangling, (), (const, override));
+    MOCK_METHOD((::mdbx::map_handle), map, (), (const, override));
+    MOCK_METHOD((CursorResult), to_first, (), (override));
+    MOCK_METHOD((CursorResult), to_first, (bool), (override));
+    MOCK_METHOD((CursorResult), to_previous, (), (override));
+    MOCK_METHOD((CursorResult), to_previous, (bool), (override));
+    MOCK_METHOD((CursorResult), current, (), (const, override));
+    MOCK_METHOD((CursorResult), current, (bool), (const, override));
+    MOCK_METHOD((CursorResult), to_next, (), (override));
+    MOCK_METHOD((CursorResult), to_next, (bool), (override));
+    MOCK_METHOD((CursorResult), to_last, (), (override));
+    MOCK_METHOD((CursorResult), to_last, (bool), (override));
+    MOCK_METHOD((CursorResult), find, (const Slice&), (override));
+    MOCK_METHOD((CursorResult), find, (const Slice&, bool), (override));
+    MOCK_METHOD((CursorResult), lower_bound, (const Slice&), (override));
+    MOCK_METHOD((CursorResult), lower_bound, (const Slice&, bool), (override));
+    MOCK_METHOD((MoveResult), move, (MoveOperation, bool), (override));
+    MOCK_METHOD((MoveResult), move, (MoveOperation, const Slice&, bool), (override));
+    MOCK_METHOD((bool), seek, (const Slice&), (override));
+    MOCK_METHOD((bool), eof, (), (const, override));
+    MOCK_METHOD((bool), on_first, (), (const, override));
+    MOCK_METHOD((bool), on_last, (), (const, override));
 };
 
 }  // namespace silkworm::db::test_util

--- a/silkworm/db/test_util/mock_cursor.hpp
+++ b/silkworm/db/test_util/mock_cursor.hpp
@@ -1,0 +1,57 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include <silkworm/db/mdbx/mdbx.hpp>
+
+namespace silkworm::db::test_util {
+
+class MockROCursor : public ROCursor {
+  public:
+    MOCK_METHOD((void), bind, (ROTxn&, const MapConfig&));
+    MOCK_METHOD((size_t), size, (), (const));
+    MOCK_METHOD((bool), empty, (), (const));
+    MOCK_METHOD((bool), is_multi_value, (), (const));
+    MOCK_METHOD((bool), is_dangling, (), (const));
+    MOCK_METHOD((::mdbx::map_handle), map, (), (const));
+    MOCK_METHOD((CursorResult), to_first, ());
+    MOCK_METHOD((CursorResult), to_first, (bool));
+    MOCK_METHOD((CursorResult), to_previous, ());
+    MOCK_METHOD((CursorResult), to_previous, (bool));
+    MOCK_METHOD((CursorResult), current, (), (const));
+    MOCK_METHOD((CursorResult), current, (bool), (const));
+    MOCK_METHOD((CursorResult), to_next, ());
+    MOCK_METHOD((CursorResult), to_next, (bool));
+    MOCK_METHOD((CursorResult), to_last, ());
+    MOCK_METHOD((CursorResult), to_last, (bool));
+    MOCK_METHOD((CursorResult), find, (const Slice&));
+    MOCK_METHOD((CursorResult), find, (const Slice&, bool));
+    MOCK_METHOD((CursorResult), lower_bound, (const Slice&));
+    MOCK_METHOD((CursorResult), lower_bound, (const Slice&, bool));
+    MOCK_METHOD((MoveResult), move, (MoveOperation, bool));
+    MOCK_METHOD((MoveResult), move, (MoveOperation, const Slice&, bool));
+    MOCK_METHOD((bool), seek, (const Slice&));
+    MOCK_METHOD((bool), eof, (), (const));
+    MOCK_METHOD((bool), on_first, (), (const));
+    MOCK_METHOD((bool), on_last, (), (const));
+
+    //CursorResult find(const Slice&) override { return CursorResult{{}, {}, false}; }
+};
+
+}  // namespace silkworm::db::test_util

--- a/silkworm/db/test_util/mock_txn.hpp
+++ b/silkworm/db/test_util/mock_txn.hpp
@@ -1,4 +1,4 @@
-#[[
+/*
    Copyright 2024 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,18 +12,28 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-]]
+*/
 
-set(TARGET silkworm_db_test_util)
+#pragma once
 
-find_package(GTest REQUIRED)
-find_package(nlohmann_json REQUIRED)
+#include <gmock/gmock.h>
 
-file(GLOB_RECURSE SRC CONFIGURE_DEPENDS "*.cpp" "*.hpp")
-add_library(${TARGET} ${SRC})
+#include <silkworm/db/mdbx/mdbx.hpp>
 
-target_link_libraries(
-  ${TARGET}
-  PUBLIC silkworm_core silkworm_infra silkworm_db GTest::gmock
-  PRIVATE nlohmann_json::nlohmann_json
-)
+namespace silkworm::db::test_util {
+
+class MockROTxn : public ROTxn {
+  public:
+    explicit MockROTxn() : ROTxn(txn_) {}
+
+    MOCK_METHOD((bool), is_open, (), (const));
+    MOCK_METHOD((mdbx::env), db, (), (const));
+    MOCK_METHOD((std::unique_ptr<ROCursor>), ro_cursor, (const MapConfig&));
+    MOCK_METHOD((std::unique_ptr<ROCursorDupSort>), ro_cursor_dup_sort, (const MapConfig&));
+    MOCK_METHOD((void), abort, ());
+
+  private:
+    ::mdbx::txn txn_;
+};
+
+}  // namespace silkworm::db::test_util

--- a/silkworm/db/test_util/mock_txn.hpp
+++ b/silkworm/db/test_util/mock_txn.hpp
@@ -26,11 +26,11 @@ class MockROTxn : public ROTxn {
   public:
     explicit MockROTxn() : ROTxn(txn_) {}
 
-    MOCK_METHOD((bool), is_open, (), (const));
-    MOCK_METHOD((mdbx::env), db, (), (const));
-    MOCK_METHOD((std::unique_ptr<ROCursor>), ro_cursor, (const MapConfig&));
-    MOCK_METHOD((std::unique_ptr<ROCursorDupSort>), ro_cursor_dup_sort, (const MapConfig&));
-    MOCK_METHOD((void), abort, ());
+    MOCK_METHOD((bool), is_open, (), (const, override));
+    MOCK_METHOD((mdbx::env), db, (), (const, override));
+    MOCK_METHOD((std::unique_ptr<ROCursor>), ro_cursor, (const MapConfig&), (override));
+    MOCK_METHOD((std::unique_ptr<ROCursorDupSort>), ro_cursor_dup_sort, (const MapConfig&), (override));
+    MOCK_METHOD((void), abort, (), (override));
 
   private:
     ::mdbx::txn txn_;


### PR DESCRIPTION
This PR handles some data length errors in access layer by adding missing checks for encoded block numbers and hashes read from different database tables (unit tests included).

*Extras*
- demote visibility for state variable in `db::ROTxn`
- small code cleanups