### PR TITLE
sync: handle send errors for outbound p2p messages

### DIFF
--- a/silkworm/sync/messages/inbound_block_bodies.cpp
+++ b/silkworm/sync/messages/inbound_block_bodies.cpp
@@ -37,7 +37,11 @@ void InboundBlockBodies::execute(db::ROAccess, HeaderChain&, BodySequence& bs, S
     if (penalty != Penalty::NoPenalty) {
         SILK_TRACE << "Replying to " << identify(*this) << " with penalize_peer";
         SILK_TRACE << "Penalizing " << PeerPenalization(penalty, peerId_);
-        sentry.penalize_peer(peerId_, penalty);
+        try {
+            sentry.penalize_peer(peerId_, penalty);
+        } catch (const boost::system::system_error& se) {
+            SILK_TRACE << "InboundBlockBodies failed penalize_peer error: " << se.what();
+        }
     }
 }
 

--- a/silkworm/sync/messages/inbound_block_headers.cpp
+++ b/silkworm/sync/messages/inbound_block_headers.cpp
@@ -46,11 +46,19 @@ void InboundBlockHeaders::execute(db::ROAccess, HeaderChain& hc, BodySequence&, 
     if (penalty != Penalty::NoPenalty) {
         SILK_TRACE << "Replying to " << identify(*this) << " with penalize_peer";
         SILK_TRACE << "Penalizing " << PeerPenalization(penalty, peerId_);
-        sentry.penalize_peer(peerId_, penalty);
+        try {
+            sentry.penalize_peer(peerId_, penalty);
+        } catch (const boost::system::system_error& se) {
+            SILK_TRACE << "InboundBlockHeaders failed penalize_peer error: " << se.what();
+        }
     }
 
-    SILK_TRACE << "Replying to " << identify(*this) << " with peer_min_block";
-    sentry.peer_min_block(peerId_, highestBlock);
+    try {
+        SILK_TRACE << "Replying to " << identify(*this) << " with peer_min_block";
+        sentry.peer_min_block(peerId_, highestBlock);
+    } catch (const boost::system::system_error& se) {
+        SILK_TRACE << "InboundBlockHeaders failed peer_min_block error: " << se.what();
+    }
 }
 
 uint64_t InboundBlockHeaders::reqId() const { return packet_.requestId; }

--- a/silkworm/sync/messages/inbound_get_block_headers.cpp
+++ b/silkworm/sync/messages/inbound_get_block_headers.cpp
@@ -61,11 +61,14 @@ void InboundGetBlockHeaders::execute(db::ROAccess db, HeaderChain&, BodySequence
     SILK_TRACE << "Replying to " << identify(*this) << " using send_message_by_id with "
                << reply.request.size() << " headers";
 
-    OutboundBlockHeaders reply_message{std::move(reply)};
-    [[maybe_unused]] auto peers = sentry.send_message_by_id(reply_message, peerId_);
+    try {
+        OutboundBlockHeaders reply_message{std::move(reply)};
+        [[maybe_unused]] auto peers = sentry.send_message_by_id(reply_message, peerId_);
 
-    SILK_TRACE << "Received sentry result of " << identify(*this) << ": "
-               << std::to_string(peers.size()) + " peer(s)";
+        SILK_TRACE << "Received sentry result of " << identify(*this) << ": " << std::to_string(peers.size()) + " peer(s)";
+    } catch (const boost::system::system_error& se) {
+        SILK_TRACE << "InboundGetBlockHeaders failed send_message_by_id error: " << se.what();
+    }
 }
 
 uint64_t InboundGetBlockHeaders::reqId() const { return packet_.requestId; }

--- a/silkworm/sync/messages/inbound_new_block_hashes.cpp
+++ b/silkworm/sync/messages/inbound_new_block_hashes.cpp
@@ -57,11 +57,15 @@ void InboundNewBlockHashes::execute(db::ROAccess, HeaderChain& hc, BodySequence&
         // request header
         SILK_TRACE << "Replying to " << identify(*this) << " requesting header with send_message_by_id, content: " << *packet;
 
-        OutboundGetBlockHeaders request_message{packet.value()};
-        [[maybe_unused]] auto peers = sentry.send_message_by_id(request_message, peerId_);
+        try {
+            OutboundGetBlockHeaders request_message{packet.value()};
+            [[maybe_unused]] auto peers = sentry.send_message_by_id(request_message, peerId_);
 
-        SILK_TRACE << "Received sentry result of " << identify(*this) << ": "
-                   << std::to_string(peers.size()) + " peer(s)";
+            SILK_TRACE << "Received sentry result of " << identify(*this) << ": "
+                       << std::to_string(peers.size()) + " peer(s)";
+        } catch (const boost::system::system_error& se) {
+            SILK_TRACE << "Received error from sentry send_message_by_id for " << identify(*this) << " error: " << se.what();
+        }
     }
 
     hc.top_seen_block_height(max);

--- a/silkworm/sync/messages/outbound_new_block.cpp
+++ b/silkworm/sync/messages/outbound_new_block.cpp
@@ -32,10 +32,14 @@ void OutboundNewBlock::execute(db::ROAccess, HeaderChain&, BodySequence&, Sentry
     for (auto& block_ptr : blocks_to_announce_) {
         const BlockEx& block = *block_ptr;
         NewBlockPacket packet{block, block.td};  // NOLINT(cppcoreguidelines-slicing)
-        auto peers = send_packet(sentry, std::move(packet));
+        try {
+            auto peers = send_packet(sentry, std::move(packet));
 
-        // no peers available
-        if (peers.empty()) break;
+            // no peers available
+            if (peers.empty()) break;
+        } catch (const boost::system::system_error& se) {
+            SILK_TRACE << "OutboundNewBlock failed send_packet error: " << se.what();
+        }
     }
 }
 

--- a/silkworm/sync/messages/outbound_new_block_hashes.cpp
+++ b/silkworm/sync/messages/outbound_new_block_hashes.cpp
@@ -47,12 +47,15 @@ void OutboundNewBlockHashes::execute(db::ROAccess, HeaderChain& hc, BodySequence
     SILK_TRACE << "Sending message OutboundNewBlockHashes (announcements) with send_message_to_all, content:"
                << packet_;
 
-    [[maybe_unused]] auto peers = sentry.send_message_to_all(*this);
+    try {
+        [[maybe_unused]] auto peers = sentry.send_message_to_all(*this);
 
-    SILK_TRACE << "Received sentry result of OutboundNewBlockHashes: "
-               << std::to_string(peers.size()) + " peer(s)";
+        SILK_TRACE << "Received sentry result of OutboundNewBlockHashes: " << std::to_string(peers.size()) + " peer(s)";
 
-    announces_to_do.clear();  // clear announces from the queue
+        announces_to_do.clear();  // clear announces from the queue
+    } catch (const boost::system::system_error& se) {
+        SILK_TRACE << "OutboundNewBlockHashes failed send_message_to_all error: " << se.what();
+    }
 }
 
 Bytes OutboundNewBlockHashes::message_data() const {


### PR DESCRIPTION
This PR handles send errors for outbound p2p messages, which may occur if the network channel breaks while some inbound message processing is ongoing.

Currently, if any send error occurs, the program execution stops because any unhandled exception terminates the `BlockExchange` execution loop. There's not much we can do here except swallow the exception because the peer disconnection is already handled in `sentry` module and retry does not make any sense for messages with single destination.