### PR TITLE
cmake: silent mismatched-new-delete on gcc

### DIFF
--- a/cmake/compiler_warnings.cmake
+++ b/cmake/compiler_warnings.cmake
@@ -42,6 +42,8 @@ elseif((CMAKE_CXX_COMPILER_ID STREQUAL "GNU") OR ("${CMAKE_CXX_COMPILER_ID}" MAT
       add_compile_options(-Wno-error=maybe-uninitialized)
     endif()
 
+    add_compile_options(-Wno-error=mismatched-new-delete)
+
   elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES ".*Clang$")
     add_compile_options(-Wconversion) # too much noise in gcc
 


### PR DESCRIPTION
RelWithDebInfo compilation fails using default gcc on stable Ubuntu and Debian, because it produces mismatched-new-delete warnings in asio which are treated as errors.

I have looked at upstream issues, but haven't found anything related. This is about the same warning, but different code: https://github.com/chriskohlhoff/asio/issues/1391

Example:
```
/home/ubuntu/silkworm/silkworm/sync/sync_pos.cpp: In member function ‘virtual silkworm::Task<silkworm::rpc::PayloadStatus> silkworm::chainsync::PoSSync:new_payload(const silkworm::rpc::NewPayloadRequest&, std::chrono::milliseconds)’:
/home/ubuntu/silkworm/silkworm/sync/sync_pos.cpp:304:1: warning: ‘static void boost::asio::detail::awaitable_frame_base<Executor>::operator delete(void*, std::size_t) [with Executor = boost::asio::any_io_executor]’ called on pointer returned from a mismatched allocation function [-Wmismatched-new-delete]
  304 | }
      | ^
In function ‘void* boost::asio::aligned_new(std::size_t, std::size_t)’,
    inlined from ‘static void* boost::asio::detail::thread_info_base::allocate(Purpose, boost::asio::detail::thread_info_base*, std::size_t, std::size_t) [with Purpose = awaitable_frame_tag]’ at /home/ubuntu/.conan/data/boost/1.81.0/_/_/package/e418e352ad75a9cbda7a1bb57417b6e933938552/include/boost/asio/detail/thread_info_base.hpp:170:38,
    inlined from ‘static void* boost::asio::detail::awaitable_frame_base<Executor>::operator new(std::size_t) [with Executor = boost::asio::any_io_executor]’ at /home/ubuntu/.conan/data/boost/1.81.0/_/_/package/e418e352ad75a9cbda7a1bb57417b6e933938552/include/boost/asio/impl/awaitable.hpp:86:59,
    inlined from ‘virtual silkworm::Task<silkworm::rpc::PayloadStatus> silkworm::chainsync::PoSSync::new_payload(const silkworm::rpc::NewPayloadRequest&, std::chrono::milliseconds)’ at /home/ubuntu/silkworm/silkworm/sync/sync_pos.cpp:304:1:
/home/ubuntu/.conan/data/boost/1.81.0/_/_/package/e418e352ad75a9cbda7a1bb57417b6e933938552/include/boost/asio/detail/memory.hpp:120:33: note: returned from ‘void* aligned_alloc(size_t, size_t)’
  120 |   void* ptr = std::aligned_alloc(align, size);
      |               ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
```

This happens in a bunch of files working with awaitables.