### PR TITLE
rpcdaemon: add stub for remote Execution engine

### DIFF
--- a/silkworm/rpc/commands/rpc_api_table.cpp
+++ b/silkworm/rpc/commands/rpc_api_table.cpp
@@ -104,7 +104,6 @@ void RpcApiTable::add_debug_handlers() {
     method_handlers_[json_rpc::method::k_debug_accountAt] = &commands::RpcApi::handle_debug_account_at;
     method_handlers_[json_rpc::method::k_debug_getRawBlock] = &commands::RpcApi::handle_debug_get_raw_block;
     method_handlers_[json_rpc::method::k_debug_getRawHeader] = &commands::RpcApi::handle_debug_get_raw_header;
-    //    method_handlers_[json_rpc::method::k_debug_getRawReceipts] = &commands::RpcApi::;
     method_handlers_[json_rpc::method::k_debug_getRawTransaction] = &commands::RpcApi::handle_debug_get_raw_transaction;
 
     stream_handlers_[json_rpc::method::k_debug_traceCall] = &commands::RpcApi::handle_debug_trace_call;

--- a/silkworm/rpc/daemon.cpp
+++ b/silkworm/rpc/daemon.cpp
@@ -34,6 +34,7 @@
 #include <silkworm/infra/concurrency/private_service.hpp>
 #include <silkworm/infra/concurrency/shared_service.hpp>
 #include <silkworm/rpc/common/compatibility.hpp>
+#include <silkworm/rpc/engine/remote_execution_engine.hpp>
 #include <silkworm/rpc/ethbackend/remote_backend.hpp>
 #include <silkworm/rpc/ethdb/file/local_database.hpp>
 #include <silkworm/rpc/ethdb/kv/remote_database.hpp>
@@ -280,6 +281,8 @@ void Daemon::add_shared_services() {
     auto state_cache = std::make_shared<ethdb::kv::CoherentStateCache>();
     // Create the unique filter storage to be shared among the execution contexts
     auto filter_storage = std::make_shared<FilterStorage>(context_pool_.num_contexts() * kDefaultFilterStorageSize);
+    // Create the unique Execution remote client to be shared among the execution contexts
+    auto remote_execution_engine = std::make_shared<engine::RemoteExecutionEngine>();
 
     // Add the shared state to the execution contexts
     for (std::size_t i{0}; i < settings_.context_pool_settings.num_contexts; ++i) {
@@ -288,8 +291,7 @@ void Daemon::add_shared_services() {
         add_shared_service(io_context, block_cache);
         add_shared_service<ethdb::kv::StateCache>(io_context, state_cache);
         add_shared_service(io_context, filter_storage);
-        // TODO(canepat) replace w/ proper Execution remote client
-        add_shared_service<engine::ExecutionEngine>(io_context, nullptr);
+        add_shared_service<engine::ExecutionEngine>(io_context, remote_execution_engine);
     }
 }
 

--- a/silkworm/rpc/engine/remote_execution_engine.cpp
+++ b/silkworm/rpc/engine/remote_execution_engine.cpp
@@ -1,0 +1,46 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "remote_execution_engine.hpp"
+
+namespace silkworm::rpc::engine {
+
+Task<PayloadStatus> RemoteExecutionEngine::new_payload(const NewPayloadRequest& /*request*/, Msec /*timeout*/) {
+    // TODO(canepat) implement using an Execution API remote client
+    co_return PayloadStatus::Syncing;
+}
+
+Task<ForkChoiceUpdatedReply> RemoteExecutionEngine::fork_choice_updated(const ForkChoiceUpdatedRequest& /*request*/, Msec /*timeout*/) {
+    // TODO(canepat) implement using an Execution API remote client
+    co_return ForkChoiceUpdatedReply{.payload_status = PayloadStatus::Syncing};
+}
+
+Task<ExecutionPayloadAndValue> RemoteExecutionEngine::get_payload(uint64_t /*payloadId*/, Msec /*timeout*/) {
+    // TODO(canepat) implement using an Execution API remote client
+    co_return ExecutionPayloadAndValue{};
+}
+
+Task<ExecutionPayloadBodies> RemoteExecutionEngine::get_payload_bodies_by_hash(const std::vector<Hash>& /*block_hashes*/, Msec /*timeout*/) {
+    // TODO(canepat) implement using an Execution API remote client
+    co_return ExecutionPayloadBodies{};
+}
+
+Task<ExecutionPayloadBodies> RemoteExecutionEngine::get_payload_bodies_by_range(BlockNum /*start*/, uint64_t /*count*/, Msec /*timeout*/) {
+    // TODO(canepat) implement using an Execution API remote client
+    co_return ExecutionPayloadBodies{};
+}
+
+}  // namespace silkworm::rpc::engine

--- a/silkworm/rpc/engine/remote_execution_engine.hpp
+++ b/silkworm/rpc/engine/remote_execution_engine.hpp
@@ -1,0 +1,35 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include "execution_engine.hpp"
+
+namespace silkworm::rpc::engine {
+
+class RemoteExecutionEngine final : public ExecutionEngine {
+  public:
+    RemoteExecutionEngine() = default;
+    ~RemoteExecutionEngine() override = default;
+
+    Task<PayloadStatus> new_payload(const NewPayloadRequest& request, Msec timeout) override;
+    Task<ForkChoiceUpdatedReply> fork_choice_updated(const ForkChoiceUpdatedRequest& request, Msec timeout) override;
+    Task<ExecutionPayloadAndValue> get_payload(uint64_t payloadId, Msec timeout) override;
+    Task<ExecutionPayloadBodies> get_payload_bodies_by_hash(const std::vector<Hash>& block_hashes, Msec timeout) override;
+    Task<ExecutionPayloadBodies> get_payload_bodies_by_range(BlockNum start, uint64_t count, Msec timeout) override;
+};
+
+}  // namespace silkworm::rpc::engine

--- a/silkworm/rpc/json_rpc/methods.hpp
+++ b/silkworm/rpc/json_rpc/methods.hpp
@@ -98,7 +98,6 @@ inline constexpr const char* k_debug_traceBlockByNumber{"debug_traceBlockByNumbe
 inline constexpr const char* k_debug_traceBlockByHash{"debug_traceBlockByHash"};
 inline constexpr const char* k_debug_getRawBlock{"debug_getRawBlock"};
 inline constexpr const char* k_debug_getRawHeader{"debug_getRawHeader"};
-inline constexpr const char* k_debug_getRawReceipts{"debug_getRawReceipts"};
 inline constexpr const char* k_debug_getRawTransaction{"debug_getRawTransaction"};
 
 inline constexpr const char* k_trace_call{"trace_call"};
@@ -148,7 +147,6 @@ inline constexpr const char* k_txpool_content{"txpool_content"};
 
 inline constexpr const char* k_ots_getApiLevel{"ots_getApiLevel"};
 inline constexpr const char* k_ots_hasCode{"ots_hasCode"};
-
 inline constexpr const char* k_ots_getBlockDetails{"ots_getBlockDetails"};
 inline constexpr const char* k_ots_getBlockDetailsByHash{"ots_getBlockDetailsByHash"};
 inline constexpr const char* k_ots_getBlockTransactions{"ots_getBlockTransactions"};


### PR DESCRIPTION
This PR adds a stubbed remote implementation for `engine::ExecutionEngine` in `rpc` module, covering at least partially the (unusual) case of querying the Engine API endpoint in `rpcdaemon` run as standalone component.

A proper implementation will rely on a remote client of our internal Execution gRPC API, which is already available (`execution::grpc::client::RemoteClient`) but would require to refactor the `execution` module out of the `node` module in order not to add an undesired dependency between `rpc` and `node`.