### PR TITLE
node, sync: use new Execution API client/server

### DIFF
--- a/cmd/silkworm.cpp
+++ b/cmd/silkworm.cpp
@@ -295,7 +295,7 @@ int main(int argc, char* argv[]) {
         // Execution: the execution layer engine
         // NOLINTNEXTLINE(cppcoreguidelines-slicing)
         silkworm::node::Node execution_node{settings.node_settings, sentry_client, chaindata_db};
-        execution::LocalClient& execution_client{execution_node.execution_local_client()};
+        execution::api::DirectClient& execution_client{execution_node.execution_direct_client()};
 
         // Set up the execution node (e.g. load pre-verified hashes, download+index snapshots...)
         execution_node.setup();

--- a/silkworm/node/CMakeLists.txt
+++ b/silkworm/node/CMakeLists.txt
@@ -17,11 +17,13 @@
 include("${SILKWORM_MAIN_DIR}/cmake/common/targets.cmake")
 
 add_subdirectory(stagedsync/stages)
+add_subdirectory(test_util)
 
 find_package(absl REQUIRED strings)
 find_package(asio-grpc REQUIRED)
 find_package(Boost REQUIRED headers)
 find_package(gRPC REQUIRED)
+find_package(GTest REQUIRED)
 find_package(magic_enum REQUIRED)
 find_package(Microsoft.GSL REQUIRED)
 find_package(Protobuf REQUIRED)
@@ -56,4 +58,4 @@ silkworm_library(
   PRIVATE ${SILKWORM_NODE_PRIVATE_LIBS}
 )
 
-target_link_libraries(silkworm_node_test PRIVATE silkworm_db_test_util)
+target_link_libraries(silkworm_node_test PRIVATE silkworm_node_test_util GTest::gmock)

--- a/silkworm/node/execution/api/active_direct_service.cpp
+++ b/silkworm/node/execution/api/active_direct_service.cpp
@@ -41,7 +41,7 @@ bool ActiveDirectService::stop() {
 
 // rpc InsertBlocks(InsertBlocksRequest) returns(InsertionResult);
 Task<InsertionResult> ActiveDirectService::insert_blocks(const Blocks& blocks) {
-    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto bb) {
+    return concurrency::co_spawn_and_await(executor_, [](auto* self, const auto& bb) {
         return self->DirectService::insert_blocks(bb);
     }(this, blocks));
 }
@@ -57,7 +57,7 @@ Task<ValidationResult> ActiveDirectService::validate_chain(BlockNumAndHash numbe
 
 // rpc UpdateForkChoice(ForkChoice) returns(ForkChoiceReceipt);
 Task<ForkChoiceResult> ActiveDirectService::update_fork_choice(const ForkChoice& fork_choice) {
-    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto choice) {
+    return concurrency::co_spawn_and_await(executor_, [](auto* self, const auto& choice) {
         return self->DirectService::update_fork_choice(choice);
     }(this, fork_choice));
 }
@@ -66,7 +66,7 @@ Task<ForkChoiceResult> ActiveDirectService::update_fork_choice(const ForkChoice&
 
 // rpc AssembleBlock(AssembleBlockRequest) returns(AssembleBlockResponse);
 Task<AssembleBlockResult> ActiveDirectService::assemble_block(const api::BlockUnderConstruction& block) {
-    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto b) {
+    return concurrency::co_spawn_and_await(executor_, [](auto* self, const auto& b) {
         return self->DirectService::assemble_block(b);
     }(this, block));
 }
@@ -126,7 +126,7 @@ Task<BlockBodies> ActiveDirectService::get_bodies_by_range(BlockNumRange number_
 
 // rpc GetBodiesByHashes(GetBodiesByHashesRequest) returns(GetBodiesBatchResponse);
 Task<BlockBodies> ActiveDirectService::get_bodies_by_hashes(const BlockHashes& hashes) {
-    return concurrency::co_spawn_and_await(executor_, [](auto* self, auto hh) {
+    return concurrency::co_spawn_and_await(executor_, [](auto* self, const auto& hh) {
         return self->DirectService::get_bodies_by_hashes(hh);
     }(this, hashes));
 }

--- a/silkworm/node/execution/api/service.hpp
+++ b/silkworm/node/execution/api/service.hpp
@@ -34,6 +34,7 @@
 
 namespace silkworm::execution::api {
 
+//! Common Execution API definition for both in-process and out-of-process client/server
 struct Service {
     virtual ~Service() = default;
 

--- a/silkworm/node/execution/test_util/sample_protos.hpp
+++ b/silkworm/node/execution/test_util/sample_protos.hpp
@@ -1,0 +1,109 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <string>
+
+#include <silkworm/core/common/bytes_to_string.hpp>
+#include <silkworm/infra/grpc/common/conversion.hpp>
+#include <silkworm/interfaces/execution/execution.pb.h>
+#include <silkworm/interfaces/types/types.pb.h>
+#include <silkworm/node/test_util/sample_blocks.hpp>
+
+namespace silkworm::execution::test_util {
+
+using namespace silkworm::test_util;
+
+inline void sample_proto_header(::execution::Header* header) {
+    header->set_allocated_parent_hash(rpc::H256_from_bytes32(kSampleParentHash).release());
+    header->set_allocated_ommer_hash(rpc::H256_from_bytes32(kSampleOmmersHash).release());
+    header->set_allocated_coinbase(rpc::H160_from_address(kSampleBeneficiary).release());
+    header->set_allocated_state_root(rpc::H256_from_bytes32(kSampleStateRoot).release());
+    header->set_allocated_transaction_hash(rpc::H256_from_bytes32(kSampleTransactionsRoot).release());
+    header->set_allocated_receipt_root(rpc::H256_from_bytes32(kSampleReceiptsRoot).release());
+    header->set_allocated_difficulty(rpc::H256_from_uint256(kSampleDifficulty).release());
+    header->set_block_number(kSampleBlockNumber);
+    header->set_gas_limit(kSampleGasLimit);
+    header->set_gas_used(kSampleGasUsed);
+    header->set_timestamp(kSampleTimestamp);
+    header->set_extra_data(byte_ptr_cast(kSampleExtraData.data()), kSampleExtraData.size());
+    header->set_allocated_prev_randao(rpc::H256_from_bytes32(kSamplePrevRandao).release());
+    header->set_nonce(endian::load_big_u64(kSampleNonce.data()));
+    header->set_allocated_base_fee_per_gas(rpc::H256_from_uint256(kSampleBaseFeePerGas).release());
+}
+
+inline ::execution::Header sample_proto_header() {
+    ::execution::Header header;
+    sample_proto_header(&header);
+    return header;
+}
+
+inline std::string sample_proto_transaction(ByteView rlp_tx) {
+    return std::string{byte_view_to_string_view(rlp_tx)};
+}
+
+inline std::string sample_proto_tx0() {
+    Bytes rlp_tx0{};
+    rlp::encode(rlp_tx0, sample_tx0());
+    return sample_proto_transaction(rlp_tx0);
+}
+
+inline std::string sample_proto_tx1() {
+    Bytes rlp_tx1{};
+    rlp::encode(rlp_tx1, sample_tx1());
+    return sample_proto_transaction(rlp_tx1);
+}
+
+inline void sample_proto_ommer(::execution::Header* header) {
+    header->set_allocated_parent_hash(rpc::H256_from_bytes32(kSampleOmmerParentHash).release());
+    header->set_allocated_ommer_hash(rpc::H256_from_bytes32(kEmptyListHash).release());
+    header->set_allocated_coinbase(rpc::H160_from_address(kSampleOmmerBeneficiary).release());
+    header->set_allocated_state_root(rpc::H256_from_bytes32(kSampleOmmerStateRoot).release());
+    header->set_allocated_transaction_hash(rpc::H256_from_bytes32(kEmptyRoot).release());
+    header->set_allocated_receipt_root(rpc::H256_from_bytes32(kEmptyRoot).release());
+    header->set_allocated_difficulty(rpc::H256_from_uint256(kSampleOmmerDifficulty).release());
+    header->set_block_number(kSampleOmmerBlockNumber);
+    header->set_gas_limit(kSampleOmmerGasLimit);
+    header->set_gas_used(kSampleOmmerGasUsed);
+    header->set_timestamp(kSampleOmmerTimestamp);
+    //header->set_extra_data(byte_ptr_cast(kSampleExtraData.data()), kSampleExtraData.size());
+    header->set_allocated_prev_randao(rpc::H256_from_bytes32(kSampleOmmerPrevRandao).release());
+    header->set_nonce(endian::load_big_u64(kSampleOmmerNonce.data()));
+    //header->set_allocated_base_fee_per_gas(rpc::H256_from_uint256(kSampleBaseFeePerGas).release());
+}
+
+inline void sample_proto_withdrawal(::types::Withdrawal* withdrawal, const Withdrawal& w) {
+    withdrawal->set_index(w.index);
+    withdrawal->set_validator_index(w.validator_index);
+    withdrawal->set_allocated_address(rpc::H160_from_address(w.address).release());
+    withdrawal->set_amount(w.amount);
+}
+
+inline void sample_proto_body(::execution::BlockBody* body) {
+    body->set_block_number(kSampleBlockNumber);
+    body->set_allocated_block_hash(rpc::H256_from_bytes32(kSampleBlockHash).release());
+
+    body->add_transactions(sample_proto_tx0());
+    body->add_transactions(sample_proto_tx1());
+    sample_proto_ommer(body->add_uncles());
+    sample_proto_withdrawal(body->add_withdrawals(), kSampleWithdrawal0);
+    sample_proto_withdrawal(body->add_withdrawals(), kSampleWithdrawal1);
+    sample_proto_withdrawal(body->add_withdrawals(), kSampleWithdrawal2);
+    sample_proto_withdrawal(body->add_withdrawals(), kSampleWithdrawal3);
+}
+
+}  // namespace silkworm::execution::test_util

--- a/silkworm/node/execution/test_util/sample_protos.hpp
+++ b/silkworm/node/execution/test_util/sample_protos.hpp
@@ -80,10 +80,10 @@ inline void sample_proto_ommer(::execution::Header* header) {
     header->set_gas_limit(kSampleOmmerGasLimit);
     header->set_gas_used(kSampleOmmerGasUsed);
     header->set_timestamp(kSampleOmmerTimestamp);
-    //header->set_extra_data(byte_ptr_cast(kSampleExtraData.data()), kSampleExtraData.size());
+    // header->set_extra_data(byte_ptr_cast(kSampleExtraData.data()), kSampleExtraData.size());
     header->set_allocated_prev_randao(rpc::H256_from_bytes32(kSampleOmmerPrevRandao).release());
     header->set_nonce(endian::load_big_u64(kSampleOmmerNonce.data()));
-    //header->set_allocated_base_fee_per_gas(rpc::H256_from_uint256(kSampleBaseFeePerGas).release());
+    // header->set_allocated_base_fee_per_gas(rpc::H256_from_uint256(kSampleBaseFeePerGas).release());
 }
 
 inline void sample_proto_withdrawal(::types::Withdrawal* withdrawal, const Withdrawal& w) {

--- a/silkworm/node/execution/test_util/sample_protos.hpp
+++ b/silkworm/node/execution/test_util/sample_protos.hpp
@@ -27,8 +27,9 @@
 namespace silkworm::execution::test_util {
 
 using namespace silkworm::test_util;
+namespace proto = ::execution;
 
-inline void sample_proto_header(::execution::Header* header) {
+inline void sample_proto_header(proto::Header* header) {
     header->set_allocated_parent_hash(rpc::H256_from_bytes32(kSampleParentHash).release());
     header->set_allocated_ommer_hash(rpc::H256_from_bytes32(kSampleOmmersHash).release());
     header->set_allocated_coinbase(rpc::H160_from_address(kSampleBeneficiary).release());
@@ -46,8 +47,8 @@ inline void sample_proto_header(::execution::Header* header) {
     header->set_allocated_base_fee_per_gas(rpc::H256_from_uint256(kSampleBaseFeePerGas).release());
 }
 
-inline ::execution::Header sample_proto_header() {
-    ::execution::Header header;
+inline proto::Header sample_proto_header() {
+    proto::Header header;
     sample_proto_header(&header);
     return header;
 }
@@ -68,7 +69,7 @@ inline std::string sample_proto_tx1() {
     return sample_proto_transaction(rlp_tx1);
 }
 
-inline void sample_proto_ommer(::execution::Header* header) {
+inline void sample_proto_ommer(proto::Header* header) {
     header->set_allocated_parent_hash(rpc::H256_from_bytes32(kSampleOmmerParentHash).release());
     header->set_allocated_ommer_hash(rpc::H256_from_bytes32(kEmptyListHash).release());
     header->set_allocated_coinbase(rpc::H160_from_address(kSampleOmmerBeneficiary).release());
@@ -80,10 +81,8 @@ inline void sample_proto_ommer(::execution::Header* header) {
     header->set_gas_limit(kSampleOmmerGasLimit);
     header->set_gas_used(kSampleOmmerGasUsed);
     header->set_timestamp(kSampleOmmerTimestamp);
-    // header->set_extra_data(byte_ptr_cast(kSampleExtraData.data()), kSampleExtraData.size());
     header->set_allocated_prev_randao(rpc::H256_from_bytes32(kSampleOmmerPrevRandao).release());
     header->set_nonce(endian::load_big_u64(kSampleOmmerNonce.data()));
-    // header->set_allocated_base_fee_per_gas(rpc::H256_from_uint256(kSampleBaseFeePerGas).release());
 }
 
 inline void sample_proto_withdrawal(::types::Withdrawal* withdrawal, const Withdrawal& w) {
@@ -93,7 +92,7 @@ inline void sample_proto_withdrawal(::types::Withdrawal* withdrawal, const Withd
     withdrawal->set_amount(w.amount);
 }
 
-inline void sample_proto_body(::execution::BlockBody* body) {
+inline void sample_proto_body(proto::BlockBody* body) {
     body->set_block_number(kSampleBlockNumber);
     body->set_allocated_block_hash(rpc::H256_from_bytes32(kSampleBlockHash).release());
 
@@ -104,6 +103,11 @@ inline void sample_proto_body(::execution::BlockBody* body) {
     sample_proto_withdrawal(body->add_withdrawals(), kSampleWithdrawal1);
     sample_proto_withdrawal(body->add_withdrawals(), kSampleWithdrawal2);
     sample_proto_withdrawal(body->add_withdrawals(), kSampleWithdrawal3);
+}
+
+inline void sample_proto_block(proto::Block* block) {
+    sample_proto_header(block->mutable_header());
+    sample_proto_body(block->mutable_body());
 }
 
 }  // namespace silkworm::execution::test_util

--- a/silkworm/node/node.cpp
+++ b/silkworm/node/node.cpp
@@ -26,10 +26,10 @@
 #include <silkworm/infra/common/os.hpp>
 #include <silkworm/infra/concurrency/awaitable_wait_for_all.hpp>
 #include <silkworm/node/backend/ethereum_backend.hpp>
-#include <silkworm/node/remote/kv/grpc/server/backend_kv_server.hpp>
 #include <silkworm/node/common/preverified_hashes.hpp>
 #include <silkworm/node/execution/api/active_direct_service.hpp>
 #include <silkworm/node/execution/grpc/server/server.hpp>
+#include <silkworm/node/remote/kv/grpc/server/backend_kv_server.hpp>
 #include <silkworm/node/resource_usage.hpp>
 #include <silkworm/node/stagedsync/execution_engine.hpp>
 #include <silkworm/node/stagedsync/server.hpp>

--- a/silkworm/node/node.cpp
+++ b/silkworm/node/node.cpp
@@ -26,7 +26,7 @@
 #include <silkworm/infra/common/os.hpp>
 #include <silkworm/infra/concurrency/awaitable_wait_for_all.hpp>
 #include <silkworm/node/backend/ethereum_backend.hpp>
-#include <silkworm/node/backend/remote/backend_kv_server.hpp>
+#include <silkworm/node/remote/kv/grpc/server/backend_kv_server.hpp>
 #include <silkworm/node/common/preverified_hashes.hpp>
 #include <silkworm/node/execution/api/active_direct_service.hpp>
 #include <silkworm/node/execution/grpc/server/server.hpp>

--- a/silkworm/node/node.cpp
+++ b/silkworm/node/node.cpp
@@ -18,15 +18,20 @@
 
 #include <utility>
 
+#include <boost/asio/io_context.hpp>
+
 #include <silkworm/db/snapshot_sync.hpp>
 #include <silkworm/db/snapshots/bittorrent/client.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/common/os.hpp>
 #include <silkworm/infra/concurrency/awaitable_wait_for_all.hpp>
 #include <silkworm/node/backend/ethereum_backend.hpp>
+#include <silkworm/node/backend/remote/backend_kv_server.hpp>
 #include <silkworm/node/common/preverified_hashes.hpp>
-#include <silkworm/node/remote/kv/grpc/server/backend_kv_server.hpp>
+#include <silkworm/node/execution/api/active_direct_service.hpp>
+#include <silkworm/node/execution/grpc/server/server.hpp>
 #include <silkworm/node/resource_usage.hpp>
+#include <silkworm/node/stagedsync/execution_engine.hpp>
 #include <silkworm/node/stagedsync/server.hpp>
 
 namespace silkworm::node {
@@ -45,7 +50,7 @@ class NodeImpl final {
     NodeImpl(const NodeImpl&) = delete;
     NodeImpl& operator=(const NodeImpl&) = delete;
 
-    execution::LocalClient& execution_local_client() { return execution_local_client_; }
+    execution::api::DirectClient& execution_direct_client() { return execution_direct_client_; }
     std::shared_ptr<sentry::api::SentryClient> sentry_client() { return sentry_client_; }
 
     void setup();
@@ -69,8 +74,11 @@ class NodeImpl final {
     snapshots::SnapshotRepository snapshot_repository_;
 
     //! The execution layer server engine
-    execution::Server execution_server_;
-    execution::LocalClient execution_local_client_;
+    boost::asio::io_context execution_context_;
+    execution::ExecutionEngine execution_engine_;
+    std::shared_ptr<execution::api::ActiveDirectService> execution_service_;
+    execution::grpc::server::Server execution_server_;
+    execution::api::DirectClient execution_direct_client_;
     SentryClientPtr sentry_client_;
     std::unique_ptr<EthereumBackEnd> backend_;
     std::unique_ptr<rpc::BackEndKvServer> backend_kv_rpc_server_;
@@ -78,17 +86,26 @@ class NodeImpl final {
     std::unique_ptr<snapshots::bittorrent::BitTorrentClient> bittorrent_client_;
 };
 
+static auto make_execution_server_settings() {
+    return rpc::ServerSettings{
+        .address_uri = "localhost:9092",
+        .context_pool_settings = {.num_contexts = 1},  // just one execution context
+    };
+}
+
 NodeImpl::NodeImpl(Settings& settings, SentryClientPtr sentry_client, mdbx::env chaindata_db)
     : settings_{settings},
       chaindata_db_{std::move(chaindata_db)},
       snapshot_repository_{settings_.snapshot_settings},
-      execution_server_{settings_, db::RWAccess{chaindata_db_}},
-      execution_local_client_{execution_server_},
+      execution_engine_{execution_context_, settings_, db::RWAccess{chaindata_db_}},
+      execution_service_{std::make_shared<execution::api::ActiveDirectService>(execution_engine_, execution_context_)},
+      execution_server_{make_execution_server_settings(), execution_service_},
+      execution_direct_client_{execution_service_},
       sentry_client_{std::move(sentry_client)},
       resource_usage_log_{*settings_.data_directory} {
     backend_ = std::make_unique<EthereumBackEnd>(settings_, &chaindata_db_, sentry_client_);
     backend_->set_node_name(settings_.node_name);
-    backend_kv_rpc_server_ = std::make_unique<rpc::BackEndKvServer>(settings.server_settings, *backend_);
+    backend_kv_rpc_server_ = std::make_unique<rpc::BackEndKvServer>(settings_.server_settings, *backend_);
     bittorrent_client_ = std::make_unique<snapshots::bittorrent::BitTorrentClient>(settings_.snapshot_settings.bittorrent_settings);
 }
 
@@ -133,7 +150,11 @@ Task<void> NodeImpl::run_tasks() {
 
 Task<void> NodeImpl::start_execution_server() {
     // Thread running block execution requires custom stack size because of deep EVM call stacks
-    return execution_server_.async_run("exec-engine", /*stack_size=*/kExecutionThreadStackSize);
+    if (settings_.execution_server_enabled) {
+        co_await execution_server_.async_run(/*stack_size=*/kExecutionThreadStackSize);
+    } else {
+        co_await execution_service_->async_run("exec-engine", /*stack_size=*/kExecutionThreadStackSize);
+    }
 }
 
 Task<void> NodeImpl::start_backend_kv_grpc_server() {
@@ -184,8 +205,8 @@ Node::Node(Settings& settings, SentryClientPtr sentry_client, mdbx::env chaindat
 // Must be here (not in header) because NodeImpl size is necessary for std::unique_ptr in PIMPL idiom
 Node::~Node() = default;
 
-execution::LocalClient& Node::execution_local_client() {
-    return p_impl_->execution_local_client();
+execution::api::DirectClient& Node::execution_direct_client() {
+    return p_impl_->execution_direct_client();
 }
 
 void Node::setup() {

--- a/silkworm/node/node.hpp
+++ b/silkworm/node/node.hpp
@@ -23,8 +23,8 @@
 #include <silkworm/db/mdbx/mdbx.hpp>
 #include <silkworm/db/snapshots/settings.hpp>
 #include <silkworm/node/common/node_settings.hpp>
+#include <silkworm/node/execution/api/direct_client.hpp>
 #include <silkworm/node/settings.hpp>
-#include <silkworm/node/stagedsync/local_client.hpp>
 #include <silkworm/sentry/api/common/sentry_client.hpp>
 #include <silkworm/sentry/settings.hpp>
 
@@ -42,7 +42,7 @@ class Node {
     Node(const Node&) = delete;
     Node& operator=(const Node&) = delete;
 
-    execution::LocalClient& execution_local_client();
+    execution::api::DirectClient& execution_direct_client();
 
     void setup();
 

--- a/silkworm/node/settings.hpp
+++ b/silkworm/node/settings.hpp
@@ -31,6 +31,7 @@ struct Settings : public NodeSettings {
     sentry::Settings sentry_settings;               // Configuration for Sentry client + embedded server
     rpc::ServerSettings server_settings;            // Configuration for the gRPC server
     snapshots::SnapshotSettings snapshot_settings;  // Configuration for the database snapshots
+    bool execution_server_enabled{false};
 };
 
 }  // namespace silkworm::node

--- a/silkworm/node/stagedsync/forks/extending_fork.cpp
+++ b/silkworm/node/stagedsync/forks/extending_fork.cpp
@@ -95,7 +95,7 @@ void ExtendingFork::extend_with(Hash head_hash, const Block& head) {
     });
 }
 
-concurrency::AwaitableFuture<VerificationResult> ExtendingFork::verify_chain() {
+VerificationResultFuture ExtendingFork::verify_chain() {
     propagate_exception_if_any();
 
     concurrency::AwaitablePromise<VerificationResult> promise{io_context_.get_executor()};  // note: promise uses an external io_context

--- a/silkworm/node/stagedsync/forks/extending_fork.hpp
+++ b/silkworm/node/stagedsync/forks/extending_fork.hpp
@@ -48,7 +48,7 @@ class ExtendingFork {
     void extend_with(Hash head_hash, const Block& head);
 
     // verification
-    concurrency::AwaitableFuture<VerificationResult> verify_chain();
+    VerificationResultFuture verify_chain();
     concurrency::AwaitableFuture<bool> fork_choice(Hash head_block_hash,
                                                    std::optional<Hash> finalized_block_hash = {},
                                                    std::optional<Hash> safe_block_hash = {});

--- a/silkworm/node/test_util/CMakeLists.txt
+++ b/silkworm/node/test_util/CMakeLists.txt
@@ -1,0 +1,30 @@
+#[[
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+]]
+
+set(TARGET silkworm_node_test_util)
+
+find_package(Boost REQUIRED headers)
+find_package(GTest REQUIRED)
+
+file(GLOB_RECURSE SRC CONFIGURE_DEPENDS "*.cpp" "*.hpp")
+
+add_library(${TARGET} ${SRC})
+
+target_link_libraries(
+  ${TARGET}
+  PUBLIC silkworm_infra silkworm_node
+  PRIVATE silkworm_db_test_util Boost::headers glaze::glaze GTest::gmock
+)

--- a/silkworm/node/test_util/dummy.cpp
+++ b/silkworm/node/test_util/dummy.cpp
@@ -1,0 +1,17 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Empty compilation unit just to make silkworm_infra_test_util build under macOS

--- a/silkworm/node/test_util/mock_execution_engine.hpp
+++ b/silkworm/node/test_util/mock_execution_engine.hpp
@@ -1,0 +1,73 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include <gmock/gmock.h>
+
+#include <silkworm/core/chain/config.hpp>
+#include <silkworm/core/common/base.hpp>
+#include <silkworm/core/types/block.hpp>
+#include <silkworm/core/types/hash.hpp>
+#include <silkworm/db/mdbx/mdbx.hpp>
+#include <silkworm/node/stagedsync/execution_engine.hpp>
+
+namespace silkworm::execution::api {
+
+//! \brief gMock mock class for stagedsync::ExecutionEngine
+class MockExecutionEngine : public stagedsync::ExecutionEngine {
+  public:
+    MockExecutionEngine(boost::asio::io_context& ioc, NodeSettings& ns, db::RWAccess dba)
+        : ExecutionEngine(ioc, ns, std::move(dba)) {}
+    ~MockExecutionEngine() override = default;
+
+    MOCK_METHOD((void), open, ());
+    MOCK_METHOD((void), close, ());
+
+    MOCK_METHOD((void), insert_blocks, (const std::vector<std::shared_ptr<Block>>&), (override));
+    MOCK_METHOD((stagedsync::VerificationResultFuture), verify_chain, (Hash), (override));
+    MOCK_METHOD((bool), notify_fork_choice_update1, (Hash));
+    MOCK_METHOD((bool), notify_fork_choice_update2, (Hash, Hash));
+    MOCK_METHOD((bool), notify_fork_choice_update3, (Hash, Hash, Hash));
+    bool notify_fork_choice_update(Hash head_block_hash,
+                                   std::optional<Hash> finalized_block_hash,
+                                   std::optional<Hash> safe_block_hash) override {
+        if (finalized_block_hash && safe_block_hash) {
+            return notify_fork_choice_update3(head_block_hash, *finalized_block_hash, *safe_block_hash);
+        } else {
+            if (finalized_block_hash) {
+                return notify_fork_choice_update2(head_block_hash, *finalized_block_hash);
+            } else {
+                return notify_fork_choice_update1(head_block_hash);
+            }
+        }
+        return false;
+    }
+
+    MOCK_METHOD((BlockId), last_fork_choice, (), (const, override));
+    MOCK_METHOD((BlockId), last_finalized_block, (), (const, override));
+    MOCK_METHOD((BlockId), last_safe_block, (), (const, override));
+
+    MOCK_METHOD((std::optional<BlockNum>), get_block_number, (Hash), (const, override));
+
+    MOCK_METHOD((BlockHeaders), get_last_headers, (uint64_t), (const, override));
+    MOCK_METHOD((BlockNum), block_progress, (), (const, override));
+};
+
+}  // namespace silkworm::execution::api

--- a/silkworm/node/test_util/sample_blocks.hpp
+++ b/silkworm/node/test_util/sample_blocks.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <array>
+#include <memory>
 
 #include <evmc/evmc.hpp>
 #include <intx/intx.hpp>
@@ -158,6 +159,66 @@ inline BlockBody sample_block_body() {
 inline Block sample_block() {
     Block block{sample_block_body()};
     block.header = sample_block_header();
+    return block;
+}
+
+inline std::shared_ptr<Block> generate_sample_child_blocks(const BlockHeader& parent) {
+    auto block = std::make_shared<Block>();
+    auto parent_hash = parent.hash();
+
+    // BlockHeader
+    block->header.number = parent.number + 1;
+    block->header.difficulty = 17'000'000'000 + block->header.number;
+    block->header.parent_hash = parent_hash;
+    block->header.beneficiary = 0xc8ebccc5f5689fa8659d83713341e5ad19349448_address;
+    block->header.state_root = kEmptyRoot;
+    block->header.receipts_root = kEmptyRoot;
+    block->header.gas_limit = 10'000'000;
+    block->header.gas_used = 0;
+    block->header.timestamp = parent.timestamp + 12;
+    block->header.extra_data = {};
+
+    /*
+    // BlockBody: transactions
+    block.transactions.resize(1);
+    if (block.header.number % 2 == 0) {
+        block.transactions[0].nonce = 172339;
+        block.transactions[0].max_priority_fee_per_gas = 50 * kGiga;
+        block.transactions[0].max_fee_per_gas = 50 * kGiga;
+        block.transactions[0].gas_limit = 90'000;
+        block.transactions[0].to = 0xe5ef458d37212a06e3f59d40c454e76150ae7c32_address;
+        block.transactions[0].value = 1'027'501'080 * kGiga;
+        block.transactions[0].data = {};
+        CHECK(block.transactions[0].set_v(27));
+        block.transactions[0].r = 0x48b55bfa915ac795c431978d8a6a992b628d557da5ff759b307d495a36649353_u256;
+        block.transactions[0].s = 0x1fffd310ac743f371de3b9f7f9cb56c0b28ad43601b4ab949f53faa07bd2c804_u256;
+    }
+    else {
+        block.transactions[0].type = TransactionType::kEip1559;
+        block.transactions[0].nonce = 1;
+        block.transactions[0].max_priority_fee_per_gas = 5 * kGiga;
+        block.transactions[0].max_fee_per_gas = 30 * kGiga;
+        block.transactions[0].gas_limit = 1'000'000;
+        block.transactions[0].to = {};
+        block.transactions[0].value = 0;
+        block.transactions[0].data = *from_hex("602a6000556101c960015560068060166000396000f3600035600055");
+        CHECK(block.transactions[0].set_v(37));
+        block.transactions[0].r = 0x52f8f61201b2b11a78d6e866abc9c3db2ae8631fa656bfe5cb53668255367afb_u256;
+        block.transactions[0].s = 0x52f8f61201b2b11a78d6e866abc9c3db2ae8631fa656bfe5cb53668255367afb_u256;
+    }
+
+    block.header.transactions_root = protocol::compute_transaction_root(block);
+
+    // BlockBody: ommers
+    block.ommers.resize(1);
+    block.ommers[0].parent_hash = parent_hash;
+    block.ommers[0].ommers_hash = kEmptyListHash;
+    block.ommers[0].beneficiary = 0x0c729be7c39543c3d549282a40395299d987cec2_address;
+    block.ommers[0].state_root = 0xc2bcdfd012534fa0b19ffba5fae6fc81edd390e9b7d5007d1e92e8e835286e9d_bytes32;
+
+    block.header.ommers_hash = protocol::compute_ommers_hash(block);
+    */
+
     return block;
 }
 

--- a/silkworm/rpc/types/execution_payload.hpp
+++ b/silkworm/rpc/types/execution_payload.hpp
@@ -111,7 +111,7 @@ struct PayloadStatus {
     static const PayloadStatus InvalidBlockHash;
 
     std::string status;
-    std::optional<evmc::bytes32> latest_valid_hash;
+    std::optional<Hash> latest_valid_hash;
     std::optional<std::string> validation_error;
 };
 

--- a/silkworm/sync/chain_sync.cpp
+++ b/silkworm/sync/chain_sync.cpp
@@ -18,9 +18,9 @@
 
 namespace silkworm::chainsync {
 
-ChainSync::ChainSync(BlockExchange& block_exchange, execution::Client& exec_engine)
+ChainSync::ChainSync(BlockExchange& block_exchange, execution::api::Client& exec_client)
     : block_exchange_{block_exchange},
-      exec_engine_{exec_engine},
+      exec_engine_{exec_client.service()},
       chain_fork_view_{ChainForkView::head_at_genesis(block_exchange.chain_config())} {
 }
 

--- a/silkworm/sync/chain_sync.hpp
+++ b/silkworm/sync/chain_sync.hpp
@@ -16,7 +16,9 @@
 
 #pragma once
 
-#include <silkworm/node/stagedsync/client.hpp>
+#include <memory>
+
+#include <silkworm/node/execution/api/client.hpp>
 #include <silkworm/sync/block_exchange.hpp>
 #include <silkworm/sync/internals/chain_fork_view.hpp>
 
@@ -24,7 +26,7 @@ namespace silkworm::chainsync {
 
 class ChainSync {
   public:
-    ChainSync(BlockExchange&, execution::Client&);
+    ChainSync(BlockExchange&, execution::api::Client&);
     virtual ~ChainSync() = default;
 
     ChainSync(const ChainSync&) = delete;
@@ -34,7 +36,7 @@ class ChainSync {
 
   protected:
     BlockExchange& block_exchange_;
-    execution::Client& exec_engine_;
+    std::shared_ptr<execution::api::Service> exec_engine_;
     ChainForkView chain_fork_view_;
 };
 

--- a/silkworm/sync/settings.hpp
+++ b/silkworm/sync/settings.hpp
@@ -1,0 +1,45 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <optional>
+#include <string>
+
+#include <silkworm/infra/common/log.hpp>
+#include <silkworm/infra/concurrency/idle_strategy.hpp>
+#include <silkworm/rpc/common/constants.hpp>
+#include <silkworm/rpc/common/interface_log.hpp>
+
+namespace silkworm::chainsync {
+
+struct EngineRpcSettings {
+    std::string engine_end_point{kDefaultEngineEndPoint};
+    rpc::InterfaceLogSettings engine_ifc_log_settings{.ifc_name = "engine_rpc_api"};
+    std::string private_api_addr{kDefaultPrivateApiAddr};
+    log::Level log_verbosity{log::Level::kInfo};
+    concurrency::WaitMode wait_mode{concurrency::WaitMode::blocking};
+    std::optional<std::string> jwt_secret_file;
+};
+
+struct Settings {
+    std::string client_id{"silkworm"};
+    std::string private_api_addr{kDefaultPrivateApiAddr};
+    log::Settings log_settings;
+    EngineRpcSettings rpc_settings;
+};
+
+}  // namespace silkworm::chainsync

--- a/silkworm/sync/sync.cpp
+++ b/silkworm/sync/sync.cpp
@@ -25,7 +25,7 @@ namespace silkworm::chainsync {
 
 Sync::Sync(const boost::asio::any_io_executor& executor,
            mdbx::env chaindata_env,
-           execution::Client& execution,
+           execution::api::Client& execution,
            const std::shared_ptr<silkworm::sentry::api::SentryClient>& sentry_client,
            const ChainConfig& config,
            const EngineRpcSettings& rpc_settings)

--- a/silkworm/sync/sync.hpp
+++ b/silkworm/sync/sync.hpp
@@ -27,7 +27,7 @@
 #include <silkworm/db/mdbx/mdbx.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/grpc/client/client_context_pool.hpp>
-#include <silkworm/node/stagedsync/client.hpp>
+#include <silkworm/node/execution/api/client.hpp>
 #include <silkworm/rpc/common/interface_log.hpp>
 #include <silkworm/rpc/daemon.hpp>
 #include <silkworm/sentry/api/common/sentry_client.hpp>
@@ -35,23 +35,15 @@
 #include "block_exchange.hpp"
 #include "chain_sync.hpp"
 #include "sentry_client.hpp"
+#include "settings.hpp"
 
 namespace silkworm::chainsync {
-
-struct EngineRpcSettings {
-    std::string engine_end_point{kDefaultEngineEndPoint};
-    rpc::InterfaceLogSettings engine_ifc_log_settings{.ifc_name = "engine_rpc_api"};
-    std::string private_api_addr{kDefaultPrivateApiAddr};
-    log::Level log_verbosity{log::Level::kInfo};
-    concurrency::WaitMode wait_mode{concurrency::WaitMode::blocking};
-    std::optional<std::string> jwt_secret_file;
-};
 
 class Sync {
   public:
     Sync(const boost::asio::any_io_executor& executor,
          mdbx::env chaindata_env,
-         execution::Client& execution,
+         execution::api::Client& execution,
          const std::shared_ptr<silkworm::sentry::api::SentryClient>& sentry_client,
          const ChainConfig& config,
          const EngineRpcSettings& rpc_settings = {});

--- a/silkworm/sync/sync_pos.hpp
+++ b/silkworm/sync/sync_pos.hpp
@@ -36,7 +36,7 @@ namespace silkworm::chainsync {
 
 class PoSSync : public ChainSync, public rpc::engine::ExecutionEngine {
   public:
-    PoSSync(BlockExchange&, execution::Client&);
+    PoSSync(BlockExchange&, execution::api::Client&);
 
     Task<void> async_run() override;
 

--- a/silkworm/sync/sync_pos_test.cpp
+++ b/silkworm/sync/sync_pos_test.cpp
@@ -36,12 +36,13 @@
 namespace silkworm::chainsync {
 
 struct PoSSyncTest : public rpc::test::ContextTestBase {
-    SentryClient sentry_client_{io_context_.get_executor(), nullptr};  // TODO(canepat) mock
-    mdbx::env_managed chaindata_env_{};
-    db::ROAccess db_access_{chaindata_env_};
-    test_util::MockBlockExchange block_exchange_{sentry_client_, db_access_, kGoerliConfig};
-    test_util::MockClient execution_client_;
-    PoSSync sync_{block_exchange_, execution_client_};
+    SentryClient sentry_client{io_context_.get_executor(), nullptr};  // TODO(canepat) mock
+    mdbx::env_managed chaindata_env{};
+    db::ROAccess db_access{chaindata_env};
+    test_util::MockBlockExchange block_exchange{sentry_client, db_access, kGoerliConfig};
+    std::shared_ptr<test_util::MockExecutionService> execution_service{std::make_shared<test_util::MockExecutionService>()};
+    test_util::MockExecutionClient execution_client{execution_service};
+    PoSSync sync_{block_exchange, execution_client};
 };
 
 Task<void> sleep(std::chrono::milliseconds duration) {
@@ -124,24 +125,26 @@ TEST_CASE_METHOD(PoSSyncTest, "PoSSync::new_payload timeout") {
     for (size_t i{0}; i < requests.size(); ++i) {
         const auto& request{requests[i]};
         const auto& payload{request.execution_payload};
+        execution::api::BlockNumAndHash block_number_or_hash{payload.number, payload.block_hash};
+        execution::api::BlockNumberOrHash parent_number_or_hash{payload.parent_hash};
         SECTION("payload version: v" + std::to_string(payload.version) + " i=" + std::to_string(i)) {
-            EXPECT_CALL(execution_client_, get_header(payload.number - 1, Hash{payload.parent_hash}))
+            EXPECT_CALL(*execution_service, get_header(parent_number_or_hash))
                 .WillOnce(InvokeWithoutArgs([]() -> Task<std::optional<BlockHeader>> {
                     co_return BlockHeader{};
                 }));
-            EXPECT_CALL(execution_client_, get_header_td(Hash{payload.parent_hash}, std::make_optional(payload.number - 1)))
+            EXPECT_CALL(*execution_service, get_td(parent_number_or_hash))
                 .WillOnce(InvokeWithoutArgs([&]() -> Task<std::optional<TotalDifficulty>> {
                     co_return kGoerliConfig.terminal_total_difficulty;
                 }));
-            EXPECT_CALL(execution_client_, insert_blocks(_))
-                .WillOnce(InvokeWithoutArgs([]() -> Task<void> { co_return; }));
-            EXPECT_CALL(execution_client_, get_block_num(Hash{payload.block_hash}))
+            EXPECT_CALL(*execution_service, insert_blocks(_))
+                .WillOnce(InvokeWithoutArgs([]() -> Task<execution::api::InsertionResult> { co_return execution::api::InsertionResult{}; }));
+            EXPECT_CALL(*execution_service, get_header_hash_number(Hash{payload.block_hash}))
                 // NOLINTNEXTLINE(cppcoreguidelines-avoid-capturing-lambda-coroutines)
                 .WillOnce(InvokeWithoutArgs([=]() -> Task<std::optional<BlockNum>> { co_return payload.number; }));
-            EXPECT_CALL(execution_client_, validate_chain(Hash{payload.block_hash}))
-                .WillOnce(InvokeWithoutArgs([&]() -> Task<execution::ValidationResult> {
+            EXPECT_CALL(*execution_service, validate_chain(block_number_or_hash))
+                .WillOnce(InvokeWithoutArgs([&]() -> Task<execution::api::ValidationResult> {
                     co_await sleep(1h);  // simulate exaggeratedly long-running task
-                    co_return execution::ValidChain{};
+                    co_return execution::api::ValidChain{};
                 }));
 
             CHECK(spawn_and_wait(sync_.new_payload(request, 1ms)).status == rpc::PayloadStatus::kSyncing);

--- a/silkworm/sync/sync_pow.cpp
+++ b/silkworm/sync/sync_pow.cpp
@@ -27,7 +27,8 @@
 
 namespace silkworm::chainsync {
 
-PoWSync::PoWSync(BlockExchange& be, execution::Client& ee) : ChainSync(be, ee) {}
+PoWSync::PoWSync(BlockExchange& block_exchange, execution::api::Client& exec_engine)
+    : ChainSync(block_exchange, exec_engine) {}
 
 Task<void> PoWSync::async_run() {
     return ActiveComponent::async_run("pow-sync-ex");
@@ -37,28 +38,32 @@ PoWSync::NewHeight PoWSync::resume() {  // find the point (head) where we left o
     BlockId head{};
 
     // BlockExchange need a bunch of previous headers to attach the new ones
-    auto last_headers = sync_wait(in(exec_engine_), exec_engine_.get_last_headers(1000));
+    auto last_headers = sync_wait(io_context_, exec_engine_->get_last_headers(1000));
     block_exchange_.initial_state(last_headers);
 
     // We calculate a provisional head based on the previous headers
     std::ranges::for_each(last_headers, [&, this](const auto& header) {
         auto hash = header.hash();
-        auto td = sync_wait(in(exec_engine_), exec_engine_.get_header_td(hash, std::nullopt));
+        auto td = sync_wait(io_context_, exec_engine_->get_td(hash));
         chain_fork_view_.add(header, *td);  // add to cache & compute a new canonical head
     });
 
     // Now we can resume the sync from the canonical head
-    auto last_fcu = sync_wait(in(exec_engine_), exec_engine_.last_fork_choice());  // previously was get_canonical_head()
-    auto block_progress = sync_wait(in(exec_engine_), exec_engine_.block_progress());
+    const auto last_fcu = sync_wait(io_context_, exec_engine_->get_fork_choice());  // previously was get_canonical_head()
+    const auto block_progress = sync_wait(io_context_, exec_engine_->block_progress());
 
-    ensure_invariant(last_fcu.number <= block_progress, "canonical head beyond block progress");
+    const auto last_fcu_number = sync_wait(io_context_, exec_engine_->get_header_hash_number(last_fcu.head_block_hash));
+    if (!last_fcu_number) return head;
+    ensure_invariant(*last_fcu_number <= block_progress, "canonical head beyond block progress");
 
-    if (block_progress == last_fcu.number) {
-        // if fcu and header progress match than we have the actual canonical, we only need to do a forward sync...
-        ensure_invariant(last_fcu == chain_fork_view_.head(), "last fcu misaligned with canonical head");
-        chain_fork_view_.reset_head({last_fcu.number, last_fcu.hash,
-                                     chain_fork_view_.get_total_difficulty(last_fcu.hash).value()});
-        head = last_fcu;
+    if (block_progress == *last_fcu_number) {
+        // If FCU and header progress match than we have the actual canonical, we only need to do a forward sync...
+        const auto total_difficulty{chain_fork_view_.get_total_difficulty(last_fcu.head_block_hash)};
+        if (!total_difficulty) return head;
+        ChainHead fcu_as_head{*last_fcu_number, last_fcu.head_block_hash, *total_difficulty};
+        ensure_invariant(fcu_as_head == chain_fork_view_.head(), "last FCU misaligned with canonical head");
+        chain_fork_view_.reset_head(fcu_as_head);
+        head = to_BlockId(fcu_as_head);
     } else {
         // ... else we use the head computed parsing the last N headers
         head = to_BlockId(chain_fork_view_.head());
@@ -73,7 +78,7 @@ PoWSync::NewHeight PoWSync::forward_and_insert_blocks() {
 
     ResultQueue& downloading_queue = block_exchange_.result_queue();
 
-    auto initial_block_progress = sync_wait(in(exec_engine_), exec_engine_.block_progress());
+    auto initial_block_progress = sync_wait(io_context_, exec_engine_->block_progress());
     auto block_progress = initial_block_progress;
 
     block_exchange_.download_blocks(initial_block_progress, BlockExchange::Target_Tracking::kByAnnouncements);
@@ -99,10 +104,14 @@ PoWSync::NewHeight PoWSync::forward_and_insert_blocks() {
             if (block->to_announce) announcements_to_do.push_back(block);
         });
 
-        // insert blocks into database
-        sync_wait(in(exec_engine_), exec_engine_.insert_blocks(to_plain_blocks(blocks)));
+        // Insert blocks into database
+        const auto insert_result{sync_wait(io_context_, exec_engine_->insert_blocks(to_plain_blocks(blocks)))};
+        if (!insert_result) {
+            log::Error("Sync") << "Cannot insert " << blocks.size() << " blocks, error=" << insert_result.status;
+            continue;
+        }
 
-        // send announcement to peers
+        // Send announcement to peers
         send_new_block_announcements(std::move(announcements_to_do));  // according to eth/67 they must be done here,
                                                                        // after simple header verification
 
@@ -112,7 +121,7 @@ PoWSync::NewHeight PoWSync::forward_and_insert_blocks() {
                           << ", last=" << downloaded_headers.get()
                           << ", head=" << chain_fork_view_.head_height()
                           << ", lap.duration=" << StopWatch::format(timing.since_start());
-    };
+    }
 
     block_exchange_.stop_downloading();
 
@@ -134,7 +143,7 @@ void PoWSync::execution_loop() {
 
     // Main cycle
     while (!is_stopping()) {
-        // resume from previous run or download new blocks
+        // Resume from previous run or download new blocks
         NewHeight new_height = is_starting_up
                                    ? resume()                      // resuming, the following verify_chain is needed to check all stages
                                    : forward_and_insert_blocks();  // downloads new blocks and inserts them into the db
@@ -144,47 +153,47 @@ void PoWSync::execution_loop() {
             continue;
         }
 
-        // verify the new section of the chain
-        log::Info("Sync") << "Verifying chain, head= (" << new_height.number << ", " << to_hex(new_height.hash) << ")";
-        auto verification = sync_wait(in(exec_engine_), exec_engine_.validate_chain(new_height.hash));  // BLOCKING
+        // Verify the new section of the chain
+        log::Info("Sync") << "Verifying chain, head=(" << new_height.number << ", " << to_hex(new_height.hash) << ")";
+        const auto verification = sync_wait(io_context_, exec_engine_->validate_chain(new_height));  // BLOCKING
 
-        if (std::holds_alternative<ValidChain>(verification)) {
-            auto valid_chain = std::get<ValidChain>(verification);
+        if (std::holds_alternative<execution::api::ValidChain>(verification)) {
+            auto valid_chain = std::get<execution::api::ValidChain>(verification);
 
-            log::Info("Sync") << "Valid chain, new head=" << valid_chain.current_head;
+            log::Info("Sync") << "Valid chain, new head=" << valid_chain.current_head.hash;
 
-            // if it is valid, do nothing, only check invariant
-            ensure_invariant(valid_chain.current_head == new_height.hash, "invalid verify_chain result");
+            // If it is valid, do nothing, only check invariant
+            ensure_invariant(valid_chain.current_head.hash == new_height.hash, "invalid validate_chain result");
 
-            // notify fork choice update
+            // Notify the fork choice
             log::Info("Sync") << "Notifying fork choice updated, new head=" << new_height.number;
-            sync_wait(in(exec_engine_), exec_engine_.update_fork_choice(new_height.hash, std::nullopt));
+            sync_wait(io_context_, exec_engine_->update_fork_choice({new_height.hash}));
 
             send_new_block_hash_announcements();  // according to eth/67 they must be done after a full block verification
 
-        } else if (std::holds_alternative<InvalidChain>(verification)) {
-            auto invalid_chain = std::get<InvalidChain>(verification);
+        } else if (std::holds_alternative<execution::api::InvalidChain>(verification)) {
+            auto invalid_chain = std::get<execution::api::InvalidChain>(verification);
 
-            auto latest_valid_height = sync_wait(in(exec_engine_), exec_engine_.get_block_num(invalid_chain.latest_valid_head));
+            const auto latest_valid_height = sync_wait(io_context_, exec_engine_->get_header_hash_number(invalid_chain.unwind_point.hash));
             ensure_invariant(latest_valid_height.has_value(), "wrong latest_valid_head");
 
             log::Info("Sync") << "Invalid chain, unwinding down to=" << *latest_valid_height;
 
-            // if it is not valid, unwind the chain
-            unwind({*latest_valid_height, invalid_chain.latest_valid_head}, invalid_chain.bad_block);
+            // If it is not valid, unwind the chain
+            unwind({*latest_valid_height, invalid_chain.unwind_point.hash}, invalid_chain.bad_block);
 
             if (!invalid_chain.bad_headers.empty()) {
                 update_bad_headers(std::move(invalid_chain.bad_headers));
             }
 
-            // notify fork choice update
-            log::Info("Sync") << "Notifying fork choice updated, head=" << to_hex(invalid_chain.latest_valid_head);
-            sync_wait(in(exec_engine_), exec_engine_.update_fork_choice(invalid_chain.latest_valid_head, std::nullopt));
+            // Notify the fork choice
+            log::Info("Sync") << "Notifying fork choice updated, head=" << to_hex(invalid_chain.unwind_point.hash);
+            sync_wait(io_context_, exec_engine_->update_fork_choice({invalid_chain.unwind_point.hash}));
 
-        } else if (std::holds_alternative<ValidationError>(verification)) {
-            // if it returned a validation error, raise an exception
-            auto validation_error = std::get<ValidationError>(verification);
-            throw std::logic_error("Consensus validation error: last point=" + to_hex(validation_error.latest_valid_head) +
+        } else if (std::holds_alternative<execution::api::ValidationError>(verification)) {
+            // If it returned a validation error, raise an exception
+            const auto validation_error = std::get<execution::api::ValidationError>(verification);
+            throw std::logic_error("Consensus validation error: last point=" + validation_error.latest_valid_head.hash.to_hex() +
                                    ", error=" + validation_error.error);
 
         } else {
@@ -194,11 +203,11 @@ void PoWSync::execution_loop() {
         is_first_sync_ = is_starting_up;
         is_starting_up = false;
     }
-};
+}
 
 std::shared_ptr<InternalMessage<void>> PoWSync::update_bad_headers(std::set<Hash> bad_headers) {
     auto message = std::make_shared<InternalMessage<void>>(
-        [bads = std::move(bad_headers)](HeaderChain& hc, BodySequence&) { hc.add_bad_headers(bads); });
+        [bad_headers = std::move(bad_headers)](HeaderChain& hc, BodySequence&) { hc.add_bad_headers(bad_headers); });
 
     block_exchange_.accept(message);
 

--- a/silkworm/sync/sync_pow.hpp
+++ b/silkworm/sync/sync_pow.hpp
@@ -21,7 +21,7 @@
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/concurrency/active_component.hpp>
 #include <silkworm/node/common/node_settings.hpp>
-#include <silkworm/node/stagedsync/client.hpp>
+#include <silkworm/node/execution/api/client.hpp>
 #include <silkworm/sync/internals/chain_fork_view.hpp>
 #include <silkworm/sync/messages/internal_message.hpp>
 
@@ -34,7 +34,7 @@ namespace asio = boost::asio;
 
 class PoWSync : public ChainSync, ActiveComponent {
   public:
-    PoWSync(BlockExchange&, execution::Client&);
+    PoWSync(BlockExchange&, execution::api::Client&);
 
     Task<void> async_run() override;
 


### PR DESCRIPTION
This PR changes the `node` and `sync` modules to use the client/server abstractions built around the [`execution`](https://github.com/ledgerwatch/interfaces/blob/master/execution/execution.proto) interface. Specifically:

- create Execution API DirectClient and Server (disabled by config for now) in `node` module facade
- migrate usage of Execution API Client in `sync` module
- bridge Execution API DirectClient from `node` to `sync` facade in `silkworm` main

*Extras*
- extract sample block generation as common fixture in unit tests
- improve readability by adding some type alias
- handle some more error conditions in PoS sync

This PR depends on #2004 

This PR does *not* remove the old in-process-only implementation yet, another PR will follow