### PR TITLE
cmake: update conan

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,12 @@ commands:
                 cmake --build ~/build -j16 --target <<parameters.target>>
             fi
 
+  install_conan:
+    steps:
+      - run:
+          name: "Install Conan"
+          command: sudo pip3 install conan==1.64.1 chardet
+
   build_using_conan:
     parameters:
       build_type:
@@ -92,9 +98,7 @@ commands:
         type: string
         default: all
     steps:
-      - run:
-          name: "Install Conan"
-          command: sudo pip3 install conan==1.60.2 chardet
+      - install_conan
       - run:
           name: "Select Conan profile"
           command: |
@@ -130,8 +134,7 @@ commands:
           command: |
             sudo apt-get update
             sudo apt install -y python3-pip
-            sudo pip install conan==1.60.2 chardet
-            sudo apt-get update
+      - install_conan
       - run:
           name: "Install compiler"
           command: cmake/setup/compiler_install.sh clang 15
@@ -378,9 +381,7 @@ jobs:
           command: |
             sudo apt-get update
             sudo apt-get install -y texinfo libtinfo5
-      - run:
-          name: "Install Conan"
-          command: sudo pip3 install conan==1.60.2 chardet
+      - install_conan
       - run:
           name: "Install Wasmer"
           working_directory: ~/tmp2

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Install Prerequisites
       run: |
         brew install gmp
-        pip3 install --user conan==1.60.2 chardet
+        pip3 install --user conan==1.64.1 chardet
         echo "$(python3 -m site --user-base)/bin" >> $GITHUB_PATH
         echo "$($(python3 -m site --user-base)/bin/conan --version)"
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -47,7 +47,7 @@ jobs:
       id: conan
       uses: turtlebrowser/get-conan@main
       with:
-        version: 1.60.2
+        version: 1.64.1
 
     - name: Create Build Environment
       # Some projects don't allow in-source building, so create a separate build directory

--- a/README.md
+++ b/README.md
@@ -90,12 +90,12 @@ or AppleClang ([Xcode](https://developer.apple.com/xcode/) >= 15)
 
 Conan requires Python, and can be installed using:
 
-    pip3 install --user conan==1.60.2 chardet
+    pip3 install --user conan==1.64.1 chardet
 
-and adding its binary to PATH:
+On Linux the conan binary gets installed into `$HOME/.local/bin` which is typically in PATH already.
+On macOS need to add the binary to PATH manually:
 
     export "PATH=$HOME/Library/Python/3.9/bin:$PATH"
-
 
 Once the prerequisites are installed, bootstrap cmake by running
 ```

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -6,7 +6,7 @@ FROM cimg/python:3.12.0 as base
 # 1 Install dependencies
 RUN sudo apt-get update
 RUN sudo apt install -y python3-pip
-RUN sudo pip install conan==1.60.2 chardet
+RUN sudo pip install conan==1.64.1 chardet
 RUN sudo apt-get update
 
 # 2 Get repo and submodules


### PR DESCRIPTION
conan 1.60.2 doesn't work on Ubuntu 24.04 producing an error:

    ModuleNotFoundError: No module named 'imp'

because Ubuntu 24.04 has upgraded to Python 3.12 where imp is deprecated and is turned into importlib. conan 1.60.2 doesn't support Python 3.12.