### PR TITLE
execution: direct client + gRPC client and server

### DIFF
--- a/silkworm/infra/concurrency/co_spawn_sw.hpp
+++ b/silkworm/infra/concurrency/co_spawn_sw.hpp
@@ -369,4 +369,12 @@ inline BOOST_ASIO_INITFN_AUTO_RESULT_TYPE(
                          std::forward<CompletionToken>(token));
 }
 
+template <typename Executor, typename F>
+inline BOOST_ASIO_INITFN_AUTO_RESULT_TYPE(
+    boost::asio::use_awaitable,
+    typename boost::asio::detail::awaitable_signature<typename boost::asio::result_of<F()>::type>::type = 0)
+    co_spawn_and_await(const Executor& ex, F&& f) {
+    return (co_spawn_sw)(ex, std::forward<F>(f), boost::asio::use_awaitable);
+}
+
 }  // namespace silkworm::concurrency

--- a/silkworm/infra/concurrency/task.hpp
+++ b/silkworm/infra/concurrency/task.hpp
@@ -19,6 +19,7 @@
 #include <silkworm/infra/concurrency/coroutine.hpp>
 
 #include <boost/asio/awaitable.hpp>
+#include <boost/asio/io_context.hpp>
 #include <boost/asio/use_awaitable.hpp>
 
 /// Use just \silkworm as namespace here to make these definitions available everywhere
@@ -31,5 +32,8 @@ using Task = boost::asio::awaitable<T>;
 
 //! Namespace for the current coroutine types
 namespace ThisTask = boost::asio::this_coro;
+
+//! Executor for asynchronous tasks returned by any coroutine
+using TaskExecutor = boost::asio::io_context::executor_type;
 
 }  // namespace silkworm

--- a/silkworm/infra/grpc/common/conversion.cpp
+++ b/silkworm/infra/grpc/common/conversion.cpp
@@ -205,9 +205,9 @@ void span_from_H128(const ::types::H128& h128, ByteSpan<16> bytes) {
 
 std::unique_ptr<::types::H2048> H2048_from_string(std::string_view orig) {
     auto lo_lo = H512_from_string(orig);
-    auto lo_hi = H512_from_string(orig.substr(512));
-    auto hi_lo = H512_from_string(orig.substr(1024));
-    auto hi_hi = H512_from_string(orig.substr(1536));
+    auto lo_hi = H512_from_string(orig.substr(64));
+    auto hi_lo = H512_from_string(orig.substr(128));
+    auto hi_hi = H512_from_string(orig.substr(192));
 
     auto hi = std::make_unique<::types::H1024>();
     auto lo = std::make_unique<::types::H1024>();

--- a/silkworm/infra/grpc/server/server.hpp
+++ b/silkworm/infra/grpc/server/server.hpp
@@ -130,13 +130,13 @@ class Server {
         SILK_TRACE << "Server::shutdown " << this << " END";
     }
 
-    Task<void> async_run(const char* thread_name) {
+    Task<void> async_run(const char* thread_name, std::optional<std::size_t> stack_size = {}) {
         auto run = [this] {
             this->build_and_start();
             this->join();
         };
         auto stop = [this] { this->shutdown(); };
-        co_await concurrency::async_thread(std::move(run), std::move(stop), thread_name);
+        co_await concurrency::async_thread(std::move(run), std::move(stop), thread_name, stack_size);
     }
 
     //! Returns the number of server contexts.

--- a/silkworm/node/execution/api/active_direct_service.cpp
+++ b/silkworm/node/execution/api/active_direct_service.cpp
@@ -41,8 +41,8 @@ bool ActiveDirectService::stop() {
 
 // rpc InsertBlocks(InsertBlocksRequest) returns(InsertionResult);
 Task<InsertionResult> ActiveDirectService::insert_blocks(const Blocks& blocks) {
-    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto blocks) {
-        return self->DirectService::insert_blocks(blocks);
+    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto bb) {
+        return self->DirectService::insert_blocks(bb);
     }(this, blocks));
 }
 
@@ -50,15 +50,15 @@ Task<InsertionResult> ActiveDirectService::insert_blocks(const Blocks& blocks) {
 
 // rpc ValidateChain(ValidationRequest) returns(ValidationReceipt);
 Task<ValidationResult> ActiveDirectService::validate_chain(BlockNumAndHash number_and_hash) {
-    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto number_and_hash) {
-        return self->DirectService::validate_chain(number_and_hash);
+    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto num_and_hash) {
+        return self->DirectService::validate_chain(num_and_hash);
     }(this, number_and_hash));
 }
 
 // rpc UpdateForkChoice(ForkChoice) returns(ForkChoiceReceipt);
 Task<ForkChoiceResult> ActiveDirectService::update_fork_choice(const ForkChoice& fork_choice) {
-    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto fork_choice) {
-        return self->DirectService::update_fork_choice(fork_choice);
+    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto choice) {
+        return self->DirectService::update_fork_choice(choice);
     }(this, fork_choice));
 }
 
@@ -66,15 +66,15 @@ Task<ForkChoiceResult> ActiveDirectService::update_fork_choice(const ForkChoice&
 
 // rpc AssembleBlock(AssembleBlockRequest) returns(AssembleBlockResponse);
 Task<AssembleBlockResult> ActiveDirectService::assemble_block(const api::BlockUnderConstruction& block) {
-    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto block) {
-        return self->DirectService::assemble_block(block);
+    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto b) {
+        return self->DirectService::assemble_block(b);
     }(this, block));
 }
 
 // rpc GetAssembledBlock(GetAssembledBlockRequest) returns(GetAssembledBlockResponse);
 Task<AssembledBlockResult> ActiveDirectService::get_assembled_block(PayloadId payload_id) {
-    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto payload_id) {
-        return self->DirectService::get_assembled_block(payload_id);
+    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto id) {
+        return self->DirectService::get_assembled_block(id);
     }(this, payload_id));
 }
 
@@ -89,29 +89,29 @@ Task<std::optional<BlockHeader>> ActiveDirectService::current_header() {
 
 // rpc GetTD(GetSegmentRequest) returns(GetTDResponse);
 Task<std::optional<TotalDifficulty>> ActiveDirectService::get_td(BlockNumberOrHash number_or_hash) {
-    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto number_or_hash) {
-        return self->DirectService::get_td(number_or_hash);
+    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto num_or_hash) {
+        return self->DirectService::get_td(num_or_hash);
     }(this, number_or_hash));
 }
 
 // rpc GetHeader(GetSegmentRequest) returns(GetHeaderResponse);
 Task<std::optional<BlockHeader>> ActiveDirectService::get_header(BlockNumberOrHash number_or_hash) {
-    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto number_or_hash) {
-        return self->DirectService::get_header(number_or_hash);
+    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto num_or_hash) {
+        return self->DirectService::get_header(num_or_hash);
     }(this, number_or_hash));
 }
 
 // rpc GetBody(GetSegmentRequest) returns(GetBodyResponse);
 Task<std::optional<BlockBody>> ActiveDirectService::get_body(BlockNumberOrHash number_or_hash) {
-    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto number_or_hash) {
-        return self->DirectService::get_body(number_or_hash);
+    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto num_or_hash) {
+        return self->DirectService::get_body(num_or_hash);
     }(this, number_or_hash));
 }
 
 // rpc HasBlock(GetSegmentRequest) returns(HasBlockResponse);
 Task<bool> ActiveDirectService::has_block(BlockNumberOrHash number_or_hash) {
-    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto number_or_hash) {
-        return self->DirectService::has_block(number_or_hash);
+    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto num_or_hash) {
+        return self->DirectService::has_block(num_or_hash);
     }(this, number_or_hash));
 }
 
@@ -119,15 +119,15 @@ Task<bool> ActiveDirectService::has_block(BlockNumberOrHash number_or_hash) {
 
 // rpc GetBodiesByRange(GetBodiesByRangeRequest) returns(GetBodiesBatchResponse);
 Task<BlockBodies> ActiveDirectService::get_bodies_by_range(BlockNumRange number_range) {
-    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto number_range) {
-        return self->DirectService::get_bodies_by_range(number_range);
+    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto num_range) {
+        return self->DirectService::get_bodies_by_range(num_range);
     }(this, number_range));
 }
 
 // rpc GetBodiesByHashes(GetBodiesByHashesRequest) returns(GetBodiesBatchResponse);
 Task<BlockBodies> ActiveDirectService::get_bodies_by_hashes(const BlockHashes& hashes) {
-    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto hashes) {
-        return self->DirectService::get_bodies_by_hashes(hashes);
+    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto hh) {
+        return self->DirectService::get_bodies_by_hashes(hh);
     }(this, hashes));
 }
 
@@ -135,15 +135,15 @@ Task<BlockBodies> ActiveDirectService::get_bodies_by_hashes(const BlockHashes& h
 
 // rpc IsCanonicalHash(types.H256) returns(IsCanonicalResponse);
 Task<bool> ActiveDirectService::is_canonical_hash(Hash block_hash) {
-    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto block_hash) {
-        return self->DirectService::is_canonical_hash(block_hash);
+    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto h) {
+        return self->DirectService::is_canonical_hash(h);
     }(this, block_hash));
 }
 
 // rpc GetHeaderHashNumber(types.H256) returns(GetHeaderHashNumberResponse);
 Task<std::optional<BlockNum>> ActiveDirectService::get_header_hash_number(Hash block_hash) {
-    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto block_hash) {
-        return self->DirectService::get_header_hash_number(block_hash);
+    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto h) {
+        return self->DirectService::get_header_hash_number(h);
     }(this, block_hash));
 }
 
@@ -173,8 +173,8 @@ Task<uint64_t> ActiveDirectService::frozen_blocks() {
 /** Additional non-RPC methods **/
 
 Task<BlockHeaders> ActiveDirectService::get_last_headers(uint64_t n) {
-    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto n) {
-        return self->DirectService::get_last_headers(n);
+    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto how_many) {
+        return self->DirectService::get_last_headers(how_many);
     }(this, n));
 }
 

--- a/silkworm/node/execution/api/active_direct_service.cpp
+++ b/silkworm/node/execution/api/active_direct_service.cpp
@@ -1,0 +1,187 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "active_direct_service.hpp"
+
+#include <silkworm/infra/concurrency/co_spawn_sw.hpp>
+
+namespace silkworm::execution::api {
+
+ActiveDirectService::ActiveDirectService(stagedsync::ExecutionEngine& exec_engine, boost::asio::io_context& context)
+    : DirectService{exec_engine}, context_{context}, executor_{context_.get_executor()} {}
+
+void ActiveDirectService::execution_loop() {
+    exec_engine_.open();
+
+    boost::asio::executor_work_guard<decltype(executor_)> work{executor_};
+    context_.run();
+
+    exec_engine_.close();
+}
+
+bool ActiveDirectService::stop() {
+    context_.stop();
+    return ActiveComponent::stop();
+}
+
+/** Chain Putters **/
+
+// rpc InsertBlocks(InsertBlocksRequest) returns(InsertionResult);
+Task<InsertionResult> ActiveDirectService::insert_blocks(const Blocks& blocks) {
+    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto blocks) {
+        return self->DirectService::insert_blocks(blocks);
+    }(this, blocks));
+}
+
+/** Chain Validation and ForkChoice **/
+
+// rpc ValidateChain(ValidationRequest) returns(ValidationReceipt);
+Task<ValidationResult> ActiveDirectService::validate_chain(BlockNumAndHash number_and_hash) {
+    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto number_and_hash) {
+        return self->DirectService::validate_chain(number_and_hash);
+    }(this, number_and_hash));
+}
+
+// rpc UpdateForkChoice(ForkChoice) returns(ForkChoiceReceipt);
+Task<ForkChoiceResult> ActiveDirectService::update_fork_choice(const ForkChoice& fork_choice) {
+    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto fork_choice) {
+        return self->DirectService::update_fork_choice(fork_choice);
+    }(this, fork_choice));
+}
+
+/** Block Assembly **/
+
+// rpc AssembleBlock(AssembleBlockRequest) returns(AssembleBlockResponse);
+Task<AssembleBlockResult> ActiveDirectService::assemble_block(const api::BlockUnderConstruction& block) {
+    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto block) {
+        return self->DirectService::assemble_block(block);
+    }(this, block));
+}
+
+// rpc GetAssembledBlock(GetAssembledBlockRequest) returns(GetAssembledBlockResponse);
+Task<AssembledBlockResult> ActiveDirectService::get_assembled_block(PayloadId payload_id) {
+    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto payload_id) {
+        return self->DirectService::get_assembled_block(payload_id);
+    }(this, payload_id));
+}
+
+/** Chain Getters **/
+
+// rpc CurrentHeader(google.protobuf.Empty) returns(GetHeaderResponse);
+Task<std::optional<BlockHeader>> ActiveDirectService::current_header() {
+    return concurrency::co_spawn_and_await(executor_, [](auto* self) {
+        return self->DirectService::current_header();
+    }(this));
+}
+
+// rpc GetTD(GetSegmentRequest) returns(GetTDResponse);
+Task<std::optional<TotalDifficulty>> ActiveDirectService::get_td(BlockNumberOrHash number_or_hash) {
+    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto number_or_hash) {
+        return self->DirectService::get_td(number_or_hash);
+    }(this, number_or_hash));
+}
+
+// rpc GetHeader(GetSegmentRequest) returns(GetHeaderResponse);
+Task<std::optional<BlockHeader>> ActiveDirectService::get_header(BlockNumberOrHash number_or_hash) {
+    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto number_or_hash) {
+        return self->DirectService::get_header(number_or_hash);
+    }(this, number_or_hash));
+}
+
+// rpc GetBody(GetSegmentRequest) returns(GetBodyResponse);
+Task<std::optional<BlockBody>> ActiveDirectService::get_body(BlockNumberOrHash number_or_hash) {
+    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto number_or_hash) {
+        return self->DirectService::get_body(number_or_hash);
+    }(this, number_or_hash));
+}
+
+// rpc HasBlock(GetSegmentRequest) returns(HasBlockResponse);
+Task<bool> ActiveDirectService::has_block(BlockNumberOrHash number_or_hash) {
+    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto number_or_hash) {
+        return self->DirectService::has_block(number_or_hash);
+    }(this, number_or_hash));
+}
+
+/** Ranges **/
+
+// rpc GetBodiesByRange(GetBodiesByRangeRequest) returns(GetBodiesBatchResponse);
+Task<BlockBodies> ActiveDirectService::get_bodies_by_range(BlockNumRange number_range) {
+    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto number_range) {
+        return self->DirectService::get_bodies_by_range(number_range);
+    }(this, number_range));
+}
+
+// rpc GetBodiesByHashes(GetBodiesByHashesRequest) returns(GetBodiesBatchResponse);
+Task<BlockBodies> ActiveDirectService::get_bodies_by_hashes(const BlockHashes& hashes) {
+    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto hashes) {
+        return self->DirectService::get_bodies_by_hashes(hashes);
+    }(this, hashes));
+}
+
+/** Chain Checkers **/
+
+// rpc IsCanonicalHash(types.H256) returns(IsCanonicalResponse);
+Task<bool> ActiveDirectService::is_canonical_hash(Hash block_hash) {
+    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto block_hash) {
+        return self->DirectService::is_canonical_hash(block_hash);
+    }(this, block_hash));
+}
+
+// rpc GetHeaderHashNumber(types.H256) returns(GetHeaderHashNumberResponse);
+Task<std::optional<BlockNum>> ActiveDirectService::get_header_hash_number(Hash block_hash) {
+    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto block_hash) {
+        return self->DirectService::get_header_hash_number(block_hash);
+    }(this, block_hash));
+}
+
+// rpc GetForkChoice(google.protobuf.Empty) returns(ForkChoice);
+Task<ForkChoice> ActiveDirectService::get_fork_choice() {
+    return concurrency::co_spawn_and_await(executor_, [](auto* self) {
+        return self->DirectService::get_fork_choice();
+    }(this));
+}
+
+/** Misc **/
+
+// rpc Ready(google.protobuf.Empty) returns(ReadyResponse);
+Task<bool> ActiveDirectService::ready() {
+    return concurrency::co_spawn_and_await(executor_, [](auto* self) {
+        return self->DirectService::ready();
+    }(this));
+}
+
+// rpc FrozenBlocks(google.protobuf.Empty) returns(FrozenBlocksResponse);
+Task<uint64_t> ActiveDirectService::frozen_blocks() {
+    return concurrency::co_spawn_and_await(executor_, [](auto* self) {
+        return self->DirectService::frozen_blocks();
+    }(this));
+}
+
+/** Additional non-RPC methods **/
+
+Task<BlockHeaders> ActiveDirectService::get_last_headers(uint64_t n) {
+    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto n) {
+        return self->DirectService::get_last_headers(n);
+    }(this, n));
+}
+
+Task<BlockNum> ActiveDirectService::block_progress() {
+    return concurrency::co_spawn_and_await(executor_, [](auto* self) {
+        return self->DirectService::block_progress();
+    }(this));
+}
+
+}  // namespace silkworm::execution::api

--- a/silkworm/node/execution/api/active_direct_service.hpp
+++ b/silkworm/node/execution/api/active_direct_service.hpp
@@ -1,0 +1,119 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <silkworm/infra/concurrency/active_component.hpp>
+#include <silkworm/infra/concurrency/task.hpp>
+#include <silkworm/node/stagedsync/execution_engine.hpp>
+
+#include "direct_service.hpp"
+
+namespace silkworm::execution::api {
+
+//! Active \code DirectService implementation running on one \code TaskExecutor.
+class ActiveDirectService : public DirectService, public ActiveComponent {
+  public:
+    ActiveDirectService(stagedsync::ExecutionEngine& exec_engine, boost::asio::io_context& context);
+    ~ActiveDirectService() override = default;
+
+    ActiveDirectService(const ActiveDirectService&) = delete;
+    ActiveDirectService& operator=(const ActiveDirectService&) = delete;
+
+    ActiveDirectService(ActiveDirectService&&) = delete;
+    ActiveDirectService& operator=(ActiveDirectService&&) = delete;
+
+    /** Chain Putters **/
+
+    // rpc InsertBlocks(InsertBlocksRequest) returns(InsertionResult);
+    Task<InsertionResult> insert_blocks(const Blocks& blocks) override;
+
+    /** Chain Validation and ForkChoice **/
+
+    // rpc ValidateChain(ValidationRequest) returns(ValidationReceipt);
+    Task<ValidationResult> validate_chain(BlockNumAndHash number_and_hash) override;
+
+    // rpc UpdateForkChoice(ForkChoice) returns(ForkChoiceReceipt);
+    Task<ForkChoiceResult> update_fork_choice(const ForkChoice& fork_choice) override;
+
+    /** Block Assembly **/
+
+    // rpc AssembleBlock(AssembleBlockRequest) returns(AssembleBlockResponse);
+    Task<AssembleBlockResult> assemble_block(const BlockUnderConstruction&) override;
+
+    // rpc GetAssembledBlock(GetAssembledBlockRequest) returns(GetAssembledBlockResponse);
+    Task<AssembledBlockResult> get_assembled_block(PayloadId id) override;
+
+    /** Chain Getters **/
+
+    // rpc CurrentHeader(google.protobuf.Empty) returns(GetHeaderResponse);
+    Task<std::optional<BlockHeader>> current_header() override;
+
+    // rpc GetTD(GetSegmentRequest) returns(GetTDResponse);
+    Task<std::optional<TotalDifficulty>> get_td(BlockNumberOrHash number_or_hash) override;
+
+    // rpc GetHeader(GetSegmentRequest) returns(GetHeaderResponse);
+    Task<std::optional<BlockHeader>> get_header(BlockNumberOrHash number_or_hash) override;
+
+    // rpc GetBody(GetSegmentRequest) returns(GetBodyResponse);
+    Task<std::optional<BlockBody>> get_body(BlockNumberOrHash number_or_hash) override;
+
+    // rpc HasBlock(GetSegmentRequest) returns(HasBlockResponse);
+    Task<bool> has_block(BlockNumberOrHash number_or_hash) override;
+
+    /** Ranges **/
+
+    // rpc GetBodiesByRange(GetBodiesByRangeRequest) returns(GetBodiesBatchResponse);
+    Task<BlockBodies> get_bodies_by_range(BlockNumRange range) override;
+
+    // rpc GetBodiesByHashes(GetBodiesByHashesRequest) returns(GetBodiesBatchResponse);
+    Task<BlockBodies> get_bodies_by_hashes(const BlockHashes& hashes) override;
+
+    /** Chain Checkers **/
+
+    // rpc IsCanonicalHash(types.H256) returns(IsCanonicalResponse);
+    Task<bool> is_canonical_hash(Hash block_hash) override;
+
+    // rpc GetHeaderHashNumber(types.H256) returns(GetHeaderHashNumberResponse);
+    Task<std::optional<BlockNum>> get_header_hash_number(Hash block_hash) override;
+
+    // rpc GetForkChoice(google.protobuf.Empty) returns(ForkChoice);
+    Task<ForkChoice> get_fork_choice() override;
+
+    /** Misc **/
+
+    // rpc Ready(google.protobuf.Empty) returns(ReadyResponse);
+    Task<bool> ready() override;
+
+    // rpc FrozenBlocks(google.protobuf.Empty) returns(FrozenBlocksResponse);
+    Task<uint64_t> frozen_blocks() override;
+
+    /** Additional non-RPC methods **/
+
+    Task<BlockHeaders> get_last_headers(uint64_t n) override;
+
+    Task<BlockNum> block_progress() override;
+
+  protected:
+    void execution_loop() override;
+    bool stop() override;
+
+  private:
+    boost::asio::io_context& context_;
+    TaskExecutor executor_;
+};
+
+}  // namespace silkworm::execution::api

--- a/silkworm/node/execution/api/active_direct_service.hpp
+++ b/silkworm/node/execution/api/active_direct_service.hpp
@@ -16,8 +16,9 @@
 
 #pragma once
 
-#include <silkworm/infra/concurrency/active_component.hpp>
 #include <silkworm/infra/concurrency/task.hpp>
+
+#include <silkworm/infra/concurrency/active_component.hpp>
 #include <silkworm/node/stagedsync/execution_engine.hpp>
 
 #include "direct_service.hpp"

--- a/silkworm/node/execution/api/client.hpp
+++ b/silkworm/node/execution/api/client.hpp
@@ -1,0 +1,31 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <memory>
+
+#include "service.hpp"
+
+namespace silkworm::execution::api {
+
+struct Client {
+    virtual ~Client() = default;
+
+    virtual std::shared_ptr<Service> service() = 0;
+};
+
+}  // namespace silkworm::execution::api

--- a/silkworm/node/execution/api/direct_client.cpp
+++ b/silkworm/node/execution/api/direct_client.cpp
@@ -1,0 +1,28 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "direct_client.hpp"
+
+namespace silkworm::execution::api {
+
+DirectClient::DirectClient(std::shared_ptr<DirectService> direct_service)
+    : direct_service_(std::move(direct_service)) {}
+
+std::shared_ptr<api::Service> DirectClient::service() {
+    return direct_service_;
+}
+
+}  // namespace silkworm::execution::api

--- a/silkworm/node/execution/api/direct_client.hpp
+++ b/silkworm/node/execution/api/direct_client.hpp
@@ -1,0 +1,36 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <memory>
+
+#include "../api/client.hpp"
+#include "../api/direct_service.hpp"
+
+namespace silkworm::execution::api {
+
+struct DirectClient : public api::Client {
+    explicit DirectClient(std::shared_ptr<DirectService> direct_service);
+    ~DirectClient() override = default;
+
+    std::shared_ptr<api::Service> service() override;
+
+  private:
+    std::shared_ptr<DirectService> direct_service_;
+};
+
+}  // namespace silkworm::execution::api

