### PR TITLE
sync: fix validity check for zero-difficulty headers

### DIFF
--- a/silkworm/sync/internals/header_chain.hpp
+++ b/silkworm/sync/internals/header_chain.hpp
@@ -17,6 +17,9 @@
 #pragma once
 
 #include <cstdio>
+#include <optional>
+
+#include <intx/intx.hpp>
 
 #include <silkworm/core/common/lru_cache.hpp>
 #include <silkworm/core/protocol/rule_set.hpp>
@@ -56,9 +59,8 @@ namespace silkworm {
  */
 class HeaderChain {
   public:
-    explicit HeaderChain(const ChainConfig&);
-
-    explicit HeaderChain(protocol::RuleSetPtr);  // alternative constructor
+    explicit HeaderChain(const ChainConfig& chain_config);
+    explicit HeaderChain(protocol::RuleSetPtr rule_set, std::optional<intx::uint256> terminal_total_difficulty = {});
 
     // sync current state - this must be done at header forward
     void initial_state(const std::vector<BlockHeader>& last_headers);
@@ -176,6 +178,7 @@ class HeaderChain {
     CustomHeaderOnlyChainState chain_state_;
     time_point_t last_skeleton_request_;
     time_point_t last_nack_;
+    std::optional<intx::uint256> terminal_total_difficulty_;
 
     uint64_t generate_request_id();
     uint64_t is_valid_request_id(uint64_t request_id) const;

--- a/silkworm/sync/internals/header_retrieval_test.cpp
+++ b/silkworm/sync/internals/header_retrieval_test.cpp
@@ -1,0 +1,39 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "header_retrieval.hpp"
+
+#include <catch2/catch.hpp>
+
+#include <silkworm/db/test_util/temp_chain_data.hpp>
+
+namespace silkworm {
+
+TEST_CASE("HeaderRetrieval") {
+    db::test_util::TempChainData context;
+    context.add_genesis_data();
+    context.commit_txn();
+    HeaderRetrieval header_retrieval{db::ROAccess{context.env()}};
+
+    SECTION("recover_by_hash") {
+        const auto headers{header_retrieval.recover_by_hash({}, 1, 0, false)};
+    }
+    SECTION("recover_by_number") {
+        const auto headers{header_retrieval.recover_by_number({}, 1, 0, false)};
+    }
+}
+
+}  // namespace silkworm


### PR DESCRIPTION
This PR changes the validity check for zero-difficulty headers by rejecting them only if the chain terminal total difficulty is not set.

*Extras*
add unit test for header retrieval