### PR TITLE
qa-tests: record the db version used for test

### DIFF
--- a/.github/workflows/rpc-performance-tests.yml
+++ b/.github/workflows/rpc-performance-tests.yml
@@ -118,6 +118,7 @@ jobs:
                     --commit $(git rev-parse HEAD) \
                     --test_name rpc-performance-test-${servers[i-1]}-$method \
                     --chain mainnet \
+                    --runner ${{ runner.name }} \
                     --db_version $db_version \
                     --outcome success \ 
                     --result_file ${{runner.workspace}}/rpc-tests/perf/reports/mainnet/result.json
@@ -130,6 +131,7 @@ jobs:
                      --commit $(git rev-parse HEAD) \
                      --test_name rpc-performance-test-${servers[i-1]}-$method \
                      --chain mainnet \
+                     --runner ${{ runner.name }} \
                      --db_version $db_version \
                      --outcome failure
                fi

--- a/.github/workflows/rpc-performance-tests.yml
+++ b/.github/workflows/rpc-performance-tests.yml
@@ -97,6 +97,10 @@ jobs:
 
                # Save test results to a directory with timestamp and commit hash
                cp -r ${{runner.workspace}}/rpc-tests/perf/reports/mainnet $RPC_PAST_TEST_DIR/mainnet_$(date +%Y%m%d_%H%M%S)_perf_$(git -C ${{runner.workspace}}/silkworm rev-parse --short HEAD)
+               
+               # Detect the pre-built db version
+               db_version=$(python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/prod_info.py $ERIGON_DIR/production.ini production erigon_repo_commit) 
+               
                # Check test runner script exit status
                if [ $perf_exit_status -eq 0 ]; then
 
@@ -107,13 +111,27 @@ jobs:
                   cp -r ${{runner.workspace}}/rpc-tests/perf/reports/bin ${{runner.workspace}}/last_execution_test/
 
                   echo "Save test result on DB"
-                  cd ${{runner.workspace}}/silkworm
-                  python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/upload_test_results.py --repo silkworm --branch ${{ github.ref_name }} --commit $(git rev-parse HEAD) --test_name rpc-performance-test-${servers[i-1]}-$method --chain mainnet --outcome success --result_file ${{runner.workspace}}/rpc-tests/perf/reports/mainnet/result.json
+                  cd ${{runner.workspace}}/silkworm                                             
+                  python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/upload_test_results.py \
+                    --repo silkworm \
+                    --branch ${{ github.ref_name }} \
+                    --commit $(git rev-parse HEAD) \
+                    --test_name rpc-performance-test-${servers[i-1]}-$method \
+                    --chain mainnet \
+                    --db_version $db_version \
+                    --outcome success \ 
+                    --result_file ${{runner.workspace}}/rpc-tests/perf/reports/mainnet/result.json
                else
                   failed_test=1
                   cd ${{runner.workspace}}/silkworm
-                  python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/upload_test_results.py --repo silkworm --branch ${{ github.ref_name }} --commit $(git rev-parse HEAD) --test_name rpc-performance-test-${servers[i-1]}-$method --chain mainnet --outcome failure
-
+                  python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/upload_test_results.py \
+                     --repo silkworm \
+                     --branch ${{ github.ref_name }} \
+                     --commit $(git rev-parse HEAD) \
+                     --test_name rpc-performance-test-${servers[i-1]}-$method \
+                     --chain mainnet \
+                     --db_version $db_version \
+                     --outcome failure
                fi
             done
 


### PR DESCRIPTION
Some tests utilise a prebuilt database.
To facilitate historical comparisons, it is useful to record the exact version of Erigon used to pre-build this database