--- a/silkworm/node/execution/api/direct_service.cpp
+++ b/silkworm/node/execution/api/direct_service.cpp
@@ -1,0 +1,234 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "direct_service.hpp"
+
+namespace silkworm::execution::api {
+
+DirectService::DirectService(stagedsync::ExecutionEngine& exec_engine)
+    : exec_engine_{exec_engine} {}
+
+/** Chain Putters **/
+
+// rpc InsertBlocks(InsertBlocksRequest) returns(InsertionResult);
+Task<InsertionResult> DirectService::insert_blocks(const Blocks& blocks) {
+    const bool ready_for_insertion{co_await ready()};
+    if (!ready_for_insertion) {
+        co_return InsertionResult{.status = api::ExecutionStatus::kBusy};
+    }
+    // TODO(canepat) handle more errors out of insert_blocks (e.g. bad block...)
+    exec_engine_.insert_blocks(blocks);
+    co_return InsertionResult{.status = api::ExecutionStatus::kSuccess};
+}
+
+/** Chain Validation and ForkChoice **/
+
+// rpc ValidateChain(ValidationRequest) returns(ValidationReceipt);
+Task<ValidationResult> DirectService::validate_chain(BlockNumAndHash number_and_hash) {
+    auto future_result = exec_engine_.verify_chain(number_and_hash.hash);
+    const auto verification = co_await future_result.get_async();
+
+    ValidationResult validation;
+    if (std::holds_alternative<stagedsync::ValidChain>(verification)) {
+        const auto valid = std::get<stagedsync::ValidChain>(verification);
+        validation = ValidChain{valid.current_head};
+    } else if (std::holds_alternative<stagedsync::InvalidChain>(verification)) {
+        const auto invalid = std::get<stagedsync::InvalidChain>(verification);
+        validation = InvalidChain{invalid.unwind_point, invalid.bad_block, invalid.bad_headers};
+    } else if (std::holds_alternative<stagedsync::ValidationError>(verification)) {
+        const auto error = std::get<stagedsync::ValidationError>(verification);
+        validation = ValidationError{error.latest_valid_head};
+    } else {
+        throw std::logic_error("DirectService::validate_chain unknown error: " + std::to_string(verification.index()));
+    }
+    co_return validation;
+}
+
+// rpc UpdateForkChoice(ForkChoice) returns(ForkChoiceReceipt);
+Task<ForkChoiceResult> DirectService::update_fork_choice(const ForkChoice& fork_choice) {
+    const auto& head_block_hash{fork_choice.head_block_hash};
+    const auto& finalized_block_hash{fork_choice.finalized_block_hash};
+    const auto& safe_block_hash{fork_choice.safe_block_hash};
+    const bool updated = exec_engine_.notify_fork_choice_update(head_block_hash,
+                                                                finalized_block_hash,
+                                                                safe_block_hash);  // BLOCKING, will block the entire io_context thread
+
+    const auto last_fork_choice = exec_engine_.last_fork_choice();
+    ForkChoiceResult result{
+        .status = updated ? api::ExecutionStatus::kSuccess : api::ExecutionStatus::kInvalidForkchoice,
+        .latest_valid_head = last_fork_choice.hash,
+        // TODO(canepat) add support for validation error
+    };
+    co_return result;
+}
+
+/** Block Assembly **/
+
+// rpc AssembleBlock(AssembleBlockRequest) returns(AssembleBlockResponse);
+Task<AssembleBlockResult> DirectService::assemble_block(const api::BlockUnderConstruction&) {
+    // TODO(canepat) not yet supported
+    co_return AssembleBlockResult{};
+}
+
+// rpc GetAssembledBlock(GetAssembledBlockRequest) returns(GetAssembledBlockResponse);
+Task<AssembledBlockResult> DirectService::get_assembled_block(PayloadId) {
+    // TODO(canepat) not yet supported
+    co_return AssembledBlockResult{};
+}
+
+/** Chain Getters **/
+
+// rpc CurrentHeader(google.protobuf.Empty) returns(GetHeaderResponse);
+Task<std::optional<BlockHeader>> DirectService::current_header() {
+    const auto last_number_and_hash{exec_engine_.last_finalized_block()};
+    co_return exec_engine_.get_header(last_number_and_hash.hash);
+}
+
+// rpc GetTD(GetSegmentRequest) returns(GetTDResponse);
+Task<std::optional<TotalDifficulty>> DirectService::get_td(BlockNumberOrHash number_or_hash) {
+    if (std::holds_alternative<Hash>(number_or_hash)) {
+        co_return exec_engine_.get_header_td(std::get<Hash>(number_or_hash));
+    } else {
+        SILKWORM_ASSERT(std::holds_alternative<BlockNum>(number_or_hash));
+        const auto block_number{std::get<BlockNum>(number_or_hash)};
+        const auto canonical_hash{exec_engine_.get_canonical_hash(block_number)};
+        if (!canonical_hash) {
+            co_return std::nullopt;
+        }
+        co_return exec_engine_.get_header_td(*canonical_hash, block_number);
+    }
+}
+
+// rpc GetHeader(GetSegmentRequest) returns(GetHeaderResponse);
+Task<std::optional<BlockHeader>> DirectService::get_header(BlockNumberOrHash number_or_hash) {
+    if (std::holds_alternative<Hash>(number_or_hash)) {
+        co_return exec_engine_.get_header(std::get<Hash>(number_or_hash));
+    } else {
+        SILKWORM_ASSERT(std::holds_alternative<BlockNum>(number_or_hash));
+        const auto block_number{std::get<BlockNum>(number_or_hash)};
+        co_return exec_engine_.get_canonical_header(block_number);
+    }
+}
+
+// rpc GetBody(GetSegmentRequest) returns(GetBodyResponse);
+Task<std::optional<BlockBody>> DirectService::get_body(BlockNumberOrHash number_or_hash) {
+    if (std::holds_alternative<Hash>(number_or_hash)) {
+        co_return exec_engine_.get_body(std::get<Hash>(number_or_hash));
+    } else {
+        SILKWORM_ASSERT(std::holds_alternative<BlockNum>(number_or_hash));
+        const auto block_number{std::get<BlockNum>(number_or_hash)};
+        co_return exec_engine_.get_canonical_body(block_number);
+    }
+}
+
+// rpc HasBlock(GetSegmentRequest) returns(HasBlockResponse);
+Task<bool> DirectService::has_block(BlockNumberOrHash number_or_hash) {
+    if (std::holds_alternative<Hash>(number_or_hash)) {
+        co_return exec_engine_.get_header(std::get<Hash>(number_or_hash));
+    } else {
+        SILKWORM_ASSERT(std::holds_alternative<BlockNum>(number_or_hash));
+        const auto block_number{std::get<BlockNum>(number_or_hash)};
+        const auto canonical_hash{exec_engine_.get_canonical_hash(block_number)};
+        if (!canonical_hash) {
+            co_return false;
+        }
+        co_return exec_engine_.get_header(*canonical_hash);
+    }
+}
+
+/** Ranges **/
+
+// rpc GetBodiesByRange(GetBodiesByRangeRequest) returns(GetBodiesBatchResponse);
+Task<BlockBodies> DirectService::get_bodies_by_range(BlockNumRange number_range) {
+    BlockBodies bodies;
+    const auto [start_block_number, end_block_number] = number_range;
+    if (start_block_number > end_block_number) {
+        co_return bodies;
+    }
+    bodies.reserve(end_block_number - start_block_number + 1);
+    for (BlockNum number{start_block_number}; number <= end_block_number; ++number) {
+        auto block_body{exec_engine_.get_canonical_body(number)};
+        auto block_hash{exec_engine_.get_canonical_hash(number)};
+        if (block_body && block_hash) {
+            bodies.push_back(Body{std::move(*block_body), *block_hash, number});
+        }
+    }
+    co_return bodies;
+}
+
+// rpc GetBodiesByHashes(GetBodiesByHashesRequest) returns(GetBodiesBatchResponse);
+Task<BlockBodies> DirectService::get_bodies_by_hashes(const BlockHashes& hashes) {
+    BlockBodies bodies;
+    bodies.reserve(hashes.size());
+    for (const auto& block_hash : hashes) {
+        auto block_body{exec_engine_.get_body(block_hash)};
+        auto block_number{exec_engine_.get_block_number(block_hash)};
+        if (block_body && block_number) {
+            bodies.push_back(Body{std::move(*block_body), block_hash, *block_number});
+        }
+    }
+    co_return bodies;
+}
+
+/** Chain Checkers **/
+
+// rpc IsCanonicalHash(types.H256) returns(IsCanonicalResponse);
+Task<bool> DirectService::is_canonical_hash(Hash block_hash) {
+    co_return exec_engine_.is_canonical(block_hash);
+}
+
+// rpc GetHeaderHashNumber(types.H256) returns(GetHeaderHashNumberResponse);
+Task<std::optional<BlockNum>> DirectService::get_header_hash_number(Hash block_hash) {
+    co_return exec_engine_.get_block_number(block_hash);
+}
+
+// rpc GetForkChoice(google.protobuf.Empty) returns(ForkChoice);
+Task<ForkChoice> DirectService::get_fork_choice() {
+    const auto last_fork_choice_number_and_hash{exec_engine_.last_fork_choice()};
+    const auto last_finalized_number_and_hash{exec_engine_.last_finalized_block()};
+    const auto last_safe_number_and_hash{exec_engine_.last_safe_block()};
+    ForkChoice last_fork_choice{
+        .head_block_hash = last_fork_choice_number_and_hash.hash,
+        .finalized_block_hash = last_finalized_number_and_hash.hash,
+        .safe_block_hash = last_safe_number_and_hash.hash,
+    };
+    co_return last_fork_choice;
+}
+
+/** Misc **/
+
+// rpc Ready(google.protobuf.Empty) returns(ReadyResponse);
+Task<bool> DirectService::ready() {
+    // TODO(canepat) use semaphore to sync access to the database wrt block execution
+    co_return true;
+}
+
+// rpc FrozenBlocks(google.protobuf.Empty) returns(FrozenBlocksResponse);
+Task<uint64_t> DirectService::frozen_blocks() {
+    co_return db::DataModel::highest_frozen_block_number();
+}
+
+/** Additional non-RPC methods **/
+
+Task<BlockHeaders> DirectService::get_last_headers(uint64_t n) {
+    co_return exec_engine_.get_last_headers(n);
+}
+
+Task<BlockNum> DirectService::block_progress() {
+    co_return exec_engine_.block_progress();
+}
+
+}  // namespace silkworm::execution::api

--- a/silkworm/node/execution/api/direct_service.hpp
+++ b/silkworm/node/execution/api/direct_service.hpp
@@ -1,0 +1,113 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <silkworm/node/stagedsync/execution_engine.hpp>
+
+#include "service.hpp"
+
+namespace silkworm::execution::api {
+
+//! Straightforward asynchronous implementation of Execution API service relying on \code ExecutionEngine.
+//! This is used both client-side by 'direct' (i.e. no-gRPC) implementation and server-side by gRPC server.
+class DirectService : public Service {
+  public:
+    explicit DirectService(stagedsync::ExecutionEngine& exec_engine);
+    ~DirectService() override = default;
+
+    DirectService(const DirectService&) = delete;
+    DirectService& operator=(const DirectService&) = delete;
+
+    DirectService(DirectService&&) = delete;
+    DirectService& operator=(DirectService&&) = delete;
+
+    /** Chain Putters **/
+
+    // rpc InsertBlocks(InsertBlocksRequest) returns(InsertionResult);
+    Task<InsertionResult> insert_blocks(const Blocks& blocks) override;
+
+    /** Chain Validation and ForkChoice **/
+
+    // rpc ValidateChain(ValidationRequest) returns(ValidationReceipt);
+    Task<ValidationResult> validate_chain(BlockNumAndHash number_and_hash) override;
+
+    // rpc UpdateForkChoice(ForkChoice) returns(ForkChoiceReceipt);
+    Task<ForkChoiceResult> update_fork_choice(const ForkChoice& fork_choice) override;
+
+    /** Block Assembly **/
+
+    // rpc AssembleBlock(AssembleBlockRequest) returns(AssembleBlockResponse);
+    Task<AssembleBlockResult> assemble_block(const BlockUnderConstruction&) override;
+
+    // rpc GetAssembledBlock(GetAssembledBlockRequest) returns(GetAssembledBlockResponse);
+    Task<AssembledBlockResult> get_assembled_block(PayloadId id) override;
+
+    /** Chain Getters **/
+
+    // rpc CurrentHeader(google.protobuf.Empty) returns(GetHeaderResponse);
+    Task<std::optional<BlockHeader>> current_header() override;
+
+    // rpc GetTD(GetSegmentRequest) returns(GetTDResponse);
+    Task<std::optional<TotalDifficulty>> get_td(BlockNumberOrHash number_or_hash) override;
+
+    // rpc GetHeader(GetSegmentRequest) returns(GetHeaderResponse);
+    Task<std::optional<BlockHeader>> get_header(BlockNumberOrHash number_or_hash) override;
+
+    // rpc GetBody(GetSegmentRequest) returns(GetBodyResponse);
+    Task<std::optional<BlockBody>> get_body(BlockNumberOrHash number_or_hash) override;
+
+    // rpc HasBlock(GetSegmentRequest) returns(HasBlockResponse);
+    Task<bool> has_block(BlockNumberOrHash number_or_hash) override;
+
+    /** Ranges **/
+
+    // rpc GetBodiesByRange(GetBodiesByRangeRequest) returns(GetBodiesBatchResponse);
+    Task<BlockBodies> get_bodies_by_range(BlockNumRange range) override;
+
+    // rpc GetBodiesByHashes(GetBodiesByHashesRequest) returns(GetBodiesBatchResponse);
+    Task<BlockBodies> get_bodies_by_hashes(const BlockHashes& hashes) override;
+
+    /** Chain Checkers **/
+
+    // rpc IsCanonicalHash(types.H256) returns(IsCanonicalResponse);
+    Task<bool> is_canonical_hash(Hash block_hash) override;
+
+    // rpc GetHeaderHashNumber(types.H256) returns(GetHeaderHashNumberResponse);
+    Task<std::optional<BlockNum>> get_header_hash_number(Hash block_hash) override;
+
+    // rpc GetForkChoice(google.protobuf.Empty) returns(ForkChoice);
+    Task<ForkChoice> get_fork_choice() override;
+
+    /** Misc **/
+
+    // rpc Ready(google.protobuf.Empty) returns(ReadyResponse);
+    Task<bool> ready() override;
+
+    // rpc FrozenBlocks(google.protobuf.Empty) returns(FrozenBlocksResponse);
+    Task<uint64_t> frozen_blocks() override;
+
+    /** Additional non-RPC methods **/
+
+    Task<BlockHeaders> get_last_headers(uint64_t n) override;
+
+    Task<BlockNum> block_progress() override;
+
+  protected:
+    stagedsync::ExecutionEngine& exec_engine_;
+};
+
+}  // namespace silkworm::execution::api

--- a/silkworm/node/execution/api/direct_service_test.cpp
+++ b/silkworm/node/execution/api/direct_service_test.cpp
@@ -1,0 +1,284 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "direct_service.hpp"
+
+#include <stdexcept>
+#include <utility>
+
+#include <catch2/catch.hpp>
+#include <gmock/gmock.h>
+
+#include <silkworm/infra/test_util/log.hpp>
+#include <silkworm/infra/test_util/task_runner.hpp>
+#include <silkworm/db/test_util/temp_chain_data.hpp>
+#include <silkworm/node/stagedsync/execution_engine.hpp>
+#include <silkworm/node/test_util/temp_chain_data_node_settings.hpp>
+
+namespace silkworm::execution::api {
+
+using testing::_;
+using testing::InvokeWithoutArgs;
+
+using silkworm::test_util::SetLogVerbosityGuard;
+using silkworm::test_util::TaskRunner;
+using silkworm::db::test_util::TempChainData;
+using silkworm::node::test_util::make_node_settings_from_temp_chain_data;
+
+class MockExecutionEngine : public stagedsync::ExecutionEngine {
+  public:
+    MockExecutionEngine(boost::asio::io_context& ioc, NodeSettings& ns, db::RWAccess dba)
+        : ExecutionEngine(ioc, ns, std::move(dba)) {}
+    ~MockExecutionEngine() override = default;
+
+    MOCK_METHOD((void), open, ());
+    MOCK_METHOD((void), close, ());
+
+    MOCK_METHOD((void), insert_blocks, (const std::vector<std::shared_ptr<Block>>&), (override));
+    MOCK_METHOD((stagedsync::VerificationResultFuture), verify_chain, (Hash), (override));
+    MOCK_METHOD((bool), notify_fork_choice_update1, (Hash));
+    MOCK_METHOD((bool), notify_fork_choice_update2, (Hash, Hash));
+    MOCK_METHOD((bool), notify_fork_choice_update3, (Hash, Hash, Hash));
+    bool notify_fork_choice_update(Hash head_block_hash,
+                                   std::optional<Hash> finalized_block_hash,
+                                   std::optional<Hash> safe_block_hash) override {
+        if (finalized_block_hash && safe_block_hash) {
+            return notify_fork_choice_update3(head_block_hash, *finalized_block_hash, *safe_block_hash);
+        } else {
+            if (finalized_block_hash) {
+                return notify_fork_choice_update2(head_block_hash, *finalized_block_hash);
+            } else {
+                return notify_fork_choice_update1(head_block_hash);
+            }
+        }
+        return false;
+    }
+
+    MOCK_METHOD((BlockId), last_fork_choice, (), (const, override));
+    MOCK_METHOD((BlockId), last_finalized_block, (), (const, override));
+    MOCK_METHOD((BlockId), last_safe_block, (), (const, override));
+
+    MOCK_METHOD((std::optional<BlockNum>), get_block_number, (Hash), (const, override));
+
+    MOCK_METHOD((BlockHeaders), get_last_headers, (uint64_t), (const, override));
+    MOCK_METHOD((BlockNum), block_progress, (), (const, override));
+};
+
+struct DirectServiceTest : public TaskRunner {
+    explicit DirectServiceTest()
+        : log_guard{log::Level::kNone},
+          settings{make_node_settings_from_temp_chain_data(tmp_chaindata)},
+          dba{tmp_chaindata.env()} {
+        tmp_chaindata.add_genesis_data();
+        tmp_chaindata.commit_txn();
+        mock_execution_engine = std::make_unique<MockExecutionEngine>(context(), settings, dba);
+        direct_service = std::make_unique<DirectService>(*mock_execution_engine);
+    }
+
+    SetLogVerbosityGuard log_guard;
+    TempChainData tmp_chaindata;
+    NodeSettings settings;
+    db::RWAccess dba;
+    std::unique_ptr<MockExecutionEngine> mock_execution_engine;
+    std::unique_ptr<DirectService> direct_service;
+};
+
+TEST_CASE_METHOD(DirectServiceTest, "DirectService::insert_blocks", "[node][execution][api]") {
+    const std::vector<Blocks> test_vectors = {
+        Blocks{},
+        Blocks{std::make_shared<Block>()},
+    };
+    for (const auto& blocks : test_vectors) {
+        SECTION("blocks: " + std::to_string(blocks.size())) {
+            EXPECT_CALL(*mock_execution_engine, insert_blocks(blocks))
+                .WillOnce(InvokeWithoutArgs([]() -> void {
+                    return;
+                }));
+            auto future = spawn_future(direct_service->insert_blocks(blocks));
+            context().run();
+            CHECK(future.get().status == api::ExecutionStatus::kSuccess);
+        }
+    }
+}
+
+TEST_CASE_METHOD(DirectServiceTest, "DirectService::verify_chain", "[node][execution][api]") {
+    const Hash latest_valid_hash{0x000000000000000000000000000000000000000000000000000000000000000A_bytes32};
+    const Hash new_hash{0x000000000000000000000000000000000000000000000000000000000000000B_bytes32};
+    const BlockNumAndHash latest_valid_head{
+        .number = 1,
+        .hash = latest_valid_hash,
+    };
+    const BlockNumAndHash new_head{
+        .number = 2,
+        .hash = new_hash,
+    };
+    const std::vector<std::pair<stagedsync::VerificationResult, execution::api::ValidationResult>> test_vectors{
+        {stagedsync::ValidChain{.current_head = new_head}, api::ValidChain{.current_head = new_head}},
+        {stagedsync::InvalidChain{.unwind_point = latest_valid_head}, api::InvalidChain{.unwind_point = latest_valid_head}},
+        {stagedsync::ValidationError{.latest_valid_head = latest_valid_head}, api::ValidationError{.latest_valid_head = latest_valid_head}},
+    };
+    for (const auto& [stagedsync_result, api_result] : test_vectors) {
+        SECTION("result: " + std::to_string(stagedsync_result.index())) {
+            EXPECT_CALL(*mock_execution_engine, verify_chain(new_head.hash))
+                .WillOnce(InvokeWithoutArgs([&, result = stagedsync_result]() -> stagedsync::VerificationResultFuture {
+                    stagedsync::VerificationResultPromise promise{context().get_executor()};
+                    promise.set_value(result);
+                    return promise.get_future();
+                }));
+            auto future = spawn_future(direct_service->validate_chain(new_head));
+            context().run();
+            const auto result{future.get()};
+            if (std::holds_alternative<stagedsync::ValidChain>(stagedsync_result)) {
+                CHECK(std::holds_alternative<api::ValidChain>(result));
+                const auto stagedsync_valid_chain{std::get<stagedsync::ValidChain>(stagedsync_result)};
+                const auto api_valid_chain{std::get<api::ValidChain>(result)};
+                CHECK(stagedsync_valid_chain.current_head == api_valid_chain.current_head);
+            } else if (std::holds_alternative<stagedsync::InvalidChain>(stagedsync_result)) {
+                CHECK(std::holds_alternative<api::InvalidChain>(result));
+                const auto stagedsync_invalid_chain{std::get<stagedsync::InvalidChain>(stagedsync_result)};
+                const auto api_invalid_chain{std::get<api::InvalidChain>(result)};
+                CHECK(stagedsync_invalid_chain.unwind_point == api_invalid_chain.unwind_point);
+                CHECK(stagedsync_invalid_chain.bad_headers == api_invalid_chain.bad_headers);
+                CHECK(stagedsync_invalid_chain.bad_block == api_invalid_chain.bad_block);
+            } else if (std::holds_alternative<stagedsync::ValidationError>(stagedsync_result)) {
+                CHECK(std::holds_alternative<api::ValidationError>(result));
+                const auto stagedsync_error{std::get<stagedsync::ValidationError>(stagedsync_result)};
+                const auto api_error{std::get<api::ValidationError>(result)};
+                CHECK(stagedsync_error.latest_valid_head == api_error.latest_valid_head);
+            } else {
+                REQUIRE(false);
+            }
+        }
+    }
+}
+
+TEST_CASE_METHOD(DirectServiceTest, "DirectService::update_fork_choice", "[node][execution][api]") {
+    const Hash head_block_hash{0x000000000000000000000000000000000000000000000000000000000000000A_bytes32};
+    const Hash finalized_block_hash{0x0000000000000000000000000000000000000000000000000000000000000002_bytes32};
+    const Hash safe_block_hash{0x0000000000000000000000000000000000000000000000000000000000000001_bytes32};
+    const ForkChoice fork_choice{
+        .head_block_hash = head_block_hash,
+        .timeout = 0,
+        .finalized_block_hash = finalized_block_hash,
+        .safe_block_hash = safe_block_hash,
+    };
+    const std::vector<std::pair<bool, ForkChoiceResult>> test_vectors{
+        {true, ForkChoiceResult{.status = api::ExecutionStatus::kSuccess, .latest_valid_head = head_block_hash}},
+        {false, ForkChoiceResult{.status = api::ExecutionStatus::kInvalidForkchoice, .latest_valid_head = finalized_block_hash}},
+    };
+    for (const auto& [updated, expected_choice_result] : test_vectors) {
+        SECTION("updated: " + std::to_string(updated)) {
+            EXPECT_CALL(*mock_execution_engine, notify_fork_choice_update3(head_block_hash, finalized_block_hash, safe_block_hash))
+                .WillOnce(InvokeWithoutArgs([result = updated]() -> bool {
+                    return result;
+                }));
+            EXPECT_CALL(*mock_execution_engine, last_fork_choice())
+                .WillOnce(InvokeWithoutArgs([=, result = updated]() -> BlockId {
+                    return result ? BlockId{10, head_block_hash} : BlockId{2, finalized_block_hash};
+                }));
+            auto future = spawn_future(direct_service->update_fork_choice(fork_choice));
+            context().run();
+            const auto fork_choice_result{future.get()};
+            CHECK(fork_choice_result.status == expected_choice_result.status);
+            CHECK(fork_choice_result.latest_valid_head == expected_choice_result.latest_valid_head);
+        }
+    }
+}
+
+TEST_CASE_METHOD(DirectServiceTest, "DirectService::get_block_number", "[node][execution][api]") {
+    const Hash block_hash{0x000000000000000000000000000000000000000000000000000000000000000A_bytes32};
+    SECTION("non-existent") {
+        EXPECT_CALL(*mock_execution_engine, get_block_number(block_hash))
+            .WillOnce(InvokeWithoutArgs([=]() -> std::optional<BlockNum> {
+                return {};
+            }));
+        auto future = spawn_future(direct_service->get_header_hash_number(block_hash));
+        context().run();
+        CHECK(future.get() == std::nullopt);
+    }
+    SECTION("existent") {
+        const BlockNum block_number{2};
+        EXPECT_CALL(*mock_execution_engine, get_block_number(block_hash))
+            .WillOnce(InvokeWithoutArgs([=]() -> std::optional<BlockNum> {
+                return block_number;
+            }));
+        auto future = spawn_future(direct_service->get_header_hash_number(block_hash));
+        context().run();
+        CHECK(future.get() == block_number);
+    }
+}
+
+TEST_CASE_METHOD(DirectServiceTest, "DirectService::get_fork_choice", "[node][execution][api]") {
+    const Hash head_block_hash{0x000000000000000000000000000000000000000000000000000000000000000A_bytes32};
+    const Hash finalized_block_hash{0x0000000000000000000000000000000000000000000000000000000000000002_bytes32};
+    const Hash safe_block_hash{0x0000000000000000000000000000000000000000000000000000000000000001_bytes32};
+    const ForkChoice expected_fork_choice{
+        .head_block_hash = head_block_hash,
+        .timeout = 0,
+        .finalized_block_hash = finalized_block_hash,
+        .safe_block_hash = safe_block_hash,
+    };
+    EXPECT_CALL(*mock_execution_engine, last_fork_choice())
+        .WillOnce(InvokeWithoutArgs([=]() -> BlockId {
+            return {10, head_block_hash};
+        }));
+    EXPECT_CALL(*mock_execution_engine, last_finalized_block())
+        .WillOnce(InvokeWithoutArgs([=]() -> BlockId {
+            return {2, finalized_block_hash};
+        }));
+    EXPECT_CALL(*mock_execution_engine, last_safe_block())
+        .WillOnce(InvokeWithoutArgs([=]() -> BlockId {
+            return {1, safe_block_hash};
+        }));
+    auto future = spawn_future(direct_service->get_fork_choice());
+    context().run();
+    const auto last_choice{future.get()};
+    CHECK(last_choice.head_block_hash == expected_fork_choice.head_block_hash);
+    CHECK(last_choice.timeout == expected_fork_choice.timeout);
+    CHECK(last_choice.finalized_block_hash == expected_fork_choice.finalized_block_hash);
+    CHECK(last_choice.safe_block_hash == expected_fork_choice.safe_block_hash);
+}
+
+TEST_CASE_METHOD(DirectServiceTest, "DirectService::get_last_headers", "[node][execution][api]") {
+    const std::vector<std::pair<uint64_t, BlockHeaders>> test_vectors = {
+        {0, {}},
+        {1, {BlockHeader{}}},
+    };
+    for (const auto& [how_many, last_headers] : test_vectors) {
+        SECTION("how_many: " + std::to_string(how_many)) {
+            EXPECT_CALL(*mock_execution_engine, get_last_headers(how_many))
+                .WillOnce(InvokeWithoutArgs([&, headers = last_headers]() -> BlockHeaders {
+                    return headers;
+                }));
+            auto future = spawn_future(direct_service->get_last_headers(how_many));
+            context().run();
+            CHECK(future.get() == last_headers);
+        }
+    }
+}
+
+TEST_CASE_METHOD(DirectServiceTest, "DirectService::block_progress", "[node][execution][api]") {
+    const BlockNum progress{123'456'789};
+    EXPECT_CALL(*mock_execution_engine, block_progress())
+        .WillOnce(InvokeWithoutArgs([=]() -> BlockNum {
+            return progress;
+        }));
+    auto future = spawn_future(direct_service->block_progress());
+    context().run();
+    CHECK(future.get() == progress);
+}
+
+}  // namespace silkworm::execution::api

--- a/silkworm/node/execution/api/direct_service_test.cpp
+++ b/silkworm/node/execution/api/direct_service_test.cpp
@@ -22,9 +22,9 @@
 #include <catch2/catch.hpp>
 #include <gmock/gmock.h>
 
+#include <silkworm/db/test_util/temp_chain_data.hpp>
 #include <silkworm/infra/test_util/log.hpp>
 #include <silkworm/infra/test_util/task_runner.hpp>
-#include <silkworm/db/test_util/temp_chain_data.hpp>
 #include <silkworm/node/stagedsync/execution_engine.hpp>
 #include <silkworm/node/test_util/temp_chain_data_node_settings.hpp>
 
