### PR TITLE
execution: fix OOM crash due to db::Buffer::accounts realloc (#2064)

### DIFF
--- a/cmd/dev/check_changes.cpp
+++ b/cmd/dev/check_changes.cpp
@@ -128,7 +128,8 @@ int main(int argc, char* argv[]) {
                 break;
             }
 
-            db::Buffer buffer{txn, /*prune_history_threshold=*/0, /*historical_block=*/block_num};
+            db::Buffer buffer{txn};
+            buffer.set_historical_block(block_num);
 
             ExecutionProcessor processor{block, *rule_set, buffer, *chain_config};
             processor.evm().analysis_cache = &analysis_cache;

--- a/cmd/dev/check_changes.cpp
+++ b/cmd/dev/check_changes.cpp
@@ -135,10 +135,12 @@ int main(int argc, char* argv[]) {
             processor.evm().analysis_cache = &analysis_cache;
             processor.evm().state_pool = &state_pool;
 
-            if (const auto res{processor.execute_and_write_block(receipts)}; res != ValidationResult::kOk) {
+            if (const ValidationResult res = processor.execute_block(receipts); res != ValidationResult::kOk) {
                 log::Error() << "Failed execution for block " << block_num << " result " << magic_enum::enum_name<>(res);
                 continue;
             }
+
+            processor.flush_state();
 
             db::AccountChanges db_account_changes{db::read_account_changes(txn, block_num)};
 

--- a/cmd/dev/scan_txs.cpp
+++ b/cmd/dev/scan_txs.cpp
@@ -97,9 +97,11 @@ int main(int argc, char* argv[]) {
             processor.evm().state_pool = &state_pool;
 
             // Execute the block and retrieve the receipts
-            if (const auto res{processor.execute_and_write_block(receipts)}; res != ValidationResult::kOk) {
+            if (const ValidationResult res = processor.execute_block(receipts); res != ValidationResult::kOk) {
                 std::cerr << "Validation error " << static_cast<int>(res) << " at block " << block_num << "\n";
             }
+
+            processor.flush_state();
 
             // There is one receipt per transaction
             assert(block.transactions.size() == receipts.size());

--- a/cmd/dev/scan_txs.cpp
+++ b/cmd/dev/scan_txs.cpp
@@ -89,7 +89,8 @@ int main(int argc, char* argv[]) {
                 break;
             }
 
-            db::Buffer buffer{txn, /*prune_history_threshold=*/0, /*historical_block=*/block_num};
+            db::Buffer buffer{txn};
+            buffer.set_historical_block(block_num);
 
             ExecutionProcessor processor{block, *rule_set, buffer, *chain_config};
             processor.evm().analysis_cache = &analysis_cache;

--- a/silkworm/capi/silkworm.cpp
+++ b/silkworm/capi/silkworm.cpp
@@ -456,11 +456,11 @@ class BlockExecutor {
         }
 
         std::vector<Receipt> receipts;
-        const auto result{processor.execute_and_write_block(receipts)};
-
-        if (result != ValidationResult::kOk) {
-            return result;
+        if (const ValidationResult res = processor.execute_block(receipts); res != ValidationResult::kOk) {
+            return res;
         }
+
+        processor.flush_state();
 
         if (write_receipts_) {
             state_buffer.insert_receipts(block.header.number, receipts);
@@ -484,7 +484,7 @@ class BlockExecutor {
             log_time_ = now + 20s;
         }
 
-        return result;
+        return ValidationResult::kOk;
     }
 
   private:

--- a/silkworm/capi/silkworm.cpp
+++ b/silkworm/capi/silkworm.cpp
@@ -536,7 +536,8 @@ int silkworm_execute_blocks_ephemeral(SilkwormHandle handle, MDBX_txn* mdbx_txn,
         auto txn = db::RWTxnUnmanaged{mdbx_txn};
         const auto db_path{txn.db().get_path()};
 
-        db::Buffer state_buffer{txn, /*prune_history_threshold=*/0};
+        db::Buffer state_buffer{txn};
+        state_buffer.set_memory_limit(batch_size);
 
         const size_t max_batch_size{batch_size};
         auto signal_check_time{std::chrono::steady_clock::now()};
@@ -629,7 +630,9 @@ int silkworm_execute_blocks_perpetual(SilkwormHandle handle, MDBX_env* mdbx_env,
         auto txn = db::RWTxnManaged{unmanaged_env};
         const auto db_path{unmanaged_env.get_path()};
 
-        db::Buffer state_buffer{txn, /*prune_history_threshold=*/0};
+        db::Buffer state_buffer{txn};
+        state_buffer.set_memory_limit(batch_size);
+
         BoundedBuffer<std::optional<Block>> block_buffer{kMaxBlockBufferSize};
         BlockProvider block_provider{&block_buffer, unmanaged_env, start_block, max_block};
         boost::strict_scoped_thread<boost::interrupt_and_join_if_joinable> block_provider_thread(block_provider);

--- a/silkworm/core/execution/execution.hpp
+++ b/silkworm/core/execution/execution.hpp
@@ -45,7 +45,14 @@ namespace silkworm {
         return ValidationResult::kUnknownProtocolRuleSet;
     }
     ExecutionProcessor processor{block, *rule_set, state, chain_config};
-    return processor.execute_and_write_block(receipts);
+
+    if (const ValidationResult res = processor.execute_block(receipts); res != ValidationResult::kOk) {
+        return res;
+    }
+
+    processor.flush_state();
+
+    return ValidationResult::kOk;
 }
 
 /**

--- a/silkworm/core/execution/execution_test.cpp
+++ b/silkworm/core/execution/execution_test.cpp
@@ -173,7 +173,7 @@ TEST_CASE("Execute block with tracing") {
     CallTracer call_tracer{call_traces};
     processor.evm().add_tracer(call_tracer);
 
-    REQUIRE(processor.execute_and_write_block(receipts) == ValidationResult::kOk);
+    REQUIRE(processor.execute_block(receipts) == ValidationResult::kOk);
 
     CHECK((block_tracer.block_start_called() && block_tracer.block_end_called()));
     CHECK(call_traces.senders.empty());

--- a/silkworm/core/execution/processor.cpp
+++ b/silkworm/core/execution/processor.cpp
@@ -159,7 +159,7 @@ ValidationResult ExecutionProcessor::execute_block_no_post_validation(std::vecto
     return ValidationResult::kOk;
 }
 
-ValidationResult ExecutionProcessor::execute_and_write_block(std::vector<Receipt>& receipts) noexcept {
+ValidationResult ExecutionProcessor::execute_block(std::vector<Receipt>& receipts) noexcept {
     if (const ValidationResult res{execute_block_no_post_validation(receipts)}; res != ValidationResult::kOk) {
         return res;
     }
@@ -188,9 +188,11 @@ ValidationResult ExecutionProcessor::execute_and_write_block(std::vector<Receipt
         return ValidationResult::kWrongLogsBloom;
     }
 
-    state_.write_to_db(header.number);
-
     return ValidationResult::kOk;
+}
+
+void ExecutionProcessor::flush_state() {
+    state_.write_to_db(evm_.block().header.number);
 }
 
 //! \brief Notify the registered tracers at the start of block execution.

--- a/silkworm/core/execution/processor.hpp
+++ b/silkworm/core/execution/processor.hpp
@@ -41,10 +41,13 @@ class ExecutionProcessor {
      */
     void execute_transaction(const Transaction& txn, Receipt& receipt) noexcept;
 
-    //! \brief Execute the block and write the result to the DB.
+    //! \brief Execute the block.
     //! \remarks Warning: This method does not verify state root; pre-Byzantium receipt root isn't validated either.
     //! \pre RuleSet's validate_block_header & pre_validate_block_body must return kOk.
-    [[nodiscard]] ValidationResult execute_and_write_block(std::vector<Receipt>& receipts) noexcept;
+    [[nodiscard]] ValidationResult execute_block(std::vector<Receipt>& receipts) noexcept;
+
+    //! \brief Flush IntraBlockState into cumulative State.
+    void flush_state();
 
     uint64_t available_gas() const noexcept;
 

--- a/silkworm/core/protocol/blockchain.cpp
+++ b/silkworm/core/protocol/blockchain.cpp
@@ -93,9 +93,11 @@ ValidationResult Blockchain::execute_block(const Block& block, bool check_state_
     processor.evm().state_pool = state_pool;
     processor.evm().exo_evm = exo_evm;
 
-    if (const auto res{processor.execute_and_write_block(receipts_)}; res != ValidationResult::kOk) {
+    if (const ValidationResult res = processor.execute_block(receipts_); res != ValidationResult::kOk) {
         return res;
     }
+
+    processor.flush_state();
 
     if (check_state_root) {
         evmc::bytes32 state_root{state_.state_root_hash()};

--- a/silkworm/core/state/in_memory_state.cpp
+++ b/silkworm/core/state/in_memory_state.cpp
@@ -142,7 +142,7 @@ void InMemoryState::insert_receipts(BlockNum, const std::vector<Receipt>&) {}
 
 void InMemoryState::insert_call_traces(BlockNum /*block_number*/, const CallTraces& /*traces*/) {}
 
-void InMemoryState::begin_block(BlockNum block_number) {
+void InMemoryState::begin_block(BlockNum block_number, size_t /*updated_accounts_count*/) {
     block_number_ = block_number;
     account_changes_.erase(block_number);
     storage_changes_.erase(block_number);

--- a/silkworm/core/state/in_memory_state.hpp
+++ b/silkworm/core/state/in_memory_state.hpp
@@ -70,7 +70,7 @@ class InMemoryState : public State {
 
     void insert_call_traces(BlockNum block_number, const CallTraces& traces) override;
 
-    void begin_block(BlockNum block_number) override;
+    void begin_block(BlockNum block_number, size_t updated_accounts_count) override;
 
     void update_account(const evmc::address& address, std::optional<Account> initial,
                         std::optional<Account> current) override;

--- a/silkworm/core/state/intra_block_state.cpp
+++ b/silkworm/core/state/intra_block_state.cpp
@@ -322,7 +322,7 @@ void IntraBlockState::set_transient_storage(const evmc::address& addr, const evm
 }
 
 void IntraBlockState::write_to_db(uint64_t block_number) {
-    db_.begin_block(block_number);
+    db_.begin_block(block_number, objects_.size());
 
     for (const auto& [address, storage] : storage_) {
         auto it1{objects_.find(address)};

--- a/silkworm/core/state/state.hpp
+++ b/silkworm/core/state/state.hpp
@@ -72,7 +72,7 @@ class State : public BlockState {
     /** Mark the beginning of a new block.
      * Must be called prior to calling update_account/update_account_code/update_storage.
      */
-    virtual void begin_block(BlockNum block_number) = 0;
+    virtual void begin_block(BlockNum block_number, size_t updated_accounts_count) = 0;
 
     virtual void update_account(const evmc::address& address, std::optional<Account> initial,
                                 std::optional<Account> current) = 0;

--- a/silkworm/db/buffer.cpp
+++ b/silkworm/db/buffer.cpp
@@ -52,8 +52,11 @@ size_t flat_hash_map_memory_size_after_inserts(const TFlatHashMap& map, size_t i
 }
 
 void Buffer::begin_block(uint64_t block_number, size_t updated_accounts_count) {
+    if (current_batch_state_size() > memory_limit_) {
+        throw MemoryLimitError();
+    }
     if (flat_hash_map_memory_size_after_inserts(accounts_, updated_accounts_count) > memory_limit_) {
-        // TODO: error
+        throw MemoryLimitError();
     }
 
     block_number_ = block_number;

--- a/silkworm/db/buffer.cpp
+++ b/silkworm/db/buffer.cpp
@@ -85,11 +85,7 @@ void Buffer::update_account(const evmc::address& address, std::optional<Account>
             encoded_initial = initial->encode_for_storage(omit_code_hash);
         }
 
-        size_t payload_size{block_account_changes_.contains(block_number_) ? 0 : sizeof(BlockNum)};
-        if (block_account_changes_[block_number_].insert_or_assign(address, encoded_initial).second) {
-            payload_size += kAddressLength + encoded_initial.length();
-        }
-        batch_history_size_ += payload_size;
+        block_account_changes_[block_number_].insert_or_assign(address, encoded_initial);
     }
 
     if (equal) {
@@ -138,11 +134,7 @@ void Buffer::update_storage(const evmc::address& address, uint64_t incarnation, 
     if (block_number_ >= prune_history_threshold_) {
         changed_storage_.insert(address);
         ByteView initial_val{zeroless_view(initial.bytes)};
-        if (block_storage_changes_[block_number_][address][incarnation]
-                .insert_or_assign(location, initial_val)
-                .second) {
-            batch_history_size_ += kPlainStoragePrefixLength + kHashLength + initial_val.size();
-        }
+        block_storage_changes_[block_number_][address][incarnation].insert_or_assign(location, initial_val);
     }
 
     // Iterator in insert_or_assign return value "is pointing at the element that was inserted or updated"
@@ -280,7 +272,6 @@ void Buffer::write_history_to_db(bool write_change_sets) {
         }
     }
 
-    batch_history_size_ = 0;
     auto [finish_time, _]{sw.stop()};
     if (should_trace) [[unlikely]] {
         log::Trace("Flushed history",
@@ -426,15 +417,12 @@ void Buffer::insert_receipts(uint64_t block_number, const std::vector<Receipt>& 
         Bytes key{log_key(block_number, i)};
         Bytes value{cbor_encode(receipts[i].logs)};
 
-        if (logs_.insert_or_assign(key, value).second) {
-            batch_history_size_ += key.size() + value.size();
-        }
+        logs_.insert_or_assign(key, value);
     }
 
     Bytes key{block_key(block_number)};
     Bytes value{cbor_encode(receipts)};
     receipts_[key] = value;
-    batch_history_size_ += key.size() + value.size();
 }
 
 void Buffer::insert_call_traces(BlockNum block_number, const CallTraces& traces) {
@@ -448,8 +436,6 @@ void Buffer::insert_call_traces(BlockNum block_number, const CallTraces& traces)
     }
 
     if (!touched_accounts.empty()) {
-        batch_history_size_ += sizeof(BlockNum);
-
         absl::btree_set<Bytes> values;
         for (const auto& account : touched_accounts) {
             Bytes value(kAddressLength + 1, '\0');
@@ -460,7 +446,6 @@ void Buffer::insert_call_traces(BlockNum block_number, const CallTraces& traces)
             if (traces.recipients.contains(account)) {
                 value[kAddressLength] |= 2;
             }
-            batch_history_size_ += value.size();
             values.insert(std::move(value));
         }
         call_traces_.emplace(block_number, values);

--- a/silkworm/db/buffer.hpp
+++ b/silkworm/db/buffer.hpp
@@ -18,6 +18,7 @@
 
 #include <limits>
 #include <optional>
+#include <stdexcept>
 #include <vector>
 
 #include <absl/container/btree_map.h>
@@ -146,6 +147,11 @@ class Buffer : public State {
 
     //! \brief Persists *state* accrued contents into db
     void write_state_to_db();
+
+    class MemoryLimitError : public std::runtime_error {
+      public:
+        MemoryLimitError() : std::runtime_error("db::Buffer::MemoryLimitError") {}
+    };
 
   private:
     RWTxn& txn_;

--- a/silkworm/db/buffer.hpp
+++ b/silkworm/db/buffer.hpp
@@ -135,9 +135,6 @@ class Buffer : public State {
     //! \brief Approximate size of accrued state in bytes.
     [[nodiscard]] size_t current_batch_state_size() const noexcept { return batch_state_size_; }
 
-    //! \brief Approximate size of accrued history in bytes.
-    [[nodiscard]] size_t current_batch_history_size() const noexcept { return batch_history_size_; }
-
     //! \brief Persists *all* accrued contents into db
     //! \remarks write_history_to_db is implicitly called
     //! @param write_change_sets flag indicating if state changes should be written or not (default: true)
@@ -186,8 +183,8 @@ class Buffer : public State {
     absl::btree_map<Bytes, Bytes> logs_;
     absl::btree_map<BlockNum, absl::btree_set<Bytes>> call_traces_;
 
-    mutable size_t batch_state_size_{0};    // Accounts in memory data for state
-    mutable size_t batch_history_size_{0};  // Accounts in memory data for history
+    // Accounts in memory data for state
+    mutable size_t batch_state_size_{0};
 
     // Current block stuff
     uint64_t block_number_{0};

--- a/silkworm/db/buffer_test.cpp
+++ b/silkworm/db/buffer_test.cpp
@@ -51,7 +51,7 @@ TEST_CASE("Storage update") {
     upsert_storage_value(*state, key, location_a.bytes, value_a1.bytes);
     upsert_storage_value(*state, key, location_b.bytes, value_b.bytes);
 
-    Buffer buffer{txn, 0};
+    Buffer buffer{txn};
 
     CHECK(buffer.read_storage(address, kDefaultIncarnation, location_a) == value_a1);
 
@@ -108,8 +108,8 @@ TEST_CASE("Account update") {
         Account current_account;
         current_account.balance = kEther;
 
-        Buffer buffer{txn, 0};
-        buffer.begin_block(1);
+        Buffer buffer{txn};
+        buffer.begin_block(1, 1);
         buffer.update_account(address, /*initial=*/std::nullopt, current_account);
         REQUIRE(!buffer.account_changes().empty());
         // Current state batch: current account address + current account encoding
@@ -143,8 +143,8 @@ TEST_CASE("Account update") {
         current_account.nonce = 2;
         current_account.balance = kEther;
 
-        Buffer buffer{txn, 0};
-        buffer.begin_block(1);
+        Buffer buffer{txn};
+        buffer.begin_block(1, 1);
         buffer.update_account(address, /*initial=*/initial_account, current_account);
         REQUIRE(!buffer.account_changes().empty());
         // Current state batch: current account address + current account encoding
@@ -177,8 +177,8 @@ TEST_CASE("Account update") {
         account.incarnation = kDefaultIncarnation;
         account.code_hash = to_bytes32(keccak256(address.bytes).bytes);  // Just a fake hash
 
-        Buffer buffer{txn, 0};
-        buffer.begin_block(1);
+        Buffer buffer{txn};
+        buffer.begin_block(1, 1);
         buffer.update_account(address, /*initial=*/account, /*current=*/std::nullopt);
         REQUIRE(!buffer.account_changes().empty());
         // Current state batch: initial account for delete + (initial account + incarnation) for incarnation
@@ -201,14 +201,14 @@ TEST_CASE("Account update") {
         account.code_hash = to_bytes32(keccak256(address.bytes).bytes);  // Just a fake hash
 
         // Block 1: create contract account
-        Buffer buffer{txn, 0};
-        buffer.begin_block(1);
+        Buffer buffer{txn};
+        buffer.begin_block(1, 1);
         buffer.update_account(address, /*initial=*/std::nullopt, /*current=*/account);
         REQUIRE(!buffer.account_changes().empty());
         REQUIRE_NOTHROW(buffer.write_to_db());
 
         // Block 2 : destroy contract and recreate account as EOA
-        buffer.begin_block(2);
+        buffer.begin_block(2, 1);
         Account eoa;
         eoa.balance = kEther;
         buffer.update_account(address, /*initial=*/account, /*current=*/eoa);
@@ -232,8 +232,8 @@ TEST_CASE("Account update") {
         current_account.nonce = 2;
         current_account.balance = kEther;
 
-        Buffer buffer{txn, 0};
-        buffer.begin_block(1);
+        Buffer buffer{txn};
+        buffer.begin_block(1, 1);
         buffer.update_account(address, /*initial=*/initial_account, current_account);
         REQUIRE(buffer.account_changes().empty());
         CHECK(buffer.current_batch_state_size() == 0);    // No change in current state batch

--- a/silkworm/db/test_util/test_database_context.cpp
+++ b/silkworm/db/test_util/test_database_context.cpp
@@ -127,7 +127,7 @@ void populate_blocks(db::RWTxn& txn, const std::filesystem::path& tests_dir, InM
         // FIX 4b: populate receipts and logs table
         std::vector<silkworm::Receipt> receipts;
         ExecutionProcessor processor{block, *ruleSet, state_buffer, *chain_config};
-        db::Buffer db_buffer{txn, 0};
+        db::Buffer db_buffer{txn};
         for (auto& block_txn : block.transactions) {
             silkworm::Receipt receipt{};
             processor.execute_transaction(block_txn, receipt);

--- a/silkworm/node/stagedsync/stages/stage_bodies.cpp
+++ b/silkworm/node/stagedsync/stages/stage_bodies.cpp
@@ -32,7 +32,7 @@ BodiesStage::BodyDataModel::BodyDataModel(db::RWTxn& tx, BlockNum bodies_stage_h
       data_model_(tx_),
       chain_config_{chain_config},
       rule_set_{protocol::rule_set_factory(chain_config)},
-      chain_state_{tx, /*prune_history_threshold=*/0, /*historical_block=null*/} {
+      chain_state_{tx} {
     initial_height_ = bodies_stage_height;
     highest_height_ = bodies_stage_height;
 }

--- a/silkworm/node/stagedsync/stages/stage_execution.cpp
+++ b/silkworm/node/stagedsync/stages/stage_execution.cpp
@@ -199,7 +199,10 @@ Stage::Result Execution::execute_batch(db::RWTxn& txn, BlockNum max_block_num, A
     auto log_time{std::chrono::steady_clock::now()};
 
     try {
-        db::Buffer buffer(txn, prune_history_threshold);
+        db::Buffer buffer{txn};
+        buffer.set_prune_history_threshold(prune_history_threshold);
+        buffer.set_memory_limit(batch_size_);
+
         std::vector<Receipt> receipts;
 
         // Transform batch_size limit into Ggas

--- a/silkworm/node/stagedsync/stages/stage_history_index_test.cpp
+++ b/silkworm/node/stagedsync/stages/stage_history_index_test.cpp
@@ -86,7 +86,7 @@ TEST_CASE("Stage History Index") {
         block.transactions[0].s = 1;  // dummy
         block.transactions[0].set_sender(sender);
 
-        db::Buffer buffer{txn, 0};
+        db::Buffer buffer{txn};
         Account sender_account{};
         sender_account.balance = kEther;
         buffer.update_account(sender, std::nullopt, sender_account);
@@ -446,7 +446,7 @@ TEST_CASE("HistoryIndex + Account access_layer") {
     db::test_util::TempChainData context;
     db::RWTxn& txn{context.rw_txn()};
 
-    db::Buffer buffer{txn, 0};
+    db::Buffer buffer{txn};
 
     const auto miner_a{0x00000000000000000000000000000000000000aa_address};
     const auto miner_b{0x00000000000000000000000000000000000000bb_address};

--- a/silkworm/node/stagedsync/stages_test.cpp
+++ b/silkworm/node/stagedsync/stages_test.cpp
@@ -324,7 +324,7 @@ TEST_CASE("Sync Stages") {
         block.transactions[0].s = 1;  // dummy
         block.transactions[0].set_sender(sender);
 
-        db::Buffer buffer{txn, 0};
+        db::Buffer buffer{txn};
         Account sender_account{};
         sender_account.balance = kEther;
         buffer.update_account(sender, std::nullopt, sender_account);
@@ -387,7 +387,7 @@ TEST_CASE("Sync Stages") {
             stagedsync::Execution stage = make_execution_stage(&sync_context, node_settings);
             REQUIRE(stage.unwind(txn) == stagedsync::Stage::Result::kSuccess);
 
-            db::Buffer buffer2{txn, 0};
+            db::Buffer buffer2{txn};
 
             std::optional<Account> contract_account{buffer2.read_account(contract_address)};
             REQUIRE(contract_account.has_value());

--- a/silkworm/rpc/core/local_state.hpp
+++ b/silkworm/rpc/core/local_state.hpp
@@ -67,7 +67,7 @@ class LocalState : public silkworm::State {
 
     void insert_call_traces(BlockNum /*block_number*/, const CallTraces& /*traces*/) override {}
 
-    void begin_block(BlockNum /*block_number*/) override {}
+    void begin_block(BlockNum /*block_number*/, size_t /*updated_accounts_count*/) override {}
 
     void update_account(
         const evmc::address& /*address*/,

--- a/silkworm/rpc/core/override_state.hpp
+++ b/silkworm/rpc/core/override_state.hpp
@@ -75,8 +75,8 @@ class OverrideState : public silkworm::State {
         return inner_state_.insert_call_traces(block_number, traces);
     }
 
-    void begin_block(BlockNum block_number) override {
-        return inner_state_.begin_block(block_number);
+    void begin_block(BlockNum block_number, size_t updated_accounts_count) override {
+        return inner_state_.begin_block(block_number, updated_accounts_count);
     }
 
     void update_account(

--- a/silkworm/rpc/core/remote_state.hpp
+++ b/silkworm/rpc/core/remote_state.hpp
@@ -101,7 +101,7 @@ class RemoteState : public silkworm::State {
 
     void insert_call_traces(BlockNum /*block_number*/, const CallTraces& /*traces*/) override {}
 
-    void begin_block(BlockNum /*block_number*/) override {}
+    void begin_block(BlockNum /*block_number*/, size_t /*updated_accounts_count*/) override {}
 
     void update_account(
         const evmc::address& /*address*/,

--- a/silkworm/rpc/core/remote_state_test.cpp
+++ b/silkworm/rpc/core/remote_state_test.cpp
@@ -378,7 +378,7 @@ TEST_CASE_METHOD(RemoteStateTest, "RemoteState") {
         CHECK_NOTHROW(remote_state.canonize_block(0, evmc::bytes32{}));
         CHECK_NOTHROW(remote_state.decanonize_block(0));
         CHECK_NOTHROW(remote_state.insert_receipts(0, std::vector<silkworm::Receipt>{}));
-        CHECK_NOTHROW(remote_state.begin_block(0));
+        CHECK_NOTHROW(remote_state.begin_block(0, 0));
         CHECK_NOTHROW(remote_state.update_account(evmc::address{}, std::nullopt, std::nullopt));
         CHECK_NOTHROW(remote_state.update_account_code(evmc::address{}, 0, evmc::bytes32{}, silkworm::ByteView{}));
         CHECK_NOTHROW(remote_state.update_storage(evmc::address{}, 0, evmc::bytes32{}, evmc::bytes32{}, evmc::bytes32{}));


### PR DESCRIPTION
The flat_hash_map has a policy (in `rehash_and_grow_if_necessary()`) to grow 2x when its size reaches 25/32 (78%) of capacity.

Previously the batch execution logic was adding things to db::Buffer, and then testing if its size becomes bigger than batch_size. This lead to significant overshooting, because at the growth threshold it will double the memory size and make it batch_size * 2 (even more, because there's also unused 22% of capacity).

In standalone silkworm execution stage the batch_size estimation was based on a gas-based heuristic formula, which lead to significant underestimation and an OOM crash when trying to allocate 4 Gb of RAM at once.

This changes the logic from checking batch_size aposteriori to apriori. If there's a possibility to grow the buffer significantly and overshoot the limit, we shouldn't take the risk, and commit the batch.

Additional changes:
* execution stage: flush history after each block as in CAPI
* capi: persist the executed work before quitting on invalid block
* remove unused db::Buffer::current_batch_history_size()
* ExecutionProcessor: split flush_state from execute_block
* block_buffer.terminate_and_release_all using gsl::finally
