### PR TITLE
fuzzer: increase available memory

### DIFF
--- a/.github/workflows/rpc-fuzzer-tests.yml
+++ b/.github/workflows/rpc-fuzzer-tests.yml
@@ -79,7 +79,7 @@ jobs:
           # ./rpcdaemon_fuzzer_test $RPC_PAST_TEST_DIR/silkworm-fuzzer/corpus artifacts -max_total_time=86300 -detect_leaks=0
 
           # Multi-thread execution
-          ./rpcdaemon_fuzzer_test $RPC_PAST_TEST_DIR/silkworm-fuzzer/corpus artifacts -max_total_time=86300 -detect_leaks=0 -jobs=8
+          ./rpcdaemon_fuzzer_test $RPC_PAST_TEST_DIR/silkworm-fuzzer/corpus artifacts -max_total_time=86300 -detect_leaks=0 -jobs=4 -rss_limit_mb=8192
 
       - name: Tear Down
         if: always()


### PR DESCRIPTION
The recent fuzzer error https://github.com/erigontech/silkworm/actions/runs/8954213003/job/24593581330 is probably caused by the fuzzer engine and not related to the Silkworm RPC. This appeared after we enabled parallel fuzzer jobs. 

In this PR I reduce jobs and increase available memory.