@@ -33,10 +33,10 @@ namespace silkworm::execution::api {
 using testing::_;
 using testing::InvokeWithoutArgs;
 
-using silkworm::test_util::SetLogVerbosityGuard;
-using silkworm::test_util::TaskRunner;
 using silkworm::db::test_util::TempChainData;
 using silkworm::node::test_util::make_node_settings_from_temp_chain_data;
+using silkworm::test_util::SetLogVerbosityGuard;
+using silkworm::test_util::TaskRunner;
 
 class MockExecutionEngine : public stagedsync::ExecutionEngine {
   public:

--- a/silkworm/node/execution/api/endpoint/assembly.hpp
+++ b/silkworm/node/execution/api/endpoint/assembly.hpp
@@ -1,0 +1,86 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include <evmc/evmc.hpp>
+
+#include <silkworm/core/types/block.hpp>
+
+namespace silkworm::execution::api {
+
+using PayloadId = uint64_t;
+
+struct BlockUnderConstruction {
+    Hash parent_hash;
+    uint64_t timestamp{0};
+    evmc::bytes32 prev_randao;
+    evmc::address suggested_fee_recipient;
+    std::optional<std::vector<Withdrawal>> withdrawals;
+    std::optional<Hash> parent_beacon_block_root;
+};
+
+struct AssembleBlockResult {
+    bool success{false};
+    PayloadId payload_id{0};
+};
+
+using ListOfBytes = std::vector<Bytes>;
+
+struct ExecutionPayload {
+    uint32_t version{0};
+    Hash parent_hash;
+    evmc::address suggested_fee_recipient;
+    Hash state_root;
+    Hash receipts_root;
+    Bloom logs_bloom{};
+    evmc::bytes32 prev_randao;
+    BlockNum block_number;
+    uint64_t gas_limit{0};
+    uint64_t gas_used{0};
+    uint64_t timestamp{0};
+    Bytes extra_data;
+    intx::uint256 base_fee_per_gas;
+    Hash block_hash;
+    std::vector<Bytes> transactions;
+    std::optional<std::vector<Withdrawal>> withdrawals;
+    std::optional<uint64_t> blob_gas_used;
+    std::optional<uint64_t> excess_blob_gas;
+};
+
+struct BlobsBundleV1 {
+    ListOfBytes commitments;
+    ListOfBytes blobs;
+    ListOfBytes proofs;
+};
+
+struct AssembledBlock {
+    ExecutionPayload execution_payload;
+    Hash block_hash;
+    BlobsBundleV1 blobs_bundle;
+};
+
+struct AssembledBlockResult {
+    bool success{false};
+    std::optional<AssembledBlock> data;
+};
+
+}  // namespace silkworm::execution::api

--- a/silkworm/node/execution/api/endpoint/block.hpp
+++ b/silkworm/node/execution/api/endpoint/block.hpp
@@ -1,0 +1,29 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <silkworm/core/types/block.hpp>
+#include <silkworm/core/types/hash.hpp>
+
+namespace silkworm::execution::api {
+
+struct Body : public BlockBody {
+    Hash block_hash;
+    BlockNum block_number{0};
+};
+
+}  // namespace silkworm::execution::api

--- a/silkworm/node/execution/api/endpoint/checkers.hpp
+++ b/silkworm/node/execution/api/endpoint/checkers.hpp
@@ -1,0 +1,44 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <optional>
+#include <string>
+
+#include <silkworm/core/common/base.hpp>
+#include <silkworm/core/types/hash.hpp>
+
+#include "status.hpp"
+
+namespace silkworm::execution::api {
+
+struct ForkChoice {
+    Hash head_block_hash;
+    uint64_t timeout{0};
+    std::optional<Hash> finalized_block_hash;
+    std::optional<Hash> safe_block_hash;
+};
+
+struct ForkChoiceResult {
+    ExecutionStatus status;
+    Hash latest_valid_head;
+    std::string validation_error;
+
+    operator bool() const { return success(status); }
+};
+
+}  // namespace silkworm::execution::api

--- a/silkworm/node/execution/api/endpoint/getters.hpp
+++ b/silkworm/node/execution/api/endpoint/getters.hpp
@@ -1,0 +1,28 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <variant>
+
+#include <silkworm/core/common/base.hpp>
+#include <silkworm/core/types/hash.hpp>
+
+namespace silkworm::execution::api {
+
+using BlockNumberOrHash = std::variant<BlockNum, Hash>;
+
+}  // namespace silkworm::execution::api

--- a/silkworm/node/execution/api/endpoint/insertion.hpp
+++ b/silkworm/node/execution/api/endpoint/insertion.hpp
@@ -1,0 +1,36 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include <silkworm/core/types/block.hpp>
+
+#include "status.hpp"
+
+namespace silkworm::execution::api {
+
+using Blocks = std::vector<std::shared_ptr<Block>>;
+
+struct InsertionResult{
+    ExecutionStatus status;
+
+    operator bool() const { return success(status); }
+};
+
+}  // namespace silkworm::execution::api

--- a/silkworm/node/execution/api/endpoint/insertion.hpp
+++ b/silkworm/node/execution/api/endpoint/insertion.hpp
@@ -27,7 +27,7 @@ namespace silkworm::execution::api {
 
 using Blocks = std::vector<std::shared_ptr<Block>>;
 
-struct InsertionResult{
+struct InsertionResult {
     ExecutionStatus status;
 
     operator bool() const { return success(status); }

--- a/silkworm/node/execution/api/endpoint/range.hpp
+++ b/silkworm/node/execution/api/endpoint/range.hpp
@@ -1,0 +1,29 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <vector>
+
+#include "block.hpp"
+
+namespace silkworm::execution::api {
+
+using BlockHashes = std::vector<Hash>;
+using BlockBodies = std::vector<Body>;
+using BlockHeaders = std::vector<BlockHeader>;
+
+}  // namespace silkworm::execution::api

--- a/silkworm/node/execution/api/endpoint/status.hpp
+++ b/silkworm/node/execution/api/endpoint/status.hpp
@@ -1,0 +1,34 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <cstdint>
+
+namespace silkworm::execution::api {
+
+enum ExecutionStatus : uint8_t {
+    kSuccess,
+    kBadBlock,
+    kTooFarAway,
+    kMissingSegment,
+    kInvalidForkchoice,
+    kBusy,
+};
+
+inline bool success(ExecutionStatus status) { return status == ExecutionStatus::kSuccess; }
+
+}  // namespace silkworm::execution::api

--- a/silkworm/node/execution/api/endpoint/validation.hpp
+++ b/silkworm/node/execution/api/endpoint/validation.hpp
@@ -1,0 +1,52 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <set>
+#include <string>
+
+#include <silkworm/core/common/base.hpp>
+#include <silkworm/core/types/block_id.hpp>
+#include <silkworm/core/types/hash.hpp>
+
+#include "checkers.hpp"
+#include "status.hpp"
+
+namespace silkworm::execution::api {
+
+using BlockNumAndHash = BlockId;
+
+struct ValidChain {
+    BlockNumAndHash current_head;
+};
+
+struct InvalidChain {
+    BlockNumAndHash unwind_point;
+    std::optional<Hash> bad_block;
+    std::set<Hash> bad_headers;
+};
+
+struct ValidationError {
+    BlockNumAndHash latest_valid_head;
+    std::string error;
+};
+
+using ValidationResult = std::variant<ValidChain, InvalidChain, ValidationError>;
+
+}  // namespace silkworm::execution::api

--- a/silkworm/node/execution/api/endpoint/validation.hpp
+++ b/silkworm/node/execution/api/endpoint/validation.hpp
@@ -20,6 +20,7 @@
 #include <optional>
 #include <set>
 #include <string>
+#include <variant>
 
 #include <silkworm/core/common/base.hpp>
 #include <silkworm/core/types/block_id.hpp>

--- a/silkworm/node/execution/api/service.hpp
+++ b/silkworm/node/execution/api/service.hpp
@@ -1,0 +1,112 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include <silkworm/infra/concurrency/task.hpp>
+
+#include <silkworm/core/types/hash.hpp>
+
+#include "endpoint/assembly.hpp"
+#include "endpoint/checkers.hpp"
+#include "endpoint/getters.hpp"
+#include "endpoint/insertion.hpp"
+#include "endpoint/range.hpp"
+#include "endpoint/validation.hpp"
+
+namespace silkworm::execution::api {
+
+struct Service {
+    virtual ~Service() = default;
+
+    /** Chain Putters **/
+
+    // rpc InsertBlocks(InsertBlocksRequest) returns(InsertionResult);
+    virtual Task<InsertionResult> insert_blocks(const Blocks&) = 0;
+
+    /** Chain Validation and ForkChoice **/
+
+    // rpc ValidateChain(ValidationRequest) returns(ValidationReceipt);
+    virtual Task<ValidationResult> validate_chain(BlockNumAndHash) = 0;
+
+    // rpc UpdateForkChoice(ForkChoice) returns(ForkChoiceReceipt);
+    virtual Task<ForkChoiceResult> update_fork_choice(const ForkChoice&) = 0;
+
+    /** Block Assembly **/
+
+    // rpc AssembleBlock(AssembleBlockRequest) returns(AssembleBlockResponse);
+    virtual Task<AssembleBlockResult> assemble_block(const api::BlockUnderConstruction&) = 0;
+
+    // rpc GetAssembledBlock(GetAssembledBlockRequest) returns(GetAssembledBlockResponse);
+    virtual Task<AssembledBlockResult> get_assembled_block(PayloadId) = 0;
+
+    /** Chain Getters **/
+
+    // rpc CurrentHeader(google.protobuf.Empty) returns(GetHeaderResponse);
+    virtual Task<std::optional<BlockHeader>> current_header() = 0;
+
+    // rpc GetTD(GetSegmentRequest) returns(GetTDResponse);
+    virtual Task<std::optional<TotalDifficulty>> get_td(BlockNumberOrHash) = 0;
+
+    // rpc GetHeader(GetSegmentRequest) returns(GetHeaderResponse);
+    virtual Task<std::optional<BlockHeader>> get_header(BlockNumberOrHash) = 0;
+
+    // rpc GetBody(GetSegmentRequest) returns(GetBodyResponse);
+    virtual Task<std::optional<BlockBody>> get_body(BlockNumberOrHash) = 0;
+
+    // rpc HasBlock(GetSegmentRequest) returns(HasBlockResponse);
+    virtual Task<bool> has_block(BlockNumberOrHash) = 0;
+
+    /** Ranges **/
+
+    // rpc GetBodiesByRange(GetBodiesByRangeRequest) returns(GetBodiesBatchResponse);
+    virtual Task<BlockBodies> get_bodies_by_range(BlockNumRange) = 0;
+
+    // rpc GetBodiesByHashes(GetBodiesByHashesRequest) returns(GetBodiesBatchResponse);
+    virtual Task<BlockBodies> get_bodies_by_hashes(const BlockHashes&) = 0;
+
+    /** Chain Checkers **/
+
+    // rpc IsCanonicalHash(types.H256) returns(IsCanonicalResponse);
+    virtual Task<bool> is_canonical_hash(Hash block_hash) = 0;
+
+    // rpc GetHeaderHashNumber(types.H256) returns(GetHeaderHashNumberResponse);
+    virtual Task<std::optional<BlockNum>> get_header_hash_number(Hash block_hash) = 0;
+
+    // rpc GetForkChoice(google.protobuf.Empty) returns(ForkChoice);
+    virtual Task<ForkChoice> get_fork_choice() = 0;
+
+    /** Misc **/
+
+    // rpc Ready(google.protobuf.Empty) returns(ReadyResponse);
+    virtual Task<bool> ready() = 0;
+
+    // rpc FrozenBlocks(google.protobuf.Empty) returns(FrozenBlocksResponse);
+    virtual Task<uint64_t> frozen_blocks() = 0;
+
+    /** Additional non-RPC methods **/
+
+    virtual Task<BlockHeaders> get_last_headers(uint64_t n) = 0;
+
+    virtual Task<BlockNum> block_progress() = 0;
+};
+
+}  // namespace silkworm::execution::api

--- a/silkworm/node/execution/grpc/client/endpoint/assembly.cpp
+++ b/silkworm/node/execution/grpc/client/endpoint/assembly.cpp
@@ -1,0 +1,129 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "assembly.hpp"
+
+#include <silkworm/core/common/bytes_to_string.hpp>
+#include <silkworm/infra/grpc/common/conversion.hpp>
+
+#include "../../common/block.hpp"
+
+namespace silkworm::execution::grpc::client {
+
+namespace proto = ::execution;
+
+api::ExecutionPayload execution_payload_from_proto(const ::types::ExecutionPayload& payload) {
+    api::ExecutionPayload execution_payload;
+    execution_payload.version = payload.version();
+    execution_payload.parent_hash = rpc::bytes32_from_H256(payload.parent_hash());
+    execution_payload.suggested_fee_recipient = rpc::address_from_H160(payload.coinbase());
+    execution_payload.state_root = rpc::bytes32_from_H256(payload.state_root());
+    execution_payload.receipts_root = rpc::bytes32_from_H256(payload.receipt_root());
+    rpc::span_from_H2048(payload.logs_bloom(), execution_payload.logs_bloom);
+    execution_payload.prev_randao = rpc::bytes32_from_H256(payload.prev_randao());
+    execution_payload.block_number = payload.block_number();
+    execution_payload.gas_limit = payload.gas_limit();
+    execution_payload.gas_used = payload.gas_used();
+    execution_payload.timestamp = payload.timestamp();
+    std::copy(payload.extra_data().cbegin(), payload.extra_data().cend(), execution_payload.extra_data.begin());
+    execution_payload.base_fee_per_gas = rpc::uint256_from_H256(payload.base_fee_per_gas());
+    execution_payload.block_hash = rpc::bytes32_from_H256(payload.block_hash());
+    execution_payload.transactions.reserve(static_cast<std::size_t>(payload.transactions_size()));
+    for (const auto& proto_transaction : payload.transactions()) {
+        execution_payload.transactions.emplace_back(string_view_to_byte_view(proto_transaction));
+    }
+    if (payload.withdrawals_size() > 0) {
+        std::vector<Withdrawal> withdrawals;
+        withdrawals.reserve(static_cast<std::size_t>(payload.withdrawals_size()));
+        execution_payload.withdrawals = std::move(withdrawals);
+    }
+    for (const auto& proto_withdrawal : payload.withdrawals()) {
+        execution_payload.withdrawals->emplace_back(withdrawal_from_proto_type(proto_withdrawal));
+    }
+    if (payload.has_blob_gas_used()) {
+        execution_payload.blob_gas_used = payload.blob_gas_used();
+    }
+    if (payload.has_excess_blob_gas()) {
+        execution_payload.excess_blob_gas = payload.excess_blob_gas();
+    }
+    return execution_payload;
+}
+
+api::BlobsBundleV1 blobs_bundle_from_proto(const ::types::BlobsBundleV1& bundle) {
+    api::BlobsBundleV1 blobs_bundle;
+    for (int i{0}; i < bundle.commitments_size(); ++i) {
+        deserialize_hex_as_bytes(bundle.commitments(i), blobs_bundle.commitments);
+    }
+    for (int i{0}; i < bundle.blobs_size(); ++i) {
+        deserialize_hex_as_bytes(bundle.blobs(i), blobs_bundle.blobs);
+    }
+    for (int i{0}; i < bundle.proofs_size(); ++i) {
+        deserialize_hex_as_bytes(bundle.proofs(i), blobs_bundle.proofs);
+    }
+    return blobs_bundle;
+}
+
+api::AssembledBlock assembled_from_data(const ::execution::AssembledBlockData& data) {
+    api::ExecutionPayload payload{execution_payload_from_proto(data.execution_payload())};
+    Hash block_hash{rpc::bytes32_from_H256(data.block_value())};
+    api::BlobsBundleV1 blobs_bundle{blobs_bundle_from_proto(data.blobs_bundle())};
+    return {std::move(payload), block_hash, std::move(blobs_bundle)};
+}
+
+proto::AssembleBlockRequest assemble_request_from_block(const api::BlockUnderConstruction& block) {
+    proto::AssembleBlockRequest request;
+    request.set_timestamp(block.timestamp);
+    request.set_allocated_parent_hash(rpc::H256_from_bytes32(block.parent_hash).release());
+    request.set_allocated_prev_randao(rpc::H256_from_bytes32(block.prev_randao).release());
+    if (block.parent_beacon_block_root) {
+        request.set_allocated_parent_beacon_block_root(
+            rpc::H256_from_bytes32(*block.parent_beacon_block_root).release());
+    }
+    request.set_allocated_suggested_fee_recipient(rpc::H160_from_address(block.suggested_fee_recipient).release());
+    if (block.withdrawals) {
+        for (const auto& withdrawal : *block.withdrawals) {
+            ::types::Withdrawal* w{request.add_withdrawals()};
+            serialize_withdrawal(withdrawal, w);
+        }
+    }
+    return request;
+}
+
+api::AssembleBlockResult assemble_result_from_response(const proto::AssembleBlockResponse& response) {
+    api::AssembleBlockResult result{
+        .success = !response.busy(),
+        .payload_id = response.id(),
+    };
+    return result;
+}
+
+proto::GetAssembledBlockRequest get_assembled_request_from_payload_id(api::PayloadId payload_id) {
+    proto::GetAssembledBlockRequest request;
+    request.set_id(payload_id);
+    return request;
+}
+
+api::AssembledBlockResult get_assembled_result_from_response(const proto::GetAssembledBlockResponse& response) {
+    api::AssembledBlockResult result{
+        .success = !response.busy(),
+    };
+    if (response.has_data()) {
+        result.data = assembled_from_data(response.data());
+    }
+    return result;
+}
+
+}  // namespace silkworm::execution::grpc::client

--- a/silkworm/node/execution/grpc/client/endpoint/assembly.hpp
+++ b/silkworm/node/execution/grpc/client/endpoint/assembly.hpp
@@ -1,0 +1,38 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <memory>
+
+#include <silkworm/interfaces/execution/execution.pb.h>
+
+#include "../../../api/endpoint/assembly.hpp"
+
+namespace silkworm::execution::grpc::client {
+
+api::ExecutionPayload execution_payload_from_proto(const ::types::ExecutionPayload&);
+api::BlobsBundleV1 blobs_bundle_from_proto(const ::types::BlobsBundleV1&);
+
+api::AssembledBlock assembled_from_data(const ::execution::AssembledBlockData&);
+
+::execution::AssembleBlockRequest assemble_request_from_block(const api::BlockUnderConstruction&);
+api::AssembleBlockResult assemble_result_from_response(const ::execution::AssembleBlockResponse&);
+
+::execution::GetAssembledBlockRequest get_assembled_request_from_payload_id(api::PayloadId);
+api::AssembledBlockResult get_assembled_result_from_response(const ::execution::GetAssembledBlockResponse&);
+
+}  // namespace silkworm::execution::grpc::client

--- a/silkworm/node/execution/grpc/client/endpoint/checkers.cpp
+++ b/silkworm/node/execution/grpc/client/endpoint/checkers.cpp
@@ -34,9 +34,13 @@ api::ForkChoice fork_choice_from_response(const ::execution::ForkChoice& respons
     api::ForkChoice fork_choice{
         .head_block_hash = rpc::bytes32_from_H256(response.head_block_hash()),
         .timeout = response.timeout(),
-        .finalized_block_hash = rpc::bytes32_from_H256(response.finalized_block_hash()),
-        .safe_block_hash = rpc::bytes32_from_H256(response.safe_block_hash()),
     };
+    if (response.has_finalized_block_hash()) {
+        fork_choice.finalized_block_hash = rpc::bytes32_from_H256(response.finalized_block_hash());
+    }
+    if (response.has_safe_block_hash()) {
+        fork_choice.safe_block_hash = rpc::bytes32_from_H256(response.safe_block_hash());
+    }
     return fork_choice;
 }
 

--- a/silkworm/node/execution/grpc/client/endpoint/checkers.cpp
+++ b/silkworm/node/execution/grpc/client/endpoint/checkers.cpp
@@ -1,0 +1,43 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "checkers.hpp"
+
+#include <silkworm/infra/grpc/common/conversion.hpp>
+
+namespace silkworm::execution::grpc::client {
+
+::types::H256 h256_from_block_hash(const Hash& block_hash) {
+    ::types::H256 request;
+    rpc::H256_from_bytes32(block_hash, &request);
+    return request;
+}
+
+std::optional<BlockNum> block_number_from_response(const ::execution::GetHeaderHashNumberResponse& reply) {
+    return reply.has_block_number() ? std::make_optional(reply.block_number()) : std::nullopt;
+}
+
+api::ForkChoice fork_choice_from_response(const ::execution::ForkChoice& response) {
+    api::ForkChoice fork_choice{
+        .head_block_hash = rpc::bytes32_from_H256(response.head_block_hash()),
+        .timeout = response.timeout(),
+        .finalized_block_hash = rpc::bytes32_from_H256(response.finalized_block_hash()),
+        .safe_block_hash = rpc::bytes32_from_H256(response.safe_block_hash()),
+    };
+    return fork_choice;
+}
+
+}  // namespace silkworm::execution::grpc::client

--- a/silkworm/node/execution/grpc/client/endpoint/checkers.hpp
+++ b/silkworm/node/execution/grpc/client/endpoint/checkers.hpp
@@ -1,0 +1,35 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <optional>
+
+#include <silkworm/core/common/base.hpp>
+#include <silkworm/core/types/hash.hpp>
+#include <silkworm/interfaces/execution/execution.pb.h>
+
+#include "../../../api/endpoint/checkers.hpp"
+
+namespace silkworm::execution::grpc::client {
+
+::types::H256 h256_from_block_hash(const Hash& block_hash);
+
+std::optional<BlockNum> block_number_from_response(const ::execution::GetHeaderHashNumberResponse&);
+
+api::ForkChoice fork_choice_from_response(const ::execution::ForkChoice&);
+
+}  // namespace silkworm::execution::grpc::client

--- a/silkworm/node/execution/grpc/client/endpoint/checkers_test.cpp
+++ b/silkworm/node/execution/grpc/client/endpoint/checkers_test.cpp
@@ -26,22 +26,25 @@
 #include <silkworm/interfaces/execution/execution.pb.h>
 #include <silkworm/node/test_util/fixture.hpp>
 
-using namespace evmc::literals;
+#include "../../../test_util/sample_protos.hpp"
 
 namespace silkworm::execution::grpc::client {
 
-static constexpr BlockNum kBlockNumber{100};
+using namespace evmc::literals;
+using namespace silkworm::execution::test_util;
+using namespace silkworm::test_util;
+namespace proto = ::execution;
 
-static ::execution::GetHeaderHashNumberResponse sample_response() {
-    ::execution::GetHeaderHashNumberResponse response;
-    response.set_block_number(kBlockNumber);
+static proto::GetHeaderHashNumberResponse sample_response() {
+    proto::GetHeaderHashNumberResponse response;
+    response.set_block_number(kSampleBlockNumber);
     return response;
 }
 
 TEST_CASE("block_number_from_response", "[node][execution][grpc]") {
-    const test_util::Fixtures<::execution::GetHeaderHashNumberResponse, std::optional<BlockNum>> fixtures{
+    const Fixtures<proto::GetHeaderHashNumberResponse, std::optional<BlockNum>> fixtures{
         {{}, std::nullopt},
-        {sample_response(), kBlockNumber},
+        {sample_response(), kSampleBlockNumber},
     };
     for (const auto& [response, expected_block_num] : fixtures) {
         SECTION("rps block number: " + std::to_string(response.block_number())) {
@@ -55,8 +58,8 @@ static constexpr auto kFinalizedHash{0x00000000000000000000000000000000000000000
 static constexpr auto kSafeHash{0x0000000000000000000000000000000000000000000000000000000000000003_bytes32};
 static constexpr auto kTimeout{100u};
 
-static ::execution::ForkChoice sample_proto_fork_choice() {
-    ::execution::ForkChoice fork_choice;
+static proto::ForkChoice sample_proto_fork_choice() {
+    proto::ForkChoice fork_choice;
     fork_choice.set_allocated_head_block_hash(rpc::H256_from_bytes32(kHeadHash).release());
     fork_choice.set_timeout(kTimeout);
     fork_choice.set_allocated_finalized_block_hash(rpc::H256_from_bytes32(kFinalizedHash).release());
@@ -76,7 +79,7 @@ static api::ForkChoice sample_fork_choice() {
 }
 
 TEST_CASE("fork_choice_from_response", "[node][execution][grpc]") {
-    const test_util::Fixtures<::execution::ForkChoice, api::ForkChoice> fixtures{
+    const Fixtures<proto::ForkChoice, api::ForkChoice> fixtures{
         {{}, {}},
         {sample_proto_fork_choice(), sample_fork_choice()},
     };

--- a/silkworm/node/execution/grpc/client/endpoint/checkers_test.cpp
+++ b/silkworm/node/execution/grpc/client/endpoint/checkers_test.cpp
@@ -30,7 +30,7 @@ using namespace evmc::literals;
 
 namespace silkworm::execution::grpc::client {
 
-static const BlockNum kBlockNumber{100};
+static constexpr BlockNum kBlockNumber{100};
 
 static ::execution::GetHeaderHashNumberResponse sample_response() {
     ::execution::GetHeaderHashNumberResponse response;
@@ -81,7 +81,7 @@ TEST_CASE("fork_choice_from_response", "[node][execution][grpc]") {
         {sample_proto_fork_choice(), sample_fork_choice()},
     };
     for (const auto& [proto_fork_choice, expected_fork_choice] : fixtures) {
-        SECTION("rps head hash: " + std::to_string(proto_fork_choice.timeout())) {
+        SECTION("response: " + std::to_string(proto_fork_choice.timeout())) {
             const auto fork_choice{fork_choice_from_response(proto_fork_choice)};
             CHECK(fork_choice.head_block_hash == expected_fork_choice.head_block_hash);
             CHECK(fork_choice.timeout == expected_fork_choice.timeout);

--- a/silkworm/node/execution/grpc/client/endpoint/checkers_test.cpp
+++ b/silkworm/node/execution/grpc/client/endpoint/checkers_test.cpp
@@ -1,0 +1,94 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "checkers.hpp"
+
+#include <optional>
+
+#include <catch2/catch.hpp>
+#include <evmc/evmc.hpp>
+#include <intx/intx.hpp>
+
+#include <silkworm/infra/grpc/common/conversion.hpp>
+#include <silkworm/interfaces/execution/execution.pb.h>
+#include <silkworm/node/test_util/fixture.hpp>
+
+using namespace evmc::literals;
+
+namespace silkworm::execution::grpc::client {
+
+static const BlockNum kBlockNumber{100};
+
+static ::execution::GetHeaderHashNumberResponse sample_response() {
+    ::execution::GetHeaderHashNumberResponse response;
+    response.set_block_number(kBlockNumber);
+    return response;
+}
+
+TEST_CASE("block_number_from_response", "[node][execution][grpc]") {
+    const test_util::Fixtures<::execution::GetHeaderHashNumberResponse, std::optional<BlockNum>> fixtures{
+        {{}, std::nullopt},
+        {sample_response(), kBlockNumber},
+    };
+    for (const auto& [response, expected_block_num] : fixtures) {
+        SECTION("rps block number: " + std::to_string(response.block_number())) {
+            CHECK(block_number_from_response(response) == expected_block_num);
+        }
+    }
+}
+
+static constexpr auto kHeadHash{0x0000000000000000000000000000000000000000000000000000000000000001_bytes32};
+static constexpr auto kFinalizedHash{0x0000000000000000000000000000000000000000000000000000000000000002_bytes32};
+static constexpr auto kSafeHash{0x0000000000000000000000000000000000000000000000000000000000000003_bytes32};
+static constexpr auto kTimeout{100u};
+
+static ::execution::ForkChoice sample_proto_fork_choice() {
+    ::execution::ForkChoice fork_choice;
+    fork_choice.set_allocated_head_block_hash(rpc::H256_from_bytes32(kHeadHash).release());
+    fork_choice.set_timeout(kTimeout);
+    fork_choice.set_allocated_finalized_block_hash(rpc::H256_from_bytes32(kFinalizedHash).release());
+    fork_choice.set_allocated_safe_block_hash(rpc::H256_from_bytes32(kSafeHash).release());
+    return fork_choice;
+}
+
+static api::ForkChoice sample_fork_choice() {
+    api::ForkChoice fork_choice{
+        .head_block_hash = kHeadHash,
+        .timeout = kTimeout,
+        .finalized_block_hash = kFinalizedHash,
+        .safe_block_hash = kSafeHash,
+    };
+
+    return fork_choice;
+}
+
+TEST_CASE("fork_choice_from_response", "[node][execution][grpc]") {
+    const test_util::Fixtures<::execution::ForkChoice, api::ForkChoice> fixtures{
+        {{}, {}},
+        {sample_proto_fork_choice(), sample_fork_choice()},
+    };
+    for (const auto& [proto_fork_choice, expected_fork_choice] : fixtures) {
+        SECTION("rps head hash: " + std::to_string(proto_fork_choice.timeout())) {
+            const auto fork_choice{fork_choice_from_response(proto_fork_choice)};
+            CHECK(fork_choice.head_block_hash == expected_fork_choice.head_block_hash);
+            CHECK(fork_choice.timeout == expected_fork_choice.timeout);
+            CHECK(fork_choice.finalized_block_hash == expected_fork_choice.finalized_block_hash);
+            CHECK(fork_choice.safe_block_hash == expected_fork_choice.safe_block_hash);
+        }
+    }
+}
+
+}  // namespace silkworm::execution::grpc::client

--- a/silkworm/node/execution/grpc/client/endpoint/getters.cpp
+++ b/silkworm/node/execution/grpc/client/endpoint/getters.cpp
@@ -1,0 +1,59 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "getters.hpp"
+
+#include <silkworm/infra/grpc/common/conversion.hpp>
+
+#include "../../common/block.hpp"
+
+namespace silkworm::execution::grpc::client {
+
+::execution::GetSegmentRequest request_from_block_number_or_hash(const api::BlockNumberOrHash& number_or_hash) {
+    ::execution::GetSegmentRequest request;
+    if (std::holds_alternative<Hash>(number_or_hash)) {
+        const auto& block_hash{std::get<Hash>(number_or_hash)};
+        request.set_allocated_block_hash(rpc::H256_from_bytes32(block_hash).release());
+    } else {
+        SILKWORM_ASSERT(std::holds_alternative<BlockNum>(number_or_hash));
+        const auto block_number{std::get<BlockNum>(number_or_hash)};
+        request.set_block_number(block_number);
+    }
+    return request;
+}
+
+std::optional<TotalDifficulty> total_difficulty_from_response(const ::execution::GetTDResponse& response) {
+    if (!response.has_td()) {
+        return {};
+    }
+    return rpc::uint256_from_H256(response.td());
+}
+
+std::optional<BlockHeader> header_from_response(const ::execution::GetHeaderResponse& response) {
+    if (!response.has_header()) {
+        return {};
+    }
+    return header_from_proto(response.header());
+}
+
+std::optional<BlockBody> body_from_response(const ::execution::GetBodyResponse& response) {
+    if (!response.has_body()) {
+        return {};
+    }
+    return body_from_proto(response.body());
+}
+
+}  // namespace silkworm::execution::grpc::client

--- a/silkworm/node/execution/grpc/client/endpoint/getters.hpp
+++ b/silkworm/node/execution/grpc/client/endpoint/getters.hpp
@@ -1,0 +1,36 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <optional>
+
+#include <silkworm/core/types/block.hpp>
+#include <silkworm/interfaces/execution/execution.pb.h>
+
+#include "../../../api/endpoint/getters.hpp"
+
+namespace silkworm::execution::grpc::client {
+
+::execution::GetSegmentRequest request_from_block_number_or_hash(const api::BlockNumberOrHash&);
+
+std::optional<TotalDifficulty> total_difficulty_from_response(const ::execution::GetTDResponse&);
+
+std::optional<BlockHeader> header_from_response(const ::execution::GetHeaderResponse&);
+
+std::optional<BlockBody> body_from_response(const ::execution::GetBodyResponse&);
+
+}  // namespace silkworm::execution::grpc::client

--- a/silkworm/node/execution/grpc/client/endpoint/getters_test.cpp
+++ b/silkworm/node/execution/grpc/client/endpoint/getters_test.cpp
@@ -1,0 +1,105 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "getters.hpp"
+
+#include <optional>
+
+#include <catch2/catch.hpp>
+#include <evmc/evmc.hpp>
+#include <intx/intx.hpp>
+
+#include <silkworm/infra/grpc/common/conversion.hpp>
+#include <silkworm/interfaces/execution/execution.pb.h>
+#include <silkworm/node/test_util/fixture.hpp>
+
+using namespace evmc::literals;
+
+namespace silkworm::execution::grpc::client {
+
+static constexpr BlockNum kBlockNumber{100};
+static constexpr auto kBlockHash{0x0000000000000000000000000000000000000000000000000000000000000001_bytes32};
+
+static api::BlockNumberOrHash sample_block_number_or_hash(bool has_number) {
+    if (has_number) {
+        return kBlockNumber;
+    } else {
+        return kBlockHash;
+    }
+}
+
+static ::execution::GetSegmentRequest sample_proto_get_segment_request(std::optional<BlockNum> number,
+                                                                       std::optional<Hash> hash) {
+    ::execution::GetSegmentRequest request;
+    if (number) {
+        request.set_block_number(*number);
+    }
+    if (hash) {
+        request.set_allocated_block_hash(rpc::H256_from_bytes32(*hash).release());
+    }
+    return request;
+}
+
+TEST_CASE("request_from_block_number_or_hash", "[node][execution][grpc]") {
+    const test_util::Fixtures<api::BlockNumberOrHash, ::execution::GetSegmentRequest> fixtures{
+        {{}, sample_proto_get_segment_request(0, {})},  // BlockNumberOrHash contains 1st variant as default
+        {sample_block_number_or_hash(true), sample_proto_get_segment_request(kBlockNumber, {})},
+        {sample_block_number_or_hash(false), sample_proto_get_segment_request({}, kBlockHash)},
+    };
+    for (const auto& [number_or_hash, expected_segment_request] : fixtures) {
+        SECTION("block_number_or_hash index: " + std::to_string(number_or_hash.index())) {
+            const auto segment_request{request_from_block_number_or_hash(number_or_hash)};
+            // CHECK(segment_request == expected_segment_request);  // requires operator== in gRPC generated code
+            CHECK(segment_request.has_block_number() == expected_segment_request.has_block_number());
+            if (segment_request.has_block_number()) {
+                CHECK(segment_request.block_number() == expected_segment_request.block_number());
+            }
+            CHECK(segment_request.has_block_hash() == expected_segment_request.has_block_hash());
+            if (segment_request.has_block_hash()) {
+                CHECK(segment_request.block_hash() == expected_segment_request.block_hash());
+            }
+        }
+    }
+}
+
+static constexpr TotalDifficulty kTotalDifficulty{1'000'000};
+
+static ::execution::GetTDResponse sample_td_response(bool has_value) {
+    ::execution::GetTDResponse response;
+    if (has_value) {
+        response.set_allocated_td(rpc::H256_from_uint256(kTotalDifficulty).release());
+    }
+    return response;
+}
+
+static std::optional<TotalDifficulty> sample_total_difficulty(bool has_value) {
+    return has_value ? std::make_optional(kTotalDifficulty) : std::nullopt;
+}
+
+TEST_CASE("total_difficulty_from_response", "[node][execution][grpc]") {
+    const test_util::Fixtures<::execution::GetTDResponse, std::optional<TotalDifficulty>> fixtures{
+        {sample_td_response(false), sample_total_difficulty(false)},
+        {sample_td_response(true), sample_total_difficulty(true)},
+    };
+    for (const auto& [response, expected_total_difficulty] : fixtures) {
+        SECTION("expected_total_difficulty: " + std::to_string(expected_total_difficulty.has_value())) {
+            const auto total_difficulty{total_difficulty_from_response(response)};
+            CHECK(total_difficulty == expected_total_difficulty);
+        }
+    }
+}
+
+}  // namespace silkworm::execution::grpc::client

--- a/silkworm/node/execution/grpc/client/endpoint/getters_test.cpp
+++ b/silkworm/node/execution/grpc/client/endpoint/getters_test.cpp
@@ -33,6 +33,7 @@ namespace silkworm::execution::grpc::client {
 using namespace evmc::literals;
 using namespace silkworm::execution::test_util;
 using namespace silkworm::test_util;
+namespace proto = ::execution;
 
 static api::BlockNumberOrHash sample_block_number_or_hash(bool has_number) {
     if (has_number) {
@@ -42,9 +43,9 @@ static api::BlockNumberOrHash sample_block_number_or_hash(bool has_number) {
     }
 }
 
-static ::execution::GetSegmentRequest sample_proto_get_segment_request(std::optional<BlockNum> number,
-                                                                       std::optional<Hash> hash) {
-    ::execution::GetSegmentRequest request;
+static proto::GetSegmentRequest sample_proto_get_segment_request(std::optional<BlockNum> number,
+                                                                 std::optional<Hash> hash) {
+    proto::GetSegmentRequest request;
     if (number) {
         request.set_block_number(*number);
     }
@@ -55,7 +56,7 @@ static ::execution::GetSegmentRequest sample_proto_get_segment_request(std::opti
 }
 
 TEST_CASE("request_from_block_number_or_hash", "[node][execution][grpc]") {
-    const Fixtures<api::BlockNumberOrHash, ::execution::GetSegmentRequest> fixtures{
+    const Fixtures<api::BlockNumberOrHash, proto::GetSegmentRequest> fixtures{
         {{}, sample_proto_get_segment_request(0, {})},  // BlockNumberOrHash contains 1st variant as default
         {sample_block_number_or_hash(true), sample_proto_get_segment_request(kSampleBlockNumber, {})},
         {sample_block_number_or_hash(false), sample_proto_get_segment_request({}, kSampleBlockHash)},
@@ -78,8 +79,8 @@ TEST_CASE("request_from_block_number_or_hash", "[node][execution][grpc]") {
 
 static constexpr TotalDifficulty kTotalDifficulty{1'000'000};
 
-static ::execution::GetTDResponse sample_td_response(bool has_value) {
-    ::execution::GetTDResponse response;
+static proto::GetTDResponse sample_td_response(bool has_value) {
+    proto::GetTDResponse response;
     if (has_value) {
         response.set_allocated_td(rpc::H256_from_uint256(kTotalDifficulty).release());
     }
@@ -91,7 +92,7 @@ static std::optional<TotalDifficulty> sample_total_difficulty(bool has_value) {
 }
 
 TEST_CASE("total_difficulty_from_response", "[node][execution][grpc]") {
-    const Fixtures<::execution::GetTDResponse, std::optional<TotalDifficulty>> fixtures{
+    const Fixtures<proto::GetTDResponse, std::optional<TotalDifficulty>> fixtures{
         {sample_td_response(false), sample_total_difficulty(false)},
         {sample_td_response(true), sample_total_difficulty(true)},
     };
@@ -103,14 +104,14 @@ TEST_CASE("total_difficulty_from_response", "[node][execution][grpc]") {
     }
 }
 
-static ::execution::GetHeaderResponse sample_get_header_response() {
-    ::execution::GetHeaderResponse response;
+static proto::GetHeaderResponse sample_get_header_response() {
+    proto::GetHeaderResponse response;
     sample_proto_header(response.mutable_header());
     return response;
 }
 
 TEST_CASE("header_from_response", "[node][execution][grpc]") {
-    const Fixtures<::execution::GetHeaderResponse, std::optional<BlockHeader>> fixtures{
+    const Fixtures<proto::GetHeaderResponse, std::optional<BlockHeader>> fixtures{
         {{}, {}},
         {sample_get_header_response(), sample_block_header()},
     };
@@ -122,14 +123,14 @@ TEST_CASE("header_from_response", "[node][execution][grpc]") {
     }
 }
 
-static ::execution::GetBodyResponse sample_get_body_response() {
-    ::execution::GetBodyResponse response;
+static proto::GetBodyResponse sample_get_body_response() {
+    proto::GetBodyResponse response;
     sample_proto_body(response.mutable_body());
     return response;
 }
 
 TEST_CASE("body_from_response", "[node][execution][grpc]") {
-    const Fixtures<::execution::GetBodyResponse, std::optional<BlockBody>> fixtures{
+    const Fixtures<proto::GetBodyResponse, std::optional<BlockBody>> fixtures{
         {{}, {}},
         {sample_get_body_response(), sample_block_body()},
     };

--- a/silkworm/node/execution/grpc/client/endpoint/insertion.cpp
+++ b/silkworm/node/execution/grpc/client/endpoint/insertion.cpp
@@ -1,0 +1,42 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "insertion.hpp"
+
+#include "../../common/block.hpp"
+#include "status.hpp"
+
+namespace silkworm::execution::grpc::client {
+
+namespace proto = ::execution;
+
+proto::InsertBlocksRequest insertion_request_from_blocks(const api::Blocks& blocks) {
+    proto::InsertBlocksRequest request;
+    for (const auto& block : blocks) {
+        proto::Block* b = request.add_blocks();
+        proto::Header* header = b->mutable_header();
+        proto_from_header(block->header, header);
+        proto::BlockBody* body = b->mutable_body();
+        proto_from_body(*block, body);
+    }
+    return request;
+}
+
+api::InsertionResult insertion_result_from_response(const proto::InsertionResult& response) {
+    return {.status = execution_status_from_proto(response.result())};
+}
+
+}  // namespace silkworm::execution::grpc::client

--- a/silkworm/node/execution/grpc/client/endpoint/insertion.hpp
+++ b/silkworm/node/execution/grpc/client/endpoint/insertion.hpp
@@ -1,0 +1,29 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <silkworm/core/types/block.hpp>
+#include <silkworm/interfaces/execution/execution.pb.h>
+
+#include "../../../api/endpoint/insertion.hpp"
+
+namespace silkworm::execution::grpc::client {
+
+::execution::InsertBlocksRequest insertion_request_from_blocks(const api::Blocks&);
+api::InsertionResult insertion_result_from_response(const ::execution::InsertionResult&);
+
+}  // namespace silkworm::execution::grpc::client

--- a/silkworm/node/execution/grpc/client/endpoint/insertion_test.cpp
+++ b/silkworm/node/execution/grpc/client/endpoint/insertion_test.cpp
@@ -52,7 +52,7 @@ static proto::InsertBlocksRequest sample_proto_insert_block_request() {
 
 TEST_CASE("insertion_request_from_blocks", "[node][execution][grpc]") {
     const Fixtures<api::Blocks, proto::InsertBlocksRequest> fixtures{
-        //{{}, {}},
+        {{}, {}},
         {sample_blocks(), sample_proto_insert_block_request()},
     };
     for (const auto& [blocks, expected_insertion_request] : fixtures) {

--- a/silkworm/node/execution/grpc/client/endpoint/insertion_test.cpp
+++ b/silkworm/node/execution/grpc/client/endpoint/insertion_test.cpp
@@ -1,0 +1,81 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "insertion.hpp"
+
+#include <optional>
+
+#include <catch2/catch.hpp>
+#include <intx/intx.hpp>
+
+#include <silkworm/interfaces/execution/execution.pb.h>
+#include <silkworm/node/test_util/fixture.hpp>
+#include <silkworm/node/test_util/sample_blocks.hpp>
+
+#include "../../../test_util/sample_protos.hpp"
+
+namespace silkworm::execution::grpc::client {
+
+using namespace evmc::literals;
+using namespace silkworm::execution::test_util;
+using namespace silkworm::test_util;
+namespace proto = ::execution;
+
+static api::Blocks sample_blocks() {
+    return {std::make_shared<Block>(), std::make_shared<Block>(sample_block())};
+}
+
+static void empty_proto_block(proto::Block* proto_block) {
+    proto_block->mutable_header();
+    proto_block->mutable_body();
+}
+
+static proto::InsertBlocksRequest sample_proto_insert_block_request() {
+    proto::InsertBlocksRequest request;
+    empty_proto_block(request.add_blocks());  // first empty block
+    sample_proto_block(request.add_blocks());
+    return request;
+}
+
+TEST_CASE("insertion_request_from_blocks", "[node][execution][grpc]") {
+    const Fixtures<api::Blocks, proto::InsertBlocksRequest> fixtures{
+        //{{}, {}},
+        {sample_blocks(), sample_proto_insert_block_request()},
+    };
+    for (const auto& [blocks, expected_insertion_request] : fixtures) {
+        SECTION("blocks size: " + std::to_string(blocks.size())) {
+            const auto insertion_request{insertion_request_from_blocks(blocks)};
+            // CHECK(insertion_request == expected_insertion_request);  // requires operator== in gRPC generated code
+            CHECK(insertion_request.blocks_size() == expected_insertion_request.blocks_size());
+            if (insertion_request.blocks_size() == expected_insertion_request.blocks_size()) {
+                for (int i{0}; i < insertion_request.blocks_size(); ++i) {
+                    const auto& block{insertion_request.blocks(i)};
+                    const auto& expected_block{expected_insertion_request.blocks(i)};
+                    // CHECK(block == expected_block);  // requires operator== in gRPC generated code
+                    CHECK(block.has_header() == expected_block.has_header());
+                    if (block.has_header()) {
+                        const auto& header{block.header()};
+                        const auto& expected_header{expected_block.header()};
+                        CHECK(header.block_number() == expected_header.block_number());
+                    }
+                    CHECK(block.has_body() == expected_block.has_body());
+                }
+            }
+        }
+    }
+}
+
+}  // namespace silkworm::execution::grpc::client

--- a/silkworm/node/execution/grpc/client/endpoint/range.cpp
+++ b/silkworm/node/execution/grpc/client/endpoint/range.cpp
@@ -1,0 +1,53 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "range.hpp"
+
+#include <silkworm/infra/grpc/common/conversion.hpp>
+
+#include "../../common/block.hpp"
+
+namespace silkworm::execution::grpc::client {
+
+namespace proto = ::execution;
+
+proto::GetBodiesByRangeRequest bodies_request_from_block_range(BlockNumRange number_range) {
+    SILKWORM_ASSERT(number_range.first <= number_range.second);
+    proto::GetBodiesByRangeRequest request;
+    request.set_start(number_range.first);
+    request.set_count(number_range.second - number_range.first);
+    return request;
+}
+
+proto::GetBodiesByHashesRequest bodies_request_from_block_hashes(const api::BlockHashes& block_hashes) {
+    proto::GetBodiesByHashesRequest request;
+    for (const auto& hash : block_hashes) {
+        ::types::H256* h256{request.add_hashes()};
+        rpc::H256_from_bytes32(hash, h256);
+    }
+    return request;
+}
+
+api::BlockBodies block_bodies_from_response(const proto::GetBodiesBatchResponse& response) {
+    api::BlockBodies bodies;
+    bodies.reserve(static_cast<size_t>(response.bodies_size()));
+    for (const auto& received_body : response.bodies()) {
+        bodies.emplace_back(body_from_proto(received_body));
+    }
+    return bodies;
+}
+
+}  // namespace silkworm::execution::grpc::client

--- a/silkworm/node/execution/grpc/client/endpoint/range.hpp
+++ b/silkworm/node/execution/grpc/client/endpoint/range.hpp
@@ -1,0 +1,29 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <silkworm/interfaces/execution/execution.pb.h>
+
+#include "../../../api/endpoint/range.hpp"
+
+namespace silkworm::execution::grpc::client {
+
+::execution::GetBodiesByRangeRequest bodies_request_from_block_range(BlockNumRange);
+::execution::GetBodiesByHashesRequest bodies_request_from_block_hashes(const api::BlockHashes&);
+api::BlockBodies block_bodies_from_response(const ::execution::GetBodiesBatchResponse&);
+
+}  // namespace silkworm::execution::grpc::client

--- a/silkworm/node/execution/grpc/client/endpoint/status.cpp
+++ b/silkworm/node/execution/grpc/client/endpoint/status.cpp
@@ -1,0 +1,44 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "status.hpp"
+
+#include <stdexcept>
+
+namespace silkworm::execution::grpc::client {
+
+namespace proto = ::execution;
+
+api::ExecutionStatus execution_status_from_proto(const proto::ExecutionStatus& proto_status) {
+    switch (proto_status) {
+        case proto::ExecutionStatus::Success:
+            return api::ExecutionStatus::kSuccess;
+        case proto::ExecutionStatus::BadBlock:
+            return api::ExecutionStatus::kBadBlock;
+        case proto::ExecutionStatus::TooFarAway:
+            return api::ExecutionStatus::kTooFarAway;
+        case proto::ExecutionStatus::MissingSegment:
+            return api::ExecutionStatus::kMissingSegment;
+        case proto::ExecutionStatus::InvalidForkchoice:
+            return api::ExecutionStatus::kInvalidForkchoice;
+        case proto::ExecutionStatus::Busy:
+            return api::ExecutionStatus::kBusy;
+        default:
+            throw std::logic_error{"unsupported ::execution::ExecutionStatus value " + std::to_string(int(proto_status))};
+    }
+}
+
+}  // namespace silkworm::execution::grpc::client

--- a/silkworm/node/execution/grpc/client/endpoint/status.hpp
+++ b/silkworm/node/execution/grpc/client/endpoint/status.hpp
@@ -1,0 +1,27 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <silkworm/interfaces/execution/execution.pb.h>
+
+#include "../../../api/endpoint/status.hpp"
+
+namespace silkworm::execution::grpc::client {
+
+api::ExecutionStatus execution_status_from_proto(const ::execution::ExecutionStatus&);
+
+}  // namespace silkworm::execution::grpc::client

--- a/silkworm/node/execution/grpc/client/endpoint/validation.cpp
+++ b/silkworm/node/execution/grpc/client/endpoint/validation.cpp
@@ -1,0 +1,75 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "validation.hpp"
+
+#include <silkworm/infra/grpc/common/conversion.hpp>
+
+#include "status.hpp"
+
+namespace silkworm::execution::grpc::client {
+
+namespace proto = ::execution;
+
+proto::ValidationRequest request_from_block_num_and_hash(const api::BlockNumAndHash& number_and_hash) {
+    proto::ValidationRequest request;
+    request.set_number(number_and_hash.number);
+    request.set_allocated_hash(rpc::H256_from_bytes32(number_and_hash.hash).release());
+    return request;
+}
+
+api::ValidationResult validation_result_from_response(const proto::ValidationReceipt& receipt) {
+    api::ValidationResult result;
+    const Hash latest_valid_head{rpc::bytes32_from_H256(receipt.latest_valid_hash())};
+    if (receipt.validation_status() == proto::ExecutionStatus::Success) {
+        result = api::ValidChain{
+            .current_head = BlockId{.hash = latest_valid_head},
+        };
+    } else if (receipt.validation_status()  == proto::ExecutionStatus::InvalidForkchoice) {
+        result = api::InvalidChain{
+            .unwind_point = BlockId{.hash = latest_valid_head},
+        };
+    } else {
+        result = api::ValidationError{
+            .latest_valid_head = BlockId{.hash = latest_valid_head},
+            .error = receipt.validation_error(),
+        };
+    }
+    return result;
+}
+
+proto::ForkChoice request_from_fork_choice(const api::ForkChoice& fork_choice) {
+    proto::ForkChoice request;
+    request.set_allocated_head_block_hash(rpc::H256_from_bytes32(fork_choice.head_block_hash).release());
+    request.set_timeout(fork_choice.timeout);
+    if (fork_choice.finalized_block_hash) {
+        request.set_allocated_finalized_block_hash(rpc::H256_from_bytes32(*fork_choice.finalized_block_hash).release());
+    }
+    if (fork_choice.safe_block_hash) {
+        request.set_allocated_safe_block_hash(rpc::H256_from_bytes32(*fork_choice.safe_block_hash).release());
+    }
+    return request;
+}
+
+api::ForkChoiceResult fork_choice_result_from_response(const proto::ForkChoiceReceipt& receipt) {
+    return {
+        .status = execution_status_from_proto(receipt.status()),
+        .latest_valid_head = rpc::bytes32_from_H256(receipt.latest_valid_hash()),
+        .validation_error = receipt.validation_error(),
+    };
+}
+
+}  // namespace silkworm::execution::grpc::client

--- a/silkworm/node/execution/grpc/client/endpoint/validation.cpp
+++ b/silkworm/node/execution/grpc/client/endpoint/validation.cpp
@@ -38,7 +38,7 @@ api::ValidationResult validation_result_from_response(const proto::ValidationRec
         result = api::ValidChain{
             .current_head = BlockId{.hash = latest_valid_head},
         };
-    } else if (receipt.validation_status()  == proto::ExecutionStatus::InvalidForkchoice) {
+    } else if (receipt.validation_status() == proto::ExecutionStatus::InvalidForkchoice) {
         result = api::InvalidChain{
             .unwind_point = BlockId{.hash = latest_valid_head},
         };

--- a/silkworm/node/execution/grpc/client/endpoint/validation.hpp
+++ b/silkworm/node/execution/grpc/client/endpoint/validation.hpp
@@ -1,0 +1,31 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <silkworm/interfaces/execution/execution.pb.h>
+
+#include "../../../api/endpoint/validation.hpp"
+
+namespace silkworm::execution::grpc::client {
+
+::execution::ValidationRequest request_from_block_num_and_hash(const api::BlockNumAndHash&);
+api::ValidationResult validation_result_from_response(const ::execution::ValidationReceipt&);
+
+::execution::ForkChoice request_from_fork_choice(const api::ForkChoice&);
+api::ForkChoiceResult fork_choice_result_from_response(const ::execution::ForkChoiceReceipt&);
+
+}  // namespace silkworm::execution::grpc::client

--- a/silkworm/node/execution/grpc/client/remote_client.cpp
+++ b/silkworm/node/execution/grpc/client/remote_client.cpp
@@ -1,0 +1,233 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "remote_client.hpp"
+
+#include <grpcpp/grpcpp.h>
+
+#include <silkworm/infra/common/log.hpp>
+#include <silkworm/infra/grpc/client/call.hpp>
+#include <silkworm/interfaces/execution/execution.grpc.pb.h>
+
+#include "endpoint/assembly.hpp"
+#include "endpoint/checkers.hpp"
+#include "endpoint/getters.hpp"
+#include "endpoint/insertion.hpp"
+#include "endpoint/range.hpp"
+#include "endpoint/validation.hpp"
+
+namespace silkworm::execution::grpc::client {
+
+namespace proto = ::execution;
+using Stub = proto::Execution::Stub;
+
+static std::shared_ptr<::grpc::Channel> make_grpc_channel(const std::string& address_uri) {
+    return ::grpc::CreateChannel(address_uri, ::grpc::InsecureChannelCredentials());
+}
+
+class RemoteClientImpl final : public api::Service {
+  public:
+    explicit RemoteClientImpl(const std::string& address_uri, agrpc::GrpcContext& grpc_context)
+        : channel_{make_grpc_channel(address_uri)},
+          stub_{proto::Execution::NewStub(channel_)},
+          grpc_context_{grpc_context} {}
+
+    ~RemoteClientImpl() override = default;
+
+    RemoteClientImpl(const RemoteClientImpl&) = delete;
+    RemoteClientImpl& operator=(const RemoteClientImpl&) = delete;
+
+    /** Chain Putters **/
+
+    // rpc InsertBlocks(InsertBlocksRequest) returns(InsertionResult);
+    Task<api::InsertionResult> insert_blocks(const api::Blocks& blocks) override {
+        auto request = insertion_request_from_blocks(blocks);
+        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncInsertBlocks, stub_, std::move(request), grpc_context_);
+        co_return insertion_result_from_response(reply);
+    }
+
+    /** Chain Validation and ForkChoice **/
+
+    // rpc ValidateChain(ValidationRequest) returns(ValidationReceipt);
+    Task<api::ValidationResult> validate_chain(api::BlockNumAndHash number_and_hash) override {
+        auto request = request_from_block_num_and_hash(number_and_hash);
+        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncValidateChain, stub_, std::move(request), grpc_context_);
+        co_return validation_result_from_response(reply);
+    }
+
+    // rpc UpdateForkChoice(ForkChoice) returns(ForkChoiceReceipt);
+    Task<api::ForkChoiceResult> update_fork_choice(const api::ForkChoice& fork_choice) override {
+        auto request = request_from_fork_choice(fork_choice);
+        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncUpdateForkChoice, stub_, std::move(request), grpc_context_);
+        co_return fork_choice_result_from_response(reply);
+    }
+
+    /** Block Assembly **/
+
+    // rpc AssembleBlock(AssembleBlockRequest) returns(AssembleBlockResponse);
+    Task<api::AssembleBlockResult> assemble_block(const api::BlockUnderConstruction& block) override {
+        auto request = assemble_request_from_block(block);
+        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncAssembleBlock, stub_, std::move(request), grpc_context_);
+        co_return assemble_result_from_response(reply);
+    }
+
+    // rpc GetAssembledBlock(GetAssembledBlockRequest) returns(GetAssembledBlockResponse);
+    Task<api::AssembledBlockResult> get_assembled_block(api::PayloadId id) override {
+        auto request = get_assembled_request_from_payload_id(id);
+        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncGetAssembledBlock, stub_, std::move(request), grpc_context_);
+        co_return get_assembled_result_from_response(reply);
+    }
+
+    /** Chain Getters **/
+
+    // rpc CurrentHeader(google.protobuf.Empty) returns(GetHeaderResponse);
+    Task<std::optional<BlockHeader>> current_header() override {
+        google::protobuf::Empty request;
+        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncCurrentHeader, stub_, std::move(request), grpc_context_);
+        co_return header_from_response(reply);
+    }
+
+    // rpc GetTD(GetSegmentRequest) returns(GetTDResponse);
+    Task<std::optional<TotalDifficulty>> get_td(api::BlockNumberOrHash number_or_hash) override {
+        auto request = request_from_block_number_or_hash(number_or_hash);
+        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncGetTD, stub_, std::move(request), grpc_context_);
+        co_return total_difficulty_from_response(reply);
+    }
+
+    // rpc GetHeader(GetSegmentRequest) returns(GetHeaderResponse);
+    Task<std::optional<BlockHeader>> get_header(api::BlockNumberOrHash number_or_hash) override {
+        auto request = request_from_block_number_or_hash(number_or_hash);
+        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncGetHeader, stub_, std::move(request), grpc_context_);
+        co_return header_from_response(reply);
+    }
+
+    // rpc GetBody(GetSegmentRequest) returns(GetBodyResponse);
+    Task<std::optional<BlockBody>> get_body(api::BlockNumberOrHash number_or_hash) override {
+        auto request = request_from_block_number_or_hash(number_or_hash);
+        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncGetBody, stub_, std::move(request), grpc_context_);
+        co_return body_from_response(reply);
+    }
+
+    // rpc HasBlock(GetSegmentRequest) returns(HasBlockResponse);
+    Task<bool> has_block(api::BlockNumberOrHash number_or_hash) override {
+        auto request = request_from_block_number_or_hash(number_or_hash);
+        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncHasBlock, stub_, std::move(request), grpc_context_);
+        co_return reply.has_block();
+    }
+
+    /** Ranges **/
+
+    // rpc GetBodiesByRange(GetBodiesByRangeRequest) returns(GetBodiesBatchResponse);
+    Task<api::BlockBodies> get_bodies_by_range(BlockNumRange range) override {
+        auto request = bodies_request_from_block_range(range);
+        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncGetBodiesByRange, stub_, std::move(request), grpc_context_);
+        co_return block_bodies_from_response(reply);
+    }
+
+    // rpc GetBodiesByHashes(GetBodiesByHashesRequest) returns(GetBodiesBatchResponse);
+    Task<api::BlockBodies> get_bodies_by_hashes(const api::BlockHashes& hashes) override {
+        auto request = bodies_request_from_block_hashes(hashes);
+        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncGetBodiesByHashes, stub_, std::move(request), grpc_context_);
+        co_return block_bodies_from_response(reply);
+    }
+
+    /** Chain Checkers **/
+
+    // rpc IsCanonicalHash(types.H256) returns(IsCanonicalResponse);
+    Task<bool> is_canonical_hash(Hash block_hash) override {
+        auto request = h256_from_block_hash(block_hash);
+        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncIsCanonicalHash, stub_, std::move(request), grpc_context_);
+        co_return reply.canonical();
+    }
+
+    // rpc GetHeaderHashNumber(types.H256) returns(GetHeaderHashNumberResponse);
+    Task<std::optional<BlockNum>> get_header_hash_number(Hash block_hash) override {
+        auto request = h256_from_block_hash(block_hash);
+        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncGetHeaderHashNumber, stub_, std::move(request), grpc_context_);
+        co_return block_number_from_response(reply);
+    }
+
+    // rpc GetForkChoice(google.protobuf.Empty) returns(ForkChoice);
+    Task<api::ForkChoice> get_fork_choice() override {
+        google::protobuf::Empty request;
+        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncGetForkChoice, stub_, std::move(request), grpc_context_);
+        co_return fork_choice_from_response(reply);
+    }
+
+    /** Misc **/
+
+    // rpc Ready(google.protobuf.Empty) returns(ReadyResponse);
+    Task<bool> ready() override {
+        google::protobuf::Empty request;
+        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncReady, stub_, std::move(request), grpc_context_);
+        co_return reply.ready();
+    }
+
+    // rpc FrozenBlocks(google.protobuf.Empty) returns(FrozenBlocksResponse);
+    Task<uint64_t> frozen_blocks() override {
+        google::protobuf::Empty request;
+        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncFrozenBlocks, stub_, std::move(request), grpc_context_);
+        co_return reply.frozen_blocks();
+    }
+
+    /** Additional non-RPC methods **/
+
+    Task<api::BlockHeaders> get_last_headers(uint64_t n) override {
+        api::BlockHeaders last_headers;
+        if (n == 0) {
+            co_return last_headers;
+        }
+        last_headers.reserve(n);
+        auto last_finalized_header{co_await current_header()};
+        if (!last_finalized_header) {
+            co_return last_headers;
+        }
+        BlockNum last_number{last_finalized_header->number};
+        last_headers.push_back(std::move(*last_finalized_header));
+        for (BlockNum number{last_number - 1}; number < last_number - n; --number) {
+            auto header{co_await get_header(number)};
+            if (header) {
+                last_headers.push_back(std::move(*header));
+            }
+        }
+        co_return last_headers;
+    }
+
+    Task<BlockNum> block_progress() override {
+        // This should return the last header inserted into the database but such RPC does not exist
+        // TODO(canepat) we should either add RPC or get rid of this by refactoring sync
+        const auto last_finalized_header{co_await current_header()};
+        co_return last_finalized_header->number;
+    }
+
+  private:
+    std::shared_ptr<::grpc::Channel> channel_;
+    std::unique_ptr<Stub> stub_;
+    agrpc::GrpcContext& grpc_context_;
+    std::function<Task<void>()> on_disconnect_;
+};
+
+RemoteClient::RemoteClient(const std::string& address_uri, agrpc::GrpcContext& grpc_context)
+    : p_impl_(std::make_shared<RemoteClientImpl>(address_uri, grpc_context)) {}
+
+// Must be here (not in header) because RemoteClientImpl size is necessary for std::unique_ptr in PIMPL idiom
+RemoteClient::~RemoteClient() = default;
+
+std::shared_ptr<api::Service> RemoteClient::service() {
+    return p_impl_;
+}
+
+}  // namespace silkworm::execution::grpc::client

--- a/silkworm/node/execution/grpc/client/remote_client.hpp
+++ b/silkworm/node/execution/grpc/client/remote_client.hpp
@@ -1,0 +1,40 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <memory>
+
+#include <agrpc/detail/forward.hpp>
+
+#include "../../api/client.hpp"
+#include "../../api/service.hpp"
+
+namespace silkworm::execution::grpc::client {
+
+class RemoteClientImpl;
+
+struct RemoteClient : public api::Client {
+    RemoteClient(const std::string& address_uri, agrpc::GrpcContext& grpc_context);
+    ~RemoteClient() override;
+
+    std::shared_ptr<api::Service> service() override;
+
+  private:
+    std::shared_ptr<RemoteClientImpl> p_impl_;
+};
+
+}  // namespace silkworm::execution::grpc::client

--- a/silkworm/node/execution/grpc/common/block.cpp
+++ b/silkworm/node/execution/grpc/common/block.cpp
@@ -1,0 +1,175 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include <silkworm/core/common/bytes_to_string.hpp>
+#include <silkworm/core/common/util.hpp>
+#include <silkworm/infra/grpc/common/conversion.hpp>
+
+#include "block.hpp"
+
+namespace silkworm::execution::grpc {
+
+namespace proto = ::execution;
+
+void deserialize_hex_as_bytes(const std::string& hex, std::vector<Bytes>& sequence) {
+    auto blob_bytes{from_hex(hex)};
+    if (blob_bytes) {
+        sequence.push_back(std::move(*blob_bytes));
+    }
+}
+
+void header_from_proto(const ::execution::Header& proto_header, BlockHeader& header) {
+    header.parent_hash = rpc::bytes32_from_H256(proto_header.parent_hash());
+    header.ommers_hash = rpc::bytes32_from_H256(proto_header.ommer_hash());
+    header.beneficiary = rpc::address_from_H160(proto_header.coinbase());
+    header.state_root = rpc::bytes32_from_H256(proto_header.state_root());
+    header.transactions_root = rpc::bytes32_from_H256(proto_header.transaction_hash());
+    header.receipts_root = rpc::bytes32_from_H256(proto_header.receipt_root());
+    header.difficulty = rpc::uint256_from_H256(proto_header.difficulty());
+    header.number = proto_header.block_number();
+    header.gas_limit = proto_header.gas_limit();
+    header.gas_used = proto_header.gas_used();
+    header.timestamp = proto_header.timestamp();
+    header.prev_randao = rpc::bytes32_from_H256(proto_header.prev_randao());
+    rpc::span_from_H2048(proto_header.logs_bloom(), header.logs_bloom);
+    endian::store_big_u64(header.nonce.data(), proto_header.nonce());
+    std::copy(proto_header.extra_data().cbegin(), proto_header.extra_data().cend(), header.extra_data.begin());
+    if (proto_header.has_base_fee_per_gas()) {
+        header.base_fee_per_gas = rpc::uint256_from_H256(proto_header.base_fee_per_gas());
+    }
+    if (proto_header.has_withdrawal_hash()) {
+        header.withdrawals_root = rpc::bytes32_from_H256(proto_header.withdrawal_hash());
+    }
+    if (proto_header.has_blob_gas_used()) {
+        header.blob_gas_used = proto_header.blob_gas_used();
+    }
+    if (proto_header.has_excess_blob_gas()) {
+        header.excess_blob_gas = proto_header.excess_blob_gas();
+    }
+}
+
+BlockHeader header_from_proto(const proto::Header& proto_header) {
+    BlockHeader header;
+    header_from_proto(proto_header, header);
+    return header;
+}
+
+void body_from_proto(const ::execution::BlockBody& proto_body, BlockBody& body, Hash& block_hash, BlockNum& block_number) {
+    block_hash = rpc::bytes32_from_H256(proto_body.block_hash());
+    block_number = proto_body.block_number();
+    body.transactions.reserve(static_cast<std::size_t>(proto_body.transactions_size()));
+    for (const auto& received_tx : proto_body.transactions()) {
+        ByteView raw_tx_rlp{string_view_to_byte_view(received_tx)};
+        Transaction tx;
+        rlp::decode(raw_tx_rlp, tx);
+        body.transactions.push_back(std::move(tx));
+    }
+    body.ommers.reserve(static_cast<std::size_t>(proto_body.uncles_size()));
+    for (const auto& received_ommer : proto_body.uncles()) {
+        body.ommers.emplace_back(header_from_proto(received_ommer));
+    }
+    if (proto_body.withdrawals_size() > 0) {
+        std::vector<Withdrawal> withdrawals;
+        withdrawals.reserve(static_cast<std::size_t>(proto_body.withdrawals_size()));
+        body.withdrawals = std::move(withdrawals);
+    }
+    for (const auto& received_withdrawal : proto_body.withdrawals()) {
+        body.withdrawals->emplace_back(withdrawal_from_proto_type(received_withdrawal));
+    }
+}
+
+api::Body body_from_proto(const proto::BlockBody& proto_body) {
+    api::Body body;
+    body_from_proto(proto_body, body, body.block_hash, body.block_number);
+    return body;
+}
+
+void proto_from_header(const BlockHeader& bh, proto::Header* header) {
+    header->set_allocated_parent_hash(rpc::H256_from_bytes32(bh.parent_hash).release());
+    header->set_allocated_coinbase(rpc::H160_from_address(bh.beneficiary).release());
+    header->set_allocated_state_root(rpc::H256_from_bytes32(bh.state_root).release());
+    header->set_allocated_receipt_root(rpc::H256_from_bytes32(bh.receipts_root).release());
+    header->set_allocated_logs_bloom(rpc::H2048_from_string(to_string(bh.logs_bloom)).release());
+    header->set_allocated_prev_randao(rpc::H256_from_bytes32(bh.prev_randao).release());
+    header->set_block_number(bh.number);
+    header->set_gas_limit(bh.gas_limit);
+    header->set_gas_used(bh.gas_used);
+    header->set_timestamp(bh.timestamp);
+    header->set_nonce(endian::load_big_u64(bh.nonce.data()));
+    header->set_extra_data(bh.extra_data.data(), bh.extra_data.size());
+    header->set_allocated_difficulty(rpc::H256_from_uint256(bh.difficulty).release());
+    header->set_allocated_block_hash(rpc::H256_from_bytes32(bh.hash()).release());
+    header->set_allocated_ommer_hash(rpc::H256_from_bytes32(bh.ommers_hash).release());
+    header->set_allocated_transaction_hash(rpc::H256_from_bytes32(bh.transactions_root).release());
+    if (bh.base_fee_per_gas) {
+        header->set_allocated_base_fee_per_gas(rpc::H256_from_uint256(*bh.base_fee_per_gas).release());
+    }
+    if (bh.withdrawals_root) {
+        header->set_allocated_withdrawal_hash(rpc::H256_from_bytes32(*bh.withdrawals_root).release());
+    }
+    if (bh.blob_gas_used) {
+        header->set_blob_gas_used(*bh.blob_gas_used);
+    }
+    if (bh.excess_blob_gas) {
+        header->set_excess_blob_gas(*bh.excess_blob_gas);
+    }
+}
+
+void proto_from_body(const BlockBody& body, const Hash& h, BlockNum n, proto::BlockBody* proto_body) {
+    proto_body->set_allocated_block_hash(rpc::H256_from_bytes32(h).release());
+    proto_body->set_block_number(n);
+    for (const auto& transaction : body.transactions) {
+        Bytes tx_rlp;
+        rlp::encode(tx_rlp, transaction);
+        proto_body->add_transactions(tx_rlp.data(), tx_rlp.size());
+    }
+    for (const auto& ommer : body.ommers) {
+        proto::Header* uncle = proto_body->add_uncles();
+        proto_from_header(ommer, uncle);
+    }
+    if (body.withdrawals) {
+        for (const auto& withdrawal : *body.withdrawals) {
+            ::types::Withdrawal* w = proto_body->add_withdrawals();
+            serialize_withdrawal(withdrawal, w);
+        }
+    }
+}
+
+void proto_from_body(const api::Body& body, proto::BlockBody* proto_body) {
+    proto_from_body(body, body.block_hash, body.block_number, proto_body);
+}
+
+void proto_from_body(const Block& block, ::execution::BlockBody* proto_body) {
+    proto_from_body(block, block.header.hash(), block.header.number, proto_body);
+}
+
+void serialize_withdrawal(const Withdrawal& withdrawal, ::types::Withdrawal* w) {
+    w->set_index(withdrawal.index);
+    w->set_validator_index(withdrawal.validator_index);
+    w->set_allocated_address(rpc::H160_from_address(withdrawal.address).release());
+    w->set_amount(withdrawal.amount);
+}
+
+Withdrawal withdrawal_from_proto_type(const ::types::Withdrawal& w) {
+    return {
+        .index = w.index(),
+        .validator_index = w.validator_index(),
+        .address = rpc::address_from_H160(w.address()),
+        .amount = w.amount(),
+    };
+}
+
+}  // namespace silkworm::execution::grpc

--- a/silkworm/node/execution/grpc/common/block.cpp
+++ b/silkworm/node/execution/grpc/common/block.cpp
@@ -14,11 +14,11 @@
    limitations under the License.
 */
 
+#include "block.hpp"
+
 #include <silkworm/core/common/bytes_to_string.hpp>
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/infra/grpc/common/conversion.hpp>
-
-#include "block.hpp"
 
 namespace silkworm::execution::grpc {
 

--- a/silkworm/node/execution/grpc/common/block.hpp
+++ b/silkworm/node/execution/grpc/common/block.hpp
@@ -1,0 +1,48 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <silkworm/core/common/bytes.hpp>
+#include <silkworm/core/types/block.hpp>
+#include <silkworm/core/types/transaction.hpp>
+#include <silkworm/core/types/withdrawal.hpp>
+#include <silkworm/interfaces/execution/execution.pb.h>
+#include <silkworm/interfaces/types/types.pb.h>
+
+#include "../../api/endpoint/block.hpp"
+
+namespace silkworm::execution::grpc {
+
+void deserialize_hex_as_bytes(const std::string&, std::vector<Bytes>&);
+
+void header_from_proto(const ::execution::Header&, BlockHeader&);
+BlockHeader header_from_proto(const ::execution::Header&);
+void body_from_proto(const ::execution::BlockBody&, BlockBody&, Hash&, BlockNum&);
+api::Body body_from_proto(const ::execution::BlockBody&);
+
+void proto_from_header(const BlockHeader&, ::execution::Header*);
+void proto_from_body(const api::Body&, ::execution::BlockBody*);
+void proto_from_body(const Block&, ::execution::BlockBody*);
+void proto_from_body(const BlockBody&, const Hash&, BlockNum, ::execution::BlockBody*);
+
+void serialize_withdrawal(const Withdrawal&, ::types::Withdrawal*);
+Withdrawal withdrawal_from_proto_type(const ::types::Withdrawal&);
+
+}  // namespace silkworm::execution::grpc

--- a/silkworm/node/execution/grpc/common/block.hpp
+++ b/silkworm/node/execution/grpc/common/block.hpp
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <string>
+#include <string_view>
 #include <vector>
 
 #include <silkworm/core/common/bytes.hpp>
@@ -30,7 +30,7 @@
 
 namespace silkworm::execution::grpc {
 
-void deserialize_hex_as_bytes(const std::string&, std::vector<Bytes>&);
+void deserialize_hex_as_bytes(std::string_view, std::vector<Bytes>&);
 
 void header_from_proto(const ::execution::Header&, BlockHeader&);
 BlockHeader header_from_proto(const ::execution::Header&);

--- a/silkworm/node/execution/grpc/common/block_test.cpp
+++ b/silkworm/node/execution/grpc/common/block_test.cpp
@@ -1,0 +1,138 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "block.hpp"
+
+#include <string_view>
+#include <utility>
+
+#include <catch2/catch.hpp>
+
+#include <silkworm/core/common/bytes_to_string.hpp>
+#include <silkworm/infra/grpc/common/conversion.hpp>
+
+namespace silkworm::execution::grpc {
+
+TEST_CASE("deserialize_hex_as_bytes", "[node][execution][grpc]") {
+    const std::vector<std::pair<std::string_view, std::vector<Bytes>>> fixtures{
+        {"", {Bytes{}}},
+        {"0x01", {Bytes{0x01}}},
+        {"0x0102", {Bytes{0x01, 0x02}}},
+    };
+    for (const auto& [hex, expected_byte_vector] : fixtures) {
+        SECTION("hex bytes: " + std::to_string(expected_byte_vector.size())) {
+            std::vector<Bytes> bb;
+            CHECK_NOTHROW(deserialize_hex_as_bytes(hex, bb));
+            CHECK(bb == expected_byte_vector);
+        }
+    }
+    SECTION("invalid hex") {
+        std::vector<Bytes> bb;
+        CHECK_NOTHROW(deserialize_hex_as_bytes("00zz", bb));
+        CHECK(bb.empty());
+    }
+}
+
+static auto parent_hash{0x374f3a049e006f36f6cf91b02a3b0ee16c858af2f75858733eb0e927b5b7126c_bytes32};
+static auto ommers_hash{0x474f3a049e006f36f6cf91b02a3b0ee16c858af2f75858733eb0e927b5b7126d_bytes32};
+static auto beneficiary{0x0715a7794a1dc8e42615f059dd6e406a6594651a_address};
+static auto state_root{0xb02a3b0ee16c858afaa34bcd6770b3c20ee56aa2f75858733eb0e927b5b7126d_bytes32};
+static auto transactions_root{0xb02a3b0ee16c858afaa34bcd6770b3c20ee56aa2f75858733eb0e927b5b7126e_bytes32};
+static auto receipts_root{0xb02a3b0ee16c858afaa34bcd6770b3c20ee56aa2f75858733eb0e927b5b7126f_bytes32};
+static auto difficulty{intx::uint256{1234}};
+static auto block_number{5u};
+static auto gas_limit{1000000u};
+static auto gas_used{1000000u};
+static auto timestamp{5405021u};
+static Bytes extra_data{*from_hex("0001FF0100")};
+static auto prev_randao{0x0000000000000000000000000000000000000000000000000000000000000001_bytes32};
+static auto nonce{255u};
+static auto nonce_as_array{std::array<uint8_t, 8>{0, 0, 0, 0, 0, 0, 0, 255}};
+static auto base_fee_per_gas{0x244428u};
+
+static ::execution::Header sample_proto_header() {
+    ::execution::Header header;
+    header.set_allocated_parent_hash(rpc::H256_from_bytes32(parent_hash).release());
+    header.set_allocated_ommer_hash(rpc::H256_from_bytes32(ommers_hash).release());
+    header.set_allocated_coinbase(rpc::H160_from_address(beneficiary).release());
+    header.set_allocated_state_root(rpc::H256_from_bytes32(state_root).release());
+    header.set_allocated_transaction_hash(rpc::H256_from_bytes32(transactions_root).release());
+    header.set_allocated_receipt_root(rpc::H256_from_bytes32(receipts_root).release());
+    header.set_allocated_difficulty(rpc::H256_from_uint256(difficulty).release());
+    header.set_block_number(block_number);
+    header.set_gas_limit(gas_limit);
+    header.set_gas_used(gas_used);
+    header.set_timestamp(timestamp);
+    header.set_extra_data(byte_ptr_cast(extra_data.data()), extra_data.size());
+    header.set_allocated_prev_randao(rpc::H256_from_bytes32(prev_randao).release());
+    header.set_nonce(nonce);
+    header.set_allocated_base_fee_per_gas(rpc::H256_from_uint256(base_fee_per_gas).release());
+    return header;
+}
+
+static BlockHeader sample_block_header() {
+    return {
+        .parent_hash = parent_hash,
+        .ommers_hash = ommers_hash,
+        .beneficiary = beneficiary,
+        .state_root = state_root,
+        .transactions_root = transactions_root,
+        .receipts_root = receipts_root,
+        .difficulty = difficulty,
+        .number = block_number,
+        .gas_limit = gas_limit,
+        .gas_used = gas_used,
+        .timestamp = timestamp,
+        .extra_data = extra_data,
+        .prev_randao = prev_randao,
+        .nonce = nonce_as_array,
+        .base_fee_per_gas = base_fee_per_gas,
+    };
+}
+
+TEST_CASE("header_from_proto", "[node][execution][grpc]") {
+    const std::vector<std::pair<::execution::Header, BlockHeader>> fixtures{
+        {{}, {}},
+        {sample_proto_header(), sample_block_header()},
+    };
+    for (const auto& [proto_header, expected_block_header] : fixtures) {
+        SECTION("header: " + std::to_string(proto_header.block_number())) {
+            BlockHeader header;
+            CHECK_NOTHROW(header_from_proto(proto_header, header));
+            CHECK(header == expected_block_header);
+            CHECK(header_from_proto(proto_header) == expected_block_header);
+        }
+    }
+}
+
+TEST_CASE("convertibility", "[node][execution][grpc]") {
+    const std::vector<std::pair<::execution::Header, BlockHeader>> fixtures{
+        {{}, {}},
+        {sample_proto_header(), sample_block_header()},
+    };
+    for (const auto& [expected_proto_header, expected_block_header] : fixtures) {
+        SECTION("header: " + std::to_string(expected_proto_header.block_number())) {
+            const BlockHeader header = header_from_proto(expected_proto_header);
+            CHECK(header == expected_block_header);
+            ::execution::Header proto_header;
+            proto_from_header(header, &proto_header);
+            // CHECK(proto_header == expected_proto_header);  // requires operator== for ::execution::Header
+            CHECK(header_from_proto(proto_header) == expected_block_header);
+        }
+    }
+}
+
+}  // namespace silkworm::execution::grpc

--- a/silkworm/node/execution/grpc/common/block_test.cpp
+++ b/silkworm/node/execution/grpc/common/block_test.cpp
@@ -17,17 +17,17 @@
 #include "block.hpp"
 
 #include <string_view>
-#include <utility>
 
 #include <catch2/catch.hpp>
 
 #include <silkworm/core/common/bytes_to_string.hpp>
 #include <silkworm/infra/grpc/common/conversion.hpp>
+#include <silkworm/node/test_util/fixture.hpp>
 
 namespace silkworm::execution::grpc {
 
 TEST_CASE("deserialize_hex_as_bytes", "[node][execution][grpc]") {
-    const std::vector<std::pair<std::string_view, std::vector<Bytes>>> fixtures{
+    const test_util::Fixtures<std::string_view, std::vector<Bytes>> fixtures{
         {"", {Bytes{}}},
         {"0x01", {Bytes{0x01}}},
         {"0x0102", {Bytes{0x01, 0x02}}},
@@ -46,8 +46,8 @@ TEST_CASE("deserialize_hex_as_bytes", "[node][execution][grpc]") {
     }
 }
 
-static auto parent_hash{0x374f3a049e006f36f6cf91b02a3b0ee16c858af2f75858733eb0e927b5b7126c_bytes32};
-static auto ommers_hash{0x474f3a049e006f36f6cf91b02a3b0ee16c858af2f75858733eb0e927b5b7126d_bytes32};
+static constexpr auto parent_hash{0x374f3a049e006f36f6cf91b02a3b0ee16c858af2f75858733eb0e927b5b7126c_bytes32};
+static constexpr auto ommers_hash{0x474f3a049e006f36f6cf91b02a3b0ee16c858af2f75858733eb0e927b5b7126d_bytes32};
 static auto beneficiary{0x0715a7794a1dc8e42615f059dd6e406a6594651a_address};
 static auto state_root{0xb02a3b0ee16c858afaa34bcd6770b3c20ee56aa2f75858733eb0e927b5b7126d_bytes32};
 static auto transactions_root{0xb02a3b0ee16c858afaa34bcd6770b3c20ee56aa2f75858733eb0e927b5b7126e_bytes32};
@@ -57,7 +57,7 @@ static auto block_number{5u};
 static auto gas_limit{1000000u};
 static auto gas_used{1000000u};
 static auto timestamp{5405021u};
-static Bytes extra_data{*from_hex("0001FF0100")};
+static const Bytes extra_data{*from_hex("0001FF0100")};
 static auto prev_randao{0x0000000000000000000000000000000000000000000000000000000000000001_bytes32};
 static auto nonce{255u};
 static auto nonce_as_array{std::array<uint8_t, 8>{0, 0, 0, 0, 0, 0, 0, 255}};
@@ -104,7 +104,7 @@ static BlockHeader sample_block_header() {
 }
 
 TEST_CASE("header_from_proto", "[node][execution][grpc]") {
-    const std::vector<std::pair<::execution::Header, BlockHeader>> fixtures{
+    const test_util::Fixtures<::execution::Header, BlockHeader> fixtures{
         {{}, {}},
         {sample_proto_header(), sample_block_header()},
     };
@@ -119,7 +119,7 @@ TEST_CASE("header_from_proto", "[node][execution][grpc]") {
 }
 
 TEST_CASE("convertibility", "[node][execution][grpc]") {
-    const std::vector<std::pair<::execution::Header, BlockHeader>> fixtures{
+    const test_util::Fixtures<::execution::Header, BlockHeader> fixtures{
         {{}, {}},
         {sample_proto_header(), sample_block_header()},
     };

--- a/silkworm/node/execution/grpc/common/block_test.cpp
+++ b/silkworm/node/execution/grpc/common/block_test.cpp
@@ -30,6 +30,7 @@ namespace silkworm::execution::grpc {
 
 using namespace silkworm::execution::test_util;
 using namespace silkworm::test_util;
+namespace proto = ::execution;
 
 TEST_CASE("deserialize_hex_as_bytes", "[node][execution][grpc]") {
     const Fixtures<std::string_view, std::vector<Bytes>> fixtures{
@@ -52,7 +53,7 @@ TEST_CASE("deserialize_hex_as_bytes", "[node][execution][grpc]") {
 }
 
 TEST_CASE("header_from_proto", "[node][execution][grpc]") {
-    const Fixtures<::execution::Header, BlockHeader> fixtures{
+    const Fixtures<proto::Header, BlockHeader> fixtures{
         {{}, {}},
         {sample_proto_header(), sample_block_header()},
     };
@@ -67,7 +68,7 @@ TEST_CASE("header_from_proto", "[node][execution][grpc]") {
 }
 
 TEST_CASE("convertibility", "[node][execution][grpc]") {
-    const Fixtures<::execution::Header, BlockHeader> fixtures{
+    const Fixtures<proto::Header, BlockHeader> fixtures{
         {{}, {}},
         {sample_proto_header(), sample_block_header()},
     };
@@ -75,9 +76,9 @@ TEST_CASE("convertibility", "[node][execution][grpc]") {
         SECTION("header: " + std::to_string(expected_proto_header.block_number())) {
             const BlockHeader header = header_from_proto(expected_proto_header);
             CHECK(header == expected_block_header);
-            ::execution::Header proto_header;
+            proto::Header proto_header;
             proto_from_header(header, &proto_header);
-            // CHECK(proto_header == expected_proto_header);  // requires operator== for ::execution::Header
+            // CHECK(proto_header == expected_proto_header);  // requires operator== for proto::Header
             CHECK(header_from_proto(proto_header) == expected_block_header);
         }
     }

--- a/silkworm/node/execution/grpc/common/block_test.cpp
+++ b/silkworm/node/execution/grpc/common/block_test.cpp
@@ -21,13 +21,18 @@
 #include <catch2/catch.hpp>
 
 #include <silkworm/core/common/bytes_to_string.hpp>
-#include <silkworm/infra/grpc/common/conversion.hpp>
 #include <silkworm/node/test_util/fixture.hpp>
+#include <silkworm/node/test_util/sample_blocks.hpp>
+
+#include "../../test_util/sample_protos.hpp"
 
 namespace silkworm::execution::grpc {
 
+using namespace silkworm::execution::test_util;
+using namespace silkworm::test_util;
+
 TEST_CASE("deserialize_hex_as_bytes", "[node][execution][grpc]") {
-    const test_util::Fixtures<std::string_view, std::vector<Bytes>> fixtures{
+    const Fixtures<std::string_view, std::vector<Bytes>> fixtures{
         {"", {Bytes{}}},
         {"0x01", {Bytes{0x01}}},
         {"0x0102", {Bytes{0x01, 0x02}}},
@@ -46,65 +51,8 @@ TEST_CASE("deserialize_hex_as_bytes", "[node][execution][grpc]") {
     }
 }
 
-static constexpr auto parent_hash{0x374f3a049e006f36f6cf91b02a3b0ee16c858af2f75858733eb0e927b5b7126c_bytes32};
-static constexpr auto ommers_hash{0x474f3a049e006f36f6cf91b02a3b0ee16c858af2f75858733eb0e927b5b7126d_bytes32};
-static auto beneficiary{0x0715a7794a1dc8e42615f059dd6e406a6594651a_address};
-static auto state_root{0xb02a3b0ee16c858afaa34bcd6770b3c20ee56aa2f75858733eb0e927b5b7126d_bytes32};
-static auto transactions_root{0xb02a3b0ee16c858afaa34bcd6770b3c20ee56aa2f75858733eb0e927b5b7126e_bytes32};
-static auto receipts_root{0xb02a3b0ee16c858afaa34bcd6770b3c20ee56aa2f75858733eb0e927b5b7126f_bytes32};
-static auto difficulty{intx::uint256{1234}};
-static auto block_number{5u};
-static auto gas_limit{1000000u};
-static auto gas_used{1000000u};
-static auto timestamp{5405021u};
-static const Bytes extra_data{*from_hex("0001FF0100")};
-static auto prev_randao{0x0000000000000000000000000000000000000000000000000000000000000001_bytes32};
-static auto nonce{255u};
-static auto nonce_as_array{std::array<uint8_t, 8>{0, 0, 0, 0, 0, 0, 0, 255}};
-static auto base_fee_per_gas{0x244428u};
-
-static ::execution::Header sample_proto_header() {
-    ::execution::Header header;
-    header.set_allocated_parent_hash(rpc::H256_from_bytes32(parent_hash).release());
-    header.set_allocated_ommer_hash(rpc::H256_from_bytes32(ommers_hash).release());
-    header.set_allocated_coinbase(rpc::H160_from_address(beneficiary).release());
-    header.set_allocated_state_root(rpc::H256_from_bytes32(state_root).release());
-    header.set_allocated_transaction_hash(rpc::H256_from_bytes32(transactions_root).release());
-    header.set_allocated_receipt_root(rpc::H256_from_bytes32(receipts_root).release());
-    header.set_allocated_difficulty(rpc::H256_from_uint256(difficulty).release());
-    header.set_block_number(block_number);
-    header.set_gas_limit(gas_limit);
-    header.set_gas_used(gas_used);
-    header.set_timestamp(timestamp);
-    header.set_extra_data(byte_ptr_cast(extra_data.data()), extra_data.size());
-    header.set_allocated_prev_randao(rpc::H256_from_bytes32(prev_randao).release());
-    header.set_nonce(nonce);
-    header.set_allocated_base_fee_per_gas(rpc::H256_from_uint256(base_fee_per_gas).release());
-    return header;
-}
-
-static BlockHeader sample_block_header() {
-    return {
-        .parent_hash = parent_hash,
-        .ommers_hash = ommers_hash,
-        .beneficiary = beneficiary,
-        .state_root = state_root,
-        .transactions_root = transactions_root,
-        .receipts_root = receipts_root,
-        .difficulty = difficulty,
-        .number = block_number,
-        .gas_limit = gas_limit,
-        .gas_used = gas_used,
-        .timestamp = timestamp,
-        .extra_data = extra_data,
-        .prev_randao = prev_randao,
-        .nonce = nonce_as_array,
-        .base_fee_per_gas = base_fee_per_gas,
-    };
-}
-
 TEST_CASE("header_from_proto", "[node][execution][grpc]") {
-    const test_util::Fixtures<::execution::Header, BlockHeader> fixtures{
+    const Fixtures<::execution::Header, BlockHeader> fixtures{
         {{}, {}},
         {sample_proto_header(), sample_block_header()},
     };
@@ -119,7 +67,7 @@ TEST_CASE("header_from_proto", "[node][execution][grpc]") {
 }
 
 TEST_CASE("convertibility", "[node][execution][grpc]") {
-    const test_util::Fixtures<::execution::Header, BlockHeader> fixtures{
+    const Fixtures<::execution::Header, BlockHeader> fixtures{
         {{}, {}},
         {sample_proto_header(), sample_block_header()},
     };

--- a/silkworm/node/execution/grpc/server/endpoint/assembly.cpp
+++ b/silkworm/node/execution/grpc/server/endpoint/assembly.cpp
@@ -1,0 +1,41 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "assembly.hpp"
+
+namespace silkworm::execution::grpc::server {
+
+api::BlockUnderConstruction block_from_assemble_request(const ::execution::AssembleBlockRequest&) {
+    // TODO(canepat) implement
+    return {};
+}
+
+::execution::AssembleBlockResponse response_from_assemble_result(const api::AssembleBlockResult&) {
+    // TODO(canepat) implement
+    return {};
+}
+
+api::PayloadId get_assembled_request_from_payload_id(const ::execution::GetAssembledBlockRequest&) {
+    // TODO(canepat) implement
+    return {};
+}
+
+::execution::GetAssembledBlockResponse response_from_get_assembled_result(const api::AssembledBlockResult&) {
+    // TODO(canepat) implement
+    return {};
+}
+
+}  // namespace silkworm::execution::grpc::server

--- a/silkworm/node/execution/grpc/server/endpoint/assembly.hpp
+++ b/silkworm/node/execution/grpc/server/endpoint/assembly.hpp
@@ -1,0 +1,33 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <memory>
+
+#include <silkworm/interfaces/execution/execution.pb.h>
+
+#include "../../../api/endpoint/assembly.hpp"
+
+namespace silkworm::execution::grpc::server {
+
+api::BlockUnderConstruction block_from_assemble_request(const ::execution::AssembleBlockRequest&);
+::execution::AssembleBlockResponse response_from_assemble_result(const api::AssembleBlockResult&);
+
+api::PayloadId get_assembled_request_from_payload_id(const ::execution::GetAssembledBlockRequest&);
+::execution::GetAssembledBlockResponse response_from_get_assembled_result(const api::AssembledBlockResult&);
+
+}  // namespace silkworm::execution::grpc::server

--- a/silkworm/node/execution/grpc/server/endpoint/checkers.cpp
+++ b/silkworm/node/execution/grpc/server/endpoint/checkers.cpp
@@ -1,0 +1,42 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "checkers.hpp"
+
+namespace silkworm::execution::grpc::server {
+
+::execution::GetHeaderHashNumberResponse response_from_block_number(std::optional<BlockNum> block_number) {
+    ::execution::GetHeaderHashNumberResponse response;
+    if (block_number) {
+        response.set_block_number(*block_number);
+    }
+    return response;
+}
+
+::execution::ForkChoice response_from_fork_choice(const api::ForkChoice& fork_choice) {
+    ::execution::ForkChoice response;
+    response.set_allocated_head_block_hash(rpc::H256_from_bytes32(fork_choice.head_block_hash).release());
+    response.set_timeout(fork_choice.timeout);
+    if (fork_choice.finalized_block_hash) {
+        response.set_allocated_finalized_block_hash(rpc::H256_from_bytes32(*fork_choice.finalized_block_hash).release());
+    }
+    if (fork_choice.safe_block_hash) {
+        response.set_allocated_safe_block_hash(rpc::H256_from_bytes32(*fork_choice.safe_block_hash).release());
+    }
+    return response;
+}
+
+}  // namespace silkworm::execution::grpc::server

--- a/silkworm/node/execution/grpc/server/endpoint/checkers.hpp
+++ b/silkworm/node/execution/grpc/server/endpoint/checkers.hpp
@@ -1,0 +1,34 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <optional>
+
+#include <silkworm/core/common/base.hpp>
+#include <silkworm/core/types/hash.hpp>
+#include <silkworm/infra/grpc/common/conversion.hpp>
+#include <silkworm/interfaces/execution/execution.pb.h>
+
+#include "../../../api/endpoint/checkers.hpp"
+
+namespace silkworm::execution::grpc::server {
+
+::execution::GetHeaderHashNumberResponse response_from_block_number(std::optional<BlockNum>);
+
+::execution::ForkChoice response_from_fork_choice(const api::ForkChoice&);
+
+}  // namespace silkworm::execution::grpc::server

--- a/silkworm/node/execution/grpc/server/endpoint/getters.cpp
+++ b/silkworm/node/execution/grpc/server/endpoint/getters.cpp
@@ -16,26 +16,48 @@
 
 #include "getters.hpp"
 
+#include <silkworm/infra/grpc/common/conversion.hpp>
+
+#include "../../common/block.hpp"
+
 namespace silkworm::execution::grpc::server {
 
-api::BlockNumberOrHash block_number_or_hash_from_request(const ::execution::GetSegmentRequest&) {
-    // TODO(canepat) implement
-    return {};
+namespace proto = ::execution;
+
+api::BlockNumberOrHash block_number_or_hash_from_request(const proto::GetSegmentRequest& request) {
+    api::BlockNumberOrHash number_or_hash;
+    if (request.has_block_number()) {
+        number_or_hash = request.block_number();
+    } else if (request.has_block_hash()) {
+        number_or_hash = rpc::bytes32_from_H256(request.block_hash());
+    }
+    return number_or_hash;
 }
 
-::execution::GetTDResponse response_from_total_difficulty(const std::optional<TotalDifficulty>&) {
-    // TODO(canepat) implement
-    return {};
+proto::GetTDResponse response_from_total_difficulty(const std::optional<TotalDifficulty>& total_difficulty) {
+    proto::GetTDResponse response;
+    if (total_difficulty) {
+        response.set_allocated_td(rpc::H256_from_uint256(*total_difficulty).release());
+    }
+    return response;
 }
 
-::execution::GetHeaderResponse response_from_header(const std::optional<BlockHeader>&) {
-    // TODO(canepat) implement
-    return {};
+proto::GetHeaderResponse response_from_header(const std::optional<BlockHeader>& header) {
+    proto::GetHeaderResponse response;
+    if (header) {
+        proto::Header* proto_header = response.mutable_header();
+        proto_from_header(*header, proto_header);
+    }
+    return response;
 }
 
-::execution::GetBodyResponse response_from_body(const std::optional<BlockBody>&) {
-    // TODO(canepat) implement
-    return {};
+proto::GetBodyResponse response_from_body(const std::optional<BlockBody>& body, const Hash& block_hash, BlockNum block_number) {
+    proto::GetBodyResponse response;
+    if (body) {
+        proto::BlockBody* proto_body = response.mutable_body();
+        proto_from_body(*body, block_hash, block_number, proto_body);
+    }
+    return response;
 }
 
 }  // namespace silkworm::execution::grpc::server

--- a/silkworm/node/execution/grpc/server/endpoint/getters.cpp
+++ b/silkworm/node/execution/grpc/server/endpoint/getters.cpp
@@ -1,0 +1,41 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "getters.hpp"
+
+namespace silkworm::execution::grpc::server {
+
+api::BlockNumberOrHash block_number_or_hash_from_request(const ::execution::GetSegmentRequest&) {
+    // TODO(canepat) implement
+    return {};
+}
+
+::execution::GetTDResponse response_from_total_difficulty(const std::optional<TotalDifficulty>&) {
+    // TODO(canepat) implement
+    return {};
+}
+
+::execution::GetHeaderResponse response_from_header(const std::optional<BlockHeader>&) {
+    // TODO(canepat) implement
+    return {};
+}
+
+::execution::GetBodyResponse response_from_body(const std::optional<BlockBody>&) {
+    // TODO(canepat) implement
+    return {};
+}
+
+}  // namespace silkworm::execution::grpc::server

--- a/silkworm/node/execution/grpc/server/endpoint/getters.hpp
+++ b/silkworm/node/execution/grpc/server/endpoint/getters.hpp
@@ -1,0 +1,33 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <optional>
+
+#include <silkworm/core/types/block.hpp>
+#include <silkworm/interfaces/execution/execution.pb.h>
+
+#include "../../../api/endpoint/getters.hpp"
+
+namespace silkworm::execution::grpc::server {
+
+api::BlockNumberOrHash block_number_or_hash_from_request(const ::execution::GetSegmentRequest&);
+::execution::GetTDResponse response_from_total_difficulty(const std::optional<TotalDifficulty>&);
+::execution::GetHeaderResponse response_from_header(const std::optional<BlockHeader>&);
+::execution::GetBodyResponse response_from_body(const std::optional<BlockBody>&);
+
+}  // namespace silkworm::execution::grpc::server

--- a/silkworm/node/execution/grpc/server/endpoint/getters.hpp
+++ b/silkworm/node/execution/grpc/server/endpoint/getters.hpp
@@ -28,6 +28,6 @@ namespace silkworm::execution::grpc::server {
 api::BlockNumberOrHash block_number_or_hash_from_request(const ::execution::GetSegmentRequest&);
 ::execution::GetTDResponse response_from_total_difficulty(const std::optional<TotalDifficulty>&);
 ::execution::GetHeaderResponse response_from_header(const std::optional<BlockHeader>&);
-::execution::GetBodyResponse response_from_body(const std::optional<BlockBody>&);
+::execution::GetBodyResponse response_from_body(const std::optional<BlockBody>&, const Hash&, BlockNum);
 
 }  // namespace silkworm::execution::grpc::server

--- a/silkworm/node/execution/grpc/server/endpoint/getters_test.cpp
+++ b/silkworm/node/execution/grpc/server/endpoint/getters_test.cpp
@@ -1,0 +1,164 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "getters.hpp"
+
+#include <optional>
+
+#include <catch2/catch.hpp>
+#include <intx/intx.hpp>
+
+#include <silkworm/infra/grpc/common/conversion.hpp>
+#include <silkworm/interfaces/execution/execution.pb.h>
+#include <silkworm/node/test_util/fixture.hpp>
+#include <silkworm/node/test_util/sample_blocks.hpp>
+
+#include "../../../test_util/sample_protos.hpp"
+
+namespace silkworm::execution::grpc::server {
+
+using namespace evmc::literals;
+using namespace silkworm::execution::test_util;
+using namespace silkworm::test_util;
+namespace proto = ::execution;
+
+static api::BlockNumberOrHash sample_block_number_or_hash(bool has_number) {
+    if (has_number) {
+        return kSampleBlockNumber;
+    } else {
+        return kSampleBlockHash;
+    }
+}
+
+static proto::GetSegmentRequest sample_proto_get_segment_request(std::optional<BlockNum> number,
+                                                                 std::optional<Hash> hash) {
+    proto::GetSegmentRequest request;
+    if (number) {
+        request.set_block_number(*number);
+    }
+    if (hash) {
+        request.set_allocated_block_hash(rpc::H256_from_bytes32(*hash).release());
+    }
+    return request;
+}
+
+TEST_CASE("block_number_or_hash_from_request", "[node][execution][grpc]") {
+    const Fixtures<proto::GetSegmentRequest, api::BlockNumberOrHash> fixtures{
+        {sample_proto_get_segment_request({}, {}), {}},  // BlockNumberOrHash contains 1st variant as default
+        {sample_proto_get_segment_request(0, {}), {}},  // BlockNumberOrHash contains 1st variant as default
+        {sample_proto_get_segment_request(kSampleBlockNumber, {}), sample_block_number_or_hash(true)},
+        {sample_proto_get_segment_request({}, kSampleBlockHash), sample_block_number_or_hash(false)},
+    };
+    for (const auto& [segment_request, expected_number_or_hash] : fixtures) {
+        SECTION("block_number_or_hash index: " + std::to_string(expected_number_or_hash.index())) {
+            const auto number_or_hash{block_number_or_hash_from_request(segment_request)};
+            CHECK(number_or_hash == expected_number_or_hash);
+        }
+    }
+}
+
+static constexpr TotalDifficulty kTotalDifficulty{1'000'000};
+
+static proto::GetTDResponse sample_td_response(bool has_value) {
+    proto::GetTDResponse response;
+    if (has_value) {
+        response.set_allocated_td(rpc::H256_from_uint256(kTotalDifficulty).release());
+    }
+    return response;
+}
+
+static std::optional<TotalDifficulty> sample_total_difficulty(bool has_value) {
+    return has_value ? std::make_optional(kTotalDifficulty) : std::nullopt;
+}
+
+TEST_CASE("response_from_total_difficulty", "[node][execution][grpc]") {
+    const Fixtures<std::optional<TotalDifficulty>, proto::GetTDResponse> fixtures{
+        {sample_total_difficulty(false), sample_td_response(false)},
+        {sample_total_difficulty(true), sample_td_response(true)},
+    };
+    for (const auto& [total_difficulty, expected_response] : fixtures) {
+        SECTION("total_difficulty: " + std::to_string(total_difficulty.has_value())) {
+            const auto response{response_from_total_difficulty(total_difficulty)};
+            // CHECK(response == expected_response);  // requires operator== in gRPC
+            CHECK(response.has_td() == expected_response.has_td());
+            if (response.has_td()) {
+                CHECK(response.td() == expected_response.td());
+            }
+        }
+    }
+}
+
+static proto::GetHeaderResponse sample_get_header_response() {
+    proto::GetHeaderResponse response;
+    proto::Header* proto_header = response.mutable_header();
+    sample_proto_header(proto_header);
+    proto_header->set_allocated_block_hash(rpc::H256_from_bytes32(kSampleBlockHash).release());
+    return response;
+}
+
+TEST_CASE("response_from_header", "[node][execution][grpc]") {
+    const Fixtures<std::optional<BlockHeader>, proto::GetHeaderResponse> fixtures{
+        {{}, {}},
+        {sample_block_header(), sample_get_header_response()},
+    };
+    for (const auto& [block_header, expected_response] : fixtures) {
+        SECTION("block_header: " + std::to_string(block_header.has_value())) {
+            const auto response{response_from_header(block_header)};
+            // CHECK(response == expected_response);  // requires operator== in gRPC generated code
+            CHECK(response.has_header() == expected_response.has_header());
+            if (response.has_header()) {
+                const auto& header{response.header()};
+                const auto& expected_header{expected_response.header()};
+                CHECK(header.block_number() == expected_header.block_number());
+                CHECK(header.has_block_hash() == expected_header.has_block_hash());
+                CHECK(header.block_hash() == expected_header.block_hash());
+                CHECK(header.extra_data() == expected_header.extra_data());
+                CHECK(header.parent_hash() == expected_header.parent_hash());
+            }
+        }
+    }
+}
+
+static proto::GetBodyResponse sample_get_body_response() {
+    proto::GetBodyResponse response;
+    sample_proto_body(response.mutable_body());
+    return response;
+}
+
+TEST_CASE("response_from_body", "[node][execution][grpc]") {
+    const Fixtures<std::optional<BlockBody>, proto::GetBodyResponse> fixtures{
+        {{}, {}},
+        {sample_block_body(), sample_get_body_response()},
+    };
+    for (const auto& [block_body, expected_response] : fixtures) {
+        SECTION("block_body: " + std::to_string(block_body.has_value())) {
+            const auto response{response_from_body(block_body, kSampleBlockHash, kSampleBlockNumber)};
+            // CHECK(response == expected_response);  // requires operator== in gRPC generated code
+            CHECK(response.has_body() == expected_response.has_body());
+            if (response.has_body()) {
+                const auto& body{response.body()};
+                const auto& expected_body{expected_response.body()};
+                CHECK(body.block_hash() == expected_body.block_hash());
+                CHECK(body.block_number() == expected_body.block_number());
+                CHECK(body.transactions_size() == expected_body.transactions_size());
+                CHECK(body.uncles_size() == expected_body.uncles_size());
+                CHECK(body.withdrawals_size() == expected_body.withdrawals_size());
+            }
+        }
+    }
+}
+
+}  // namespace silkworm::execution::grpc::server

--- a/silkworm/node/execution/grpc/server/endpoint/getters_test.cpp
+++ b/silkworm/node/execution/grpc/server/endpoint/getters_test.cpp
@@ -58,7 +58,7 @@ static proto::GetSegmentRequest sample_proto_get_segment_request(std::optional<B
 TEST_CASE("block_number_or_hash_from_request", "[node][execution][grpc]") {
     const Fixtures<proto::GetSegmentRequest, api::BlockNumberOrHash> fixtures{
         {sample_proto_get_segment_request({}, {}), {}},  // BlockNumberOrHash contains 1st variant as default
-        {sample_proto_get_segment_request(0, {}), {}},  // BlockNumberOrHash contains 1st variant as default
+        {sample_proto_get_segment_request(0, {}), {}},   // BlockNumberOrHash contains 1st variant as default
         {sample_proto_get_segment_request(kSampleBlockNumber, {}), sample_block_number_or_hash(true)},
         {sample_proto_get_segment_request({}, kSampleBlockHash), sample_block_number_or_hash(false)},
     };

--- a/silkworm/node/execution/grpc/server/endpoint/insertion.cpp
+++ b/silkworm/node/execution/grpc/server/endpoint/insertion.cpp
@@ -23,7 +23,7 @@ namespace silkworm::execution::grpc::server {
 
 namespace proto = ::execution;
 
-api::Blocks blocks_from_insertion_request(const proto::InsertBlocksRequest& request) {
+std::optional<api::Blocks> blocks_from_insertion_request(const proto::InsertBlocksRequest& request) {
     api::Blocks blocks;
     for (int index{0}; index < request.blocks_size(); ++index) {
         const auto& request_block{request.blocks(index)};
@@ -31,7 +31,9 @@ api::Blocks blocks_from_insertion_request(const proto::InsertBlocksRequest& requ
         header_from_proto(request_block.header(), block->header);
         Hash block_hash;
         body_from_proto(request_block.body(), *block, block_hash, block->header.number);
-        SILKWORM_ASSERT(block->header.hash() == block_hash);
+        if (block->header.hash() != block_hash) {
+            return {};
+        }
         blocks.emplace_back(std::move(block));
     }
     return blocks;

--- a/silkworm/node/execution/grpc/server/endpoint/insertion.cpp
+++ b/silkworm/node/execution/grpc/server/endpoint/insertion.cpp
@@ -1,0 +1,46 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "insertion.hpp"
+
+#include "../../common/block.hpp"
+#include "status.hpp"
+
+namespace silkworm::execution::grpc::server {
+
+namespace proto = ::execution;
+
+api::Blocks blocks_from_insertion_request(const proto::InsertBlocksRequest& request) {
+    api::Blocks blocks;
+    for (int index{0}; index < request.blocks_size(); ++index) {
+        const auto& request_block{request.blocks(index)};
+        auto block{std::make_shared<Block>()};
+        header_from_proto(request_block.header(), block->header);
+        Hash block_hash;
+        body_from_proto(request_block.body(), *block, block_hash, block->header.number);
+        SILKWORM_ASSERT(block->header.hash() == block_hash);
+        blocks.emplace_back(std::move(block));
+    }
+    return blocks;
+}
+
+proto::InsertionResult response_from_insertion_result(const api::InsertionResult& result) {
+    proto::InsertionResult response;
+    response.set_result(proto_from_execution_status(result.status));
+    return response;
+}
+
+}  // namespace silkworm::execution::grpc::server

--- a/silkworm/node/execution/grpc/server/endpoint/insertion.hpp
+++ b/silkworm/node/execution/grpc/server/endpoint/insertion.hpp
@@ -1,0 +1,28 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <silkworm/interfaces/execution/execution.pb.h>
+
+#include "../../../api/endpoint/insertion.hpp"
+
+namespace silkworm::execution::grpc::server {
+
+api::Blocks blocks_from_insertion_request(const ::execution::InsertBlocksRequest&);
+::execution::InsertionResult response_from_insertion_result(const api::InsertionResult& result);
+
+}  // namespace silkworm::execution::grpc::server

--- a/silkworm/node/execution/grpc/server/endpoint/insertion.hpp
+++ b/silkworm/node/execution/grpc/server/endpoint/insertion.hpp
@@ -16,13 +16,15 @@
 
 #pragma once
 
+#include <optional>
+
 #include <silkworm/interfaces/execution/execution.pb.h>
 
 #include "../../../api/endpoint/insertion.hpp"
 
 namespace silkworm::execution::grpc::server {
 
-api::Blocks blocks_from_insertion_request(const ::execution::InsertBlocksRequest&);
+std::optional<api::Blocks> blocks_from_insertion_request(const ::execution::InsertBlocksRequest&);
 ::execution::InsertionResult response_from_insertion_result(const api::InsertionResult& result);
 
 }  // namespace silkworm::execution::grpc::server

--- a/silkworm/node/execution/grpc/server/endpoint/insertion_test.cpp
+++ b/silkworm/node/execution/grpc/server/endpoint/insertion_test.cpp
@@ -1,0 +1,88 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "insertion.hpp"
+
+#include <optional>
+
+#include <catch2/catch.hpp>
+#include <intx/intx.hpp>
+
+#include <silkworm/interfaces/execution/execution.pb.h>
+#include <silkworm/node/test_util/fixture.hpp>
+#include <silkworm/node/test_util/sample_blocks.hpp>
+
+#include "../../../test_util/sample_protos.hpp"
+
+namespace silkworm::execution::grpc::server {
+
+using namespace evmc::literals;
+using namespace silkworm::execution::test_util;
+using namespace silkworm::test_util;
+namespace proto = ::execution;
+
+static api::Blocks sample_blocks() {
+    return {std::make_shared<Block>(), std::make_shared<Block>(sample_block())};
+}
+
+static void empty_proto_block(proto::Block* proto_block) {
+    static const auto kEmptyHeaderHash{BlockHeader{}.hash()};
+    proto_block->mutable_header()->set_allocated_block_hash(rpc::H256_from_bytes32(kEmptyHeaderHash).release());
+    proto_block->mutable_body()->set_allocated_block_hash(rpc::H256_from_bytes32(kEmptyHeaderHash).release());;
+}
+
+static proto::InsertBlocksRequest sample_proto_insert_block_request() {
+    proto::InsertBlocksRequest request;
+    empty_proto_block(request.add_blocks());  // first empty block
+    sample_proto_block(request.add_blocks());
+    return request;
+}
+
+static proto::InsertBlocksRequest sample_bad_proto_insert_block_request() {
+    proto::InsertBlocksRequest request;
+    proto::Block* proto_block = request.add_blocks();
+    sample_proto_block(proto_block);
+    // Block hash in both header and body set to wrong value (i.e. hash of empty string)
+    proto_block->mutable_header()->set_allocated_block_hash(rpc::H256_from_bytes32(kEmptyHash).release());
+    proto_block->mutable_body()->set_allocated_block_hash(rpc::H256_from_bytes32(kEmptyHash).release());
+    return request;
+}
+
+TEST_CASE("blocks_from_insertion_request", "[node][execution][grpc]") {
+    const Fixtures<proto::InsertBlocksRequest, std::optional<api::Blocks>> fixtures{
+        {{}, api::Blocks{}},
+        {sample_proto_insert_block_request(), sample_blocks()},
+        {sample_bad_proto_insert_block_request(), std::nullopt},
+    };
+    for (const auto& [insertion_request, expected_blocks] : fixtures) {
+        SECTION("blocks size: " + (expected_blocks ? std::to_string(expected_blocks->size()) : "null")) {
+            const auto blocks{blocks_from_insertion_request(insertion_request)};
+            REQUIRE(blocks.has_value() == expected_blocks.has_value());
+            if (blocks) {
+                REQUIRE(blocks->size() == expected_blocks->size());
+                const size_t block_count{blocks->size()};
+                for (size_t i{0}; i < block_count; ++i) {
+                    const auto& block{blocks->at(i)};
+                    const auto& expected_block{expected_blocks->at(i)};
+                    REQUIRE((block && expected_block));
+                    CHECK(*block == *expected_block);
+                }
+            }
+        }
+    }
+}
+
+}  // namespace silkworm::execution::grpc::server

--- a/silkworm/node/execution/grpc/server/endpoint/insertion_test.cpp
+++ b/silkworm/node/execution/grpc/server/endpoint/insertion_test.cpp
@@ -41,7 +41,8 @@ static api::Blocks sample_blocks() {
 static void empty_proto_block(proto::Block* proto_block) {
     static const auto kEmptyHeaderHash{BlockHeader{}.hash()};
     proto_block->mutable_header()->set_allocated_block_hash(rpc::H256_from_bytes32(kEmptyHeaderHash).release());
-    proto_block->mutable_body()->set_allocated_block_hash(rpc::H256_from_bytes32(kEmptyHeaderHash).release());;
+    proto_block->mutable_body()->set_allocated_block_hash(rpc::H256_from_bytes32(kEmptyHeaderHash).release());
+    ;
 }
 
 static proto::InsertBlocksRequest sample_proto_insert_block_request() {

--- a/silkworm/node/execution/grpc/server/endpoint/range.cpp
+++ b/silkworm/node/execution/grpc/server/endpoint/range.cpp
@@ -1,0 +1,49 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "range.hpp"
+
+#include <silkworm/infra/grpc/common/conversion.hpp>
+
+#include "../../common/block.hpp"
+
+namespace silkworm::execution::grpc::server {
+
+namespace proto = ::execution;
+
+BlockNumRange block_num_range_from_request(const proto::GetBodiesByRangeRequest& request) {
+    return {request.start(), request.start() + request.count()};
+}
+
+api::BlockHashes block_hashes_from_request(const proto::GetBodiesByHashesRequest& request) {
+    api::BlockHashes hashes;
+    hashes.reserve(static_cast<size_t>(request.hashes_size()));
+    for (const auto& h256 : request.hashes()) {
+        hashes.emplace_back(rpc::bytes32_from_H256(h256));
+    }
+    return hashes;
+}
+
+proto::GetBodiesBatchResponse response_from_bodies(const api::BlockBodies & bodies) {
+    proto::GetBodiesBatchResponse response;
+    for (const auto& body : bodies) {
+        proto::BlockBody* proto_body{response.add_bodies()};
+        proto_from_body(body, proto_body);
+    }
+    return response;
+}
+
+}  // namespace silkworm::execution::grpc::server

--- a/silkworm/node/execution/grpc/server/endpoint/range.cpp
+++ b/silkworm/node/execution/grpc/server/endpoint/range.cpp
@@ -37,7 +37,7 @@ api::BlockHashes block_hashes_from_request(const proto::GetBodiesByHashesRequest
     return hashes;
 }
 
-proto::GetBodiesBatchResponse response_from_bodies(const api::BlockBodies & bodies) {
+proto::GetBodiesBatchResponse response_from_bodies(const api::BlockBodies& bodies) {
     proto::GetBodiesBatchResponse response;
     for (const auto& body : bodies) {
         proto::BlockBody* proto_body{response.add_bodies()};

--- a/silkworm/node/execution/grpc/server/endpoint/range.hpp
+++ b/silkworm/node/execution/grpc/server/endpoint/range.hpp
@@ -1,0 +1,29 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <silkworm/interfaces/execution/execution.pb.h>
+
+#include "../../../api/endpoint/range.hpp"
+
+namespace silkworm::execution::grpc::server {
+
+BlockNumRange block_num_range_from_request(const ::execution::GetBodiesByRangeRequest&);
+api::BlockHashes block_hashes_from_request(const ::execution::GetBodiesByHashesRequest&);
+::execution::GetBodiesBatchResponse response_from_bodies(const api::BlockBodies&);
+
+}  // namespace silkworm::execution::grpc::server

--- a/silkworm/node/execution/grpc/server/endpoint/status.cpp
+++ b/silkworm/node/execution/grpc/server/endpoint/status.cpp
@@ -1,0 +1,44 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "status.hpp"
+
+#include <stdexcept>
+
+namespace silkworm::execution::grpc::server {
+
+namespace proto = ::execution;
+
+::execution::ExecutionStatus proto_from_execution_status(const api::ExecutionStatus& status) {
+    switch (status) {
+        case api::ExecutionStatus::kSuccess:
+            return proto::ExecutionStatus::Success;
+        case api::ExecutionStatus::kBadBlock:
+            return proto::ExecutionStatus::BadBlock;
+        case api::ExecutionStatus::kTooFarAway:
+            return proto::ExecutionStatus::TooFarAway;
+        case api::ExecutionStatus::kMissingSegment:
+            return proto::ExecutionStatus::MissingSegment;
+        case api::ExecutionStatus::kInvalidForkchoice:
+            return proto::ExecutionStatus::InvalidForkchoice;
+        case api::ExecutionStatus::kBusy:
+            return proto::ExecutionStatus::Busy;
+        default:
+            throw std::logic_error{"unsupported api::ExecutionStatus value " + std::to_string(int(status))};
+    }
+}
+
+}  // namespace silkworm::execution::grpc::server

--- a/silkworm/node/execution/grpc/server/endpoint/status.hpp
+++ b/silkworm/node/execution/grpc/server/endpoint/status.hpp
@@ -1,0 +1,27 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <silkworm/interfaces/execution/execution.pb.h>
+
+#include "../../../api/endpoint/status.hpp"
+
+namespace silkworm::execution::grpc::server {
+
+::execution::ExecutionStatus proto_from_execution_status(const api::ExecutionStatus&);
+
+}  // namespace silkworm::execution::grpc::server

--- a/silkworm/node/execution/grpc/server/endpoint/validation.cpp
+++ b/silkworm/node/execution/grpc/server/endpoint/validation.cpp
@@ -1,0 +1,72 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "validation.hpp"
+
+#include <silkworm/infra/grpc/common/conversion.hpp>
+
+#include "status.hpp"
+
+namespace silkworm::execution::grpc::server {
+
+namespace proto = ::execution;
+
+api::BlockNumAndHash block_num_and_hash_from_request(const proto::ValidationRequest& request) {
+    return {
+        .number = request.number(),
+        .hash = rpc::bytes32_from_H256(request.hash()),
+    };
+}
+
+proto::ValidationReceipt response_from_validation_result(const api::ValidationResult& result) {
+    proto::ValidationReceipt reply;
+    if (std::holds_alternative<api::ValidChain>(result)) {
+        reply.set_validation_status(proto::ExecutionStatus::Success);
+        const auto& valid_chain{std::get<api::ValidChain>(result)};
+        reply.set_allocated_latest_valid_hash(rpc::H256_from_bytes32(valid_chain.current_head.hash).release());
+    } else if (std::holds_alternative<api::InvalidChain>(result)) {
+        reply.set_validation_status(proto::ExecutionStatus::InvalidForkchoice);
+        const auto& invalid_chain{std::get<api::InvalidChain>(result)};
+        reply.set_allocated_latest_valid_hash(rpc::H256_from_bytes32(invalid_chain.unwind_point.hash).release());
+    } else if (std::holds_alternative<api::ValidationError>(result)) {
+        // TODO(canepat) extend result to cover ::execution::ExecutionStatus error values
+        reply.set_validation_status(proto::ExecutionStatus::InvalidForkchoice);
+        const auto& validation_error{std::get<api::ValidationError>(result)};
+        reply.set_validation_error(validation_error.error);
+    } else {
+        throw std::logic_error{"execution::grpc::server::response_from_validation_result unexpected result"};
+    }
+    return reply;
+}
+
+api::ForkChoice fork_choice_from_request(const proto::ForkChoice& request) {
+    return {
+        .head_block_hash = rpc::bytes32_from_H256(request.head_block_hash()),
+        .timeout = request.timeout(),
+        .finalized_block_hash = rpc::bytes32_from_H256(request.finalized_block_hash()),
+        .safe_block_hash = rpc::bytes32_from_H256(request.safe_block_hash()),
+    };
+}
+
+proto::ForkChoiceReceipt response_from_fork_choice_result(const api::ForkChoiceResult& result) {
+    proto::ForkChoiceReceipt reply;
+    reply.set_status(proto_from_execution_status(result.status));
+    reply.set_allocated_latest_valid_hash(rpc::H256_from_bytes32(result.latest_valid_head).release());
+    reply.set_validation_error(result.validation_error);
+    return reply;
+}
+
+}  // namespace silkworm::execution::grpc::server

--- a/silkworm/node/execution/grpc/server/endpoint/validation.hpp
+++ b/silkworm/node/execution/grpc/server/endpoint/validation.hpp
@@ -1,0 +1,33 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <silkworm/interfaces/execution/execution.pb.h>
+
+#include "../../../api/endpoint/validation.hpp"
+
+namespace silkworm::execution::grpc::server {
+
+api::ExecutionStatus execution_status_from_proto(const ::execution::ExecutionStatus&);
+
+api::BlockNumAndHash block_num_and_hash_from_request(const ::execution::ValidationRequest&);
+::execution::ValidationReceipt response_from_validation_result(const api::ValidationResult&);
+
+api::ForkChoice fork_choice_from_request(const ::execution::ForkChoice&);
+::execution::ForkChoiceReceipt response_from_fork_choice_result(const api::ForkChoiceResult&);
+
+}  // namespace silkworm::execution::grpc::server

--- a/silkworm/node/execution/grpc/server/server.cpp
+++ b/silkworm/node/execution/grpc/server/server.cpp
@@ -1,0 +1,120 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "server.hpp"
+
+#include <utility>
+
+#include <agrpc/grpc_context.hpp>
+
+#include <silkworm/infra/common/log.hpp>
+#include <silkworm/infra/grpc/server/call.hpp>
+#include <silkworm/infra/grpc/server/server.hpp>
+#include <silkworm/interfaces/execution/execution.grpc.pb.h>
+
+#include "server_calls.hpp"
+
+namespace silkworm::execution::grpc::server {
+
+using namespace silkworm::log;
+using AsyncService = ::execution::Execution::AsyncService;
+
+class ServerImpl final : public rpc::Server {
+  public:
+    ServerImpl(rpc::ServerSettings settings, std::shared_ptr<api::DirectService> service);
+
+    ServerImpl(const ServerImpl&) = delete;
+    ServerImpl& operator=(const ServerImpl&) = delete;
+
+  private:
+    void register_async_services(::grpc::ServerBuilder& builder) override;
+    void register_request_calls() override;
+    void register_request_calls(agrpc::GrpcContext* grpc_context);
+
+    // Register one requested call repeatedly for each RPC: asio-grpc will take care of re-registration on any incoming call
+    template <class RequestHandler, typename RPC>
+    void request_repeatedly(RPC rpc, agrpc::GrpcContext* grpc_context) {
+        auto async_service = &async_service_;
+        auto& service = service_;
+        // Registering repeatedly in asio-grpc will guarantee the RequestHandler lambda lifetime
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-capturing-lambda-coroutines)
+        rpc::request_repeatedly(*grpc_context, async_service, rpc, [&service](auto&&... args) -> Task<void> {
+            co_await RequestHandler{std::forward<decltype(args)>(args)...}(*service);
+        });
+    }
+
+    std::shared_ptr<api::DirectService> service_;
+    AsyncService async_service_;
+};
+
+ServerImpl::ServerImpl(rpc::ServerSettings settings, std::shared_ptr<api::DirectService> service)
+    : rpc::Server(std::move(settings)), service_{std::move(service)} {
+    log::Info("execution") << "rpc::Server created listening on: "
+                           << this->settings().address_uri
+                           << " contexts: " << this->settings().context_pool_settings.num_contexts;
+}
+
+// Register the gRPC services: they must exist for the lifetime of the server built by builder.
+void ServerImpl::register_async_services(::grpc::ServerBuilder& builder) {
+    builder.RegisterService(&async_service_);
+}
+
+//! Start server-side RPC requests as required by gRPC async model: one RPC per type is requested in advance.
+void ServerImpl::register_request_calls() {
+    for (std::size_t i = 0; i < num_contexts(); i++) {
+        const auto& context = next_context();
+        register_request_calls(context.server_grpc_context());
+    }
+}
+
+void ServerImpl::register_request_calls(agrpc::GrpcContext* grpc_context) {
+    request_repeatedly<InsertBlocksCall>(&AsyncService::RequestInsertBlocks, grpc_context);
+
+    request_repeatedly<ValidateChainCall>(&AsyncService::RequestValidateChain, grpc_context);
+    request_repeatedly<UpdateForkChoiceCall>(&AsyncService::RequestUpdateForkChoice, grpc_context);
+
+    request_repeatedly<AssembleBlockCall>(&AsyncService::RequestAssembleBlock, grpc_context);
+    request_repeatedly<GetAssembledBlockCall>(&AsyncService::RequestGetAssembledBlock, grpc_context);
+
+    request_repeatedly<CurrentHeaderCall>(&AsyncService::RequestCurrentHeader, grpc_context);
+    request_repeatedly<GetTDCall>(&AsyncService::RequestGetTD, grpc_context);
+    request_repeatedly<GetHeaderCall>(&AsyncService::RequestGetHeader, grpc_context);
+    request_repeatedly<GetBodyCall>(&AsyncService::RequestGetBody, grpc_context);
+    request_repeatedly<HasBlockCall>(&AsyncService::RequestHasBlock, grpc_context);
+
+    request_repeatedly<GetBodiesByRangeCall>(&AsyncService::RequestGetBodiesByRange, grpc_context);
+    request_repeatedly<GetBodiesByHashesCall>(&AsyncService::RequestGetBodiesByHashes, grpc_context);
+
+    request_repeatedly<IsCanonicalHashCall>(&AsyncService::RequestIsCanonicalHash, grpc_context);
+    request_repeatedly<GetHeaderHashNumberCall>(&AsyncService::RequestGetHeaderHashNumber, grpc_context);
+    request_repeatedly<GetForkChoiceCall>(&AsyncService::RequestGetForkChoice, grpc_context);
+
+    request_repeatedly<ReadyCall>(&AsyncService::RequestReady, grpc_context);
+    request_repeatedly<FrozenBlocksCall>(&AsyncService::RequestFrozenBlocks, grpc_context);
+}
+
+Server::Server(rpc::ServerSettings settings, std::shared_ptr<api::DirectService> service)
+    : p_impl_(std::make_unique<ServerImpl>(std::move(settings), std::move(service))) {}
+
+Server::~Server() {
+    log::Trace("sentry") << "silkworm::execution::grpc::server::Server::~Server";
+}
+
+Task<void> Server::async_run(std::optional<std::size_t> stack_size) {
+    return p_impl_->async_run("exec-engine", stack_size);
+}
+
+}  // namespace silkworm::execution::grpc::server

--- a/silkworm/node/execution/grpc/server/server.hpp
+++ b/silkworm/node/execution/grpc/server/server.hpp
@@ -1,0 +1,45 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <memory>
+
+#include <silkworm/infra/concurrency/task.hpp>
+
+#include <silkworm/infra/grpc/server/server_settings.hpp>
+
+#include "../../api/direct_service.hpp"
+
+namespace silkworm::execution::grpc::server {
+
+class ServerImpl;
+
+class Server final {
+  public:
+    Server(rpc::ServerSettings settings, std::shared_ptr<api::DirectService> service);
+    ~Server();
+
+    Server(const Server&) = delete;
+    Server& operator=(const Server&) = delete;
+
+    Task<void> async_run(std::optional<std::size_t> stack_size = {});
+
+  private:
+    std::unique_ptr<ServerImpl> p_impl_;
+};
+
+}  // namespace silkworm::execution::grpc::server

--- a/silkworm/node/execution/grpc/server/server_calls.cpp
+++ b/silkworm/node/execution/grpc/server/server_calls.cpp
@@ -1,0 +1,266 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "server_calls.hpp"
+
+#include <stdexcept>
+
+#include <silkworm/infra/grpc/common/conversion.hpp>
+
+#include "endpoint/assembly.hpp"
+#include "endpoint/checkers.hpp"
+#include "endpoint/getters.hpp"
+#include "endpoint/insertion.hpp"
+#include "endpoint/range.hpp"
+#include "endpoint/validation.hpp"
+
+namespace silkworm::execution::grpc::server {
+
+Task<void> InsertBlocksCall::operator()(api::DirectService& service) {
+    proto::InsertionResult reply;
+    ::grpc::Status status;
+    try {
+        const auto blocks{blocks_from_insertion_request(request_)};
+        const api::InsertionResult result = co_await service.insert_blocks(blocks);
+        reply = response_from_insertion_result(result);
+        status = ::grpc::Status::OK;
+    } catch (const std::exception& e) {
+        status = ::grpc::Status{::grpc::StatusCode::INTERNAL, e.what()};
+    }
+    co_await agrpc::finish(responder_, reply, status);
+}
+
+Task<void> ValidateChainCall::operator()(api::DirectService& service) {
+    proto::ValidationReceipt reply;
+    ::grpc::Status status;
+    try {
+        const auto block_num_and_hash{block_num_and_hash_from_request(request_)};
+        const api::ValidationResult result = co_await service.validate_chain(block_num_and_hash);
+        reply = response_from_validation_result(result);
+        status = ::grpc::Status::OK;
+    } catch (const std::exception& e) {
+        status = ::grpc::Status{::grpc::StatusCode::INTERNAL, e.what()};
+    }
+    co_await agrpc::finish(responder_, reply, status);
+}
+
+Task<void> UpdateForkChoiceCall::operator()(api::DirectService& service) {
+    proto::ForkChoiceReceipt reply;
+    ::grpc::Status status;
+    try {
+        const auto fork_choice{fork_choice_from_request(request_)};
+        const api::ForkChoiceResult result = co_await service.update_fork_choice(fork_choice);
+        reply = response_from_fork_choice_result(result);
+        status = ::grpc::Status::OK;
+    } catch (const std::exception& e) {
+        status = ::grpc::Status{::grpc::StatusCode::INTERNAL, e.what()};
+    }
+    co_await agrpc::finish(responder_, reply, status);
+}
+
+Task<void> AssembleBlockCall::operator()(api::DirectService& service) {
+    proto::AssembleBlockResponse reply;
+    ::grpc::Status status;
+    try {
+        const auto block{block_from_assemble_request(request_)};
+        const api::AssembleBlockResult result = co_await service.assemble_block(block);
+        reply = response_from_assemble_result(result);
+        status = ::grpc::Status::OK;
+    } catch (const std::exception& e) {
+        status = ::grpc::Status{::grpc::StatusCode::INTERNAL, e.what()};
+    }
+    co_await agrpc::finish(responder_, reply, status);
+}
+
+Task<void> GetAssembledBlockCall::operator()(api::DirectService& service) {
+    proto::GetAssembledBlockResponse reply;
+    ::grpc::Status status;
+    try {
+        const auto payload_id{get_assembled_request_from_payload_id(request_)};
+        const api::AssembledBlockResult result = co_await service.get_assembled_block(payload_id);
+        reply = response_from_get_assembled_result(result);
+        status = ::grpc::Status::OK;
+    } catch (const std::exception& e) {
+        status = ::grpc::Status{::grpc::StatusCode::INTERNAL, e.what()};
+    }
+    co_await agrpc::finish(responder_, reply, status);
+}
+
+Task<void> CurrentHeaderCall::operator()(api::DirectService& service) {
+    proto::GetHeaderResponse reply;
+    ::grpc::Status status;
+    try {
+        const std::optional<BlockHeader> result = co_await service.current_header();
+        reply = response_from_header(result);
+        status = ::grpc::Status::OK;
+    } catch (const std::exception& e) {
+        status = ::grpc::Status{::grpc::StatusCode::INTERNAL, e.what()};
+    }
+    co_await agrpc::finish(responder_, reply, status);
+}
+
+Task<void> GetTDCall::operator()(api::DirectService& service) {
+    proto::GetTDResponse reply;
+    ::grpc::Status status;
+    try {
+        const auto block_number_or_hash{block_number_or_hash_from_request(request_)};
+        const std::optional<TotalDifficulty> result = co_await service.get_td(block_number_or_hash);
+        reply = response_from_total_difficulty(result);
+        status = ::grpc::Status::OK;
+    } catch (const std::exception& e) {
+        status = ::grpc::Status{::grpc::StatusCode::INTERNAL, e.what()};
+    }
+    co_await agrpc::finish(responder_, reply, status);
+}
+
+Task<void> GetHeaderCall::operator()(api::DirectService& service) {
+    proto::GetHeaderResponse reply;
+    ::grpc::Status status;
+    try {
+        const auto block_number_or_hash{block_number_or_hash_from_request(request_)};
+        const std::optional<BlockHeader> result = co_await service.get_header(block_number_or_hash);
+        reply = response_from_header(result);
+        status = ::grpc::Status::OK;
+    } catch (const std::exception& e) {
+        status = ::grpc::Status{::grpc::StatusCode::INTERNAL, e.what()};
+    }
+    co_await agrpc::finish(responder_, reply, status);
+}
+
+Task<void> GetBodyCall::operator()(api::DirectService& service) {
+    proto::GetBodyResponse reply;
+    ::grpc::Status status;
+    try {
+        const auto block_number_or_hash{block_number_or_hash_from_request(request_)};
+        const std::optional<BlockBody> result = co_await service.get_body(block_number_or_hash);
+        reply = response_from_body(result);
+        status = ::grpc::Status::OK;
+    } catch (const std::exception& e) {
+        status = ::grpc::Status{::grpc::StatusCode::INTERNAL, e.what()};
+    }
+    co_await agrpc::finish(responder_, reply, status);
+}
+
+Task<void> HasBlockCall::operator()(api::DirectService& service) {
+    proto::HasBlockResponse reply;
+    ::grpc::Status status;
+    try {
+        const auto block_number_or_hash{block_number_or_hash_from_request(request_)};
+        const bool has_block = co_await service.has_block(block_number_or_hash);
+        reply.set_has_block(has_block);
+        status = ::grpc::Status::OK;
+    } catch (const std::exception& e) {
+        status = ::grpc::Status{::grpc::StatusCode::INTERNAL, e.what()};
+    }
+    co_await agrpc::finish(responder_, reply, status);
+}
+
+Task<void> GetBodiesByRangeCall::operator()(api::DirectService& service) {
+    proto::GetBodiesBatchResponse reply;
+    ::grpc::Status status;
+    try {
+        const auto block_number_range{block_num_range_from_request(request_)};
+        const auto block_bodies = co_await service.get_bodies_by_range(block_number_range);
+        reply = response_from_bodies(block_bodies);
+        status = ::grpc::Status::OK;
+    } catch (const std::exception& e) {
+        status = ::grpc::Status{::grpc::StatusCode::INTERNAL, e.what()};
+    }
+    co_await agrpc::finish(responder_, reply, status);
+}
+
+Task<void> GetBodiesByHashesCall::operator()(api::DirectService& service) {
+    proto::GetBodiesBatchResponse reply;
+    ::grpc::Status status;
+    try {
+        const auto block_hashes{block_hashes_from_request(request_)};
+        const auto block_bodies = co_await service.get_bodies_by_hashes(block_hashes);
+        reply = response_from_bodies(block_bodies);
+        status = ::grpc::Status::OK;
+    } catch (const std::exception& e) {
+        status = ::grpc::Status{::grpc::StatusCode::INTERNAL, e.what()};
+    }
+    co_await agrpc::finish(responder_, reply, status);
+}
+
+Task<void> IsCanonicalHashCall::operator()(api::DirectService& service) {
+    proto::IsCanonicalResponse reply;
+    ::grpc::Status status;
+    try {
+        const auto block_hash{rpc::bytes32_from_H256(request_)};
+        const bool is_canonical = co_await service.is_canonical_hash(block_hash);
+        reply.set_canonical(is_canonical);
+        status = ::grpc::Status::OK;
+    } catch (const std::exception& e) {
+        status = ::grpc::Status{::grpc::StatusCode::INTERNAL, e.what()};
+    }
+    co_await agrpc::finish(responder_, reply, status);
+}
+
+Task<void> GetHeaderHashNumberCall::operator()(api::DirectService& service) {
+    proto::GetHeaderHashNumberResponse reply;
+    ::grpc::Status status;
+    try {
+        const auto block_hash{rpc::bytes32_from_H256(request_)};
+        const auto block_number = co_await service.get_header_hash_number(block_hash);
+        reply = response_from_block_number(block_number);
+        status = ::grpc::Status::OK;
+    } catch (const std::exception& e) {
+        status = ::grpc::Status{::grpc::StatusCode::INTERNAL, e.what()};
+    }
+    co_await agrpc::finish(responder_, reply, status);
+}
+
+Task<void> GetForkChoiceCall::operator()(api::DirectService& service) {
+    proto::ForkChoice reply;
+    ::grpc::Status status;
+    try {
+        const auto fork_choice = co_await service.get_fork_choice();
+        reply = response_from_fork_choice(fork_choice);
+        status = ::grpc::Status::OK;
+    } catch (const std::exception& e) {
+        status = ::grpc::Status{::grpc::StatusCode::INTERNAL, e.what()};
+    }
+    co_await agrpc::finish(responder_, reply, status);
+}
+
+Task<void> ReadyCall::operator()(api::DirectService& service) {
+    proto::ReadyResponse reply;
+    ::grpc::Status status;
+    try {
+        const bool is_ready = co_await service.ready();
+        reply.set_ready(is_ready);
+        status = ::grpc::Status::OK;
+    } catch (const std::exception& e) {
+        status = ::grpc::Status{::grpc::StatusCode::INTERNAL, e.what()};
+    }
+    co_await agrpc::finish(responder_, reply, status);
+}
+
+Task<void> FrozenBlocksCall::operator()(api::DirectService& service) {
+    proto::FrozenBlocksResponse reply;
+    ::grpc::Status status;
+    try {
+        const uint64_t num_frozen_blocks = co_await service.frozen_blocks();
+        reply.set_frozen_blocks(num_frozen_blocks);
+        status = ::grpc::Status::OK;
+    } catch (const std::exception& e) {
+        status = ::grpc::Status{::grpc::StatusCode::INTERNAL, e.what()};
+    }
+    co_await agrpc::finish(responder_, reply, status);
+}
+
+}  // namespace silkworm::execution::grpc::server

--- a/silkworm/node/execution/grpc/server/server_calls.hpp
+++ b/silkworm/node/execution/grpc/server/server_calls.hpp
@@ -1,0 +1,173 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include <silkworm/infra/concurrency/task.hpp>
+
+#include <grpcpp/grpcpp.h>
+#include <gsl/util>
+
+#include <silkworm/core/common/base.hpp>
+#include <silkworm/infra/common/log.hpp>
+#include <silkworm/infra/concurrency/awaitable_future.hpp>
+#include <silkworm/infra/grpc/server/call.hpp>
+#include <silkworm/interfaces/execution/execution.grpc.pb.h>
+
+#include "../../api/direct_service.hpp"
+
+namespace silkworm::execution::grpc::server {
+
+namespace protobuf = google::protobuf;
+namespace proto = ::execution;
+namespace proto_types = ::types;
+using AsyncService = proto::Execution::AsyncService;
+
+// rpc InsertBlocks(InsertBlocksRequest) returns(InsertionResult);
+class InsertBlocksCall : public rpc::server::UnaryCall<proto::InsertBlocksRequest, proto::InsertionResult> {
+  public:
+    using Base::UnaryCall;
+
+    Task<void> operator()(api::DirectService& service);
+};
+
+// rpc ValidateChain(ValidationRequest) returns(ValidationReceipt);
+class ValidateChainCall : public rpc::server::UnaryCall<proto::ValidationRequest, proto::ValidationReceipt> {
+  public:
+    using Base::UnaryCall;
+
+    Task<void> operator()(api::DirectService& service);
+};
+
+// rpc UpdateForkChoice(ForkChoice) returns(ForkChoiceReceipt);
+class UpdateForkChoiceCall : public rpc::server::UnaryCall<proto::ForkChoice, proto::ForkChoiceReceipt> {
+  public:
+    using Base::UnaryCall;
+
+    Task<void> operator()(api::DirectService& service);
+};
+
+// rpc AssembleBlock(AssembleBlockRequest) returns(AssembleBlockResponse);
+class AssembleBlockCall : public rpc::server::UnaryCall<proto::AssembleBlockRequest, proto::AssembleBlockResponse> {
+  public:
+    using Base::UnaryCall;
+
+    Task<void> operator()(api::DirectService& service);
+};
+
+// rpc GetAssembledBlock(GetAssembledBlockRequest) returns(GetAssembledBlockResponse);
+class GetAssembledBlockCall : public rpc::server::UnaryCall<proto::GetAssembledBlockRequest, proto::GetAssembledBlockResponse> {
+  public:
+    using Base::UnaryCall;
+
+    Task<void> operator()(api::DirectService& service);
+};
+
+// rpc CurrentHeader(google.protobuf.Empty) returns(GetHeaderResponse);
+class CurrentHeaderCall : public rpc::server::UnaryCall<protobuf::Empty, proto::GetHeaderResponse> {
+  public:
+    using Base::UnaryCall;
+
+    Task<void> operator()(api::DirectService& service);
+};
+
+// rpc GetTD(GetSegmentRequest) returns(GetTDResponse);
+class GetTDCall : public rpc::server::UnaryCall<proto::GetSegmentRequest, proto::GetTDResponse> {
+  public:
+    using Base::UnaryCall;
+
+    Task<void> operator()(api::DirectService& service);
+};
+
+// rpc GetHeader(GetSegmentRequest) returns(GetHeaderResponse);
+class GetHeaderCall : public rpc::server::UnaryCall<proto::GetSegmentRequest, proto::GetHeaderResponse> {
+  public:
+    using Base::UnaryCall;
+
+    Task<void> operator()(api::DirectService& service);
+};
+
+// rpc GetBody(GetSegmentRequest) returns(GetBodyResponse);
+class GetBodyCall : public rpc::server::UnaryCall<proto::GetSegmentRequest, proto::GetBodyResponse> {
+  public:
+    using Base::UnaryCall;
+
+    Task<void> operator()(api::DirectService& service);
+};
+
+// rpc HasBlock(GetSegmentRequest) returns(HasBlockResponse);
+class HasBlockCall : public rpc::server::UnaryCall<proto::GetSegmentRequest, proto::HasBlockResponse> {
+  public:
+    using Base::UnaryCall;
+
+    Task<void> operator()(api::DirectService& service);
+};
+
+// rpc GetBodiesByRange(GetBodiesByRangeRequest) returns(GetBodiesBatchResponse);
+class GetBodiesByRangeCall : public rpc::server::UnaryCall<proto::GetBodiesByRangeRequest, proto::GetBodiesBatchResponse> {
+  public:
+    using Base::UnaryCall;
+
+    Task<void> operator()(api::DirectService& service);
+};
+
+// rpc GetBodiesByHashes(GetBodiesByHashesRequest) returns(GetBodiesBatchResponse);
+class GetBodiesByHashesCall : public rpc::server::UnaryCall<proto::GetBodiesByHashesRequest, proto::GetBodiesBatchResponse> {
+  public:
+    using Base::UnaryCall;
+
+    Task<void> operator()(api::DirectService& service);
+};
+
+// rpc IsCanonicalHash(types.H256) returns(IsCanonicalResponse);
+class IsCanonicalHashCall : public rpc::server::UnaryCall<proto_types::H256, proto::IsCanonicalResponse> {
+  public:
+    using Base::UnaryCall;
+
+    Task<void> operator()(api::DirectService& service);
+};
+
+// rpc GetHeaderHashNumber(types.H256) returns(GetHeaderHashNumberResponse);
+class GetHeaderHashNumberCall : public rpc::server::UnaryCall<proto_types::H256, proto::GetHeaderHashNumberResponse> {
+  public:
+    using Base::UnaryCall;
+
+    Task<void> operator()(api::DirectService& service);
+};
+
+// rpc GetForkChoice(google.protobuf.Empty) returns(ForkChoice);
+class GetForkChoiceCall : public rpc::server::UnaryCall<protobuf::Empty, proto::ForkChoice> {
+  public:
+    using Base::UnaryCall;
+
+    Task<void> operator()(api::DirectService& service);
+};
+
+// rpc Ready(google.protobuf.Empty) returns(ReadyResponse);
+class ReadyCall : public rpc::server::UnaryCall<protobuf::Empty, proto::ReadyResponse> {
+  public:
+    using Base::UnaryCall;
+
+    Task<void> operator()(api::DirectService& service);
+};
+
+// rpc FrozenBlocks(google.protobuf.Empty) returns(FrozenBlocksResponse);
+class FrozenBlocksCall : public rpc::server::UnaryCall<protobuf::Empty, proto::FrozenBlocksResponse> {
+  public:
+    using Base::UnaryCall;
+
+    Task<void> operator()(api::DirectService& service);
+};
+
+}  // namespace silkworm::execution::grpc::server

--- a/silkworm/node/execution/test_util/sample_protos.hpp
+++ b/silkworm/node/execution/test_util/sample_protos.hpp
@@ -1,0 +1,109 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <string>
+
+#include <silkworm/core/common/bytes_to_string.hpp>
+#include <silkworm/infra/grpc/common/conversion.hpp>
+#include <silkworm/interfaces/execution/execution.pb.h>
+#include <silkworm/interfaces/types/types.pb.h>
+#include <silkworm/node/test_util/sample_blocks.hpp>
+
+namespace silkworm::execution::test_util {
+
+using namespace silkworm::test_util;
+
+inline void sample_proto_header(::execution::Header* header) {
+    header->set_allocated_parent_hash(rpc::H256_from_bytes32(kSampleParentHash).release());
+    header->set_allocated_ommer_hash(rpc::H256_from_bytes32(kSampleOmmersHash).release());
+    header->set_allocated_coinbase(rpc::H160_from_address(kSampleBeneficiary).release());
+    header->set_allocated_state_root(rpc::H256_from_bytes32(kSampleStateRoot).release());
+    header->set_allocated_transaction_hash(rpc::H256_from_bytes32(kSampleTransactionsRoot).release());
+    header->set_allocated_receipt_root(rpc::H256_from_bytes32(kSampleReceiptsRoot).release());
+    header->set_allocated_difficulty(rpc::H256_from_uint256(kSampleDifficulty).release());
+    header->set_block_number(kSampleBlockNumber);
+    header->set_gas_limit(kSampleGasLimit);
+    header->set_gas_used(kSampleGasUsed);
+    header->set_timestamp(kSampleTimestamp);
+    header->set_extra_data(byte_ptr_cast(kSampleExtraData.data()), kSampleExtraData.size());
+    header->set_allocated_prev_randao(rpc::H256_from_bytes32(kSamplePrevRandao).release());
+    header->set_nonce(endian::load_big_u64(kSampleNonce.data()));
+    header->set_allocated_base_fee_per_gas(rpc::H256_from_uint256(kSampleBaseFeePerGas).release());
+}
+
+inline ::execution::Header sample_proto_header() {
+    ::execution::Header header;
+    sample_proto_header(&header);
+    return header;
+}
+
+inline std::string sample_proto_transaction(ByteView rlp_tx) {
+    return std::string{byte_view_to_string_view(rlp_tx)};
+}
+
+inline std::string sample_proto_tx0() {
+    Bytes rlp_tx0{};
+    rlp::encode(rlp_tx0, sample_tx0());
+    return sample_proto_transaction(rlp_tx0);
+}
+
+inline std::string sample_proto_tx1() {
+    Bytes rlp_tx1{};
+    rlp::encode(rlp_tx1, sample_tx1());
+    return sample_proto_transaction(rlp_tx1);
+}
+
+inline void sample_proto_ommer(::execution::Header* header) {
+    header->set_allocated_parent_hash(rpc::H256_from_bytes32(kSampleOmmerParentHash).release());
+    header->set_allocated_ommer_hash(rpc::H256_from_bytes32(kEmptyListHash).release());
+    header->set_allocated_coinbase(rpc::H160_from_address(kSampleOmmerBeneficiary).release());
+    header->set_allocated_state_root(rpc::H256_from_bytes32(kSampleOmmerStateRoot).release());
+    header->set_allocated_transaction_hash(rpc::H256_from_bytes32(kEmptyRoot).release());
+    header->set_allocated_receipt_root(rpc::H256_from_bytes32(kEmptyRoot).release());
+    header->set_allocated_difficulty(rpc::H256_from_uint256(kSampleOmmerDifficulty).release());
+    header->set_block_number(kSampleOmmerBlockNumber);
+    header->set_gas_limit(kSampleOmmerGasLimit);
+    header->set_gas_used(kSampleOmmerGasUsed);
+    header->set_timestamp(kSampleOmmerTimestamp);
+    //header->set_extra_data(byte_ptr_cast(kSampleExtraData.data()), kSampleExtraData.size());
+    header->set_allocated_prev_randao(rpc::H256_from_bytes32(kSampleOmmerPrevRandao).release());
+    header->set_nonce(endian::load_big_u64(kSampleOmmerNonce.data()));
+    //header->set_allocated_base_fee_per_gas(rpc::H256_from_uint256(kSampleBaseFeePerGas).release());
+}
+
+inline void sample_proto_withdrawal(::types::Withdrawal* withdrawal, const Withdrawal& w) {
+    withdrawal->set_index(w.index);
+    withdrawal->set_validator_index(w.validator_index);
+    withdrawal->set_allocated_address(rpc::H160_from_address(w.address).release());
+    withdrawal->set_amount(w.amount);
+}
+
+inline void sample_proto_body(::execution::BlockBody* body) {
+    body->set_block_number(kSampleBlockNumber);
+    body->set_allocated_block_hash(rpc::H256_from_bytes32(kSampleBlockHash).release());
+
+    body->add_transactions(sample_proto_tx0());
+    body->add_transactions(sample_proto_tx1());
+    sample_proto_ommer(body->add_uncles());
+    sample_proto_withdrawal(body->add_withdrawals(), kSampleWithdrawal0);
+    sample_proto_withdrawal(body->add_withdrawals(), kSampleWithdrawal1);
+    sample_proto_withdrawal(body->add_withdrawals(), kSampleWithdrawal2);
+    sample_proto_withdrawal(body->add_withdrawals(), kSampleWithdrawal3);
+}
+
+}  // namespace silkworm::execution::test_util

--- a/silkworm/node/execution/test_util/sample_protos.hpp
+++ b/silkworm/node/execution/test_util/sample_protos.hpp
@@ -80,10 +80,10 @@ inline void sample_proto_ommer(::execution::Header* header) {
     header->set_gas_limit(kSampleOmmerGasLimit);
     header->set_gas_used(kSampleOmmerGasUsed);
     header->set_timestamp(kSampleOmmerTimestamp);
-    //header->set_extra_data(byte_ptr_cast(kSampleExtraData.data()), kSampleExtraData.size());
+    // header->set_extra_data(byte_ptr_cast(kSampleExtraData.data()), kSampleExtraData.size());
     header->set_allocated_prev_randao(rpc::H256_from_bytes32(kSampleOmmerPrevRandao).release());
     header->set_nonce(endian::load_big_u64(kSampleOmmerNonce.data()));
-    //header->set_allocated_base_fee_per_gas(rpc::H256_from_uint256(kSampleBaseFeePerGas).release());
+    // header->set_allocated_base_fee_per_gas(rpc::H256_from_uint256(kSampleBaseFeePerGas).release());
 }
 
 inline void sample_proto_withdrawal(::types::Withdrawal* withdrawal, const Withdrawal& w) {

--- a/silkworm/node/execution/test_util/sample_protos.hpp
+++ b/silkworm/node/execution/test_util/sample_protos.hpp
@@ -27,8 +27,9 @@
 namespace silkworm::execution::test_util {
 
 using namespace silkworm::test_util;
+namespace proto = ::execution;
 
-inline void sample_proto_header(::execution::Header* header) {
+inline void sample_proto_header(proto::Header* header) {
     header->set_allocated_parent_hash(rpc::H256_from_bytes32(kSampleParentHash).release());
     header->set_allocated_ommer_hash(rpc::H256_from_bytes32(kSampleOmmersHash).release());
     header->set_allocated_coinbase(rpc::H160_from_address(kSampleBeneficiary).release());
@@ -46,8 +47,8 @@ inline void sample_proto_header(::execution::Header* header) {
     header->set_allocated_base_fee_per_gas(rpc::H256_from_uint256(kSampleBaseFeePerGas).release());
 }
 
-inline ::execution::Header sample_proto_header() {
-    ::execution::Header header;
+inline proto::Header sample_proto_header() {
+    proto::Header header;
     sample_proto_header(&header);
     return header;
 }
@@ -68,7 +69,7 @@ inline std::string sample_proto_tx1() {
     return sample_proto_transaction(rlp_tx1);
 }
 
-inline void sample_proto_ommer(::execution::Header* header) {
+inline void sample_proto_ommer(proto::Header* header) {
     header->set_allocated_parent_hash(rpc::H256_from_bytes32(kSampleOmmerParentHash).release());
     header->set_allocated_ommer_hash(rpc::H256_from_bytes32(kEmptyListHash).release());
     header->set_allocated_coinbase(rpc::H160_from_address(kSampleOmmerBeneficiary).release());
@@ -80,10 +81,8 @@ inline void sample_proto_ommer(::execution::Header* header) {
     header->set_gas_limit(kSampleOmmerGasLimit);
     header->set_gas_used(kSampleOmmerGasUsed);
     header->set_timestamp(kSampleOmmerTimestamp);
-    // header->set_extra_data(byte_ptr_cast(kSampleExtraData.data()), kSampleExtraData.size());
     header->set_allocated_prev_randao(rpc::H256_from_bytes32(kSampleOmmerPrevRandao).release());
     header->set_nonce(endian::load_big_u64(kSampleOmmerNonce.data()));
-    // header->set_allocated_base_fee_per_gas(rpc::H256_from_uint256(kSampleBaseFeePerGas).release());
 }
 
 inline void sample_proto_withdrawal(::types::Withdrawal* withdrawal, const Withdrawal& w) {
@@ -93,7 +92,7 @@ inline void sample_proto_withdrawal(::types::Withdrawal* withdrawal, const Withd
     withdrawal->set_amount(w.amount);
 }
 
-inline void sample_proto_body(::execution::BlockBody* body) {
+inline void sample_proto_body(proto::BlockBody* body) {
     body->set_block_number(kSampleBlockNumber);
     body->set_allocated_block_hash(rpc::H256_from_bytes32(kSampleBlockHash).release());
 
@@ -104,6 +103,11 @@ inline void sample_proto_body(::execution::BlockBody* body) {
     sample_proto_withdrawal(body->add_withdrawals(), kSampleWithdrawal1);
     sample_proto_withdrawal(body->add_withdrawals(), kSampleWithdrawal2);
     sample_proto_withdrawal(body->add_withdrawals(), kSampleWithdrawal3);
+}
+
+inline void sample_proto_block(proto::Block* block) {
+    sample_proto_header(block->mutable_header());
+    sample_proto_body(block->mutable_body());
 }
 
 }  // namespace silkworm::execution::test_util

--- a/silkworm/node/stagedsync/execution_engine.hpp
+++ b/silkworm/node/stagedsync/execution_engine.hpp
@@ -59,20 +59,20 @@ class ExecutionEngine : public Stoppable {
     void close();
 
     // actions
-    void insert_blocks(const std::vector<std::shared_ptr<Block>>& blocks);
+    virtual void insert_blocks(const std::vector<std::shared_ptr<Block>>& blocks);
     bool insert_block(const std::shared_ptr<Block>& block);
 
-    concurrency::AwaitableFuture<VerificationResult> verify_chain(Hash head_block_hash);
+    virtual VerificationResultFuture verify_chain(Hash head_block_hash);
 
-    bool notify_fork_choice_update(Hash head_block_hash,
-                                   std::optional<Hash> finalized_block_hash = {},
-                                   std::optional<Hash> safe_block_hash = {});
+    virtual bool notify_fork_choice_update(Hash head_block_hash,
+                                           std::optional<Hash> finalized_block_hash = {},
+                                           std::optional<Hash> safe_block_hash = {});
 
     // state
-    BlockNum block_progress() const;
-    BlockId last_fork_choice() const;
-    BlockId last_finalized_block() const;
-    BlockId last_safe_block() const;
+    virtual BlockNum block_progress() const;
+    virtual BlockId last_fork_choice() const;
+    virtual BlockId last_finalized_block() const;
+    virtual BlockId last_safe_block() const;
 
     // header/body retrieval
     std::optional<BlockHeader> get_header(Hash) const;
@@ -82,8 +82,8 @@ class ExecutionEngine : public Stoppable {
     std::optional<BlockBody> get_body(Hash) const;
     std::optional<BlockBody> get_canonical_body(BlockNum) const;
     bool is_canonical(Hash) const;
-    std::optional<BlockNum> get_block_number(Hash) const;
-    std::vector<BlockHeader> get_last_headers(uint64_t limit) const;
+    virtual std::optional<BlockNum> get_block_number(Hash) const;
+    virtual std::vector<BlockHeader> get_last_headers(uint64_t limit) const;
     std::optional<TotalDifficulty> get_header_td(Hash, std::optional<BlockNum> = std::nullopt) const;
 
   protected:

--- a/silkworm/node/stagedsync/execution_engine.hpp
+++ b/silkworm/node/stagedsync/execution_engine.hpp
@@ -52,7 +52,8 @@ namespace asio = boost::asio;
  */
 class ExecutionEngine : public Stoppable {
   public:
-    explicit ExecutionEngine(asio::io_context&, NodeSettings&, db::RWAccess);
+    ExecutionEngine(asio::io_context&, NodeSettings&, db::RWAccess);
+    ~ExecutionEngine() override = default;
 
     void open();  // needed to circumvent mdbx threading model limitations
     void close();
@@ -63,12 +64,15 @@ class ExecutionEngine : public Stoppable {
 
     concurrency::AwaitableFuture<VerificationResult> verify_chain(Hash head_block_hash);
 
-    bool notify_fork_choice_update(Hash head_block_hash, std::optional<Hash> finalized_block_hash = std::nullopt);
+    bool notify_fork_choice_update(Hash head_block_hash,
+                                   std::optional<Hash> finalized_block_hash = {},
+                                   std::optional<Hash> safe_block_hash = {});
 
     // state
     BlockNum block_progress() const;
-    BlockId last_finalized_block() const;
     BlockId last_fork_choice() const;
+    BlockId last_finalized_block() const;
+    BlockId last_safe_block() const;
 
     // header/body retrieval
     std::optional<BlockHeader> get_header(Hash) const;
@@ -102,8 +106,9 @@ class ExecutionEngine : public Stoppable {
 
     BlockNum block_progress_{0};
     bool fork_tracking_active_{false};
-    BlockId last_finalized_block_;
     BlockId last_fork_choice_;
+    BlockId last_finalized_block_;
+    BlockId last_safe_block_;
 };
 
 }  // namespace silkworm::stagedsync

--- a/silkworm/node/stagedsync/forks/extending_fork.cpp
+++ b/silkworm/node/stagedsync/forks/extending_fork.cpp
@@ -115,16 +115,18 @@ concurrency::AwaitableFuture<VerificationResult> ExtendingFork::verify_chain() {
     return awaitable_future;
 }
 
-concurrency::AwaitableFuture<bool> ExtendingFork::fork_choice(Hash head_block_hash, std::optional<Hash> finalized_block_hash) {
+concurrency::AwaitableFuture<bool> ExtendingFork::fork_choice(Hash head_block_hash,
+                                                              std::optional<Hash> finalized_block_hash,
+                                                              std::optional<Hash> safe_block_hash) {
     propagate_exception_if_any();
 
     concurrency::AwaitablePromise<bool> promise{io_context_.get_executor()};  // note: promise uses an external io_context
     auto awaitable_future = promise.get_future();
 
-    post(*executor_, [this, promise_ = std::move(promise), head_block_hash, finalized_block_hash]() mutable {
+    post(*executor_, [this, promise_ = std::move(promise), head_block_hash, finalized_block_hash, safe_block_hash]() mutable {
         try {
             if (exception_) return;
-            auto updated = fork_->fork_choice(head_block_hash, finalized_block_hash);
+            auto updated = fork_->fork_choice(head_block_hash, finalized_block_hash, safe_block_hash);
             current_head_ = fork_->current_head();
             promise_.set_value(updated);
         } catch (...) {

--- a/silkworm/node/stagedsync/forks/extending_fork.hpp
+++ b/silkworm/node/stagedsync/forks/extending_fork.hpp
@@ -49,7 +49,9 @@ class ExtendingFork {
 
     // verification
     concurrency::AwaitableFuture<VerificationResult> verify_chain();
-    concurrency::AwaitableFuture<bool> fork_choice(Hash head_block_hash, std::optional<Hash> finalized_block_hash = std::nullopt);
+    concurrency::AwaitableFuture<bool> fork_choice(Hash head_block_hash,
+                                                   std::optional<Hash> finalized_block_hash = {},
+                                                   std::optional<Hash> safe_block_hash = {});
 
     // state
     BlockId current_head() const;

--- a/silkworm/node/stagedsync/forks/fork.hpp
+++ b/silkworm/node/stagedsync/forks/fork.hpp
@@ -50,12 +50,13 @@ class Fork {
     // verify chain up to current head
     VerificationResult verify_chain();
     // accept the current chain up to head_block_hash
-    bool fork_choice(Hash head_block_hash, std::optional<Hash> finalized_block_hash = std::nullopt);
+    bool fork_choice(Hash head_block_hash, std::optional<Hash> finalized_block_hash = {}, std::optional<Hash> safe_block_hash = {});
 
     // state
     BlockId current_head() const;
     std::optional<VerificationResult> head_status() const;
     BlockId finalized_head() const;
+    BlockId safe_head() const;
 
     // checks
     bool extends_head(const BlockHeader&) const;
@@ -83,6 +84,7 @@ class Fork {
     BlockId current_head_;
     std::optional<VerificationResult> head_status_;
     BlockId finalized_head_;
+    BlockId safe_head_;
 };
 
 // find the fork with the specified head

--- a/silkworm/node/stagedsync/forks/verification_result.hpp
+++ b/silkworm/node/stagedsync/forks/verification_result.hpp
@@ -21,6 +21,7 @@
 #include <variant>
 
 #include <silkworm/core/types/block.hpp>
+#include <silkworm/infra/concurrency/awaitable_future.hpp>
 
 namespace silkworm::stagedsync {
 
@@ -37,5 +38,8 @@ struct ValidationError {
 };
 
 using VerificationResult = std::variant<ValidChain, InvalidChain, ValidationError>;
+
+using VerificationResultFuture = concurrency::AwaitableFuture<VerificationResult>;
+using VerificationResultPromise = concurrency::AwaitablePromise<VerificationResult>;
 
 }  // namespace silkworm::stagedsync

--- a/silkworm/node/test_util/fixture.hpp
+++ b/silkworm/node/test_util/fixture.hpp
@@ -1,0 +1,31 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <utility>
+#include <vector>
+
+namespace silkworm::test_util {
+
+//! Test fixtures are predefined data sets that you initialize before running your tests
+template <typename Input, typename ExpectedResult>
+using Fixture = std::pair<Input, ExpectedResult>;
+
+template <typename Input, typename ExpectedResult>
+using Fixtures = std::vector<Fixture<Input, ExpectedResult>>;
+
+}  // namespace silkworm::test_util

--- a/silkworm/node/test_util/sample_blocks.hpp
+++ b/silkworm/node/test_util/sample_blocks.hpp
@@ -21,8 +21,8 @@
 #include <evmc/evmc.hpp>
 #include <intx/intx.hpp>
 
-#include <silkworm/core/common/empty_hashes.hpp>
 #include <silkworm/core/common/bytes.hpp>
+#include <silkworm/core/common/empty_hashes.hpp>
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/core/types/block.hpp>
 

--- a/silkworm/node/test_util/sample_blocks.hpp
+++ b/silkworm/node/test_util/sample_blocks.hpp
@@ -155,4 +155,10 @@ inline BlockBody sample_block_body() {
     return body;
 }
 
+inline Block sample_block() {
+    Block block{sample_block_body()};
+    block.header = sample_block_header();
+    return block;
+}
+
 }  // namespace silkworm::test_util

--- a/silkworm/node/test_util/sample_blocks.hpp
+++ b/silkworm/node/test_util/sample_blocks.hpp
@@ -1,0 +1,158 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <array>
+
+#include <evmc/evmc.hpp>
+#include <intx/intx.hpp>
+
+#include <silkworm/core/common/empty_hashes.hpp>
+#include <silkworm/core/common/bytes.hpp>
+#include <silkworm/core/common/util.hpp>
+#include <silkworm/core/types/block.hpp>
+
+namespace silkworm::test_util {
+
+using namespace evmc::literals;
+
+inline constexpr auto kSampleBlockHash{0xca39060462327c919e4b08d004b1ba84f59f239ff2fa9f3919f6d4769ba62bfe_bytes32};
+inline constexpr auto kSampleParentHash{0x374f3a049e006f36f6cf91b02a3b0ee16c858af2f75858733eb0e927b5b7126c_bytes32};
+inline constexpr auto kSampleOmmersHash{0x474f3a049e006f36f6cf91b02a3b0ee16c858af2f75858733eb0e927b5b7126d_bytes32};
+inline constexpr auto kSampleBeneficiary{0x0715a7794a1dc8e42615f059dd6e406a6594651a_address};
+inline constexpr auto kSampleStateRoot{0xb02a3b0ee16c858afaa34bcd6770b3c20ee56aa2f75858733eb0e927b5b7126d_bytes32};
+inline constexpr auto kSampleTransactionsRoot{0xb02a3b0ee16c858afaa34bcd6770b3c20ee56aa2f75858733eb0e927b5b7126e_bytes32};
+inline constexpr auto kSampleReceiptsRoot{0xb02a3b0ee16c858afaa34bcd6770b3c20ee56aa2f75858733eb0e927b5b7126f_bytes32};
+inline constexpr auto kSampleDifficulty{intx::uint256{1234}};
+inline constexpr auto kSampleBlockNumber{5u};
+inline constexpr auto kSampleGasLimit{1000000u};
+inline constexpr auto kSampleGasUsed{1000000u};
+inline constexpr auto kSampleTimestamp{5405021u};
+inline const Bytes kSampleExtraData{*from_hex("0001FF0100")};
+inline constexpr auto kSamplePrevRandao{0x0000000000000000000000000000000000000000000000000000000000000001_bytes32};
+inline constexpr auto kSampleNonce{std::array<uint8_t, 8>{0, 0, 0, 0, 0, 0, 0, 255}};
+inline constexpr auto kSampleBaseFeePerGas{0x244428u};
+
+inline BlockHeader sample_block_header() {
+    return {
+        .parent_hash = kSampleParentHash,
+        .ommers_hash = kSampleOmmersHash,
+        .beneficiary = kSampleBeneficiary,
+        .state_root = kSampleStateRoot,
+        .transactions_root = kSampleTransactionsRoot,
+        .receipts_root = kSampleReceiptsRoot,
+        .difficulty = kSampleDifficulty,
+        .number = kSampleBlockNumber,
+        .gas_limit = kSampleGasLimit,
+        .gas_used = kSampleGasUsed,
+        .timestamp = kSampleTimestamp,
+        .extra_data = kSampleExtraData,
+        .prev_randao = kSamplePrevRandao,
+        .nonce = kSampleNonce,
+        .base_fee_per_gas = kSampleBaseFeePerGas,
+    };
+}
+
+inline Transaction sample_tx0() {
+    Transaction tx;
+    tx.nonce = 172339;
+    tx.max_priority_fee_per_gas = 50 * kGiga;
+    tx.max_fee_per_gas = 50 * kGiga;
+    tx.gas_limit = 90'000;
+    tx.to = 0xe5ef458d37212a06e3f59d40c454e76150ae7c32_address;
+    tx.value = 1'027'501'080 * kGiga;
+    tx.data = {};
+    SILKWORM_ASSERT(tx.set_v(27));
+    tx.r = intx::from_string<intx::uint256>("0x48b55bfa915ac795c431978d8a6a992b628d557da5ff759b307d495a36649353");
+    tx.s = intx::from_string<intx::uint256>("0x1fffd310ac743f371de3b9f7f9cb56c0b28ad43601b4ab949f53faa07bd2c804");
+    return tx;
+}
+
+inline Transaction sample_tx1() {
+    Transaction tx;
+    tx.type = TransactionType::kDynamicFee;
+    tx.nonce = 1;
+    tx.max_priority_fee_per_gas = 5 * kGiga;
+    tx.max_fee_per_gas = 30 * kGiga;
+    tx.gas_limit = 1'000'000;
+    tx.to = {};
+    tx.value = 0;
+    tx.data = *from_hex("602a6000556101c960015560068060166000396000f3600035600055");
+    SILKWORM_ASSERT(tx.set_v(37));
+    tx.r = intx::from_string<intx::uint256>("0x52f8f61201b2b11a78d6e866abc9c3db2ae8631fa656bfe5cb53668255367afb");
+    tx.s = intx::from_string<intx::uint256>("0x52f8f61201b2b11a78d6e866abc9c3db2ae8631fa656bfe5cb53668255367afb");
+    return tx;
+}
+
+inline constexpr auto kSampleOmmerParentHash{0xb397a22bb95bf14753ec174f02f99df3f0bdf70d1851cdff813ebf745f5aeb55_bytes32};
+inline constexpr auto kSampleOmmerBeneficiary{0x0c729be7c39543c3d549282a40395299d987cec2_address};
+inline constexpr auto kSampleOmmerStateRoot{0xc2bcdfd012534fa0b19ffba5fae6fc81edd390e9b7d5007d1e92e8e835286e9d_bytes32};
+inline constexpr auto kSampleOmmerDifficulty{intx::uint256{12'555'442'155'599}};
+inline constexpr auto kSampleOmmerBlockNumber{13'000'013};
+inline constexpr auto kSampleOmmerGasLimit{3'141'592};
+inline constexpr auto kSampleOmmerGasUsed{0};
+inline constexpr auto kSampleOmmerTimestamp{1455404305};
+inline constexpr auto kSampleOmmerPrevRandao{0xf0a53dfdd6c2f2a661e718ef29092de60d81d45f84044bec7bf4b36630b2bc08_bytes32};
+inline constexpr auto kSampleOmmerNonce{std::array<uint8_t, 8>{0, 0, 0, 0, 0, 0, 0, 35}};
+
+inline BlockHeader sample_ommer0() {
+    BlockHeader ommer;
+    ommer.parent_hash = kSampleOmmerParentHash;
+    ommer.ommers_hash = kEmptyListHash;
+    ommer.beneficiary = kSampleOmmerBeneficiary;
+    ommer.state_root = kSampleOmmerStateRoot;
+    ommer.transactions_root = kEmptyRoot;
+    ommer.receipts_root = kEmptyRoot;
+    ommer.difficulty = kSampleOmmerDifficulty;
+    ommer.number = kSampleOmmerBlockNumber;
+    ommer.gas_limit = kSampleOmmerGasLimit;
+    ommer.gas_used = kSampleOmmerGasUsed;
+    ommer.timestamp = kSampleOmmerTimestamp;
+    ommer.prev_randao = kSampleOmmerPrevRandao;
+    ommer.nonce = kSampleOmmerNonce;
+    return ommer;
+}
+
+inline const Transaction kSampleTx0{sample_tx0()};
+inline const Transaction kSampleTx1{sample_tx1()};
+inline const BlockHeader kSampleOmmer0{sample_ommer0()};
+
+inline constexpr auto kRecipient1{0x40458B394D1C2A9aA095dd169a6EB43a73949fa3_address};
+inline constexpr auto kRecipient2{0xEdA2B3743d37a2a5bD4EB018d515DC47B7802EB4_address};
+inline const Withdrawal kSampleWithdrawal0{2733, 157233, kRecipient1, 3148401251};
+inline const Withdrawal kSampleWithdrawal1{2734, 157234, kRecipient1, 2797715671};
+inline const Withdrawal kSampleWithdrawal2{2735, 157235, kRecipient1, 2987093215};
+inline const Withdrawal kSampleWithdrawal3{2736, 157236, kRecipient2, 2917273462};
+
+inline BlockBody sample_block_body() {
+    BlockBody body;
+    body.transactions.emplace_back(kSampleTx0);
+    body.transactions.emplace_back(kSampleTx1);
+
+    body.ommers.emplace_back(kSampleOmmer0);
+
+    body.withdrawals = std::vector<Withdrawal>{
+        kSampleWithdrawal0,
+        kSampleWithdrawal1,
+        kSampleWithdrawal2,
+        kSampleWithdrawal3,
+    };
+
+    return body;
+}
+
+}  // namespace silkworm::test_util


### PR DESCRIPTION
This PR defines the following abstractions wrapped around the internal [`execution`](https://github.com/ledgerwatch/interfaces/blob/master/execution/execution.proto) interface:

- gRPC client and server
- direct (i.e. in-process, gRPC-free) client implementation

This PR adds the client/server bindings for such interface, but does not yet uses them. Another PR will follow to put these bindings in play refactoring the current implementation in `stagedsync` package and its usage in `sync` module.

*Extras*
Some more bits have been added or touched to accommodate the needed changes:

- convenience function `concurrency::co_spawn_and_await` to spawn a coroutine using `co_spawn_sw` and awaiting its completion asynchronously
- new type alias `TaskExecutor`
- optional `stack_size` parameter in `rpc::Server::async_run`
- support for missing `safe_block_hash` in `stagedsync::Fork` and `stagedsync::ExtendingFork`