### PR TITLE
infra, node, rpcdaemon: refactor application build info

### DIFF
--- a/cmd/common/common.cpp
+++ b/cmd/common/common.cpp
@@ -128,21 +128,4 @@ void add_context_pool_options(CLI::App& cli, concurrency::ContextPoolSettings& s
     add_option_wait_mode(cli, settings.wait_mode);
 }
 
-std::string get_node_name_from_build_info(const buildinfo* build_info) {
-    std::string node_name{"silkworm/"};
-    node_name.append(build_info->git_branch);
-    node_name.append(build_info->project_version);
-    node_name.append("/");
-    node_name.append(build_info->system_name);
-    node_name.append("-");
-    node_name.append(build_info->system_processor);
-    node_name.append("_");
-    node_name.append(build_info->build_type);
-    node_name.append("/");
-    node_name.append(build_info->compiler_id);
-    node_name.append("-");
-    node_name.append(build_info->compiler_version);
-    return node_name;
-}
-
 }  // namespace silkworm::cmd::common

--- a/cmd/common/common.hpp
+++ b/cmd/common/common.hpp
@@ -22,14 +22,11 @@
 
 #include <CLI/CLI.hpp>
 
-#include <silkworm/buildinfo.h>
+#include <silkworm/infra/common/application_info.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/concurrency/context_pool_settings.hpp>
 
 namespace silkworm::cmd::common {
-
-//! Assemble the full node name using the Cable build information
-std::string get_node_name_from_build_info(const buildinfo* build_info);
 
 //! \brief Set up options to populate log settings after cli.parse()
 void add_logging_options(CLI::App& cli, log::Settings& log_settings);

--- a/cmd/rpcdaemon.cpp
+++ b/cmd/rpcdaemon.cpp
@@ -14,11 +14,7 @@
    limitations under the License.
 */
 
-#include <string>
-
 #include <CLI/CLI.hpp>
-#include <boost/asio/version.hpp>
-#include <grpcpp/grpcpp.h>
 
 #include <silkworm/buildinfo.h>
 #include <silkworm/rpc/daemon.hpp>
@@ -29,20 +25,6 @@
 using namespace silkworm;
 using namespace silkworm::cmd::common;
 using namespace silkworm::rpc;
-
-//! Assemble the application fully-qualified name using the Cable build information
-std::string get_name_from_build_info() {
-    return get_node_name_from_build_info(silkworm_get_buildinfo());
-}
-
-//! Assemble the relevant library version information
-std::string get_library_versions() {
-    std::string library_versions{"gRPC: "};
-    library_versions.append(grpc::Version());
-    library_versions.append(" Boost Asio: ");
-    library_versions.append(std::to_string(BOOST_ASIO_VERSION));
-    return library_versions;
-}
 
 int main(int argc, char* argv[]) {
     CLI::App cli{"Silkrpc - C++ implementation of Ethereum JSON RPC API service"};
@@ -57,7 +39,10 @@ int main(int argc, char* argv[]) {
         add_rpcdaemon_options(cli, settings);
         cli.parse(argc, argv);
 
-        return Daemon::run(settings, {get_name_from_build_info(), get_library_versions()});
+        // Extract versioning information from Cable build information
+        settings.build_info = make_application_info(silkworm_get_buildinfo());
+
+        return Daemon::run(settings);
     } catch (const CLI::ParseError& pe) {
         return cli.exit(pe);
     }

--- a/cmd/silkworm.cpp
+++ b/cmd/silkworm.cpp
@@ -63,7 +63,6 @@ using silkworm::cmd::common::add_node_options;
 using silkworm::cmd::common::add_option_data_dir;
 using silkworm::cmd::common::add_rpcdaemon_options;
 using silkworm::cmd::common::add_sentry_options;
-using silkworm::cmd::common::get_node_name_from_build_info;
 using silkworm::cmd::common::ShutdownSignal;
 using silkworm::cmd::common::SilkwormSettings;
 
@@ -238,22 +237,9 @@ int main(int argc, char* argv[]) {
 
         // Output BuildInfo
         const auto build_info{silkworm_get_buildinfo()};
-        node_settings.build_info =
-            "version=" + std::string(build_info->git_branch) + std::string(build_info->project_version) +
-            "build=" + std::string(build_info->system_name) + "-" + std::string(build_info->system_processor) +
-            " " + std::string(build_info->build_type) +
-            "compiler=" + std::string(build_info->compiler_id) +
-            " " + std::string(build_info->compiler_version);
-        node_settings.node_name = get_node_name_from_build_info(build_info);
+        node_settings.build_info = make_application_info(build_info);
 
-        sw_log::Info(
-            "Silkworm",
-            {"version", std::string(build_info->git_branch) + std::string(build_info->project_version),
-             "build",
-             std::string(build_info->system_name) + "-" + std::string(build_info->system_processor) + " " +
-                 std::string(build_info->build_type),
-             "compiler",
-             std::string(build_info->compiler_id) + " " + std::string(build_info->compiler_version)});
+        sw_log::Info("Silkworm", build_info_as_log_args(build_info));
 
         // Output mdbx build info
         auto mdbx_ver{mdbx::get_version()};

--- a/silkworm/infra/CMakeLists.txt
+++ b/silkworm/infra/CMakeLists.txt
@@ -52,6 +52,7 @@ set(LIBS_PRIVATE
     Boost::container # required for asio-grpc
     magic_enum::magic_enum
     spdlog::spdlog
+    silkworm-buildinfo
 )
 # cmake-format: on
 

--- a/silkworm/infra/common/application_info.cpp
+++ b/silkworm/infra/common/application_info.cpp
@@ -65,9 +65,12 @@ ApplicationInfo make_application_info(const buildinfo* info) {
 
 log::Args build_info_as_log_args(const buildinfo* info) {
     return {
-        "version", std::string(info->git_branch) + std::string(info->project_version),
-        "build", std::string(info->system_name) + "-" + std::string(info->system_processor) + " " + std::string(info->build_type),
-        "compiler", std::string(info->compiler_id) + " " + std::string(info->compiler_version),
+        "version",
+        std::string(info->git_branch) + std::string(info->project_version),
+        "build",
+        std::string(info->system_name) + "-" + std::string(info->system_processor) + " " + std::string(info->build_type),
+        "compiler",
+        std::string(info->compiler_id) + " " + std::string(info->compiler_version),
     };
 }
 

--- a/silkworm/infra/common/application_info.cpp
+++ b/silkworm/infra/common/application_info.cpp
@@ -1,0 +1,74 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "application_info.hpp"
+
+#include <silkworm/buildinfo.h>
+
+namespace silkworm {
+
+std::string get_node_name_from_build_info(const buildinfo* info) {
+    std::string node_name{"silkworm/"};
+    node_name.append(info->git_branch);
+    node_name.append(info->project_version);
+    node_name.append("/");
+    node_name.append(info->system_name);
+    node_name.append("-");
+    node_name.append(info->system_processor);
+    node_name.append("_");
+    node_name.append(info->build_type);
+    node_name.append("/");
+    node_name.append(info->compiler_id);
+    node_name.append("-");
+    node_name.append(info->compiler_version);
+    return node_name;
+}
+
+std::string get_description_from_build_info(const buildinfo* info) {
+    std::string description{"version: "};
+    description.append(info->git_branch);
+    description.append(info->project_version);
+    description.append(" build: ");
+    description.append(info->system_name);
+    description.append("-");
+    description.append(info->system_processor);
+    description.append("_");
+    description.append(info->build_type);
+    description.append(" compiler: ");
+    description.append(info->compiler_id);
+    description.append("-");
+    description.append(info->compiler_version);
+    return description;
+}
+
+ApplicationInfo make_application_info(const buildinfo* info) {
+    return {
+        .version = info->project_version,
+        .commit_hash = info->git_commit_hash,
+        .build_description = get_description_from_build_info(info),
+        .node_name = get_node_name_from_build_info(info),
+    };
+}
+
+log::Args build_info_as_log_args(const buildinfo* info) {
+    return {
+        "version", std::string(info->git_branch) + std::string(info->project_version),
+        "build", std::string(info->system_name) + "-" + std::string(info->system_processor) + " " + std::string(info->build_type),
+        "compiler", std::string(info->compiler_id) + " " + std::string(info->compiler_version),
+    };
+}
+
+}  // namespace silkworm

--- a/silkworm/infra/common/application_info.hpp
+++ b/silkworm/infra/common/application_info.hpp
@@ -41,7 +41,7 @@ std::string get_description_from_build_info(const buildinfo* info);
 //! Create the application versioning information from the Cable build information
 ApplicationInfo make_application_info(const buildinfo* info);
 
-//! Format the Cable build information Get as log arguments
+//! Format the Cable build information as log arguments
 log::Args build_info_as_log_args(const buildinfo* info);
 
 }  // namespace silkworm

--- a/silkworm/infra/common/application_info.hpp
+++ b/silkworm/infra/common/application_info.hpp
@@ -1,0 +1,47 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <string>
+
+#include <silkworm/infra/common/log.hpp>
+
+struct buildinfo;
+
+namespace silkworm {
+
+//! Application versioning information
+struct ApplicationInfo {
+    std::string version;            // Extracted from version control system
+    std::string commit_hash;        // Extracted from version control system
+    std::string build_description;  // Containing compiler and platform
+    std::string node_name;          // Complete node name with identifier and build info
+};
+
+//! Assemble the complete node name using the Cable build information
+std::string get_node_name_from_build_info(const buildinfo* info);
+
+//! Assemble the build description using the Cable build information
+std::string get_description_from_build_info(const buildinfo* info);
+
+//! Create the application versioning information from the Cable build information
+ApplicationInfo make_application_info(const buildinfo* info);
+
+//! Format the Cable build information Get as log arguments
+log::Args build_info_as_log_args(const buildinfo* info);
+
+}  // namespace silkworm

--- a/silkworm/node/common/node_settings.hpp
+++ b/silkworm/node/common/node_settings.hpp
@@ -32,12 +32,13 @@
 #include <silkworm/db/etl/collector_settings.hpp>
 #include <silkworm/db/mdbx/mdbx.hpp>
 #include <silkworm/db/prune_mode.hpp>
+#include <silkworm/infra/common/application_info.hpp>
 #include <silkworm/infra/common/directories.hpp>
 
 namespace silkworm {
 
 struct NodeSettings {
-    std::string build_info{};                              // Hold build info (human-readable)
+    ApplicationInfo build_info;                            // Application build info (human-readable)
     boost::asio::io_context asio_context;                  // Async context (e.g. for timers)
     std::unique_ptr<DataDirectory> data_directory;         // Pointer to data folder
     db::EnvConfig chaindata_env_config{};                  // Chaindata db config
@@ -51,7 +52,6 @@ struct NodeSettings {
     db::PruneMode prune_mode;                              // Prune mode
     uint32_t sync_loop_throttle_seconds{0};                // Minimum interval amongst sync cycle
     uint32_t sync_loop_log_interval_seconds{30};           // Interval for sync loop to emit logs
-    std::string node_name;                                 // The node identifying name
     bool parallel_fork_tracking_enabled{false};            // Whether to track multiple parallel forks at head
 
     inline db::etl::CollectorSettings etl() const {

--- a/silkworm/node/node.cpp
+++ b/silkworm/node/node.cpp
@@ -104,7 +104,7 @@ NodeImpl::NodeImpl(Settings& settings, SentryClientPtr sentry_client, mdbx::env 
       sentry_client_{std::move(sentry_client)},
       resource_usage_log_{*settings_.data_directory} {
     backend_ = std::make_unique<EthereumBackEnd>(settings_, &chaindata_db_, sentry_client_);
-    backend_->set_node_name(settings_.node_name);
+    backend_->set_node_name(settings_.build_info.node_name);
     backend_kv_rpc_server_ = std::make_unique<rpc::BackEndKvServer>(settings_.server_settings, *backend_);
     bittorrent_client_ = std::make_unique<snapshots::bittorrent::BitTorrentClient>(settings_.snapshot_settings.bittorrent_settings);
 }

--- a/silkworm/node/stagedsync/execution_pipeline.cpp
+++ b/silkworm/node/stagedsync/execution_pipeline.cpp
@@ -135,7 +135,7 @@ void ExecutionPipeline::load_stages() {
     stages_.emplace(db::stages::kTxLookupKey,
                     std::make_unique<stagedsync::TxLookup>(sync_context_.get(), node_settings_->etl(), node_settings_->prune_mode.tx_index()));
     stages_.emplace(db::stages::kFinishKey,
-                    std::make_unique<stagedsync::Finish>(sync_context_.get(), node_settings_->build_info));
+                    std::make_unique<stagedsync::Finish>(sync_context_.get(), node_settings_->build_info.build_description));
     current_stage_ = stages_.begin();
 
     stages_forward_order_.insert(stages_forward_order_.begin(),

--- a/silkworm/rpc/daemon.cpp
+++ b/silkworm/rpc/daemon.cpp
@@ -321,7 +321,7 @@ void Daemon::start() {
                                   boost::asio::io_context& ioc,
                                   std::optional<std::string> jwt_secret,
                                   InterfaceLogSettings ilog_settings) {
-        commands::RpcApi rpc_api{ioc, worker_pool_, settings_.build_info};
+        commands::RpcApi rpc_api{ioc, worker_pool_};
         commands::RpcApiTable handler_table{api_spec};
         auto make_jsonrpc_handler = [rpc_api = std::move(rpc_api),
                                      handler_table = std::move(handler_table),

--- a/silkworm/rpc/daemon.cpp
+++ b/silkworm/rpc/daemon.cpp
@@ -24,6 +24,7 @@
 #include <stdexcept>
 
 #include <boost/asio/signal_set.hpp>
+#include <boost/asio/version.hpp>
 #include <boost/process/environment.hpp>
 #include <grpcpp/grpcpp.h>
 
@@ -56,7 +57,7 @@ void DaemonChecklist::success_or_throw() const {
     }
 }
 
-const char* current_exception_name() {
+static const char* current_exception_name() {
 #ifdef WIN32
     return "<Exception name not supported on Windows>";
 #else
@@ -65,7 +66,16 @@ const char* current_exception_name() {
 #endif
 }
 
-int Daemon::run(const DaemonSettings& settings, const DaemonInfo& info) {
+//! Assemble the relevant library version information
+static std::string get_library_versions() {
+    std::string library_versions{"gRPC: "};
+    library_versions.append(grpc::Version());
+    library_versions.append(" Boost Asio: ");
+    library_versions.append(std::to_string(BOOST_ASIO_VERSION));
+    return library_versions;
+}
+
+int Daemon::run(const DaemonSettings& settings) {
     const bool are_settings_valid{validate_settings(settings)};
     if (!are_settings_valid) {
         return -1;
@@ -76,9 +86,9 @@ int Daemon::run(const DaemonSettings& settings, const DaemonInfo& info) {
     log::init(log_settings);
     log::set_thread_name("main-thread");
 
-    auto mdbx_ver{mdbx::get_version()};
-    auto mdbx_bld{mdbx::get_build()};
-    SILK_INFO << "Silkrpc build info: " << info.build << " " << info.libraries;
+    const auto mdbx_ver{mdbx::get_version()};
+    const auto mdbx_bld{mdbx::get_build()};
+    SILK_INFO << "Silkrpc starting " << settings.build_info.build_description << " " << get_library_versions();
     SILK_INFO << "Silkrpc libmdbx version: " << mdbx_ver.git.describe << " build: " << mdbx_bld.target << " compiler: " << mdbx_bld.compiler;
 
     std::set_terminate([]() {
@@ -311,7 +321,7 @@ void Daemon::start() {
                                   boost::asio::io_context& ioc,
                                   std::optional<std::string> jwt_secret,
                                   InterfaceLogSettings ilog_settings) {
-        commands::RpcApi rpc_api{ioc, worker_pool_};
+        commands::RpcApi rpc_api{ioc, worker_pool_, settings_.build_info};
         commands::RpcApiTable handler_table{api_spec};
         auto make_jsonrpc_handler = [rpc_api = std::move(rpc_api),
                                      handler_table = std::move(handler_table),

--- a/silkworm/rpc/daemon.hpp
+++ b/silkworm/rpc/daemon.hpp
@@ -36,11 +36,6 @@
 
 namespace silkworm::rpc {
 
-struct DaemonInfo {
-    std::string build;
-    std::string libraries;
-};
-
 struct DaemonChecklist {
     std::vector<ProtocolVersionResult> protocol_checklist;
 
@@ -49,7 +44,7 @@ struct DaemonChecklist {
 
 class Daemon {
   public:
-    static int run(const DaemonSettings& settings, const DaemonInfo& info = {});
+    static int run(const DaemonSettings& settings);
 
     explicit Daemon(DaemonSettings settings, std::optional<mdbx::env> chaindata_env = {});
 

--- a/silkworm/rpc/settings.hpp
+++ b/silkworm/rpc/settings.hpp
@@ -20,6 +20,7 @@
 #include <string>
 #include <vector>
 
+#include <silkworm/infra/common/application_info.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/concurrency/context_pool_settings.hpp>
 #include <silkworm/rpc/common/constants.hpp>
@@ -29,6 +30,7 @@
 namespace silkworm::rpc {
 
 struct DaemonSettings {
+    ApplicationInfo build_info;
     log::Settings log_settings;
     InterfaceLogSettings eth_ifc_log_settings{.ifc_name = "eth_rpc_api"};
     InterfaceLogSettings engine_ifc_log_settings{.ifc_name = "engine_rpc_api"};


### PR DESCRIPTION
This PR extracts into one abstraction in `infra` module the application build information for `silkworm` and `rpcdaemon` components.

This is a prerequisite for implementing `engine_getClientVersionV1` API in next PR.