### PR TITLE
rpcdaemon: temporal KV server-side stubbed implementation

### DIFF
--- a/silkworm/node/remote/kv/grpc/server/backend_kv_server.cpp
+++ b/silkworm/node/remote/kv/grpc/server/backend_kv_server.cpp
@@ -52,35 +52,35 @@ void BackEndKvServer::register_backend_request_calls(agrpc::GrpcContext* grpc_co
 
     // Register one requested call repeatedly for each RPC: asio-grpc will take care of re-registration on any incoming call
     request_repeatedly(*grpc_context, service, &remote::ETHBACKEND::AsyncService::RequestEtherbase,
-                       [&backend](auto&&... args) -> Task<void> {
+                       [&backend](auto&&... args) -> Task<void> {  // NOLINT(cppcoreguidelines-avoid-capturing-lambda-coroutines)
                            co_await EtherbaseCall{std::forward<decltype(args)>(args)...}(backend);
                        });
     request_repeatedly(*grpc_context, service, &remote::ETHBACKEND::AsyncService::RequestNetVersion,
-                       [&backend](auto&&... args) -> Task<void> {
+                       [&backend](auto&&... args) -> Task<void> {  // NOLINT(cppcoreguidelines-avoid-capturing-lambda-coroutines)
                            co_await NetVersionCall{std::forward<decltype(args)>(args)...}(backend);
                        });
     request_repeatedly(*grpc_context, service, &remote::ETHBACKEND::AsyncService::RequestNetPeerCount,
-                       [&backend](auto&&... args) -> Task<void> {
+                       [&backend](auto&&... args) -> Task<void> {  // NOLINT(cppcoreguidelines-avoid-capturing-lambda-coroutines)
                            co_await NetPeerCountCall{std::forward<decltype(args)>(args)...}(backend);
                        });
     request_repeatedly(*grpc_context, service, &remote::ETHBACKEND::AsyncService::RequestVersion,
-                       [&backend](auto&&... args) -> Task<void> {
+                       [&backend](auto&&... args) -> Task<void> {  // NOLINT(cppcoreguidelines-avoid-capturing-lambda-coroutines)
                            co_await BackEndVersionCall{std::forward<decltype(args)>(args)...}(backend);
                        });
     request_repeatedly(*grpc_context, service, &remote::ETHBACKEND::AsyncService::RequestProtocolVersion,
-                       [&backend](auto&&... args) -> Task<void> {
+                       [&backend](auto&&... args) -> Task<void> {  // NOLINT(cppcoreguidelines-avoid-capturing-lambda-coroutines)
                            co_await ProtocolVersionCall{std::forward<decltype(args)>(args)...}(backend);
                        });
     request_repeatedly(*grpc_context, service, &remote::ETHBACKEND::AsyncService::RequestClientVersion,
-                       [&backend](auto&&... args) -> Task<void> {
+                       [&backend](auto&&... args) -> Task<void> {  // NOLINT(cppcoreguidelines-avoid-capturing-lambda-coroutines)
                            co_await ClientVersionCall{std::forward<decltype(args)>(args)...}(backend);
                        });
     request_repeatedly(*grpc_context, service, &remote::ETHBACKEND::AsyncService::RequestSubscribe,
-                       [&backend](auto&&... args) -> Task<void> {
+                       [&backend](auto&&... args) -> Task<void> {  // NOLINT(cppcoreguidelines-avoid-capturing-lambda-coroutines)
                            co_await SubscribeCall{std::forward<decltype(args)>(args)...}(backend);
                        });
     request_repeatedly(*grpc_context, service, &remote::ETHBACKEND::AsyncService::RequestNodeInfo,
-                       [&backend](auto&&... args) -> Task<void> {
+                       [&backend](auto&&... args) -> Task<void> {  // NOLINT(cppcoreguidelines-avoid-capturing-lambda-coroutines)
                            co_await NodeInfoCall{std::forward<decltype(args)>(args)...}(backend);
                        });
     SILK_TRACE << "BackEndService::register_backend_request_calls END";
@@ -97,16 +97,40 @@ void BackEndKvServer::register_kv_request_calls(agrpc::GrpcContext* grpc_context
 
     // Register one requested call repeatedly for each RPC: asio-grpc will take care of re-registration on any incoming call
     request_repeatedly(*grpc_context, service, &remote::KV::AsyncService::RequestVersion,
-                       [&backend](auto&&... args) -> Task<void> {
+                       [&backend](auto&&... args) -> Task<void> {  // NOLINT(cppcoreguidelines-avoid-capturing-lambda-coroutines)
                            co_await KvVersionCall{std::forward<decltype(args)>(args)...}(backend);
                        });
     request_repeatedly(*grpc_context, service, &remote::KV::AsyncService::RequestTx,
-                       [&backend, grpc_context](auto&&... args) -> Task<void> {
+                       [&backend, grpc_context](auto&&... args) -> Task<void> {  // NOLINT(cppcoreguidelines-avoid-capturing-lambda-coroutines)
                            co_await TxCall{*grpc_context, std::forward<decltype(args)>(args)...}(backend);
                        });
     request_repeatedly(*grpc_context, service, &remote::KV::AsyncService::RequestStateChanges,
-                       [&backend](auto&&... args) -> Task<void> {
+                       [&backend](auto&&... args) -> Task<void> {  // NOLINT(cppcoreguidelines-avoid-capturing-lambda-coroutines)
                            co_await StateChangesCall{std::forward<decltype(args)>(args)...}(backend);
+                       });
+    request_repeatedly(*grpc_context, service, &remote::KV::AsyncService::RequestSnapshots,
+                       [&backend](auto&&... args) -> Task<void> {  // NOLINT(cppcoreguidelines-avoid-capturing-lambda-coroutines)
+                           co_await SnapshotsCall{std::forward<decltype(args)>(args)...}(backend);
+                       });
+    request_repeatedly(*grpc_context, service, &remote::KV::AsyncService::RequestDomainGet,
+                       [&backend](auto&&... args) -> Task<void> {  // NOLINT(cppcoreguidelines-avoid-capturing-lambda-coroutines)
+                           co_await DomainGetCall{std::forward<decltype(args)>(args)...}(backend);
+                       });
+    request_repeatedly(*grpc_context, service, &remote::KV::AsyncService::RequestHistoryGet,
+                       [&backend](auto&&... args) -> Task<void> {  // NOLINT(cppcoreguidelines-avoid-capturing-lambda-coroutines)
+                           co_await HistoryGetCall{std::forward<decltype(args)>(args)...}(backend);
+                       });
+    request_repeatedly(*grpc_context, service, &remote::KV::AsyncService::RequestIndexRange,
+                       [&backend](auto&&... args) -> Task<void> {  // NOLINT(cppcoreguidelines-avoid-capturing-lambda-coroutines)
+                           co_await IndexRangeCall{std::forward<decltype(args)>(args)...}(backend);
+                       });
+    request_repeatedly(*grpc_context, service, &remote::KV::AsyncService::RequestHistoryRange,
+                       [&backend](auto&&... args) -> Task<void> {  // NOLINT(cppcoreguidelines-avoid-capturing-lambda-coroutines)
+                           co_await HistoryRangeCall{std::forward<decltype(args)>(args)...}(backend);
+                       });
+    request_repeatedly(*grpc_context, service, &remote::KV::AsyncService::RequestDomainRange,
+                       [&backend](auto&&... args) -> Task<void> {  // NOLINT(cppcoreguidelines-avoid-capturing-lambda-coroutines)
+                           co_await DomainRangeCall{std::forward<decltype(args)>(args)...}(backend);
                        });
     SILK_TRACE << "BackEndKvServer::register_kv_request_calls END";
 }

--- a/silkworm/node/remote/kv/grpc/server/backend_kv_server_test.cpp
+++ b/silkworm/node/remote/kv/grpc/server/backend_kv_server_test.cpp
@@ -40,6 +40,7 @@
 #include <silkworm/infra/grpc/common/conversion.hpp>
 #include <silkworm/infra/grpc/common/util.hpp>
 #include <silkworm/infra/test_util/log.hpp>
+#include <silkworm/interfaces/remote/kv.pb.h>
 #include <silkworm/interfaces/types/types.pb.h>
 #include <silkworm/node/backend/ethereum_backend.hpp>
 #include <silkworm/node/backend/state_change_collection.hpp>
@@ -150,6 +151,36 @@ class KvClient {
 
     auto statechanges_start(grpc::ClientContext* context, const remote::StateChangeRequest& request) {
         return stub_->StateChanges(context, request);
+    }
+
+    grpc::Status snapshots(const remote::SnapshotsRequest& request, remote::SnapshotsReply* response) {
+        grpc::ClientContext context;
+        return stub_->Snapshots(&context, request, response);
+    }
+
+    grpc::Status history_get(const remote::HistoryGetReq& request, remote::HistoryGetReply* response) {
+        grpc::ClientContext context;
+        return stub_->HistoryGet(&context, request, response);
+    }
+
+    grpc::Status domain_get(const remote::DomainGetReq& request, remote::DomainGetReply* response) {
+        grpc::ClientContext context;
+        return stub_->DomainGet(&context, request, response);
+    }
+
+    grpc::Status index_range(const remote::IndexRangeReq& request, remote::IndexRangeReply* response) {
+        grpc::ClientContext context;
+        return stub_->IndexRange(&context, request, response);
+    }
+
+    grpc::Status history_range(const remote::HistoryRangeReq& request, remote::Pairs* response) {
+        grpc::ClientContext context;
+        return stub_->HistoryRange(&context, request, response);
+    }
+
+    grpc::Status domain_range(const remote::DomainRangeReq& request, remote::Pairs* response) {
+        grpc::ClientContext context;
+        return stub_->DomainRange(&context, request, response);
     }
 
   private:
@@ -828,6 +859,48 @@ TEST_CASE("BackEndKvServer E2E: KV", "[silkworm][node][rpc]") {
 
         const auto status1 = subscribe_reply_reader1->Finish();
         CHECK(status1.ok());
+    }
+
+    SECTION("Snapshots: return snapshot files") {
+        remote::SnapshotsRequest request;
+        remote::SnapshotsReply response;
+        const auto status = kv_client.snapshots(request, &response);
+        CHECK(status.ok());
+    }
+
+    SECTION("HistoryGet: return value in target history") {
+        remote::HistoryGetReq request;
+        remote::HistoryGetReply response;
+        const auto status = kv_client.history_get(request, &response);
+        CHECK(status.ok());
+    }
+
+    SECTION("DomainGet: return value in target domain") {
+        remote::DomainGetReq request;
+        remote::DomainGetReply response;
+        const auto status = kv_client.domain_get(request, &response);
+        CHECK(status.ok());
+    }
+
+    SECTION("IndexRange: return value in target index range") {
+        remote::IndexRangeReq request;
+        remote::IndexRangeReply response;
+        const auto status = kv_client.index_range(request, &response);
+        CHECK(status.ok());
+    }
+
+    SECTION("HistoryRange: return value in target history range") {
+        remote::HistoryRangeReq request;
+        remote::Pairs response;
+        const auto status = kv_client.history_range(request, &response);
+        CHECK(status.ok());
+    }
+
+    SECTION("DomainRange: return value in target domain range") {
+        remote::DomainRangeReq request;
+        remote::Pairs response;
+        const auto status = kv_client.domain_range(request, &response);
+        CHECK(status.ok());
     }
 }
 

--- a/silkworm/node/remote/kv/grpc/server/kv_calls.hpp
+++ b/silkworm/node/remote/kv/grpc/server/kv_calls.hpp
@@ -58,6 +58,7 @@ constexpr std::chrono::milliseconds kMaxTxDuration{60'000};
 constexpr std::size_t kMaxTxCursors{100};
 
 //! Unary RPC for Version method of 'ethbackend' gRPC protocol.
+//! rpc Version(google.protobuf.Empty) returns (types.VersionReply);
 class KvVersionCall : public server::UnaryCall<google::protobuf::Empty, types::VersionReply> {
   public:
     using Base::UnaryCall;
@@ -71,6 +72,7 @@ class KvVersionCall : public server::UnaryCall<google::protobuf::Empty, types::V
 };
 
 //! Bidirectional-streaming RPC for Tx method of 'kv' gRPC protocol.
+//! rpc Tx(stream Cursor) returns (stream Pair);
 class TxCall : public server::BidiStreamingCall<remote::Cursor, remote::Pair> {
   public:
     using Base::BidiStreamingCall;
@@ -143,6 +145,7 @@ class TxCall : public server::BidiStreamingCall<remote::Cursor, remote::Pair> {
     void throw_with_error(grpc::Status&& status);
 
     static std::chrono::milliseconds max_ttl_duration_;
+    static inline uint64_t next_tx_id_{0};
 
     db::ROTxnManaged read_only_txn_;
     std::map<uint32_t, TxCursor> cursors_;
@@ -150,9 +153,64 @@ class TxCall : public server::BidiStreamingCall<remote::Cursor, remote::Pair> {
 };
 
 //! Server-streaming RPC for StateChanges method of 'kv' gRPC protocol.
+//! rpc StateChanges(StateChangeRequest) returns (stream StateChangeBatch);
 class StateChangesCall : public server::ServerStreamingCall<remote::StateChangeRequest, remote::StateChangeBatch> {
   public:
     using Base::ServerStreamingCall;
+
+    Task<void> operator()(const EthereumBackEnd& backend);
+};
+
+//! Unary RPC for Snapshots method of 'kv' gRPC protocol.
+//! rpc Snapshots(SnapshotsRequest) returns (SnapshotsReply);
+class SnapshotsCall : public server::UnaryCall<remote::SnapshotsRequest, remote::SnapshotsReply> {
+  public:
+    using Base::UnaryCall;
+
+    Task<void> operator()(const EthereumBackEnd& backend);
+};
+
+//! Unary RPC for HistoryGet method of 'kv' gRPC protocol.
+//! rpc HistoryGet(HistoryGetReq) returns (HistoryGetReply);
+class HistoryGetCall : public server::UnaryCall<remote::HistoryGetReq, remote::HistoryGetReply> {
+  public:
+    using Base::UnaryCall;
+
+    Task<void> operator()(const EthereumBackEnd& backend);
+};
+
+//! Unary RPC for DomainGet method of 'kv' gRPC protocol.
+//! rpc DomainGet(DomainGetReq) returns (DomainGetReply);
+class DomainGetCall : public server::UnaryCall<remote::DomainGetReq, remote::DomainGetReply> {
+  public:
+    using Base::UnaryCall;
+
+    Task<void> operator()(const EthereumBackEnd& backend);
+};
+
+//! Unary RPC for IndexRange method of 'kv' gRPC protocol.
+//! rpc IndexRange(IndexRangeReq) returns (IndexRangeReply);
+class IndexRangeCall : public server::UnaryCall<remote::IndexRangeReq, remote::IndexRangeReply> {
+  public:
+    using Base::UnaryCall;
+
+    Task<void> operator()(const EthereumBackEnd& backend);
+};
+
+//! Unary RPC for IndexRange method of 'kv' gRPC protocol.
+//! rpc HistoryRange(HistoryRangeReq) returns (Pairs);
+class HistoryRangeCall : public server::UnaryCall<remote::HistoryRangeReq, remote::Pairs> {
+  public:
+    using Base::UnaryCall;
+
+    Task<void> operator()(const EthereumBackEnd& backend);
+};
+
+//! Unary RPC for IndexRange method of 'kv' gRPC protocol.
+//! rpc DomainRange(DomainRangeReq) returns (Pairs);
+class DomainRangeCall : public server::UnaryCall<remote::DomainRangeReq, remote::Pairs> {
+  public:
+    using Base::UnaryCall;
 
     Task<void> operator()(const EthereumBackEnd& backend);
 };


### PR DESCRIPTION
This PR introduces stubbed implementation for "temporal" KV API into our BackEnd-KV gRPC server

*Extras*
Add support for `tx_id` field notification sent by gRPC server after opening `Tx` RPC