### PR TITLE
qa-tests: add Change Point analysis to perf tests

### DIFF
--- a/.github/workflows/rpc-performance-tests.yml
+++ b/.github/workflows/rpc-performance-tests.yml
@@ -162,6 +162,12 @@ jobs:
         run: |
           python3 $ERIGON_QA_PATH/test_system/db-producer/resume_production.py || true
 
+      - name: Run change point analysis
+        if: steps.test_step.outputs.TEST_RESULT == 'success'
+        working-directory: ${{runner.workspace}}/rpc-tests/perf/reports/mainnet
+        run: |
+          python3 $ERIGON_QA_PATH/test_system/qa-tests/change-points/change_point_analysis.py 
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
**This PR adds an earlier version of change point analysis to perf tests.**
The analysis will run at the end of each test, using historical data published to our MongoDB database.
Output will be added to uploaded artefacts. This is an example of output based on real data: [change_point_analysis.pdf](https://github.com/user-attachments/files/15613335/change_point_analysis.pdf)

**Change Point Analysis** is a process for automatically detecting performance changes for a software product in the presence of _noise_. It answers the question: given the measurements taken over time, is the jump we see a statistical fluctuation or is it a regression?

The version we use was developed by the MongoDB QA team and is based on the E-Divisive means statistical algorithm.
They published scientific papers on the subject and a library.

Thanks to @canepat, who was the first to raise the issue of distinguishing noise from real regressions; who sought a scientifically-based solution, found the work of the MongoDB team, and directed me towards their use

Papers:
- [The Use of Change Point Detection to Identify Software Performance Regressions in a Continuous Integration System](https://dl.acm.org/doi/abs/10.1145/3358960.3375791)
- [Automated system performance testing at MongoDB](https://dl.acm.org/doi/abs/10.1145/3395032.3395323)

Blog:
- [Using Change Point Detection to Find Performance Regressions](https://www.mongodb.com/blog/post/using-change-point-detection-find-performance-regressions) 

Library:
- https://github.com/mongodb/signal-processing-algorithms
