### PR TITLE
snapshots: optimize BodyTxsAmountQuery using skip

### DIFF
--- a/silkworm/db/snapshots/body_txs_amount_query_test.cpp
+++ b/silkworm/db/snapshots/body_txs_amount_query_test.cpp
@@ -1,0 +1,43 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "body_txs_amount_query.hpp"
+
+#include <catch2/catch.hpp>
+
+#include <silkworm/db/snapshots/test_util/common.hpp>
+#include <silkworm/infra/common/directories.hpp>
+#include <silkworm/infra/common/log.hpp>
+#include <silkworm/infra/test_util/log.hpp>
+
+namespace silkworm::snapshots {
+
+TEST_CASE("BodyTxsAmountQuery") {
+    silkworm::test_util::SetLogVerbosityGuard guard{log::Level::kNone};
+    TemporaryDirectory tmp_dir;
+    test_util::SampleBodySnapshotFile snapshot_file{tmp_dir.path()};
+    test_util::SampleBodySnapshotPath snapshot_path{snapshot_file.path()};
+    Snapshot snapshot{snapshot_path};
+    snapshot.reopen_segment();
+
+    BodyTxsAmountQuery query{snapshot};
+    auto result = query.exec();
+
+    CHECK(result.first_tx_id == 7'341'262);
+    CHECK(result.count == 12);
+}
+
+}  // namespace silkworm::snapshots

--- a/silkworm/db/snapshots/index_builder_test.cpp
+++ b/silkworm/db/snapshots/index_builder_test.cpp
@@ -79,7 +79,7 @@ TEST_CASE("TransactionIndex::build KO: invalid snapshot", "[silkworm][snapshot][
             tmp_dir.path(),
             "v1-015000-015500-bodies.seg",
             test::SnapshotHeader{
-                .words_count = 0,
+                .words_count = 7,
                 .empty_words_count = 0,
                 .patterns = {},
                 .positions = {}},
@@ -147,9 +147,9 @@ TEST_CASE("TransactionIndex::build KO: invalid snapshot", "[silkworm][snapshot][
             tmp_dir.path(),
             "000000000000000e000000000000000000000000000000000000000000000004"
             "0100010801c6837004d980c001c6837004d980c001c6837004d980c001c68370"
-            "04d980c001c6837004d980c001c6837004d980c001c6837004d980c001c78370"  // {01, c7837004d980c0} <- c7 instead of c6
             "04d980c001c6837004d980c001c6837004d980c001c6837004d980c001c68370"
-            "04d980c001c6837004d980c001c6837004d901c0"};
+            "04d980c001c6837004d980c001c6837004d980c001c6837004d980c001c68370"
+            "04d980c001c6837004d980c001c7837004d901c0"};  // {01, c7837004d980c0} <- c7 instead of c6
         test::SampleBodySnapshotPath bodies_snapshot_path{invalid_bodies_snapshot.path()};
         test::SampleTransactionSnapshotFile valid_txs_snapshot{tmp_dir.path()};
         test::SampleTransactionSnapshotPath txs_snapshot_path{valid_txs_snapshot.path()};  // necessary to tweak the block numbers

--- a/silkworm/db/snapshots/snapshot_reader.cpp
+++ b/silkworm/db/snapshots/snapshot_reader.cpp
@@ -59,6 +59,17 @@ Snapshot::Iterator& Snapshot::Iterator::operator++() {
     return *this;
 }
 
+Snapshot::Iterator& Snapshot::Iterator::operator+=(size_t count) {
+    while ((count > 1) && it_.has_next()) {
+        it_.skip();
+        count--;
+    }
+    if (count > 0) {
+        ++*this;
+    }
+    return *this;
+}
+
 bool operator==(const Snapshot::Iterator& lhs, const Snapshot::Iterator& rhs) {
     return (lhs.deserializer_ == rhs.deserializer_) &&
            (!lhs.deserializer_ || (lhs.it_ == rhs.it_));

--- a/silkworm/db/snapshots/snapshot_reader.hpp
+++ b/silkworm/db/snapshots/snapshot_reader.hpp
@@ -63,6 +63,8 @@ class Snapshot {
         Iterator operator++(int) { return std::exchange(*this, ++Iterator{*this}); }
         Iterator& operator++();
 
+        Iterator& operator+=(size_t count);
+
         friend bool operator!=(const Iterator& lhs, const Iterator& rhs) = default;
         friend bool operator==(const Iterator& lhs, const Iterator& rhs);
 
@@ -132,6 +134,11 @@ class SnapshotReader {
         Iterator operator++(int) { return std::exchange(*this, ++Iterator{*this}); }
         Iterator& operator++() {
             ++it_;
+            return *this;
+        }
+
+        Iterator& operator+=(size_t count) {
+            it_ += count;
             return *this;
         }
 


### PR DESCRIPTION
In order to reach the last element of the body snapshot, we did `it++` N times (and deserialize N times).
Instead, do `it.skip()` N-1 times and `it++` once.