### PR TITLE
fuzzer: extend job timeout

### DIFF
--- a/.github/workflows/rpc-fuzzer-tests.yml
+++ b/.github/workflows/rpc-fuzzer-tests.yml
@@ -14,7 +14,7 @@ jobs:
     env:
       RPC_PAST_TEST_DIR: /opt/rpc-past-tests
       ERIGON_QA_PATH: /opt/erigon-qa
-
+    timeout-minutes: 1440
     steps:
       - name: Checkout Silkworm Repository
         uses: actions/checkout@v4


### PR DESCRIPTION
The step timeout seems to be overridden by the job timeout, see: https://github.com/erigontech/silkworm/actions/runs/9143609277

This PR ups the job timeout to match the step timeout.