### PR TITLE
snapshots: refactor SnapshotRepository

### DIFF
--- a/cmd/capi/execute.cpp
+++ b/cmd/capi/execute.cpp
@@ -33,6 +33,7 @@
 #include <silkworm/capi/silkworm.h>
 #include <silkworm/db/access_layer.hpp>
 #include <silkworm/db/mdbx/mdbx.hpp>
+#include <silkworm/db/snapshot_bundle_factory_impl.hpp>
 #include <silkworm/db/snapshots/repository.hpp>
 #include <silkworm/infra/common/directories.hpp>
 #include <silkworm/infra/common/log.hpp>
@@ -436,7 +437,7 @@ int main(int argc, char* argv[]) {
         int status_code = -1;
         if (settings.execute_blocks_settings) {
             // Execute specified block range using Silkworm API library
-            SnapshotRepository repository{snapshot_settings};
+            SnapshotRepository repository{snapshot_settings, std::make_unique<db::SnapshotBundleFactoryImpl>()};
             repository.reopen_folder();
             status_code = execute_blocks(handle, *settings.execute_blocks_settings, repository, data_dir);
         } else if (settings.build_indexes_settings) {

--- a/cmd/capi/execute.cpp
+++ b/cmd/capi/execute.cpp
@@ -150,8 +150,8 @@ std::vector<SilkwormChainSnapshot> collect_all_snapshots(SnapshotRepository& sna
     std::vector<SilkwormBodiesSnapshot> bodies_snapshot_sequence;
     std::vector<SilkwormTransactionsSnapshot> transactions_snapshot_sequence;
 
-    snapshot_repository.view_bundles(
-        [&](const SnapshotBundle& bundle) {
+    for (const SnapshotBundle& bundle : snapshot_repository.view_bundles()) {
+        {
             {
                 SilkwormHeadersSnapshot raw_headers_snapshot{
                     .segment{
@@ -202,8 +202,8 @@ std::vector<SilkwormChainSnapshot> collect_all_snapshots(SnapshotRepository& sna
                 };
                 transactions_snapshot_sequence.push_back(raw_transactions_snapshot);
             }
-            return true;
-        });
+        }
+    }
 
     ensure(headers_snapshot_sequence.size() == snapshot_repository.bundles_count(), "invalid header snapshot count");
     ensure(bodies_snapshot_sequence.size() == snapshot_repository.bundles_count(), "invalid body snapshot count");

--- a/cmd/dev/check_changes.cpp
+++ b/cmd/dev/check_changes.cpp
@@ -25,6 +25,7 @@
 #include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/db/access_layer.hpp>
 #include <silkworm/db/buffer.hpp>
+#include <silkworm/db/snapshot_bundle_factory_impl.hpp>
 #include <silkworm/db/snapshots/repository.hpp>
 #include <silkworm/infra/common/directories.hpp>
 #include <silkworm/infra/common/log.hpp>
@@ -109,7 +110,8 @@ int main(int argc, char* argv[]) {
             throw std::runtime_error("Unable to retrieve chain config");
         }
 
-        snapshots::SnapshotRepository repository;
+        auto snapshot_bundle_factory = std::make_unique<db::SnapshotBundleFactoryImpl>();
+        snapshots::SnapshotRepository repository{snapshots::SnapshotSettings{}, std::move(snapshot_bundle_factory)};
         repository.reopen_folder();
         db::DataModel::set_snapshot_repository(&repository);
         db::DataModel access_layer{txn};

--- a/cmd/dev/snapshots.cpp
+++ b/cmd/dev/snapshots.cpp
@@ -407,7 +407,8 @@ void lookup_header_by_hash(const SnapSettings& settings) {
     std::optional<BlockHeader> matching_header;
     SnapshotRepository snapshot_repository{settings};
     snapshot_repository.reopen_folder();
-    snapshot_repository.view_header_segments([&](SnapshotRepository::SnapshotAndIndex snapshot) -> bool {
+    snapshot_repository.view_bundles([&](const SnapshotBundle& bundle) -> bool {
+        auto snapshot = bundle.snapshot_and_index(SnapshotType::headers);
         const auto header = HeaderFindByHashQuery{snapshot.snapshot, snapshot.index}.exec(*hash);
         if (header) {
             matching_header = header;
@@ -605,7 +606,8 @@ void lookup_txn_by_hash_in_all(const SnapSettings& settings, const Hash& hash) {
 
     std::optional<SnapshotPath> matching_snapshot;
     std::chrono::time_point start{std::chrono::steady_clock::now()};
-    snapshot_repository.view_tx_segments([&](SnapshotRepository::SnapshotAndIndex snapshot) -> bool {
+    snapshot_repository.view_bundles([&](const SnapshotBundle& bundle) -> bool {
+        auto snapshot = bundle.snapshot_and_index(SnapshotType::transactions);
         const auto transaction = TransactionFindByHashQuery{snapshot.snapshot, snapshot.index}.exec(hash);
         if (transaction) {
             matching_snapshot = snapshot.snapshot.path();
@@ -668,7 +670,8 @@ void lookup_txn_by_id_in_all(const SnapSettings& settings, uint64_t txn_id) {
 
     std::optional<SnapshotPath> matching_snapshot;
     std::chrono::time_point start{std::chrono::steady_clock::now()};
-    snapshot_repository.view_tx_segments([&](SnapshotRepository::SnapshotAndIndex snapshot) -> bool {
+    snapshot_repository.view_bundles([&](const SnapshotBundle& bundle) -> bool {
+        auto snapshot = bundle.snapshot_and_index(SnapshotType::transactions);
         const auto transaction = TransactionFindByIdQuery{snapshot.snapshot, snapshot.index}.exec(txn_id);
         if (transaction) {
             matching_snapshot = snapshot.snapshot.path();

--- a/cmd/dev/snapshots.cpp
+++ b/cmd/dev/snapshots.cpp
@@ -435,7 +435,7 @@ void lookup_header_by_number(const SnapSettings& settings) {
 
     SnapshotRepository snapshot_repository{settings};
     snapshot_repository.reopen_folder();
-    const auto header_snapshot{snapshot_repository.find_header_segment(block_number)};
+    const auto header_snapshot = snapshot_repository.find_segment(SnapshotType::headers, block_number);
     if (header_snapshot) {
         const auto header = HeaderFindByBlockNumQuery{header_snapshot->snapshot, header_snapshot->index}.exec(block_number);
         ensure(header.has_value(),
@@ -497,7 +497,7 @@ void lookup_body_in_all(const SnapSettings& settings, BlockNum block_number) {
     snapshot_repository.reopen_folder();
 
     std::chrono::time_point start{std::chrono::steady_clock::now()};
-    const auto body_snapshot{snapshot_repository.find_body_segment(block_number)};
+    const auto body_snapshot = snapshot_repository.find_segment(SnapshotType::bodies, block_number);
     if (body_snapshot) {
         const auto body = BodyFindByBlockNumQuery{body_snapshot->snapshot, body_snapshot->index}.exec(block_number);
         ensure(body.has_value(),

--- a/silkworm/capi/silkworm.cpp
+++ b/silkworm/capi/silkworm.cpp
@@ -34,6 +34,7 @@
 #include <silkworm/core/execution/execution.hpp>
 #include <silkworm/db/access_layer.hpp>
 #include <silkworm/db/buffer.hpp>
+#include <silkworm/db/snapshot_bundle_factory_impl.hpp>
 #include <silkworm/db/snapshots/body_index.hpp>
 #include <silkworm/db/snapshots/header_index.hpp>
 #include <silkworm/db/snapshots/index.hpp>
@@ -206,7 +207,8 @@ SILKWORM_EXPORT int silkworm_init(SilkwormHandle* handle, const struct SilkwormS
     log::init(log_settings);
     log::Info{"Silkworm build info", log_args_for_version()};  // NOLINT(*-unused-raii)
 
-    auto snapshot_repository = std::make_unique<snapshots::SnapshotRepository>();
+    auto snapshot_bundle_factory = std::make_unique<db::SnapshotBundleFactoryImpl>();
+    auto snapshot_repository = std::make_unique<snapshots::SnapshotRepository>(snapshots::SnapshotSettings{}, std::move(snapshot_bundle_factory));
     db::DataModel::set_snapshot_repository(snapshot_repository.get());
 
     // NOLINTNEXTLINE(bugprone-unhandled-exception-at-new)

--- a/silkworm/db/access_layer.cpp
+++ b/silkworm/db/access_layer.cpp
@@ -1251,11 +1251,11 @@ std::optional<BlockHeader> DataModel::read_header_from_snapshot(const Hash& hash
 
     std::optional<BlockHeader> block_header;
     // We don't know the header snapshot in advance: search for block hash in each header snapshot in reverse order
-    repository_->view_bundles([&](const SnapshotBundle& bundle) -> bool {
+    for (const SnapshotBundle& bundle : repository_->view_bundles_reverse()) {
         auto snapshot = bundle.snapshot_and_index(SnapshotType::headers);
         block_header = HeaderFindByHashQuery{snapshot.snapshot, snapshot.index}.exec(hash);
-        return block_header.has_value();
-    });
+        if (block_header) break;
+    }
     return block_header;
 }
 

--- a/silkworm/db/access_layer.cpp
+++ b/silkworm/db/access_layer.cpp
@@ -1367,7 +1367,8 @@ std::optional<BlockNum> DataModel::read_tx_lookup_from_snapshot(const evmc::byte
         return {};
     }
 
-    return repository_->find_block_number(tx_hash);
+    TransactionBlockNumByTxnHashRepoQuery query{repository_->view_bundles_reverse()};
+    return query.exec(tx_hash);
 }
 
 std::optional<intx::uint256> DataModel::read_total_difficulty(BlockNum height, const evmc::bytes32& hash) const {

--- a/silkworm/db/access_layer.cpp
+++ b/silkworm/db/access_layer.cpp
@@ -1251,7 +1251,8 @@ std::optional<BlockHeader> DataModel::read_header_from_snapshot(const Hash& hash
 
     std::optional<BlockHeader> block_header;
     // We don't know the header snapshot in advance: search for block hash in each header snapshot in reverse order
-    repository_->view_header_segments([&](snapshots::SnapshotRepository::SnapshotAndIndex snapshot) -> bool {
+    repository_->view_bundles([&](const SnapshotBundle& bundle) -> bool {
+        auto snapshot = bundle.snapshot_and_index(SnapshotType::headers);
         block_header = HeaderFindByHashQuery{snapshot.snapshot, snapshot.index}.exec(hash);
         return block_header.has_value();
     });

--- a/silkworm/db/access_layer.cpp
+++ b/silkworm/db/access_layer.cpp
@@ -1301,7 +1301,6 @@ bool DataModel::is_body_in_snapshot(BlockNum height) {
 }
 
 bool DataModel::read_transactions_from_snapshot(BlockNum height, uint64_t base_txn_id, uint64_t txn_count, std::vector<Transaction>& txs) {
-    txs.reserve(txn_count);
     if (txn_count == 0) {
         return true;
     }

--- a/silkworm/db/access_layer.cpp
+++ b/silkworm/db/access_layer.cpp
@@ -1237,9 +1237,9 @@ std::optional<BlockHeader> DataModel::read_header_from_snapshot(BlockNum height)
 
     std::optional<BlockHeader> block_header;
     // We know the header snapshot in advance: find it based on target block number
-    const auto header_snapshot = repository_->find_segment(SnapshotType::headers, height);
-    if (header_snapshot) {
-        block_header = HeaderFindByBlockNumQuery{header_snapshot->snapshot, header_snapshot->index}.exec(height);
+    const auto snapshot_and_index = repository_->find_segment(SnapshotType::headers, height);
+    if (snapshot_and_index) {
+        block_header = HeaderFindByBlockNumQuery{*snapshot_and_index}.exec(height);
     }
     return block_header;
 }
@@ -1252,8 +1252,8 @@ std::optional<BlockHeader> DataModel::read_header_from_snapshot(const Hash& hash
     std::optional<BlockHeader> block_header;
     // We don't know the header snapshot in advance: search for block hash in each header snapshot in reverse order
     for (const SnapshotBundle& bundle : repository_->view_bundles_reverse()) {
-        auto snapshot = bundle.snapshot_and_index(SnapshotType::headers);
-        block_header = HeaderFindByHashQuery{snapshot.snapshot, snapshot.index}.exec(hash);
+        auto snapshot_and_index = bundle.snapshot_and_index(SnapshotType::headers);
+        block_header = HeaderFindByHashQuery{snapshot_and_index}.exec(hash);
         if (block_header) break;
     }
     return block_header;
@@ -1265,10 +1265,10 @@ bool DataModel::read_body_from_snapshot(BlockNum height, BlockBody& body) {
     }
 
     // We know the body snapshot in advance: find it based on target block number
-    const auto body_snapshot = repository_->find_segment(SnapshotType::bodies, height);
-    if (!body_snapshot) return false;
+    const auto snapshot_and_index = repository_->find_segment(SnapshotType::bodies, height);
+    if (!snapshot_and_index) return false;
 
-    auto stored_body = BodyFindByBlockNumQuery{body_snapshot->snapshot, body_snapshot->index}.exec(height);
+    auto stored_body = BodyFindByBlockNumQuery{*snapshot_and_index}.exec(height);
     if (!stored_body) return false;
 
     // Skip first and last *system transactions* in block body
@@ -1291,9 +1291,9 @@ bool DataModel::is_body_in_snapshot(BlockNum height) {
     }
 
     // We know the body snapshot in advance: find it based on target block number
-    const auto body_snapshot = repository_->find_segment(SnapshotType::bodies, height);
-    if (body_snapshot) {
-        const auto stored_body = BodyFindByBlockNumQuery{body_snapshot->snapshot, body_snapshot->index}.exec(height);
+    const auto snapshot_and_index = repository_->find_segment(SnapshotType::bodies, height);
+    if (snapshot_and_index) {
+        const auto stored_body = BodyFindByBlockNumQuery{*snapshot_and_index}.exec(height);
         return stored_body.has_value();
     }
 
@@ -1306,18 +1306,18 @@ bool DataModel::read_transactions_from_snapshot(BlockNum height, uint64_t base_t
         return true;
     }
 
-    const auto tx_snapshot = repository_->find_segment(SnapshotType::transactions, height);
-    if (!tx_snapshot) return false;
+    const auto snapshot_and_index = repository_->find_segment(SnapshotType::transactions, height);
+    if (!snapshot_and_index) return false;
 
-    txs = TransactionRangeFromIdQuery{tx_snapshot->snapshot, tx_snapshot->index}.exec_into_vector(base_txn_id, txn_count);
+    txs = TransactionRangeFromIdQuery{*snapshot_and_index}.exec_into_vector(base_txn_id, txn_count);
 
     return true;
 }
 
 bool DataModel::read_rlp_transactions_from_snapshot(BlockNum height, std::vector<Bytes>& rlp_txs) {
-    const auto body_snapshot = repository_->find_segment(SnapshotType::bodies, height);
-    if (body_snapshot) {
-        auto stored_body = BodyFindByBlockNumQuery{body_snapshot->snapshot, body_snapshot->index}.exec(height);
+    const auto body_snapshot_and_index = repository_->find_segment(SnapshotType::bodies, height);
+    if (body_snapshot_and_index) {
+        auto stored_body = BodyFindByBlockNumQuery{*body_snapshot_and_index}.exec(height);
         if (!stored_body) return false;
 
         // Skip first and last *system transactions* in block body
@@ -1326,10 +1326,10 @@ bool DataModel::read_rlp_transactions_from_snapshot(BlockNum height, std::vector
 
         if (txn_count == 0) return true;
 
-        const auto tx_snapshot = repository_->find_segment(SnapshotType::transactions, height);
-        if (!tx_snapshot) return false;
+        const auto tx_snapshot_and_index = repository_->find_segment(SnapshotType::transactions, height);
+        if (!tx_snapshot_and_index) return false;
 
-        rlp_txs = TransactionPayloadRlpRangeFromIdQuery{tx_snapshot->snapshot, tx_snapshot->index}.exec_into_vector(base_txn_id, txn_count);
+        rlp_txs = TransactionPayloadRlpRangeFromIdQuery{*tx_snapshot_and_index}.exec_into_vector(base_txn_id, txn_count);
 
         return true;
     }

--- a/silkworm/db/access_layer.cpp
+++ b/silkworm/db/access_layer.cpp
@@ -1237,7 +1237,7 @@ std::optional<BlockHeader> DataModel::read_header_from_snapshot(BlockNum height)
 
     std::optional<BlockHeader> block_header;
     // We know the header snapshot in advance: find it based on target block number
-    const auto header_snapshot = repository_->find_header_segment(height);
+    const auto header_snapshot = repository_->find_segment(SnapshotType::headers, height);
     if (header_snapshot) {
         block_header = HeaderFindByBlockNumQuery{header_snapshot->snapshot, header_snapshot->index}.exec(height);
     }
@@ -1264,7 +1264,7 @@ bool DataModel::read_body_from_snapshot(BlockNum height, BlockBody& body) {
     }
 
     // We know the body snapshot in advance: find it based on target block number
-    const auto body_snapshot = repository_->find_body_segment(height);
+    const auto body_snapshot = repository_->find_segment(SnapshotType::bodies, height);
     if (!body_snapshot) return false;
 
     auto stored_body = BodyFindByBlockNumQuery{body_snapshot->snapshot, body_snapshot->index}.exec(height);
@@ -1290,7 +1290,7 @@ bool DataModel::is_body_in_snapshot(BlockNum height) {
     }
 
     // We know the body snapshot in advance: find it based on target block number
-    const auto body_snapshot = repository_->find_body_segment(height);
+    const auto body_snapshot = repository_->find_segment(SnapshotType::bodies, height);
     if (body_snapshot) {
         const auto stored_body = BodyFindByBlockNumQuery{body_snapshot->snapshot, body_snapshot->index}.exec(height);
         return stored_body.has_value();
@@ -1305,7 +1305,7 @@ bool DataModel::read_transactions_from_snapshot(BlockNum height, uint64_t base_t
         return true;
     }
 
-    const auto tx_snapshot = repository_->find_tx_segment(height);
+    const auto tx_snapshot = repository_->find_segment(SnapshotType::transactions, height);
     if (!tx_snapshot) return false;
 
     txs = TransactionRangeFromIdQuery{tx_snapshot->snapshot, tx_snapshot->index}.exec_into_vector(base_txn_id, txn_count);
@@ -1314,7 +1314,7 @@ bool DataModel::read_transactions_from_snapshot(BlockNum height, uint64_t base_t
 }
 
 bool DataModel::read_rlp_transactions_from_snapshot(BlockNum height, std::vector<Bytes>& rlp_txs) {
-    const auto body_snapshot = repository_->find_body_segment(height);
+    const auto body_snapshot = repository_->find_segment(SnapshotType::bodies, height);
     if (body_snapshot) {
         auto stored_body = BodyFindByBlockNumQuery{body_snapshot->snapshot, body_snapshot->index}.exec(height);
         if (!stored_body) return false;
@@ -1325,7 +1325,7 @@ bool DataModel::read_rlp_transactions_from_snapshot(BlockNum height, std::vector
 
         if (txn_count == 0) return true;
 
-        const auto tx_snapshot = repository_->find_tx_segment(height);
+        const auto tx_snapshot = repository_->find_segment(SnapshotType::transactions, height);
         if (!tx_snapshot) return false;
 
         rlp_txs = TransactionPayloadRlpRangeFromIdQuery{tx_snapshot->snapshot, tx_snapshot->index}.exec_into_vector(base_txn_id, txn_count);

--- a/silkworm/db/snapshot_benchmark.cpp
+++ b/silkworm/db/snapshot_benchmark.cpp
@@ -17,6 +17,7 @@
 #include <benchmark/benchmark.h>
 
 #include <silkworm/core/common/util.hpp>
+#include <silkworm/db/snapshot_bundle_factory_impl.hpp>
 #include <silkworm/db/snapshots/body_index.hpp>
 #include <silkworm/db/snapshots/header_index.hpp>
 #include <silkworm/db/snapshots/index_builder.hpp>
@@ -68,10 +69,14 @@ static void open_snapshot(benchmark::State& state) {
 }
 BENCHMARK(open_snapshot);
 
+static std::unique_ptr<SnapshotBundleFactory> bundle_factory() {
+    return std::make_unique<db::SnapshotBundleFactoryImpl>();
+}
+
 static void build_header_index(benchmark::State& state) {
     TemporaryDirectory tmp_dir;
     snapshots::SnapshotSettings settings{tmp_dir.path()};
-    snapshots::SnapshotRepository repository{settings};
+    snapshots::SnapshotRepository repository{settings, bundle_factory()};
 
     // These sample snapshot files just contain data for block range [1'500'012, 1'500'013], hence current snapshot
     // file name format is not sufficient to support them (see checks commented out below)
@@ -90,7 +95,7 @@ BENCHMARK(build_header_index);
 static void build_body_index(benchmark::State& state) {
     TemporaryDirectory tmp_dir;
     snapshots::SnapshotSettings settings{tmp_dir.path()};
-    snapshots::SnapshotRepository repository{settings};
+    snapshots::SnapshotRepository repository{settings, bundle_factory()};
 
     // These sample snapshot files just contain data for block range [1'500'012, 1'500'013], hence current snapshot
     // file name format is not sufficient to support them (see checks commented out below)
@@ -107,7 +112,7 @@ BENCHMARK(build_body_index);
 static void build_tx_index(benchmark::State& state) {
     TemporaryDirectory tmp_dir;
     snapshots::SnapshotSettings settings{tmp_dir.path()};
-    snapshots::SnapshotRepository repository{settings};
+    snapshots::SnapshotRepository repository{settings, bundle_factory()};
 
     // These sample snapshot files just contain data for block range [1'500'012, 1'500'013], hence current snapshot
     // file name format is not sufficient to support them (see checks commented out below)
@@ -132,7 +137,7 @@ static void reopen_folder(benchmark::State& state) {
     SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryDirectory tmp_dir;
     snapshots::SnapshotSettings settings{tmp_dir.path()};
-    snapshots::SnapshotRepository repository{settings};
+    snapshots::SnapshotRepository repository{settings, bundle_factory()};
 
     // These sample snapshot files just contain data for block range [1'500'012, 1'500'013], hence current snapshot
     // file name format is not sufficient to support them (see checks commented out below)

--- a/silkworm/db/snapshot_bundle_factory_impl.cpp
+++ b/silkworm/db/snapshot_bundle_factory_impl.cpp
@@ -1,0 +1,64 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "snapshot_bundle_factory_impl.hpp"
+
+#include <cassert>
+
+#include <silkworm/db/snapshots/body_index.hpp>
+#include <silkworm/db/snapshots/header_index.hpp>
+#include <silkworm/db/snapshots/txn_index.hpp>
+#include <silkworm/db/snapshots/txn_to_block_index.hpp>
+
+namespace silkworm::db {
+
+using namespace snapshots;
+
+SnapshotBundle SnapshotBundleFactoryImpl::make(PathByTypeProvider snapshot_path, PathByTypeProvider index_path) const {
+    return SnapshotBundle{
+        .header_snapshot = Snapshot(snapshot_path(SnapshotType::headers)),
+        .idx_header_hash = Index(index_path(SnapshotType::headers)),
+
+        .body_snapshot = Snapshot(snapshot_path(SnapshotType::bodies)),
+        .idx_body_number = Index(index_path(SnapshotType::bodies)),
+
+        .txn_snapshot = Snapshot(snapshot_path(SnapshotType::transactions)),
+        .idx_txn_hash = Index(index_path(SnapshotType::transactions)),
+        .idx_txn_hash_2_block = Index(index_path(SnapshotType::transactions_to_block)),
+    };
+}
+
+std::vector<std::shared_ptr<IndexBuilder>> SnapshotBundleFactoryImpl::index_builders(SnapshotPath seg_file) const {
+    switch (seg_file.type()) {
+        case SnapshotType::headers:
+            return {std::make_shared<IndexBuilder>(HeaderIndex::make(seg_file))};
+        case SnapshotType::bodies:
+            return {std::make_shared<IndexBuilder>(BodyIndex::make(seg_file))};
+        case SnapshotType::transactions: {
+            auto bodies_segment_path = TransactionIndex::bodies_segment_path(seg_file);
+            if (!bodies_segment_path.exists()) return {};
+            return {
+                std::make_shared<IndexBuilder>(TransactionIndex::make(bodies_segment_path, seg_file)),
+                std::make_shared<IndexBuilder>(TransactionToBlockIndex::make(bodies_segment_path, seg_file)),
+            };
+        }
+        default:
+            assert(false);
+            return {};
+    }
+}
+
+}  // namespace silkworm::db

--- a/silkworm/db/snapshot_bundle_factory_impl.hpp
+++ b/silkworm/db/snapshot_bundle_factory_impl.hpp
@@ -1,0 +1,30 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <silkworm/db/snapshots/snapshot_bundle_factory.hpp>
+
+namespace silkworm::db {
+
+struct SnapshotBundleFactoryImpl : public snapshots::SnapshotBundleFactory {
+    ~SnapshotBundleFactoryImpl() override = default;
+
+    snapshots::SnapshotBundle make(PathByTypeProvider snapshot_path, PathByTypeProvider index_path) const override;
+    std::vector<std::shared_ptr<snapshots::IndexBuilder>> index_builders(snapshots::SnapshotPath seg_file) const override;
+};
+
+}  // namespace silkworm::db

--- a/silkworm/db/snapshot_sync.cpp
+++ b/silkworm/db/snapshot_sync.cpp
@@ -25,6 +25,7 @@
 #include <silkworm/core/types/hash.hpp>
 #include <silkworm/db/mdbx/etl_mdbx_collector.hpp>
 #include <silkworm/db/snapshots/config.hpp>
+#include <silkworm/db/snapshots/header_snapshot.hpp>
 #include <silkworm/db/snapshots/index_builder.hpp>
 #include <silkworm/db/snapshots/path.hpp>
 #include <silkworm/db/stages.hpp>
@@ -245,33 +246,35 @@ void SnapshotSync::update_block_headers(db::RWTxn& txn, BlockNum max_block_avail
     db::etl_mdbx::Collector hash2bn_collector{};
     intx::uint256 total_difficulty{0};
     uint64_t block_count{0};
-    repository_->for_each_header([&](const BlockHeader& header) -> bool {
-        SILK_TRACE << "SnapshotSync: header number=" << header.number << " hash=" << Hash{header.hash()}.to_hex();
-        const auto block_number = header.number;
-        if (block_number > max_block_available) return true;
 
-        const auto block_hash = header.hash();
+    for (const SnapshotBundle& bundle : repository_->view_bundles()) {
+        for (const BlockHeader& header : HeaderSnapshotReader{bundle.header_snapshot}) {
+            SILK_TRACE << "SnapshotSync: header number=" << header.number << " hash=" << Hash{header.hash()}.to_hex();
+            const auto block_number = header.number;
+            if (block_number > max_block_available) continue;
 
-        // Write block header into kDifficulty table
-        total_difficulty += header.difficulty;
-        db::write_total_difficulty(txn, block_number, block_hash, total_difficulty);
+            const auto block_hash = header.hash();
 
-        // Write block header into kCanonicalHashes table
-        db::write_canonical_hash(txn, block_number, block_hash);
+            // Write block header into kDifficulty table
+            total_difficulty += header.difficulty;
+            db::write_total_difficulty(txn, block_number, block_hash, total_difficulty);
 
-        // Collect entries for later loading kHeaderNumbers table
-        Bytes block_hash_bytes{block_hash.bytes, kHashLength};
-        Bytes encoded_block_number(sizeof(BlockNum), '\0');
-        endian::store_big_u64(encoded_block_number.data(), block_number);
-        hash2bn_collector.collect({std::move(block_hash_bytes), std::move(encoded_block_number)});
+            // Write block header into kCanonicalHashes table
+            db::write_canonical_hash(txn, block_number, block_hash);
 
-        if (++block_count % 1'000'000 == 0) {
-            SILK_INFO << "SnapshotSync: processing block header=" << block_number << " count=" << block_count;
-            if (is_stopping()) return false;
+            // Collect entries for later loading kHeaderNumbers table
+            Bytes block_hash_bytes{block_hash.bytes, kHashLength};
+            Bytes encoded_block_number(sizeof(BlockNum), '\0');
+            endian::store_big_u64(encoded_block_number.data(), block_number);
+            hash2bn_collector.collect({std::move(block_hash_bytes), std::move(encoded_block_number)});
+
+            if (++block_count % 1'000'000 == 0) {
+                SILK_INFO << "SnapshotSync: processing block header=" << block_number << " count=" << block_count;
+                if (is_stopping()) return;
+            }
         }
+    }
 
-        return true;
-    });
     db::PooledCursor header_numbers_cursor{txn, db::table::kHeaderNumbers};
     hash2bn_collector.load(header_numbers_cursor);
     SILK_INFO << "SnapshotSync: database table HeaderNumbers updated";

--- a/silkworm/db/snapshot_sync.cpp
+++ b/silkworm/db/snapshot_sync.cpp
@@ -298,7 +298,7 @@ void SnapshotSync::update_block_bodies(db::RWTxn& txn, BlockNum max_block_availa
     }
 
     // Reset sequence for kBlockTransactions table
-    const auto tx_snapshot = repository_->find_tx_segment(max_block_available);
+    const auto tx_snapshot = repository_->find_segment(SnapshotType::transactions, max_block_available);
     ensure(tx_snapshot.has_value(), "SnapshotSync: snapshots max block not found in any snapshot");
     const auto last_tx_id = tx_snapshot->index.base_data_id() + tx_snapshot->snapshot.item_count();
     db::reset_map_sequence(txn, db::table::kBlockTransactions.name, last_tx_id + 1);

--- a/silkworm/db/snapshots/basic_queries.hpp
+++ b/silkworm/db/snapshots/basic_queries.hpp
@@ -22,6 +22,7 @@
 #include <silkworm/core/types/hash.hpp>
 
 #include "index.hpp"
+#include "snapshot_and_index.hpp"
 #include "snapshot_reader.hpp"
 
 namespace silkworm::snapshots {
@@ -30,10 +31,9 @@ template <SnapshotReaderConcept TSnapshotReader>
 class BasicQuery {
   public:
     BasicQuery(
-        const Snapshot& snapshot,
-        const Index& index)
-        : reader_{snapshot},
-          index_{index} {}
+        const SnapshotAndIndex snapshot_and_index)
+        : reader_{snapshot_and_index.snapshot},
+          index_{snapshot_and_index.index} {}
 
   protected:
     TSnapshotReader reader_;

--- a/silkworm/db/snapshots/common/iterator/iterator_read_into_vector.hpp
+++ b/silkworm/db/snapshots/common/iterator/iterator_read_into_vector.hpp
@@ -1,0 +1,38 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <algorithm>
+#include <iterator>
+#include <vector>
+
+namespace silkworm {
+
+template <std::input_iterator It>
+void iterator_read_into(It it, size_t count, std::vector<typename It::value_type>& out) {
+    std::copy_n(std::make_move_iterator(std::move(it)), count, std::back_inserter(out));
+}
+
+template <std::input_iterator It>
+std::vector<typename It::value_type> iterator_read_into_vector(It it, size_t count) {
+    std::vector<typename It::value_type> out;
+    out.reserve(count);
+    iterator_read_into(std::move(it), count, out);
+    return out;
+}
+
+}  // namespace silkworm

--- a/silkworm/db/snapshots/common/iterator/map_values_view.hpp
+++ b/silkworm/db/snapshots/common/iterator/map_values_view.hpp
@@ -75,4 +75,14 @@ class MapValuesView : std::ranges::view_interface<MapValuesView<TMapKey, TMapVal
     Iterator end_;
 };
 
+template <typename TMapKey, typename TMapValue>
+auto make_map_values_view(const std::map<TMapKey, TMapValue>& map) {
+    // std::views::values is not present on clang 15
+#if defined(__clang__) && (__clang_major__ <= 15) && !defined(__apple_build_version__)
+    return MapValuesView<TMapKey, TMapValue>{map};
+#else
+    return std::views::values(map);
+#endif
+}
+
 }  // namespace silkworm

--- a/silkworm/db/snapshots/common/iterator/map_values_view.hpp
+++ b/silkworm/db/snapshots/common/iterator/map_values_view.hpp
@@ -1,0 +1,78 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <iterator>
+#include <map>
+#include <ranges>
+#include <utility>
+
+namespace silkworm {
+
+template <typename TMapKey, typename TMapValue>
+class MapValuesView : std::ranges::view_interface<MapValuesView<TMapKey, TMapValue>> {
+  public:
+    using TMap = std::map<TMapKey, TMapValue>;
+
+    class Iterator {
+      public:
+        using value_type = typename TMap::mapped_type;
+        using iterator_category = std::bidirectional_iterator_tag;
+        using difference_type = std::ptrdiff_t;
+        using pointer = const value_type*;
+        using reference = const value_type&;
+
+        Iterator(typename TMap::const_iterator it) : it_(it) {}
+        Iterator() = default;
+
+        reference operator*() const { return it_->second; }
+
+        Iterator operator++(int) { return std::exchange(*this, ++Iterator{*this}); }
+        Iterator& operator++() {
+            ++it_;
+            return *this;
+        }
+
+        Iterator operator--(int) { return std::exchange(*this, --Iterator{*this}); }
+        Iterator& operator--() {
+            --it_;
+            return *this;
+        }
+
+        friend bool operator!=(const Iterator& lhs, const Iterator& rhs) = default;
+        friend bool operator==(const Iterator& lhs, const Iterator& rhs) = default;
+
+      private:
+        typename TMap::const_iterator it_;
+    };
+
+    static_assert(std::bidirectional_iterator<Iterator>);
+
+    MapValuesView(const TMap& map)
+        : begin_(Iterator{map.cbegin()}),
+          end_(Iterator{map.cend()}) {}
+    MapValuesView() = default;
+
+    Iterator begin() const { return begin_; }
+    Iterator end() const { return end_; }
+
+  private:
+    Iterator begin_;
+    Iterator end_;
+};
+
+}  // namespace silkworm

--- a/silkworm/db/snapshots/path.hpp
+++ b/silkworm/db/snapshots/path.hpp
@@ -28,6 +28,8 @@
 #include <silkworm/core/common/base.hpp>
 #include <silkworm/core/types/block.hpp>
 
+#include "snapshot_type.hpp"
+
 namespace silkworm::snapshots {
 
 //! The scale factor to convert the block numbers to/from the values in snapshot file names
@@ -43,16 +45,6 @@ inline constexpr const char* kTorrentExtension{".torrent"};
 inline constexpr const char* kSegmentExtension{".seg"};
 inline constexpr const char* kIdxExtension{".idx"};
 inline constexpr const char* kTmpExtension{".tmp"};
-
-//! The snapshot category corresponding to the snapshot file type
-//! @remark item names do NOT follow Google style to obtain the tag used in file names from magic_enum::enum_name
-//! @see SnapshotPath#build_filename
-enum SnapshotType : uint8_t {
-    headers = 0,
-    bodies = 1,
-    transactions = 2,
-    transactions_to_block = 3,
-};
 
 //! The snapshot version 1 aka v1
 inline constexpr uint8_t kSnapshotV1{1};

--- a/silkworm/db/snapshots/repository.cpp
+++ b/silkworm/db/snapshots/repository.cpp
@@ -158,10 +158,6 @@ std::size_t SnapshotRepository::view_header_segments(const SnapshotWalker& walke
     return view_segments(SnapshotType::headers, walker);
 }
 
-std::size_t SnapshotRepository::view_body_segments(const SnapshotWalker& walker) {
-    return view_segments(SnapshotType::bodies, walker);
-}
-
 std::size_t SnapshotRepository::view_tx_segments(const SnapshotWalker& walker) {
     return view_segments(SnapshotType::transactions, walker);
 }

--- a/silkworm/db/snapshots/repository.cpp
+++ b/silkworm/db/snapshots/repository.cpp
@@ -174,18 +174,6 @@ std::optional<SnapshotRepository::SnapshotAndIndex> SnapshotRepository::find_seg
     return std::nullopt;
 }
 
-std::optional<SnapshotRepository::SnapshotAndIndex> SnapshotRepository::find_header_segment(BlockNum number) const {
-    return find_segment(SnapshotType::headers, number);
-}
-
-std::optional<SnapshotRepository::SnapshotAndIndex> SnapshotRepository::find_body_segment(BlockNum number) const {
-    return find_segment(SnapshotType::bodies, number);
-}
-
-std::optional<SnapshotRepository::SnapshotAndIndex> SnapshotRepository::find_tx_segment(BlockNum number) const {
-    return find_segment(SnapshotType::transactions, number);
-}
-
 std::optional<BlockNum> SnapshotRepository::find_block_number(Hash txn_hash) const {
     for (const auto& entry : std::ranges::reverse_view(bundles_)) {
         const auto& bundle = entry.second;

--- a/silkworm/db/snapshots/repository.cpp
+++ b/silkworm/db/snapshots/repository.cpp
@@ -20,12 +20,8 @@
 #include <cassert>
 #include <iterator>
 
-#include <silkworm/core/common/assert.hpp>
 #include <silkworm/db/snapshots/body_index.hpp>
-#include <silkworm/db/snapshots/body_snapshot.hpp>
 #include <silkworm/db/snapshots/header_index.hpp>
-#include <silkworm/db/snapshots/header_snapshot.hpp>
-#include <silkworm/db/snapshots/index_builder.hpp>
 #include <silkworm/db/snapshots/txn_index.hpp>
 #include <silkworm/db/snapshots/txn_queries.hpp>
 #include <silkworm/db/snapshots/txn_to_block_index.hpp>
@@ -102,36 +98,6 @@ std::vector<BlockNumRange> SnapshotRepository::missing_block_ranges() const {
     return missing_ranges;
 }
 
-bool SnapshotRepository::for_each_header(const HeaderWalker& fn) {
-    for (const auto& bundle : this->view_bundles()) {
-        const Snapshot& header_snapshot = bundle.header_snapshot;
-        SILK_TRACE << "for_each_header header_snapshot: " << header_snapshot.fs_path().string();
-
-        HeaderSnapshotReader reader{header_snapshot};
-        for (auto& header : reader) {
-            const bool keep_going = fn(header);
-            if (!keep_going) return false;
-        }
-    }
-    return true;
-}
-
-bool SnapshotRepository::for_each_body(const BodyWalker& fn) {
-    for (const auto& bundle : this->view_bundles()) {
-        const Snapshot& body_snapshot = bundle.body_snapshot;
-        SILK_TRACE << "for_each_body body_snapshot: " << body_snapshot.fs_path().string();
-
-        BlockNum number = body_snapshot.block_from();
-        BodySnapshotReader reader{body_snapshot};
-        for (auto& body : reader) {
-            const bool keep_going = fn(number, body);
-            if (!keep_going) return false;
-            number++;
-        }
-    }
-    return true;
-}
-
 std::optional<SnapshotAndIndex> SnapshotRepository::find_segment(SnapshotType type, BlockNum number) const {
     auto bundle = find_bundle(number);
     if (bundle) {
@@ -190,7 +156,7 @@ std::vector<std::shared_ptr<IndexBuilder>> SnapshotRepository::missing_indexes()
                 break;
             }
             default: {
-                SILKWORM_ASSERT(false);
+                assert(false);
             }
         }
     }

--- a/silkworm/db/snapshots/repository.cpp
+++ b/silkworm/db/snapshots/repository.cpp
@@ -37,17 +37,14 @@ namespace silkworm::snapshots {
 
 namespace fs = std::filesystem;
 
-std::size_t SnapshotRepository::view_bundles(const SnapshotBundleWalker& walker) {
+void SnapshotRepository::view_bundles(const SnapshotBundleWalker& walker) {
     // Search for target segment in reverse order (from the newest segment to the oldest one)
-    std::size_t visited_views{0};
     bool walk_done{false};
     for (auto& entry : std::ranges::reverse_view(bundles_)) {
         const auto& bundle = entry.second;
         walk_done = walker(bundle);
-        ++visited_views;
         if (walk_done) break;
     }
-    return visited_views;
 }
 
 // NOLINTNEXTLINE(modernize-pass-by-value)

--- a/silkworm/db/snapshots/repository.cpp
+++ b/silkworm/db/snapshots/repository.cpp
@@ -23,7 +23,6 @@
 #include <silkworm/db/snapshots/body_index.hpp>
 #include <silkworm/db/snapshots/header_index.hpp>
 #include <silkworm/db/snapshots/txn_index.hpp>
-#include <silkworm/db/snapshots/txn_queries.hpp>
 #include <silkworm/db/snapshots/txn_to_block_index.hpp>
 #include <silkworm/infra/common/ensure.hpp>
 #include <silkworm/infra/common/log.hpp>
@@ -104,20 +103,6 @@ std::optional<SnapshotAndIndex> SnapshotRepository::find_segment(SnapshotType ty
         return bundle->snapshot_and_index(type);
     }
     return std::nullopt;
-}
-
-std::optional<BlockNum> SnapshotRepository::find_block_number(Hash txn_hash) const {
-    for (const auto& bundle : this->view_bundles_reverse()) {
-        const auto& snapshot = bundle.txn_snapshot;
-
-        const Index& idx_txn_hash = bundle.idx_txn_hash;
-        const Index& idx_txn_hash_2_block = bundle.idx_txn_hash_2_block;
-        auto block = TransactionBlockNumByTxnHashQuery{idx_txn_hash_2_block, TransactionFindByHashQuery{snapshot, idx_txn_hash}}.exec(txn_hash);
-        if (block) {
-            return block;
-        }
-    }
-    return {};
 }
 
 std::vector<std::shared_ptr<IndexBuilder>> SnapshotRepository::missing_indexes() const {

--- a/silkworm/db/snapshots/repository.cpp
+++ b/silkworm/db/snapshots/repository.cpp
@@ -148,24 +148,10 @@ bool SnapshotRepository::for_each_body(const BodyWalker& fn) {
     return true;
 }
 
-std::size_t SnapshotRepository::view_segments(SnapshotType type, const SnapshotWalker& walker) {
-    return view_bundles([&](const SnapshotBundle& bundle) {
-        return walker({bundle.snapshot(type), bundle.index(type)});
-    });
-}
-
-std::size_t SnapshotRepository::view_header_segments(const SnapshotWalker& walker) {
-    return view_segments(SnapshotType::headers, walker);
-}
-
-std::size_t SnapshotRepository::view_tx_segments(const SnapshotWalker& walker) {
-    return view_segments(SnapshotType::transactions, walker);
-}
-
-std::optional<SnapshotRepository::SnapshotAndIndex> SnapshotRepository::find_segment(SnapshotType type, BlockNum number) const {
+std::optional<SnapshotAndIndex> SnapshotRepository::find_segment(SnapshotType type, BlockNum number) const {
     auto bundle = find_bundle(number);
     if (bundle) {
-        return SnapshotAndIndex{bundle->snapshot(type), bundle->index(type)};
+        return bundle->snapshot_and_index(type);
     }
     return std::nullopt;
 }

--- a/silkworm/db/snapshots/repository.hpp
+++ b/silkworm/db/snapshots/repository.hpp
@@ -68,8 +68,8 @@ class SnapshotRepository {
     [[nodiscard]] std::vector<std::shared_ptr<IndexBuilder>> missing_indexes() const;
     void remove_stale_indexes() const;
 
-    MapValuesView<BlockNum, SnapshotBundle> view_bundles() const { return MapValuesView{bundles_}; }
-    auto view_bundles_reverse() const { return std::ranges::reverse_view(MapValuesView{bundles_}); }
+    auto view_bundles() const { return make_map_values_view(bundles_); }
+    auto view_bundles_reverse() const { return std::ranges::reverse_view(view_bundles()); }
 
     [[nodiscard]] std::optional<SnapshotAndIndex> find_segment(SnapshotType type, BlockNum number) const;
 

--- a/silkworm/db/snapshots/repository.hpp
+++ b/silkworm/db/snapshots/repository.hpp
@@ -16,8 +16,6 @@
 
 #pragma once
 
-#include <array>
-#include <cassert>
 #include <filesystem>
 #include <functional>
 #include <optional>
@@ -30,83 +28,12 @@
 #include <silkworm/db/snapshots/index.hpp>
 #include <silkworm/db/snapshots/path.hpp>
 #include <silkworm/db/snapshots/settings.hpp>
+#include <silkworm/db/snapshots/snapshot_bundle.hpp>
 #include <silkworm/db/snapshots/snapshot_reader.hpp>
 
 namespace silkworm::snapshots {
 
 struct IndexBuilder;
-
-struct SnapshotBundle {
-    Snapshot header_snapshot;
-    //! Index header_hash -> block_num -> headers_segment_offset
-    Index idx_header_hash;
-
-    Snapshot body_snapshot;
-    //! Index block_num -> bodies_segment_offset
-    Index idx_body_number;
-
-    Snapshot txn_snapshot;
-    //! Index transaction_hash -> txn_id -> transactions_segment_offset
-    Index idx_txn_hash;
-    //! Index transaction_hash -> block_num
-    Index idx_txn_hash_2_block;
-
-    static constexpr size_t kSnapshotsCount = 3;
-    static constexpr size_t kIndexesCount = 4;
-
-    std::array<std::reference_wrapper<Snapshot>, kSnapshotsCount> snapshots() {
-        return {
-            header_snapshot,
-            body_snapshot,
-            txn_snapshot,
-        };
-    }
-
-    std::array<std::reference_wrapper<Index>, kIndexesCount> indexes() {
-        return {
-            idx_header_hash,
-            idx_body_number,
-            idx_txn_hash,
-            idx_txn_hash_2_block,
-        };
-    }
-
-    const Snapshot& snapshot(SnapshotType type) const {
-        switch (type) {
-            case headers:
-                return header_snapshot;
-            case bodies:
-                return body_snapshot;
-            case transactions:
-            case transactions_to_block:
-                return txn_snapshot;
-        }
-        assert(false);
-        return header_snapshot;
-    }
-
-    const Index& index(SnapshotType type) const {
-        switch (type) {
-            case headers:
-                return idx_header_hash;
-            case bodies:
-                return idx_body_number;
-            case transactions:
-                return idx_txn_hash;
-            case transactions_to_block:
-                return idx_txn_hash_2_block;
-        }
-        assert(false);
-        return idx_header_hash;
-    }
-
-    // assume that all snapshots have the same block range, and use one of them
-    BlockNum block_from() const { return header_snapshot.block_from(); }
-    BlockNum block_to() const { return header_snapshot.block_to(); }
-
-    void reopen();
-    void close();
-};
 
 //! Read-only repository for all snapshot files.
 //! @details Some simplifications are currently in place:

--- a/silkworm/db/snapshots/repository.hpp
+++ b/silkworm/db/snapshots/repository.hpp
@@ -32,6 +32,7 @@
 #include <silkworm/db/snapshots/settings.hpp>
 #include <silkworm/db/snapshots/snapshot_and_index.hpp>
 #include <silkworm/db/snapshots/snapshot_bundle.hpp>
+#include <silkworm/db/snapshots/snapshot_bundle_factory.hpp>
 
 namespace silkworm::snapshots {
 
@@ -45,7 +46,9 @@ struct IndexBuilder;
 //! - segments have [from:to) semantic
 class SnapshotRepository {
   public:
-    explicit SnapshotRepository(const SnapshotSettings& settings = {});
+    explicit SnapshotRepository(
+        SnapshotSettings settings,
+        std::unique_ptr<SnapshotBundleFactory> bundle_factory);
     ~SnapshotRepository();
 
     [[nodiscard]] const SnapshotSettings& settings() const { return settings_; }
@@ -90,6 +93,9 @@ class SnapshotRepository {
 
     //! The configuration settings for snapshots
     SnapshotSettings settings_;
+
+    //! SnapshotBundle factory
+    std::unique_ptr<SnapshotBundleFactory> bundle_factory_;
 
     //! Full snapshot bundles ordered by block_from
     std::map<BlockNum, SnapshotBundle> bundles_;

--- a/silkworm/db/snapshots/repository.hpp
+++ b/silkworm/db/snapshots/repository.hpp
@@ -77,7 +77,6 @@ class SnapshotRepository {
     std::size_t view_bundles(const SnapshotBundleWalker& walker);
 
     std::size_t view_header_segments(const SnapshotWalker& walker);
-    std::size_t view_body_segments(const SnapshotWalker& walker);
     std::size_t view_tx_segments(const SnapshotWalker& walker);
 
     [[nodiscard]] std::optional<SnapshotRepository::SnapshotAndIndex> find_segment(SnapshotType type, BlockNum number) const;

--- a/silkworm/db/snapshots/repository.hpp
+++ b/silkworm/db/snapshots/repository.hpp
@@ -26,7 +26,6 @@
 #include <vector>
 
 #include <silkworm/core/common/base.hpp>
-#include <silkworm/core/types/hash.hpp>
 #include <silkworm/db/snapshots/common/iterator/map_values_view.hpp>
 #include <silkworm/db/snapshots/index_builder.hpp>
 #include <silkworm/db/snapshots/path.hpp>
@@ -73,8 +72,6 @@ class SnapshotRepository {
     auto view_bundles_reverse() const { return std::ranges::reverse_view(MapValuesView{bundles_}); }
 
     [[nodiscard]] std::optional<SnapshotAndIndex> find_segment(SnapshotType type, BlockNum number) const;
-
-    [[nodiscard]] std::optional<BlockNum> find_block_number(Hash txn_hash) const;
 
   private:
     const SnapshotBundle* find_bundle(BlockNum number) const;

--- a/silkworm/db/snapshots/repository.hpp
+++ b/silkworm/db/snapshots/repository.hpp
@@ -18,20 +18,21 @@
 
 #include <filesystem>
 #include <functional>
+#include <map>
+#include <memory>
 #include <optional>
 #include <ranges>
 #include <string>
 #include <vector>
 
 #include <silkworm/core/common/base.hpp>
-#include <silkworm/core/types/block.hpp>
-#include <silkworm/core/types/block_body_for_storage.hpp>
+#include <silkworm/core/types/hash.hpp>
 #include <silkworm/db/snapshots/common/iterator/map_values_view.hpp>
-#include <silkworm/db/snapshots/index.hpp>
+#include <silkworm/db/snapshots/index_builder.hpp>
 #include <silkworm/db/snapshots/path.hpp>
 #include <silkworm/db/snapshots/settings.hpp>
+#include <silkworm/db/snapshots/snapshot_and_index.hpp>
 #include <silkworm/db/snapshots/snapshot_bundle.hpp>
-#include <silkworm/db/snapshots/snapshot_reader.hpp>
 
 namespace silkworm::snapshots {
 
@@ -72,12 +73,6 @@ class SnapshotRepository {
     auto view_bundles_reverse() const { return std::ranges::reverse_view(MapValuesView{bundles_}); }
 
     [[nodiscard]] std::optional<SnapshotAndIndex> find_segment(SnapshotType type, BlockNum number) const;
-
-    using HeaderWalker = std::function<bool(const BlockHeader& header)>;
-    bool for_each_header(const HeaderWalker& fn);
-
-    using BodyWalker = std::function<bool(BlockNum number, const BlockBodyForStorage& body)>;
-    bool for_each_body(const BodyWalker& fn);
 
     [[nodiscard]] std::optional<BlockNum> find_block_number(Hash txn_hash) const;
 

--- a/silkworm/db/snapshots/repository.hpp
+++ b/silkworm/db/snapshots/repository.hpp
@@ -19,12 +19,14 @@
 #include <filesystem>
 #include <functional>
 #include <optional>
+#include <ranges>
 #include <string>
 #include <vector>
 
 #include <silkworm/core/common/base.hpp>
 #include <silkworm/core/types/block.hpp>
 #include <silkworm/core/types/block_body_for_storage.hpp>
+#include <silkworm/db/snapshots/common/iterator/map_values_view.hpp>
 #include <silkworm/db/snapshots/index.hpp>
 #include <silkworm/db/snapshots/path.hpp>
 #include <silkworm/db/snapshots/settings.hpp>
@@ -66,8 +68,8 @@ class SnapshotRepository {
     [[nodiscard]] std::vector<std::shared_ptr<IndexBuilder>> missing_indexes() const;
     void remove_stale_indexes() const;
 
-    using SnapshotBundleWalker = std::function<bool(const SnapshotBundle& bundle)>;
-    void view_bundles(const SnapshotBundleWalker& walker);
+    MapValuesView<BlockNum, SnapshotBundle> view_bundles() const { return MapValuesView{bundles_}; }
+    auto view_bundles_reverse() const { return std::ranges::reverse_view(MapValuesView{bundles_}); }
 
     [[nodiscard]] std::optional<SnapshotAndIndex> find_segment(SnapshotType type, BlockNum number) const;
 

--- a/silkworm/db/snapshots/repository.hpp
+++ b/silkworm/db/snapshots/repository.hpp
@@ -67,7 +67,7 @@ class SnapshotRepository {
     void remove_stale_indexes() const;
 
     using SnapshotBundleWalker = std::function<bool(const SnapshotBundle& bundle)>;
-    std::size_t view_bundles(const SnapshotBundleWalker& walker);
+    void view_bundles(const SnapshotBundleWalker& walker);
 
     [[nodiscard]] std::optional<SnapshotAndIndex> find_segment(SnapshotType type, BlockNum number) const;
 

--- a/silkworm/db/snapshots/repository.hpp
+++ b/silkworm/db/snapshots/repository.hpp
@@ -80,9 +80,7 @@ class SnapshotRepository {
     std::size_t view_body_segments(const SnapshotWalker& walker);
     std::size_t view_tx_segments(const SnapshotWalker& walker);
 
-    [[nodiscard]] std::optional<SnapshotAndIndex> find_header_segment(BlockNum number) const;
-    [[nodiscard]] std::optional<SnapshotAndIndex> find_body_segment(BlockNum number) const;
-    [[nodiscard]] std::optional<SnapshotAndIndex> find_tx_segment(BlockNum number) const;
+    [[nodiscard]] std::optional<SnapshotRepository::SnapshotAndIndex> find_segment(SnapshotType type, BlockNum number) const;
 
     using HeaderWalker = std::function<bool(const BlockHeader& header)>;
     bool for_each_header(const HeaderWalker& fn);
@@ -95,7 +93,6 @@ class SnapshotRepository {
   private:
     std::size_t view_segments(SnapshotType type, const SnapshotWalker& walker);
     const SnapshotBundle* find_bundle(BlockNum number) const;
-    std::optional<SnapshotRepository::SnapshotAndIndex> find_segment(SnapshotType type, BlockNum number) const;
 
     [[nodiscard]] SnapshotPathList get_segment_files() const {
         return get_files(kSegmentExtension);

--- a/silkworm/db/snapshots/repository.hpp
+++ b/silkworm/db/snapshots/repository.hpp
@@ -66,20 +66,10 @@ class SnapshotRepository {
     [[nodiscard]] std::vector<std::shared_ptr<IndexBuilder>> missing_indexes() const;
     void remove_stale_indexes() const;
 
-    struct SnapshotAndIndex {
-        const Snapshot& snapshot;
-        const Index& index;
-    };
-
-    using SnapshotWalker = std::function<bool(SnapshotAndIndex result)>;
-
     using SnapshotBundleWalker = std::function<bool(const SnapshotBundle& bundle)>;
     std::size_t view_bundles(const SnapshotBundleWalker& walker);
 
-    std::size_t view_header_segments(const SnapshotWalker& walker);
-    std::size_t view_tx_segments(const SnapshotWalker& walker);
-
-    [[nodiscard]] std::optional<SnapshotRepository::SnapshotAndIndex> find_segment(SnapshotType type, BlockNum number) const;
+    [[nodiscard]] std::optional<SnapshotAndIndex> find_segment(SnapshotType type, BlockNum number) const;
 
     using HeaderWalker = std::function<bool(const BlockHeader& header)>;
     bool for_each_header(const HeaderWalker& fn);
@@ -90,7 +80,6 @@ class SnapshotRepository {
     [[nodiscard]] std::optional<BlockNum> find_block_number(Hash txn_hash) const;
 
   private:
-    std::size_t view_segments(SnapshotType type, const SnapshotWalker& walker);
     const SnapshotBundle* find_bundle(BlockNum number) const;
 
     [[nodiscard]] SnapshotPathList get_segment_files() const {

--- a/silkworm/db/snapshots/repository_test.cpp
+++ b/silkworm/db/snapshots/repository_test.cpp
@@ -26,6 +26,7 @@
 #include <silkworm/db/snapshots/index_builder.hpp>
 #include <silkworm/db/snapshots/test_util/common.hpp>
 #include <silkworm/db/snapshots/txn_index.hpp>
+#include <silkworm/db/snapshots/txn_queries.hpp>
 #include <silkworm/db/snapshots/txn_to_block_index.hpp>
 #include <silkworm/infra/common/directories.hpp>
 #include <silkworm/infra/common/log.hpp>
@@ -236,18 +237,20 @@ TEST_CASE("SnapshotRepository::find_block_number", "[silkworm][node][snapshot]")
 
     REQUIRE_NOTHROW(repository.reopen_folder());
 
+    TransactionBlockNumByTxnHashRepoQuery query{repository.view_bundles_reverse()};
+
     // known block 1'500'012 txn hash
-    auto block_number = repository.find_block_number(silkworm::Hash{from_hex("0x2224c39c930355233f11414e9f216f381c1f6b0c32fc77b192128571c2dc9eb9").value()});
+    auto block_number = query.exec(silkworm::Hash{from_hex("0x2224c39c930355233f11414e9f216f381c1f6b0c32fc77b192128571c2dc9eb9").value()});
     CHECK(block_number.has_value());
     CHECK(block_number.value() == 1'500'012);
 
     // known block 1'500'012 txn hash
-    block_number = repository.find_block_number(silkworm::Hash{from_hex("0x3ba9a1f95b96d0a43093b1ade1174133ea88ca395e60fe9fd8144098ff7a441f").value()});
+    block_number = query.exec(silkworm::Hash{from_hex("0x3ba9a1f95b96d0a43093b1ade1174133ea88ca395e60fe9fd8144098ff7a441f").value()});
     CHECK(block_number.has_value());
     CHECK(block_number.value() == 1'500'013);
 
     // unknown txn hash
-    block_number = repository.find_block_number(silkworm::Hash{from_hex("0x0000000000000000000000000000000000000000000000000000000000000000").value()});
+    block_number = query.exec(silkworm::Hash{from_hex("0x0000000000000000000000000000000000000000000000000000000000000000").value()});
     // CHECK_FALSE(block_number.has_value());  // needs correct key check in index
 }
 

--- a/silkworm/db/snapshots/repository_test.cpp
+++ b/silkworm/db/snapshots/repository_test.cpp
@@ -244,8 +244,7 @@ TEST_CASE("SnapshotRepository::find_block_number", "[silkworm][node][snapshot]")
     // CHECK_FALSE(block_number.has_value());  // needs correct key check in index
 }
 
-template <class Rep, class Period>
-static auto move_last_write_time(const std::filesystem::path& p, const std::chrono::duration<Rep, Period>& d) {
+static auto move_last_write_time(const std::filesystem::path& p, const std::filesystem::file_time_type::duration& d) {
     const auto ftime = std::filesystem::last_write_time(p);
     std::filesystem::last_write_time(p, ftime + d);
     return std::filesystem::last_write_time(p) - ftime;
@@ -274,7 +273,7 @@ TEST_CASE("SnapshotRepository::remove_stale_indexes", "[silkworm][node][snapshot
 
     // move the snapshot last write time 1 hour to the future to make its index "stale"
     const auto last_write_time_diff = move_last_write_time(header_snapshot_path.path(), 1h);
-    CHECK(last_write_time_diff > std::filesystem::file_time_type::duration::zero());
+    CHECK(last_write_time_diff.count() > 0);
 
     // the index is stale
     repository.remove_stale_indexes();

--- a/silkworm/db/snapshots/repository_test.cpp
+++ b/silkworm/db/snapshots/repository_test.cpp
@@ -72,7 +72,6 @@ TEST_CASE("SnapshotRepository::view", "[silkworm][node][snapshot]") {
         CHECK_FALSE(repository.find_segment(SnapshotType::transactions, 15'000'000));
 
         CHECK(repository.view_header_segments(successful_walk) == 0);
-        CHECK(repository.view_body_segments(successful_walk) == 0);
         CHECK(repository.view_tx_segments(successful_walk) == 0);
 
         CHECK_FALSE(repository.find_segment(SnapshotType::headers, 14'500'000));
@@ -91,7 +90,6 @@ TEST_CASE("SnapshotRepository::view", "[silkworm][node][snapshot]") {
         CHECK_FALSE(repository.find_segment(SnapshotType::transactions, 15'000'000));
 
         CHECK(repository.view_header_segments(successful_walk) == 0);  // empty snapshots are ignored by repository
-        CHECK(repository.view_body_segments(successful_walk) == 0);    // empty snapshots are ignored by repository
         CHECK(repository.view_tx_segments(successful_walk) == 0);      // empty snapshots are ignored by repository
 
         CHECK_FALSE(repository.find_segment(SnapshotType::headers, 14'500'000));
@@ -111,7 +109,6 @@ TEST_CASE("SnapshotRepository::view", "[silkworm][node][snapshot]") {
         repository.reopen_folder();
 
         CHECK(repository.view_header_segments(failing_walk) == 1);
-        CHECK(repository.view_body_segments(failing_walk) == 1);
         CHECK(repository.view_tx_segments(failing_walk) == 1);
 
         CHECK(repository.find_segment(SnapshotType::headers, 1'500'000).has_value());
@@ -119,7 +116,6 @@ TEST_CASE("SnapshotRepository::view", "[silkworm][node][snapshot]") {
         CHECK(repository.find_segment(SnapshotType::transactions, 1'500'000).has_value());
 
         CHECK(repository.view_header_segments(successful_walk) == 1);
-        CHECK(repository.view_body_segments(successful_walk) == 1);
         CHECK(repository.view_tx_segments(successful_walk) == 1);
     }
 }

--- a/silkworm/db/snapshots/repository_test.cpp
+++ b/silkworm/db/snapshots/repository_test.cpp
@@ -70,10 +70,9 @@ TEST_CASE("SnapshotRepository::view", "[silkworm][node][snapshot]") {
         CHECK_FALSE(repository.find_segment(SnapshotType::transactions, 15'000'000));
 
         size_t bundles_count = 0;
-        repository.view_bundles([&](const SnapshotBundle&) -> bool {
+        for ([[maybe_unused]] const auto& bundle : repository.view_bundles()) {
             bundles_count++;
-            return true;
-        });
+        }
         CHECK(bundles_count == 0);
 
         CHECK_FALSE(repository.find_segment(SnapshotType::headers, 14'500'000));
@@ -92,10 +91,9 @@ TEST_CASE("SnapshotRepository::view", "[silkworm][node][snapshot]") {
         CHECK_FALSE(repository.find_segment(SnapshotType::transactions, 15'000'000));
 
         size_t bundles_count = 0;
-        repository.view_bundles([&](const SnapshotBundle&) -> bool {
+        for ([[maybe_unused]] const auto& bundle : repository.view_bundles()) {
             bundles_count++;
-            return true;
-        });
+        }
         // empty snapshots are ignored by repository
         CHECK(bundles_count == 0);
 
@@ -116,10 +114,9 @@ TEST_CASE("SnapshotRepository::view", "[silkworm][node][snapshot]") {
         repository.reopen_folder();
 
         size_t bundles_count = 0;
-        repository.view_bundles([&](const SnapshotBundle&) -> bool {
+        for ([[maybe_unused]] const auto& bundle : repository.view_bundles()) {
             bundles_count++;
-            return false;
-        });
+        }
         CHECK(bundles_count == 1);
 
         CHECK(repository.find_segment(SnapshotType::headers, 1'500'000).has_value());
@@ -127,10 +124,9 @@ TEST_CASE("SnapshotRepository::view", "[silkworm][node][snapshot]") {
         CHECK(repository.find_segment(SnapshotType::transactions, 1'500'000).has_value());
 
         bundles_count = 0;
-        repository.view_bundles([&](const SnapshotBundle&) -> bool {
+        for ([[maybe_unused]] const auto& bundle : repository.view_bundles()) {
             bundles_count++;
-            return true;
-        });
+        }
         CHECK(bundles_count == 1);
     }
 }

--- a/silkworm/db/snapshots/repository_test.cpp
+++ b/silkworm/db/snapshots/repository_test.cpp
@@ -71,8 +71,7 @@ TEST_CASE("SnapshotRepository::view", "[silkworm][node][snapshot]") {
         CHECK_FALSE(repository.find_segment(SnapshotType::bodies, 11'500'000));
         CHECK_FALSE(repository.find_segment(SnapshotType::transactions, 15'000'000));
 
-        CHECK(repository.view_header_segments(successful_walk) == 0);
-        CHECK(repository.view_tx_segments(successful_walk) == 0);
+        CHECK(repository.view_bundles(successful_walk) == 0);
 
         CHECK_FALSE(repository.find_segment(SnapshotType::headers, 14'500'000));
         CHECK_FALSE(repository.find_segment(SnapshotType::bodies, 11'500'000));
@@ -89,8 +88,7 @@ TEST_CASE("SnapshotRepository::view", "[silkworm][node][snapshot]") {
         CHECK_FALSE(repository.find_segment(SnapshotType::bodies, 11'500'000));
         CHECK_FALSE(repository.find_segment(SnapshotType::transactions, 15'000'000));
 
-        CHECK(repository.view_header_segments(successful_walk) == 0);  // empty snapshots are ignored by repository
-        CHECK(repository.view_tx_segments(successful_walk) == 0);      // empty snapshots are ignored by repository
+        CHECK(repository.view_bundles(successful_walk) == 0);  // empty snapshots are ignored by repository
 
         CHECK_FALSE(repository.find_segment(SnapshotType::headers, 14'500'000));
         CHECK_FALSE(repository.find_segment(SnapshotType::bodies, 11'500'000));
@@ -108,15 +106,13 @@ TEST_CASE("SnapshotRepository::view", "[silkworm][node][snapshot]") {
 
         repository.reopen_folder();
 
-        CHECK(repository.view_header_segments(failing_walk) == 1);
-        CHECK(repository.view_tx_segments(failing_walk) == 1);
+        CHECK(repository.view_bundles(failing_walk) == 1);
 
         CHECK(repository.find_segment(SnapshotType::headers, 1'500'000).has_value());
         CHECK(repository.find_segment(SnapshotType::bodies, 1'500'000).has_value());
         CHECK(repository.find_segment(SnapshotType::transactions, 1'500'000).has_value());
 
-        CHECK(repository.view_header_segments(successful_walk) == 1);
-        CHECK(repository.view_tx_segments(successful_walk) == 1);
+        CHECK(repository.view_bundles(successful_walk) == 1);
     }
 }
 

--- a/silkworm/db/snapshots/repository_test.cpp
+++ b/silkworm/db/snapshots/repository_test.cpp
@@ -67,17 +67,17 @@ TEST_CASE("SnapshotRepository::view", "[silkworm][node][snapshot]") {
     SECTION("no snapshots") {
         repository.reopen_folder();
 
-        CHECK_FALSE(repository.find_header_segment(14'500'000));
-        CHECK_FALSE(repository.find_body_segment(11'500'000));
-        CHECK_FALSE(repository.find_tx_segment(15'000'000));
+        CHECK_FALSE(repository.find_segment(SnapshotType::headers, 14'500'000));
+        CHECK_FALSE(repository.find_segment(SnapshotType::bodies, 11'500'000));
+        CHECK_FALSE(repository.find_segment(SnapshotType::transactions, 15'000'000));
 
         CHECK(repository.view_header_segments(successful_walk) == 0);
         CHECK(repository.view_body_segments(successful_walk) == 0);
         CHECK(repository.view_tx_segments(successful_walk) == 0);
 
-        CHECK_FALSE(repository.find_header_segment(14'500'000));
-        CHECK_FALSE(repository.find_body_segment(11'500'000));
-        CHECK_FALSE(repository.find_tx_segment(15'000'000));
+        CHECK_FALSE(repository.find_segment(SnapshotType::headers, 14'500'000));
+        CHECK_FALSE(repository.find_segment(SnapshotType::bodies, 11'500'000));
+        CHECK_FALSE(repository.find_segment(SnapshotType::transactions, 15'000'000));
     }
 
     SECTION("partial bundle") {
@@ -86,17 +86,17 @@ TEST_CASE("SnapshotRepository::view", "[silkworm][node][snapshot]") {
         test::TemporarySnapshotFile tmp_snapshot_3{tmp_dir.path(), "v1-015000-015500-transactions.seg"};
         repository.reopen_folder();
 
-        CHECK_FALSE(repository.find_header_segment(14'500'000));
-        CHECK_FALSE(repository.find_body_segment(11'500'000));
-        CHECK_FALSE(repository.find_tx_segment(15'000'000));
+        CHECK_FALSE(repository.find_segment(SnapshotType::headers, 14'500'000));
+        CHECK_FALSE(repository.find_segment(SnapshotType::bodies, 11'500'000));
+        CHECK_FALSE(repository.find_segment(SnapshotType::transactions, 15'000'000));
 
         CHECK(repository.view_header_segments(successful_walk) == 0);  // empty snapshots are ignored by repository
         CHECK(repository.view_body_segments(successful_walk) == 0);    // empty snapshots are ignored by repository
         CHECK(repository.view_tx_segments(successful_walk) == 0);      // empty snapshots are ignored by repository
 
-        CHECK_FALSE(repository.find_header_segment(14'500'000));
-        CHECK_FALSE(repository.find_body_segment(11'500'000));
-        CHECK_FALSE(repository.find_tx_segment(15'000'000));
+        CHECK_FALSE(repository.find_segment(SnapshotType::headers, 14'500'000));
+        CHECK_FALSE(repository.find_segment(SnapshotType::bodies, 11'500'000));
+        CHECK_FALSE(repository.find_segment(SnapshotType::transactions, 15'000'000));
     }
 
     SECTION("non-empty snapshots") {
@@ -114,9 +114,9 @@ TEST_CASE("SnapshotRepository::view", "[silkworm][node][snapshot]") {
         CHECK(repository.view_body_segments(failing_walk) == 1);
         CHECK(repository.view_tx_segments(failing_walk) == 1);
 
-        CHECK(repository.find_header_segment(1'500'000).has_value());
-        CHECK(repository.find_body_segment(1'500'000).has_value());
-        CHECK(repository.find_tx_segment(1'500'000).has_value());
+        CHECK(repository.find_segment(SnapshotType::headers, 1'500'000).has_value());
+        CHECK(repository.find_segment(SnapshotType::bodies, 1'500'000).has_value());
+        CHECK(repository.find_segment(SnapshotType::transactions, 1'500'000).has_value());
 
         CHECK(repository.view_header_segments(successful_walk) == 1);
         CHECK(repository.view_body_segments(successful_walk) == 1);
@@ -152,22 +152,22 @@ TEST_CASE("SnapshotRepository::find_segment", "[silkworm][node][snapshot]") {
     test::SampleTransactionSnapshotFile txn_snapshot{tmp_dir.path()};
 
     SECTION("header w/o index") {
-        CHECK_FALSE(repository.find_header_segment(1'500'011));
-        CHECK_FALSE(repository.find_header_segment(1'500'012));
-        CHECK_FALSE(repository.find_header_segment(1'500'013));
-        CHECK_FALSE(repository.find_header_segment(1'500'014));
+        CHECK_FALSE(repository.find_segment(SnapshotType::headers, 1'500'011));
+        CHECK_FALSE(repository.find_segment(SnapshotType::headers, 1'500'012));
+        CHECK_FALSE(repository.find_segment(SnapshotType::headers, 1'500'013));
+        CHECK_FALSE(repository.find_segment(SnapshotType::headers, 1'500'014));
     }
     SECTION("body w/o index") {
-        CHECK_FALSE(repository.find_body_segment(1'500'011));
-        CHECK_FALSE(repository.find_body_segment(1'500'012));
-        CHECK_FALSE(repository.find_body_segment(1'500'013));
-        CHECK_FALSE(repository.find_body_segment(1'500'014));
+        CHECK_FALSE(repository.find_segment(SnapshotType::bodies, 1'500'011));
+        CHECK_FALSE(repository.find_segment(SnapshotType::bodies, 1'500'012));
+        CHECK_FALSE(repository.find_segment(SnapshotType::bodies, 1'500'013));
+        CHECK_FALSE(repository.find_segment(SnapshotType::bodies, 1'500'014));
     }
     SECTION("tx w/o index") {
-        CHECK_FALSE(repository.find_tx_segment(1'500'011));
-        CHECK_FALSE(repository.find_tx_segment(1'500'012));
-        CHECK_FALSE(repository.find_tx_segment(1'500'013));
-        CHECK_FALSE(repository.find_tx_segment(1'500'014));
+        CHECK_FALSE(repository.find_segment(SnapshotType::transactions, 1'500'011));
+        CHECK_FALSE(repository.find_segment(SnapshotType::transactions, 1'500'012));
+        CHECK_FALSE(repository.find_segment(SnapshotType::transactions, 1'500'013));
+        CHECK_FALSE(repository.find_segment(SnapshotType::transactions, 1'500'014));
     }
 
     test::SampleHeaderSnapshotPath header_snapshot_path{header_snapshot.path()};  // necessary to tweak the block numbers
@@ -183,25 +183,25 @@ TEST_CASE("SnapshotRepository::find_segment", "[silkworm][node][snapshot]") {
     REQUIRE_NOTHROW(repository.reopen_folder());
 
     SECTION("header w/ index") {
-        CHECK_FALSE(repository.find_header_segment(1'500'011));
-        // CHECK(repository.find_header_segment(1'500'012) != nullptr);  // needs full block number in snapshot file names
-        // CHECK(repository.find_header_segment(1'500'013) != nullptr);  // needs full block number in snapshot file names
-        CHECK_FALSE(repository.find_header_segment(1'500'014));
+        CHECK_FALSE(repository.find_segment(SnapshotType::headers, 1'500'011));
+        // CHECK(repository.find_segment(SnapshotType::headers, 1'500'012) != nullptr);  // needs full block number in snapshot file names
+        // CHECK(repository.find_segment(SnapshotType::headers, 1'500'013) != nullptr);  // needs full block number in snapshot file names
+        CHECK_FALSE(repository.find_segment(SnapshotType::headers, 1'500'014));
     }
     SECTION("body w/ index") {
-        CHECK_FALSE(repository.find_body_segment(1'500'011));
-        // CHECK(repository.find_body_segment(1'500'012) != nullptr);  // needs full block number in snapshot file names
-        // CHECK(repository.find_body_segment(1'500'013) != nullptr);  // needs full block number in snapshot file names
-        CHECK_FALSE(repository.find_body_segment(1'500'014));
+        CHECK_FALSE(repository.find_segment(SnapshotType::bodies, 1'500'011));
+        // CHECK(repository.find_segment(SnapshotType::bodies, 1'500'012) != nullptr);  // needs full block number in snapshot file names
+        // CHECK(repository.find_segment(SnapshotType::bodies, 1'500'013) != nullptr);  // needs full block number in snapshot file names
+        CHECK_FALSE(repository.find_segment(SnapshotType::bodies, 1'500'014));
     }
     SECTION("tx w/ index") {
-        CHECK_FALSE(repository.find_tx_segment(1'500'011));
-        // CHECK(repository.find_tx_segment(1'500'012) != nullptr);  // needs full block number in snapshot file names
-        // CHECK(repository.find_tx_segment(1'500'013) != nullptr);  // needs full block number in snapshot file names
-        CHECK_FALSE(repository.find_tx_segment(1'500'014));
+        CHECK_FALSE(repository.find_segment(SnapshotType::transactions, 1'500'011));
+        // CHECK(repository.find_segment(SnapshotType::transactions, 1'500'012) != nullptr);  // needs full block number in snapshot file names
+        // CHECK(repository.find_segment(SnapshotType::transactions, 1'500'013) != nullptr);  // needs full block number in snapshot file names
+        CHECK_FALSE(repository.find_segment(SnapshotType::transactions, 1'500'014));
     }
     SECTION("greater than max_block_available") {
-        CHECK_FALSE(repository.find_body_segment(repository.max_block_available() + 1));
+        CHECK_FALSE(repository.find_segment(SnapshotType::bodies, repository.max_block_available() + 1));
     }
 }
 

--- a/silkworm/db/snapshots/snapshot_and_index.hpp
+++ b/silkworm/db/snapshots/snapshot_and_index.hpp
@@ -1,0 +1,29 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include "index.hpp"
+#include "snapshot_reader.hpp"
+
+namespace silkworm::snapshots {
+
+struct SnapshotAndIndex {
+    const Snapshot& snapshot;
+    const Index& index;
+};
+
+}  // namespace silkworm::snapshots

--- a/silkworm/db/snapshots/snapshot_bundle.hpp
+++ b/silkworm/db/snapshots/snapshot_bundle.hpp
@@ -23,6 +23,7 @@
 #include <silkworm/core/common/base.hpp>
 
 #include "index.hpp"
+#include "snapshot_and_index.hpp"
 #include "snapshot_reader.hpp"
 
 namespace silkworm::snapshots {
@@ -89,6 +90,10 @@ struct SnapshotBundle {
         }
         assert(false);
         return idx_header_hash;
+    }
+
+    SnapshotAndIndex snapshot_and_index(SnapshotType type) const {
+        return {snapshot(type), index(type)};
     }
 
     // assume that all snapshots have the same block range, and use one of them

--- a/silkworm/db/snapshots/snapshot_bundle.hpp
+++ b/silkworm/db/snapshots/snapshot_bundle.hpp
@@ -1,0 +1,102 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <array>
+#include <cassert>
+#include <functional>
+
+#include <silkworm/core/common/base.hpp>
+
+#include "index.hpp"
+#include "snapshot_reader.hpp"
+
+namespace silkworm::snapshots {
+
+struct SnapshotBundle {
+    Snapshot header_snapshot;
+    //! Index header_hash -> block_num -> headers_segment_offset
+    Index idx_header_hash;
+
+    Snapshot body_snapshot;
+    //! Index block_num -> bodies_segment_offset
+    Index idx_body_number;
+
+    Snapshot txn_snapshot;
+    //! Index transaction_hash -> txn_id -> transactions_segment_offset
+    Index idx_txn_hash;
+    //! Index transaction_hash -> block_num
+    Index idx_txn_hash_2_block;
+
+    static constexpr size_t kSnapshotsCount = 3;
+    static constexpr size_t kIndexesCount = 4;
+
+    std::array<std::reference_wrapper<Snapshot>, kSnapshotsCount> snapshots() {
+        return {
+            header_snapshot,
+            body_snapshot,
+            txn_snapshot,
+        };
+    }
+
+    std::array<std::reference_wrapper<Index>, kIndexesCount> indexes() {
+        return {
+            idx_header_hash,
+            idx_body_number,
+            idx_txn_hash,
+            idx_txn_hash_2_block,
+        };
+    }
+
+    const Snapshot& snapshot(SnapshotType type) const {
+        switch (type) {
+            case headers:
+                return header_snapshot;
+            case bodies:
+                return body_snapshot;
+            case transactions:
+            case transactions_to_block:
+                return txn_snapshot;
+        }
+        assert(false);
+        return header_snapshot;
+    }
+
+    const Index& index(SnapshotType type) const {
+        switch (type) {
+            case headers:
+                return idx_header_hash;
+            case bodies:
+                return idx_body_number;
+            case transactions:
+                return idx_txn_hash;
+            case transactions_to_block:
+                return idx_txn_hash_2_block;
+        }
+        assert(false);
+        return idx_header_hash;
+    }
+
+    // assume that all snapshots have the same block range, and use one of them
+    BlockNum block_from() const { return header_snapshot.block_from(); }
+    BlockNum block_to() const { return header_snapshot.block_to(); }
+
+    void reopen();
+    void close();
+};
+
+}  // namespace silkworm::snapshots

--- a/silkworm/db/snapshots/snapshot_bundle_factory.hpp
+++ b/silkworm/db/snapshots/snapshot_bundle_factory.hpp
@@ -1,0 +1,38 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+#include <functional>
+#include <memory>
+#include <vector>
+
+#include "index_builder.hpp"
+#include "path.hpp"
+#include "snapshot_bundle.hpp"
+#include "snapshot_type.hpp"
+
+namespace silkworm::snapshots {
+
+struct SnapshotBundleFactory {
+    virtual ~SnapshotBundleFactory() = default;
+
+    using PathByTypeProvider = std::function<SnapshotPath(SnapshotType)>;
+    virtual SnapshotBundle make(PathByTypeProvider snapshot_path, PathByTypeProvider index_path) const = 0;
+
+    virtual std::vector<std::shared_ptr<IndexBuilder>> index_builders(SnapshotPath seg_file) const = 0;
+};
+
+}  // namespace silkworm::snapshots

--- a/silkworm/db/snapshots/snapshot_reader.hpp
+++ b/silkworm/db/snapshots/snapshot_reader.hpp
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <algorithm>
 #include <concepts>
 #include <cstdint>
 #include <filesystem>
@@ -24,10 +23,12 @@
 #include <memory>
 #include <optional>
 #include <stdexcept>
+#include <utility>
 #include <vector>
 
 #include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/types/hash.hpp>
+#include <silkworm/db/snapshots/common/iterator/iterator_read_into_vector.hpp>
 #include <silkworm/db/snapshots/path.hpp>
 #include <silkworm/db/snapshots/seg/decompressor.hpp>
 #include <silkworm/infra/common/memory_mapped_file.hpp>
@@ -197,18 +198,5 @@ class SnapshotReader {
 template <class TSnapshotReader>
 concept SnapshotReaderConcept = std::same_as<TSnapshotReader, SnapshotReader<typename TSnapshotReader::WordDeserializer>> ||
                                 std::derived_from<TSnapshotReader, SnapshotReader<typename TSnapshotReader::WordDeserializer>>;
-
-template <std::input_iterator It>
-void iterator_read_into(It it, size_t count, std::vector<typename It::value_type>& out) {
-    std::copy_n(std::make_move_iterator(std::move(it)), count, std::back_inserter(out));
-}
-
-template <std::input_iterator It>
-std::vector<typename It::value_type> iterator_read_into_vector(It it, size_t count) {
-    std::vector<typename It::value_type> out;
-    out.reserve(count);
-    iterator_read_into(std::move(it), count, out);
-    return out;
-}
 
 }  // namespace silkworm::snapshots

--- a/silkworm/db/snapshots/snapshot_test.cpp
+++ b/silkworm/db/snapshots/snapshot_test.cpp
@@ -135,7 +135,7 @@ TEST_CASE("HeaderSnapshot::header_by_number OK", "[silkworm][node][snapshot][ind
 
     Index idx_header_hash{header_snapshot_path.index_file()};
     idx_header_hash.reopen_index();
-    HeaderFindByBlockNumQuery header_by_number{header_snapshot, idx_header_hash};
+    HeaderFindByBlockNumQuery header_by_number{{header_snapshot, idx_header_hash}};
 
     CHECK(!header_by_number.exec(1'500'011));
     CHECK(header_by_number.exec(1'500'012));
@@ -177,7 +177,7 @@ TEST_CASE("BodySnapshot::body_by_number OK", "[silkworm][node][snapshot][index]"
 
     Index idx_body_number{body_snapshot_path.index_file()};
     idx_body_number.reopen_index();
-    BodyFindByBlockNumQuery body_by_number{body_snapshot, idx_body_number};
+    BodyFindByBlockNumQuery body_by_number{{body_snapshot, idx_body_number}};
 
     CHECK(!body_by_number.exec(1'500'011));
     CHECK(body_by_number.exec(1'500'012));
@@ -206,7 +206,7 @@ TEST_CASE("TransactionSnapshot::txn_by_id OK", "[silkworm][node][snapshot][index
 
     Index idx_txn_hash{tx_snapshot_path.index_file()};
     idx_txn_hash.reopen_index();
-    TransactionFindByIdQuery txn_by_id{tx_snapshot, idx_txn_hash};
+    TransactionFindByIdQuery txn_by_id{{tx_snapshot, idx_txn_hash}};
 
     const auto transaction = txn_by_id.exec(7'341'272);
     CHECK(transaction.has_value());
@@ -235,11 +235,11 @@ TEST_CASE("TransactionSnapshot::block_num_by_txn_hash OK", "[silkworm][node][sna
 
     Index idx_txn_hash{tx_snapshot_path.index_file()};
     idx_txn_hash.reopen_index();
-    TransactionFindByIdQuery txn_by_id{tx_snapshot, idx_txn_hash};
+    TransactionFindByIdQuery txn_by_id{{tx_snapshot, idx_txn_hash}};
 
     Index idx_txn_hash_2_block{tx_snapshot_path.index_file_for_type(SnapshotType::transactions_to_block)};
     idx_txn_hash_2_block.reopen_index();
-    TransactionBlockNumByTxnHashQuery block_num_by_txn_hash{idx_txn_hash_2_block, TransactionFindByHashQuery{tx_snapshot, idx_txn_hash}};
+    TransactionBlockNumByTxnHashQuery block_num_by_txn_hash{idx_txn_hash_2_block, TransactionFindByHashQuery{{tx_snapshot, idx_txn_hash}}};
 
     // block 1'500'012: base_txn_id is 7'341'263, txn_count is 7
     auto transaction = txn_by_id.exec(7'341'269);  // known txn id in block 1'500'012
@@ -277,7 +277,7 @@ TEST_CASE("TransactionSnapshot::txn_range OK", "[silkworm][node][snapshot][index
 
     Index idx_txn_hash{tx_snapshot_path.index_file()};
     idx_txn_hash.reopen_index();
-    TransactionRangeFromIdQuery query{tx_snapshot, idx_txn_hash};
+    TransactionRangeFromIdQuery query{{tx_snapshot, idx_txn_hash}};
 
     // block 1'500'012: base_txn_id is 7'341'263, txn_count is 7
     CHECK(query.exec_into_vector(7'341'263, 0).empty());
@@ -309,7 +309,7 @@ TEST_CASE("TransactionSnapshot::txn_rlp_range OK", "[silkworm][node][snapshot][i
 
     Index idx_txn_hash{tx_snapshot_path.index_file()};
     idx_txn_hash.reopen_index();
-    TransactionPayloadRlpRangeFromIdQuery query{tx_snapshot, idx_txn_hash};
+    TransactionPayloadRlpRangeFromIdQuery query{{tx_snapshot, idx_txn_hash}};
 
     // block 1'500'012: base_txn_id is 7'341'263, txn_count is 7
     CHECK(query.exec_into_vector(7'341'263, 0).empty());

--- a/silkworm/db/snapshots/snapshot_type.hpp
+++ b/silkworm/db/snapshots/snapshot_type.hpp
@@ -1,0 +1,33 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <cstdint>
+
+namespace silkworm::snapshots {
+
+//! The snapshot category corresponding to the snapshot file type
+//! @remark item names do NOT follow Google style to obtain the tag used in file names from magic_enum::enum_name
+//! @see SnapshotPath#build_filename
+enum SnapshotType : uint8_t {
+    headers = 0,
+    bodies = 1,
+    transactions = 2,
+    transactions_to_block = 3,
+};
+
+}  // namespace silkworm::snapshots

--- a/silkworm/db/snapshots/txn_queries.hpp
+++ b/silkworm/db/snapshots/txn_queries.hpp
@@ -63,7 +63,7 @@ class TransactionBlockNumByTxnHashRepoQuery {
             const Index& idx_txn_hash = bundle.idx_txn_hash;
             const Index& idx_txn_hash_2_block = bundle.idx_txn_hash_2_block;
 
-            TransactionFindByHashQuery cross_check_query{snapshot, idx_txn_hash};
+            TransactionFindByHashQuery cross_check_query{{snapshot, idx_txn_hash}};
             TransactionBlockNumByTxnHashQuery query{idx_txn_hash_2_block, cross_check_query};
             auto block_num = query.exec(hash);
             if (block_num) {

--- a/silkworm/db/snapshots/txn_queries.hpp
+++ b/silkworm/db/snapshots/txn_queries.hpp
@@ -16,7 +16,10 @@
 
 #pragma once
 
+#include <ranges>
+
 #include <silkworm/core/common/bytes.hpp>
+#include <silkworm/core/types/hash.hpp>
 
 #include "basic_queries.hpp"
 #include "txn_snapshot.hpp"
@@ -46,6 +49,32 @@ class TransactionBlockNumByTxnHashQuery {
   private:
     const Index& index_;
     TransactionFindByHashQuery cross_check_query_;
+};
+
+template <std::ranges::view TBundlesView, class TBundle = typename std::ranges::iterator_t<TBundlesView>::value_type>
+class TransactionBlockNumByTxnHashRepoQuery {
+  public:
+    TransactionBlockNumByTxnHashRepoQuery(TBundlesView bundles)
+        : bundles_(std::move(bundles)) {}
+
+    std::optional<BlockNum> exec(const Hash& hash) {
+        for (const TBundle& bundle : bundles_) {
+            const Snapshot& snapshot = bundle.txn_snapshot;
+            const Index& idx_txn_hash = bundle.idx_txn_hash;
+            const Index& idx_txn_hash_2_block = bundle.idx_txn_hash_2_block;
+
+            TransactionFindByHashQuery cross_check_query{snapshot, idx_txn_hash};
+            TransactionBlockNumByTxnHashQuery query{idx_txn_hash_2_block, cross_check_query};
+            auto block_num = query.exec(hash);
+            if (block_num) {
+                return block_num;
+            }
+        }
+        return std::nullopt;
+    }
+
+  private:
+    TBundlesView bundles_;
 };
 
 }  // namespace silkworm::snapshots

--- a/silkworm/db/snapshots/txs_and_bodies_query.hpp
+++ b/silkworm/db/snapshots/txs_and_bodies_query.hpp
@@ -93,16 +93,16 @@ class TxsAndBodiesQuery {
         uint64_t first_tx_id,
         uint64_t expected_tx_count)
         : txs_segment_path_(std::move(txs_segment_path)),
-          txs_segment_region_(std::move(txs_segment_region)),
+          txs_segment_region_(txs_segment_region),
           bodies_segment_path_(std::move(bodies_segment_path)),
-          bodies_segment_region_(std::move(bodies_segment_region)),
+          bodies_segment_region_(bodies_segment_region),
           first_tx_id_(first_tx_id),
           expected_tx_count_(expected_tx_count) {}
 
     Iterator begin();
     Iterator end();
 
-    uint64_t expected_tx_count() { return expected_tx_count_; }
+    uint64_t expected_tx_count() const { return expected_tx_count_; }
 
   private:
     SnapshotPath txs_segment_path_;

--- a/silkworm/node/node.cpp
+++ b/silkworm/node/node.cpp
@@ -20,6 +20,7 @@
 
 #include <boost/asio/io_context.hpp>
 
+#include <silkworm/db/snapshot_bundle_factory_impl.hpp>
 #include <silkworm/db/snapshot_sync.hpp>
 #include <silkworm/db/snapshots/bittorrent/client.hpp>
 #include <silkworm/infra/common/log.hpp>
@@ -95,7 +96,7 @@ static auto make_execution_server_settings() {
 NodeImpl::NodeImpl(Settings& settings, SentryClientPtr sentry_client, mdbx::env chaindata_db)
     : settings_{settings},
       chaindata_db_{std::move(chaindata_db)},
-      snapshot_repository_{settings_.snapshot_settings},
+      snapshot_repository_{settings_.snapshot_settings, std::make_unique<db::SnapshotBundleFactoryImpl>()},
       execution_engine_{execution_context_, settings_, db::RWAccess{chaindata_db_}},
       execution_service_{std::make_shared<execution::api::ActiveDirectService>(execution_engine_, execution_context_)},
       execution_server_{make_execution_server_settings(), execution_service_},

--- a/silkworm/rpc/daemon.cpp
+++ b/silkworm/rpc/daemon.cpp
@@ -29,6 +29,7 @@
 #include <grpcpp/grpcpp.h>
 
 #include <silkworm/db/access_layer.hpp>
+#include <silkworm/db/snapshot_bundle_factory_impl.hpp>
 #include <silkworm/infra/common/ensure.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/concurrency/private_service.hpp>
@@ -137,7 +138,8 @@ int Daemon::run(const DaemonSettings& settings) {
             snapshots::SnapshotSettings snapshot_settings{
                 .repository_dir = data_folder.snapshots().path(),
             };
-            snapshot_repository = std::make_unique<snapshots::SnapshotRepository>(std::move(snapshot_settings));
+            auto snapshot_bundle_factory = std::make_unique<db::SnapshotBundleFactoryImpl>();
+            snapshot_repository = std::make_unique<snapshots::SnapshotRepository>(std::move(snapshot_settings), std::move(snapshot_bundle_factory));
             snapshot_repository->reopen_folder();
 
             db::DataModel::set_snapshot_repository(snapshot_repository.get());


### PR DESCRIPTION
Refactor data access layer (DAL) logic and schema definition out of SnapshotRepository.

* schema is defined in snapshot_bundle.hpp and snapshot_type.hpp, indexes are defined in SnapshotBundleFactory
* find_segment is exposed with a snapshot type parameter
* view_xx_segments is replaced by iteration on bundles in a forward or reverse order (view_bundles_reverse)
* find_block_number is replaced by a new query object - TransactionBlockNumByTxnHashRepoQuery
  that runs TransactionBlockNumByTxnHashQuery on a view of bundles and returns the first match
* replace for_each_xx with nested for loops
* refactor queries to take SnapshotAndIndex

DataModel::read_transactions_from_snapshot: remove an extra reserve
