### PR TITLE
rpcdaemon: add engine_getClientVersionV1 API

### DIFF
--- a/silkworm/rpc/commands/rpc_api.hpp
+++ b/silkworm/rpc/commands/rpc_api.hpp
@@ -21,6 +21,7 @@
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/thread_pool.hpp>
 
+#include <silkworm/infra/common/application_info.hpp>
 #include <silkworm/rpc/commands/admin_api.hpp>
 #include <silkworm/rpc/commands/debug_api.hpp>
 #include <silkworm/rpc/commands/engine_api.hpp>
@@ -53,7 +54,7 @@ class RpcApi : protected EthereumRpcApi,
                TxPoolRpcApi,
                OtsRpcApi {
   public:
-    explicit RpcApi(boost::asio::io_context& io_context, boost::asio::thread_pool& workers)
+    explicit RpcApi(boost::asio::io_context& io_context, boost::asio::thread_pool& workers, ApplicationInfo build_info = {})
         : EthereumRpcApi{io_context, workers},
           NetRpcApi{io_context},
           AdminRpcApi{io_context},
@@ -62,7 +63,7 @@ class RpcApi : protected EthereumRpcApi,
           ParityRpcApi{io_context},
           ErigonRpcApi{io_context},
           TraceRpcApi{io_context, workers},
-          EngineRpcApi(io_context),
+          EngineRpcApi(io_context, std::move(build_info)),
           TxPoolRpcApi(io_context),
           OtsRpcApi{io_context, workers} {}
 

--- a/silkworm/rpc/commands/rpc_api_table.cpp
+++ b/silkworm/rpc/commands/rpc_api_table.cpp
@@ -232,6 +232,8 @@ void RpcApiTable::add_engine_handlers() {
     method_handlers_[json_rpc::method::k_engine_forkchoiceUpdatedV2] = &commands::RpcApi::handle_engine_forkchoice_updated_v2;
     method_handlers_[json_rpc::method::k_engine_forkchoiceUpdatedV3] = &commands::RpcApi::handle_engine_forkchoice_updated_v3;
     method_handlers_[json_rpc::method::k_engine_exchangeTransitionConfiguration] = &commands::RpcApi::handle_engine_exchange_transition_configuration_v1;
+
+    method_handlers_glaze_[json_rpc::method::k_engine_getClientVersionV1] = &commands::RpcApi::handle_engine_get_client_version_v1;
 }
 
 void RpcApiTable::add_txpool_handlers() {

--- a/silkworm/rpc/daemon.cpp
+++ b/silkworm/rpc/daemon.cpp
@@ -321,7 +321,7 @@ void Daemon::start() {
                                   boost::asio::io_context& ioc,
                                   std::optional<std::string> jwt_secret,
                                   InterfaceLogSettings ilog_settings) {
-        commands::RpcApi rpc_api{ioc, worker_pool_, settings_.build_info};
+        commands::RpcApi rpc_api{ioc, worker_pool_};
         commands::RpcApiTable handler_table{api_spec};
         auto make_jsonrpc_handler = [rpc_api = std::move(rpc_api),
                                      handler_table = std::move(handler_table),

--- a/silkworm/rpc/daemon.cpp
+++ b/silkworm/rpc/daemon.cpp
@@ -321,7 +321,7 @@ void Daemon::start() {
                                   boost::asio::io_context& ioc,
                                   std::optional<std::string> jwt_secret,
                                   InterfaceLogSettings ilog_settings) {
-        commands::RpcApi rpc_api{ioc, worker_pool_};
+        commands::RpcApi rpc_api{ioc, worker_pool_, settings_.build_info};
         commands::RpcApiTable handler_table{api_spec};
         auto make_jsonrpc_handler = [rpc_api = std::move(rpc_api),
                                      handler_table = std::move(handler_table),

--- a/silkworm/rpc/json/client_version.cpp
+++ b/silkworm/rpc/json/client_version.cpp
@@ -1,0 +1,73 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "client_version.hpp"
+
+#include <array>
+#include <string>
+#include <utility>
+
+#include <silkworm/rpc/json/types.hpp>
+
+namespace silkworm::rpc {
+
+//! Commit hash length is hard-coded at 4-bytes hex by spec
+inline constexpr auto kCommitSize = 4 * 2;
+
+//! ClientVersionV1 as specified in https://github.com/ethereum/execution-apis/blob/main/src/engine/identification.md#clientversionv1
+struct ClientVersionV1 {
+    inline static std::string_view code{"SW"};        // never-changing value, hard-coded for efficiency
+    inline static std::string_view name{"silkworm"};  // never-changing value, hard-coded for efficiency
+    std::string_view version;
+    std::string_view commit;
+
+    struct glaze {
+        using T = ClientVersionV1;
+        static constexpr auto value = glz::object(
+            "code", &T::code,
+            "name", &T::name,
+            "version", &T::version,
+            "commit", &T::commit);
+    };
+};
+
+struct ClientVersionV1Reply {
+    std::string_view jsonrpc = kJsonVersion;
+    JsonRpcId id;
+    std::array<ClientVersionV1, 1> result;  // array with just 1 element for any EL client (multiplexers may have many)
+
+    struct glaze {
+        using T = ClientVersionV1Reply;
+        static constexpr auto value = glz::object(
+            "jsonrpc", &T::jsonrpc,
+            "id", &T::id,
+            "result", &T::result);
+    };
+};
+
+void make_glaze_json_content(const nlohmann::json& request_json, const ApplicationInfo& build_info, std::string& json_reply) {
+    ClientVersionV1Reply reply{
+        .id = make_jsonrpc_id(request_json),
+        .result = {ClientVersionV1{
+            .version = build_info.version,
+            .commit = build_info.commit_hash.substr(0, kCommitSize),
+        }},
+    };
+
+    glz::write_json(std::move(reply), json_reply);
+}
+
+}  // namespace silkworm::rpc

--- a/silkworm/rpc/json/client_version.hpp
+++ b/silkworm/rpc/json/client_version.hpp
@@ -1,0 +1,27 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <nlohmann/json.hpp>
+
+#include <silkworm/infra/common/application_info.hpp>
+
+namespace silkworm::rpc {
+
+void make_glaze_json_content(const nlohmann::json& request_json, const ApplicationInfo& build_info, std::string& json_reply);
+
+}  // namespace silkworm::rpc

--- a/silkworm/rpc/json_rpc/methods.hpp
+++ b/silkworm/rpc/json_rpc/methods.hpp
@@ -129,6 +129,7 @@ inline constexpr const char* k_parity_getBlockReceipts{"parity_getBlockReceipts"
 inline constexpr const char* k_parity_listStorageKeys{"parity_listStorageKeys"};
 
 inline constexpr const char* k_engine_exchangeCapabilities{"engine_exchangeCapabilities"};
+inline constexpr const char* k_engine_getClientVersionV1{"engine_getClientVersionV1"};
 inline constexpr const char* k_engine_getPayloadV1{"engine_getPayloadV1"};
 inline constexpr const char* k_engine_getPayloadV2{"engine_getPayloadV2"};
 inline constexpr const char* k_engine_getPayloadV3{"engine_getPayloadV3"};


### PR DESCRIPTION
This PR introduces support for [engine_getClientVersionV1](https://github.com/ethereum/execution-apis/blob/main/src/engine/identification.md#clientversionv1) API in `rpcdaemon` module.

Depends on #2039