### PR TITLE
infra: gRPC type conversions for std::span

### DIFF
--- a/silkworm/core/common/bytes.hpp
+++ b/silkworm/core/common/bytes.hpp
@@ -51,7 +51,7 @@ class ByteView : public std::basic_string_view<uint8_t> {
     [[nodiscard]] bool is_null() const noexcept { return data() == nullptr; }
 };
 
-template<std::size_t Extent>
+template <std::size_t Extent>
 using ByteSpan = std::span<uint8_t, Extent>;
 
 }  // namespace silkworm

--- a/silkworm/core/common/bytes.hpp
+++ b/silkworm/core/common/bytes.hpp
@@ -51,4 +51,7 @@ class ByteView : public std::basic_string_view<uint8_t> {
     [[nodiscard]] bool is_null() const noexcept { return data() == nullptr; }
 };
 
+template<std::size_t Extent>
+using ByteSpan = std::span<uint8_t, Extent>;
+
 }  // namespace silkworm

--- a/silkworm/infra/grpc/common/conversion.cpp
+++ b/silkworm/infra/grpc/common/conversion.cpp
@@ -19,6 +19,14 @@
 // operator== overloading is *NOT* present in gRPC generated sources
 namespace types {
 
+bool operator==(const H2048& lhs, const H2048& rhs) {
+    return lhs.hi() == rhs.hi() && lhs.lo() == rhs.lo();
+}
+
+bool operator==(const H1024& lhs, const H1024& rhs) {
+    return lhs.hi() == rhs.hi() && lhs.lo() == rhs.lo();
+}
+
 bool operator==(const H512& lhs, const H512& rhs) {
     return lhs.hi() == rhs.hi() && lhs.lo() == rhs.lo();
 }
@@ -67,6 +75,13 @@ Bytes bytes_from_H2048(const ::types::H2048& h2048) {
     return bytes;
 }
 
+void span_from_H2048(const ::types::H2048& h2048, ByteSpan<256> bytes) {
+    const auto& hi{h2048.hi()};
+    const auto& lo{h2048.lo()};
+    span_from_H1024(hi, bytes.subspan<0, 128>());
+    span_from_H1024(lo, bytes.subspan<128, 128>());
+}
+
 Bytes bytes_from_H1024(const ::types::H1024& h1024) {
     Bytes bytes(128, '\0');
     const auto& hi{h1024.hi()};
@@ -74,6 +89,13 @@ Bytes bytes_from_H1024(const ::types::H1024& h1024) {
     std::memcpy(&bytes[0], bytes_from_H512(hi).data(), 64);
     std::memcpy(&bytes[64], bytes_from_H512(lo).data(), 64);
     return bytes;
+}
+
+void span_from_H1024(const ::types::H1024& h1024, ByteSpan<128> bytes) {
+    const auto& hi{h1024.hi()};
+    const auto& lo{h1024.lo()};
+    span_from_H512(hi, bytes.subspan<0, 64>());
+    span_from_H512(lo, bytes.subspan<64, 64>());
 }
 
 std::string string_from_H512(const types::H512& orig) {
@@ -109,6 +131,13 @@ Bytes bytes_from_H512(const ::types::H512& h512) {
     return bytes;
 }
 
+void span_from_H512(const ::types::H512& h512, ByteSpan<64> bytes) {
+    const auto& hi{h512.hi()};
+    const auto& lo{h512.lo()};
+    span_from_H256(hi, bytes.subspan<0, 32>());
+    span_from_H256(lo, bytes.subspan<32, 32>());
+}
+
 evmc::bytes32 bytes32_from_H256(const ::types::H256& orig) {
     uint64_t hi_hi = orig.hi().hi();
     uint64_t hi_lo = orig.hi().lo();
@@ -131,6 +160,13 @@ Bytes bytes_from_H256(const ::types::H256& h256) {
     std::memcpy(&bytes[0], bytes_from_H128(hi).data(), 16);
     std::memcpy(&bytes[16], bytes_from_H128(lo).data(), 16);
     return bytes;
+}
+
+void span_from_H256(const ::types::H256& h256, ByteSpan<32> bytes) {
+    const auto& hi{h256.hi()};
+    const auto& lo{h256.lo()};
+    span_from_H128(hi, bytes.subspan<0, 16>());
+    span_from_H128(lo, bytes.subspan<16, 16>());
 }
 
 intx::uint256 uint256_from_H256(const ::types::H256& orig) {
@@ -160,6 +196,11 @@ Bytes bytes_from_H128(const ::types::H128& h128) {
     endian::store_big_u64(&bytes[0], h128.hi());
     endian::store_big_u64(&bytes[8], h128.lo());
     return bytes;
+}
+
+void span_from_H128(const ::types::H128& h128, ByteSpan<16> bytes) {
+    endian::store_big_u64(&bytes[0], h128.hi());
+    endian::store_big_u64(&bytes[8], h128.lo());
 }
 
 std::unique_ptr<::types::H2048> H2048_from_string(std::string_view orig) {

--- a/silkworm/infra/grpc/common/conversion.hpp
+++ b/silkworm/infra/grpc/common/conversion.hpp
@@ -31,6 +31,8 @@
 // operator== overloading is *NOT* present in gRPC generated sources
 namespace types {
 
+bool operator==(const H2048& lhs, const H2048& rhs);
+bool operator==(const H1024& lhs, const H1024& rhs);
 bool operator==(const H512& lhs, const H512& rhs);
 bool operator==(const H256& lhs, const H256& rhs);
 bool operator==(const H160& lhs, const H160& rhs);
@@ -46,13 +48,23 @@ std::string string_from_H2048(const ::types::H2048& orig);
 //! Convert internal gRPC H2048 type instance to Bytes.
 Bytes bytes_from_H2048(const ::types::H2048& h2048);
 
+//! Convert internal gRPC H2048 type instance into provided fixed-size ByteSpan.
+void span_from_H2048(const ::types::H2048& h2048, ByteSpan<256> bytes);
+
 //! Convert internal gRPC H1024 type instance to Bytes.
 Bytes bytes_from_H1024(const ::types::H1024& h1024);
+
+//! Convert internal gRPC H1024 type instance into provided fixed-size ByteSpan.
+void span_from_H1024(const ::types::H1024& h1024, ByteSpan<128> bytes);
 
 //! Convert internal gRPC H512 type instance to std::string.
 std::string string_from_H512(const ::types::H512& orig);
 
+//! Convert internal gRPC H512 type instance to Bytes.
 Bytes bytes_from_H512(const ::types::H512& h512);
+
+//! Convert internal gRPC H512 type instance into provided fixed-size ByteSpan.
+void span_from_H512(const ::types::H512& h512, ByteSpan<64> bytes);
 
 //! Convert internal gRPC H256 type instance to evmc::bytes32.
 evmc::bytes32 bytes32_from_H256(const ::types::H256& orig);
@@ -63,11 +75,17 @@ intx::uint256 uint256_from_H256(const ::types::H256& orig);
 //! Convert internal gRPC H256 type instance to Bytes.
 Bytes bytes_from_H256(const ::types::H256& h256);
 
+//! Convert internal gRPC H256 type instance into provided fixed-size ByteSpan.
+void span_from_H256(const ::types::H256& h256, ByteSpan<32> bytes);
+
 //! Convert internal gRPC H160 type instance to evmc::address.
 evmc::address address_from_H160(const ::types::H160& orig);
 
 //! Convert internal gRPC H128 type instance to Bytes.
 Bytes bytes_from_H128(const ::types::H128& h128);
+
+//! Convert internal gRPC H128 type instance into provided fixed-size ByteSpan.
+void span_from_H128(const ::types::H128& h128, ByteSpan<16> bytes);
 
 //! Convert std::string_view to internal gRPC H2048 type instance.
 std::unique_ptr<::types::H2048> H2048_from_string(std::string_view orig);

--- a/silkworm/infra/grpc/common/conversion_test.cpp
+++ b/silkworm/infra/grpc/common/conversion_test.cpp
@@ -16,6 +16,7 @@
 
 #include "conversion.hpp"
 
+#include <array>
 #include <memory>
 
 #include <catch2/catch.hpp>
@@ -25,19 +26,27 @@
 // operator== overloading is *NOT* present in gRPC generated sources
 namespace types {
 
-TEST_CASE("H512::operator==", "[silkworm][rpc][util]") {
+TEST_CASE("H2048::operator==", "[rpc][conversion]") {
+    CHECK(types::H2048{} == types::H2048{});
+}
+
+TEST_CASE("H1024::operator==", "[rpc][conversion]") {
+    CHECK(types::H1024{} == types::H1024{});
+}
+
+TEST_CASE("H512::operator==", "[rpc][conversion]") {
     CHECK(types::H512{} == types::H512{});
 }
 
-TEST_CASE("H256::operator==", "[silkworm][rpc][util]") {
+TEST_CASE("H256::operator==", "[rpc][conversion]") {
     CHECK(types::H256{} == types::H256{});
 }
 
-TEST_CASE("H160::operator==", "[silkworm][rpc][util]") {
+TEST_CASE("H160::operator==", "[rpc][conversion]") {
     CHECK(types::H160{} == types::H160{});
 }
 
-TEST_CASE("H128::operator==", "[silkworm][rpc][util]") {
+TEST_CASE("H128::operator==", "[rpc][conversion]") {
     CHECK(types::H128{} == types::H128{});
 }
 
@@ -47,63 +56,108 @@ namespace silkworm::rpc {
 
 using namespace evmc::literals;
 
-TEST_CASE("string_from_H512", "[silkworm][rpc][util]") {
-    SECTION("empty H512", "[silkworm][rpc][util]") {
+static Bytes kSampleH512Bytes{*from_hex(
+    "000000000000007f0000000000000007000000000000006f0000000000000006"
+    "000000000000002f0000000000000002000000000000001f0000000000000001")};
+static std::unique_ptr<types::H512> sample_H512() {
+    auto hi_hi = new types::H128();
+    auto hi_lo = new types::H128();
+    auto lo_hi = new types::H128();
+    auto lo_lo = new types::H128();
+    hi_hi->set_hi(0x7F);
+    hi_hi->set_lo(0x07);
+    hi_lo->set_hi(0x6F);
+    hi_lo->set_lo(0x06);
+    lo_hi->set_hi(0x2F);
+    lo_hi->set_lo(0x02);
+    lo_lo->set_hi(0x1F);
+    lo_lo->set_lo(0x01);
+    auto hi = new types::H256{};
+    auto lo = new types::H256{};
+    hi->set_allocated_hi(hi_hi);
+    hi->set_allocated_lo(hi_lo);
+    lo->set_allocated_hi(lo_hi);
+    lo->set_allocated_lo(lo_lo);
+    auto h512_ptr = std::make_unique<types::H512>();
+    h512_ptr->set_allocated_hi(hi);
+    h512_ptr->set_allocated_lo(lo);
+    return h512_ptr;
+}
+
+TEST_CASE("string_from_H512", "[rpc][conversion]") {
+    SECTION("empty H512", "[rpc][conversion]") {
         CHECK_NOTHROW(string_from_H512(types::H512{}).empty());
     }
 
-    SECTION("non-empty H512", "[silkworm][rpc][util]") {
-        auto hi_hi = new types::H128();
-        auto hi_lo = new types::H128();
-        auto lo_hi = new types::H128();
-        auto lo_lo = new types::H128();
-        hi_hi->set_hi(0x7F);
-        hi_hi->set_lo(0x07);
-        hi_lo->set_hi(0x6F);
-        hi_lo->set_lo(0x06);
-        lo_hi->set_hi(0x2F);
-        lo_hi->set_lo(0x02);
-        lo_lo->set_hi(0x1F);
-        lo_lo->set_lo(0x01);
-        auto hi = new types::H256{};
-        auto lo = new types::H256{};
-        hi->set_allocated_hi(hi_hi);
-        hi->set_allocated_lo(hi_lo);
-        lo->set_allocated_hi(lo_hi);
-        lo->set_allocated_lo(lo_lo);
-        auto h512_ptr = std::make_unique<types::H512>();
-        h512_ptr->set_allocated_hi(hi);
-        h512_ptr->set_allocated_lo(lo);
+    SECTION("non-empty H512", "[rpc][conversion]") {
+        auto h512_ptr = sample_H512();
         const std::string& s = string_from_H512(*h512_ptr);
         CHECK(s.size() == 64);
+        CHECK(Bytes{reinterpret_cast<const uint8_t*>(s.data()), s.size()} == kSampleH512Bytes);
     }
 }
 
-TEST_CASE("bytes32_from_H256", "[silkworm][rpc][util]") {
-    SECTION("empty H256", "[silkworm][rpc][util]") {
+TEST_CASE("span_from_H512", "[rpc][conversion]") {
+    SECTION("empty H512", "[rpc][conversion]") {
+        std::array<uint8_t, 64> uint8_array{};
+        span_from_H512(types::H512{}, uint8_array);
+        CHECK_NOTHROW(uint8_array.empty());
+    }
+
+    SECTION("non-empty H512", "[rpc][conversion]") {
+        auto h512_ptr = sample_H512();
+        std::array<uint8_t, 64> uint8_array{};
+        span_from_H512(*h512_ptr, uint8_array);
+        CHECK(Bytes{uint8_array.data(), uint8_array.size()} == kSampleH512Bytes);
+    }
+}
+
+static auto kSampleBytes32{0x000000000000007f0000000000000007000000000000006f0000000000000006_bytes32};
+static std::unique_ptr<types::H256> sample_H256() {
+    auto hi = new types::H128();
+    auto lo = new types::H128();
+    hi->set_hi(0x7F);
+    hi->set_lo(0x07);
+    lo->set_hi(0x6F);
+    lo->set_lo(0x06);
+    auto h256_ptr = std::make_unique<types::H256>();
+    h256_ptr->set_allocated_hi(hi);
+    h256_ptr->set_allocated_lo(lo);
+    return h256_ptr;
+}
+
+TEST_CASE("bytes32_from_H256", "[rpc][conversion]") {
+    SECTION("empty H256", "[rpc][conversion]") {
         CHECK_NOTHROW(bytes32_from_H256(types::H256{}) == evmc::bytes32{});
     }
 
-    SECTION("non-empty H256", "[silkworm][rpc][util]") {
-        auto hi = new types::H128();
-        auto lo = new types::H128();
-        hi->set_hi(0x7F);
-        hi->set_lo(0x07);
-        lo->set_hi(0x6F);
-        lo->set_lo(0x06);
-        auto h256_ptr = std::make_unique<types::H256>();
-        h256_ptr->set_allocated_hi(hi);
-        h256_ptr->set_allocated_lo(lo);
-        CHECK(bytes32_from_H256(*h256_ptr) == 0x000000000000007f0000000000000007000000000000006f0000000000000006_bytes32);
+    SECTION("non-empty H256", "[rpc][conversion]") {
+        auto h256_ptr = sample_H256();
+        CHECK(bytes32_from_H256(*h256_ptr) == kSampleBytes32);
     }
 }
 
-TEST_CASE("address_from_H160", "[silkworm][rpc][util]") {
-    SECTION("empty H160", "[silkworm][rpc][util]") {
+TEST_CASE("span_from_H256", "[rpc][conversion]") {
+    SECTION("empty H256", "[rpc][conversion]") {
+        evmc::bytes32 bytes32;
+        span_from_H256(types::H256{}, bytes32.bytes);
+        CHECK_NOTHROW(bytes32 == evmc::bytes32{});
+    }
+
+    SECTION("non-empty H256", "[rpc][conversion]") {
+        auto h256_ptr = sample_H256();
+        evmc::bytes32 bytes32;
+        span_from_H256(*h256_ptr, bytes32.bytes);
+        CHECK(bytes32 == kSampleBytes32);
+    }
+}
+
+TEST_CASE("address_from_H160", "[rpc][conversion]") {
+    SECTION("empty H160", "[rpc][conversion]") {
         CHECK_NOTHROW(address_from_H160(types::H160{}) == evmc::address{});
     }
 
-    SECTION("non-empty H160", "[silkworm][rpc][util]") {
+    SECTION("non-empty H160", "[rpc][conversion]") {
         auto hi = new types::H128();
         hi->set_lo(0x07);
         hi->set_hi(0x7F);
@@ -114,42 +168,43 @@ TEST_CASE("address_from_H160", "[silkworm][rpc][util]") {
     }
 }
 
-TEST_CASE("bytes_from_H128", "[silkworm][rpc][util]") {
-    SECTION("empty H128", "[silkworm][rpc][util]") {
+static auto kSampleBytes16{*from_hex("0x000000000000007f0000000000000007")};
+static std::unique_ptr<types::H128> sample_H128() {
+    auto h128_ptr = std::make_unique<::types::H128>();
+    h128_ptr->set_lo(0x07);
+    h128_ptr->set_hi(0x7F);
+    return h128_ptr;
+}
+
+TEST_CASE("bytes_from_H128", "[rpc][conversion]") {
+    SECTION("empty H128", "[rpc][conversion]") {
         CHECK_NOTHROW(bytes_from_H128(::types::H128{}).empty());
     }
 
-    SECTION("non-empty H128", "[silkworm][rpc][util]") {
-        auto h128_ptr = std::make_unique<::types::H128>();
-        h128_ptr->set_lo(0x07);
-        h128_ptr->set_hi(0x7F);
-        CHECK(bytes_from_H128(*h128_ptr) == *from_hex("0x000000000000007f0000000000000007"));
+    SECTION("non-empty H128", "[rpc][conversion]") {
+        auto h128_ptr = sample_H128();
+        CHECK(bytes_from_H128(*h128_ptr) == kSampleBytes16);
     }
 }
 
-TEST_CASE("invertibility", "[silkworm][rpc][util]") {
-    SECTION("H512<->string", "[silkworm][rpc][util]") {
-        auto hi_hi = new types::H128();
-        auto hi_lo = new types::H128();
-        auto lo_hi = new types::H128();
-        auto lo_lo = new types::H128();
-        hi_hi->set_hi(0x7F);
-        hi_hi->set_lo(0x07);
-        hi_lo->set_hi(0x6F);
-        hi_lo->set_lo(0x06);
-        lo_hi->set_hi(0x2F);
-        lo_hi->set_lo(0x02);
-        lo_lo->set_hi(0x1F);
-        lo_lo->set_lo(0x01);
-        auto hi = new types::H256{};
-        auto lo = new types::H256{};
-        hi->set_allocated_hi(hi_hi);
-        hi->set_allocated_lo(hi_lo);
-        lo->set_allocated_hi(lo_hi);
-        lo->set_allocated_lo(lo_lo);
-        auto h512_ptr1 = std::make_unique<types::H512>();
-        h512_ptr1->set_allocated_hi(hi);
-        h512_ptr1->set_allocated_lo(lo);
+TEST_CASE("span_from_H128", "[rpc][conversion]") {
+    SECTION("empty H128", "[rpc][conversion]") {
+        std::array<uint8_t, 16> uint8_array{};
+        span_from_H128(::types::H128{}, uint8_array);
+        CHECK_NOTHROW(uint8_array.empty());
+    }
+
+    SECTION("non-empty H128", "[rpc][conversion]") {
+        auto h128_ptr = sample_H128();
+        std::array<uint8_t, 16> uint8_array{};
+        span_from_H128(*h128_ptr, uint8_array);
+        CHECK(Bytes{uint8_array.data(), uint8_array.size()} == kSampleBytes16);
+    }
+}
+
+TEST_CASE("convertibility", "[rpc][conversion]") {
+    SECTION("H512<->string", "[rpc][conversion]") {
+        auto h512_ptr1 = sample_H512();
 
         const std::string& s1 = string_from_H512(*h512_ptr1);
         auto h512_ptr2 = H512_from_string(s1);
@@ -157,18 +212,15 @@ TEST_CASE("invertibility", "[silkworm][rpc][util]") {
         CHECK(*h512_ptr1 == *h512_ptr2);
         const auto& s2 = string_from_H512(*h512_ptr2);
         CHECK(s1 == s2);
+
+        std::array<uint8_t , 64> a1{};
+        span_from_H512(*h512_ptr1, a1);
+        const Bytes b1{bytes_from_H512(*h512_ptr1)};
+        CHECK(Bytes{a1.data(), a1.size()} == b1);
     }
 
-    SECTION("H256<->bytes32", "[silkworm][rpc][util]") {
-        auto hi = new types::H128();
-        auto lo = new types::H128();
-        hi->set_hi(0x7F);
-        hi->set_lo(0x07);
-        lo->set_hi(0x6F);
-        lo->set_lo(0x06);
-        auto h256_ptr1 = std::make_unique<types::H256>();
-        h256_ptr1->set_allocated_hi(hi);
-        h256_ptr1->set_allocated_lo(lo);
+    SECTION("H256<->bytes32", "[rpc][conversion]") {
+        auto h256_ptr1 = sample_H256();
 
         const auto& hash1 = bytes32_from_H256(*h256_ptr1);
         auto h256_ptr2 = H256_from_bytes32(hash1);
@@ -176,9 +228,13 @@ TEST_CASE("invertibility", "[silkworm][rpc][util]") {
         CHECK(*h256_ptr1 == *h256_ptr2);
         const auto& hash2 = bytes32_from_H256(*h256_ptr2);
         CHECK(hash1 == hash2);
+
+        evmc::bytes32 hash3;
+        span_from_H256(*h256_ptr1, hash3.bytes);
+        CHECK(hash1 == hash3);
     }
 
-    SECTION("H160<->address", "[silkworm][rpc][util]") {
+    SECTION("H160<->address", "[rpc][conversion]") {
         auto hi = new types::H128();
         hi->set_hi(0x7F);
         auto h160_ptr1 = std::make_unique<types::H160>();

--- a/silkworm/infra/grpc/common/conversion_test.cpp
+++ b/silkworm/infra/grpc/common/conversion_test.cpp
@@ -213,7 +213,7 @@ TEST_CASE("convertibility", "[rpc][conversion]") {
         const auto& s2 = string_from_H512(*h512_ptr2);
         CHECK(s1 == s2);
 
-        std::array<uint8_t , 64> a1{};
+        std::array<uint8_t, 64> a1{};
         span_from_H512(*h512_ptr1, a1);
         const Bytes b1{bytes_from_H512(*h512_ptr1)};
         CHECK(Bytes{a1.data(), a1.size()} == b1);


### PR DESCRIPTION
This PR introduces gRPC type conversions tailored for `std::span` byte containers. This additions will be useful to minimise memory allocation when supporting `execution` gRPC protocol types.