### PR TITLE
snapshots: support empty words in tx deserializers

### DIFF
--- a/silkworm/db/snapshots/snapshot_test.cpp
+++ b/silkworm/db/snapshots/snapshot_test.cpp
@@ -277,29 +277,21 @@ TEST_CASE("TransactionSnapshot::txn_range OK", "[silkworm][node][snapshot][index
 
     Index idx_txn_hash{tx_snapshot_path.index_file()};
     idx_txn_hash.reopen_index();
-    TransactionRangeFromIdQuery txn_range{tx_snapshot, idx_txn_hash};
+    TransactionRangeFromIdQuery query{tx_snapshot, idx_txn_hash};
 
     // block 1'500'012: base_txn_id is 7'341'263, txn_count is 7
-    SECTION("1'500'012 OK") {
-        CHECK(txn_range.exec_into_vector(7'341'263, 0).empty());
-        CHECK(txn_range.exec_into_vector(7'341'263, 7).size() == 7);
-    }
-    SECTION("1'500'012 KO") {
-        CHECK_THROWS(txn_range.exec_into_vector(7'341'262, 7));  // invalid base_txn_id
-        CHECK_THROWS(txn_range.exec_into_vector(7'341'264, 7));  // invalid base_txn_id
-        CHECK_THROWS(txn_range.exec_into_vector(7'341'263, 8));  // invalid txn_count
-    }
+    CHECK(query.exec_into_vector(7'341'263, 0).empty());
+    CHECK(query.exec_into_vector(7'341'263, 7).size() == 7);
 
     // block 1'500'013: base_txn_id is 7'341'272, txn_count is 1
-    SECTION("1'500'013 OK") {
-        CHECK(txn_range.exec_into_vector(7'341'272, 0).empty());
-        CHECK(txn_range.exec_into_vector(7'341'272, 1).size() == 1);
-    }
-    SECTION("1'500'013 KO") {
-        CHECK_THROWS(txn_range.exec_into_vector(7'341'271, 1));  // invalid base_txn_id
-        CHECK_THROWS(txn_range.exec_into_vector(7'341'273, 1));  // invalid base_txn_id
-        CHECK_THROWS(txn_range.exec_into_vector(7'341'272, 2));  // invalid txn_count
-    }
+    CHECK(query.exec_into_vector(7'341'272, 0).empty());
+    CHECK(query.exec_into_vector(7'341'272, 1).size() == 1);
+
+    // invalid base_txn_id returns empty
+    CHECK(query.exec_into_vector(0, 1).empty());
+    CHECK(query.exec_into_vector(10'000'000, 1).empty());
+    CHECK(query.exec_into_vector(7'341'261, 1).empty());  // before the first system tx
+    CHECK(query.exec_into_vector(7'341'274, 1).empty());  // after the last system tx
 }
 
 TEST_CASE("TransactionSnapshot::txn_rlp_range OK", "[silkworm][node][snapshot][index]") {
@@ -317,29 +309,21 @@ TEST_CASE("TransactionSnapshot::txn_rlp_range OK", "[silkworm][node][snapshot][i
 
     Index idx_txn_hash{tx_snapshot_path.index_file()};
     idx_txn_hash.reopen_index();
-    TransactionPayloadRlpRangeFromIdQuery txn_rlp_range{tx_snapshot, idx_txn_hash};
+    TransactionPayloadRlpRangeFromIdQuery query{tx_snapshot, idx_txn_hash};
 
     // block 1'500'012: base_txn_id is 7'341'263, txn_count is 7
-    SECTION("1'500'012 OK") {
-        CHECK(txn_rlp_range.exec_into_vector(7'341'263, 0).empty());
-        CHECK(txn_rlp_range.exec_into_vector(7'341'263, 7).size() == 7);
-    }
-    SECTION("1'500'012 KO") {
-        CHECK_THROWS(txn_rlp_range.exec_into_vector(7'341'262, 7));  // invalid base_txn_id
-        CHECK_THROWS(txn_rlp_range.exec_into_vector(7'341'264, 7));  // invalid base_txn_id
-        CHECK_THROWS(txn_rlp_range.exec_into_vector(7'341'263, 8));  // invalid txn_count
-    }
+    CHECK(query.exec_into_vector(7'341'263, 0).empty());
+    CHECK(query.exec_into_vector(7'341'263, 7).size() == 7);
 
     // block 1'500'013: base_txn_id is 7'341'272, txn_count is 1
-    SECTION("1'500'013 OK") {
-        CHECK(txn_rlp_range.exec_into_vector(7'341'272, 0).empty());
-        CHECK(txn_rlp_range.exec_into_vector(7'341'272, 1).size() == 1);
-    }
-    SECTION("1'500'013 KO") {
-        CHECK_THROWS(txn_rlp_range.exec_into_vector(7'341'271, 1));  // invalid base_txn_id
-        CHECK_THROWS(txn_rlp_range.exec_into_vector(7'341'273, 1));  // invalid base_txn_id
-        CHECK_THROWS(txn_rlp_range.exec_into_vector(7'341'272, 2));  // invalid txn_count
-    }
+    CHECK(query.exec_into_vector(7'341'272, 0).empty());
+    CHECK(query.exec_into_vector(7'341'272, 1).size() == 1);
+
+    // invalid base_txn_id returns empty
+    CHECK(query.exec_into_vector(0, 1).empty());
+    CHECK(query.exec_into_vector(10'000'000, 1).empty());
+    CHECK(query.exec_into_vector(7'341'261, 1).empty());  // before the first system tx
+    CHECK(query.exec_into_vector(7'341'274, 1).empty());  // after the last system tx
 }
 
 TEST_CASE("slice_tx_payload", "[silkworm][node][snapshot]") {

--- a/silkworm/db/snapshots/txn_snapshot_word_serializer.cpp
+++ b/silkworm/db/snapshots/txn_snapshot_word_serializer.cpp
@@ -25,6 +25,7 @@
 #include <silkworm/core/common/base.hpp>
 #include <silkworm/core/common/endian.hpp>
 #include <silkworm/core/common/util.hpp>
+#include <silkworm/core/protocol/param.hpp>
 #include <silkworm/core/types/address.hpp>
 #include <silkworm/infra/common/decoding_exception.hpp>
 #include <silkworm/infra/common/log.hpp>
@@ -79,7 +80,19 @@ ByteView slice_tx_payload(ByteView tx_rlp) {
     return tx_rlp.substr(tx_payload_offset);
 }
 
+Transaction empty_system_tx() {
+    static Transaction tx;
+    tx.type = TransactionType::kSystem;
+    tx.set_sender(protocol::kSystemAddress);
+    return tx;
+}
+
 void decode_word_into_tx(ByteView word, Transaction& tx) {
+    if (word.empty()) {
+        tx = empty_system_tx();
+        return;
+    }
+
     auto [_, senders_data, tx_rlp] = slice_tx_data(word);
     const auto result = rlp::decode(tx_rlp, tx);
     success_or_throw(result, "decode_word_into_tx: rlp::decode error");

--- a/silkworm/db/snapshots/txn_snapshot_word_serializer.hpp
+++ b/silkworm/db/snapshots/txn_snapshot_word_serializer.hpp
@@ -64,6 +64,11 @@ struct TransactionSnapshotWordPayloadRlpDeserializer : public SnapshotWordDeseri
     ~TransactionSnapshotWordPayloadRlpDeserializer() override = default;
 
     void decode_word(ByteView word) override {
+        if (word.empty()) {
+            value = TBytes{};
+            return;
+        }
+
         auto data = slice_tx_data(word);
         value = slice_tx_payload(data.tx_rlp);
     }


### PR DESCRIPTION
transactions.seg files have empty words for system transactions. The queries are not encountering them through serializers, because it was only accessing non-empty words by the indexes. Nonetheless, using "seg unzip" command would encounter them and crash.