### PR TITLE
rpcademon: remove erigon_cumulativeChainTraffic

### DIFF
--- a/silkworm/rpc/commands/erigon_api.hpp
+++ b/silkworm/rpc/commands/erigon_api.hpp
@@ -58,7 +58,6 @@ class ErigonRpcApi {
     Task<void> handle_erigon_get_logs_by_hash(const nlohmann::json& request, nlohmann::json& reply);
     Task<void> handle_erigon_forks(const nlohmann::json& request, nlohmann::json& reply);
     Task<void> handle_erigon_watch_the_burn(const nlohmann::json& request, nlohmann::json& reply);
-    Task<void> handle_erigon_cumulative_chain_traffic(const nlohmann::json& request, nlohmann::json& reply);
     Task<void> handle_erigon_node_info(const nlohmann::json& request, nlohmann::json& reply);
 
     // GLAZE

--- a/silkworm/rpc/commands/erigon_api_test.cpp
+++ b/silkworm/rpc/commands/erigon_api_test.cpp
@@ -50,9 +50,6 @@ class ErigonRpcApi_ForTest : public ErigonRpcApi {
     Task<void> erigon_block_number(const nlohmann::json& request, nlohmann::json& reply) {
         co_return co_await ErigonRpcApi::handle_erigon_block_number(request, reply);
     }
-    Task<void> erigon_cumulative_chain_traffic(const nlohmann::json& request, nlohmann::json& reply) {
-        co_return co_await ErigonRpcApi::handle_erigon_cumulative_chain_traffic(request, reply);
-    }
     Task<void> erigon_node_info(const nlohmann::json& request, nlohmann::json& reply) {
         co_return co_await ErigonRpcApi::handle_erigon_node_info(request, reply);
     }
@@ -267,38 +264,6 @@ TEST_CASE_METHOD(ErigonRpcApiTest, "ErigonRpcApi::handle_erigon_block_number", "
                                 "id":1,
                                 "method":"erigon_blockNumber",
                                 "params":[]
-                            })"_json,
-                            reply),
-                        std::exception);
-    }
-}
-
-TEST_CASE_METHOD(ErigonRpcApiTest, "ErigonRpcApi::handle_erigon_cumulative_chain_traffic", "[rpc][erigon_api]") {
-    nlohmann::json reply;
-
-    SECTION("request invalid params number") {
-        CHECK_NOTHROW(run<&ErigonRpcApi_ForTest::erigon_cumulative_chain_traffic>(
-            R"({
-                "jsonrpc":"2.0",
-                "id":1,
-                "method":"erigon_cumulativeChainTraffic",
-                "params":[]
-            })"_json,
-            reply));
-        CHECK(reply == R"({
-            "jsonrpc":"2.0",
-            "id":1,
-            "error":{"code":100,"message":"invalid erigon_cumulativeChainTraffic params: []"} 
-        })"_json);
-    }
-
-    SECTION("request block_number") {
-        CHECK_THROWS_AS(run<&ErigonRpcApi_ForTest::erigon_cumulative_chain_traffic>(
-                            R"({
-                                "jsonrpc":"2.0",
-                                "id":1,
-                                "method":"erigon_cumulativeChainTraffic",
-                                "params":["100"]
                             })"_json,
                             reply),
                         std::exception);

--- a/silkworm/rpc/commands/rpc_api_table.cpp
+++ b/silkworm/rpc/commands/rpc_api_table.cpp
@@ -192,7 +192,6 @@ void RpcApiTable::add_erigon_handlers() {
     method_handlers_[json_rpc::method::k_erigon_getLogsByHash] = &commands::RpcApi::handle_erigon_get_logs_by_hash;
     method_handlers_[json_rpc::method::k_erigon_forks] = &commands::RpcApi::handle_erigon_forks;
     method_handlers_[json_rpc::method::k_erigon_watchTheBurn] = &commands::RpcApi::handle_erigon_watch_the_burn;
-    method_handlers_[json_rpc::method::k_erigon_cumulative_chain_traffic] = &commands::RpcApi::handle_erigon_cumulative_chain_traffic;
     method_handlers_[json_rpc::method::k_erigon_nodeInfo] = &commands::RpcApi::handle_erigon_node_info;
 
     // GLAZE methods

--- a/silkworm/rpc/core/rawdb/chain.cpp
+++ b/silkworm/rpc/core/rawdb/chain.cpp
@@ -34,8 +34,6 @@
 namespace silkworm::rpc::core::rawdb {
 
 /* Local Routines */
-static Task<silkworm::Bytes> read_body_rlp(ethdb::Transaction& tx, const evmc::bytes32& block_hash, BlockNum block_number);
-
 Task<uint64_t> read_header_number(ethdb::Transaction& tx, const evmc::bytes32& block_hash) {
     const silkworm::ByteView block_hash_bytes{block_hash.bytes, silkworm::kHashLength};
     const auto value{co_await tx.get_one(db::table::kHeaderNumbersName, block_hash_bytes)};
@@ -85,31 +83,6 @@ Task<evmc::bytes32> read_head_header_hash(ethdb::Transaction& tx) {
     co_return head_header_hash;
 }
 
-Task<uint64_t> read_cumulative_transaction_count(ethdb::Transaction& tx, uint64_t block_number) {
-    const auto block_hash = co_await read_canonical_block_hash(tx, block_number);
-    const auto data = co_await read_body_rlp(tx, block_hash, block_number);
-    if (data.empty()) {
-        throw std::runtime_error{"empty block body RLP in read_body"};
-    }
-    SILK_TRACE << "RLP data for block body #" << block_number << ": " << silkworm::to_hex(data);
-
-    try {
-        silkworm::ByteView data_view{data};
-        auto stored_body{silkworm::unwrap_or_throw(silkworm::decode_stored_block_body(data_view))};
-        // 1 system txn in the beginning of block, and 1 at the end
-        SILK_DEBUG << "base_txn_id: " << stored_body.base_txn_id + 1 << " txn_count: " << stored_body.txn_count - 2;
-        co_return stored_body.base_txn_id + stored_body.txn_count - 1;
-    } catch (const silkworm::DecodingException& error) {
-        SILK_ERROR << "RLP decoding error for block body #" << block_number << " [" << error.what() << "]";
-        throw std::runtime_error{"RLP decoding error for block body [" + std::string(error.what()) + "]"};
-    }
-}
-
-Task<silkworm::Bytes> read_body_rlp(ethdb::Transaction& tx, const evmc::bytes32& block_hash, BlockNum block_number) {
-    const auto block_key = silkworm::db::block_key(block_number, block_hash.bytes);
-    co_return co_await tx.get_one(db::table::kBlockBodiesName, block_key);
-}
-
 Task<intx::uint256> read_total_issued(ethdb::Transaction& tx, BlockNum block_number) {
     const auto block_key = silkworm::db::block_key(block_number);
     const auto value = co_await tx.get_one(db::table::kIssuanceName, block_key);
@@ -133,17 +106,6 @@ Task<intx::uint256> read_total_burnt(ethdb::Transaction& tx, BlockNum block_numb
     }
     SILK_DEBUG << "rawdb::read_total_burnt: " << total_burnt;
     co_return total_burnt;
-}
-
-Task<intx::uint256> read_cumulative_gas_used(ethdb::Transaction& tx, BlockNum block_number) {
-    const auto block_key = silkworm::db::block_key(block_number);
-    const auto value = co_await tx.get_one(db::table::kCumulativeGasIndexName, block_key);
-    intx::uint256 cumulative_gas_index = 0;
-    if (!value.empty()) {
-        cumulative_gas_index = std::stoul(silkworm::to_hex(value), nullptr, 16);
-    }
-    SILK_DEBUG << "rawdb::read_cumulative_gas_used: " << cumulative_gas_index;
-    co_return cumulative_gas_index;
 }
 
 }  // namespace silkworm::rpc::core::rawdb

--- a/silkworm/rpc/core/rawdb/chain.hpp
+++ b/silkworm/rpc/core/rawdb/chain.hpp
@@ -41,12 +41,8 @@ Task<intx::uint256> read_total_difficulty(ethdb::Transaction& tx, const evmc::by
 
 Task<evmc::bytes32> read_head_header_hash(ethdb::Transaction& tx);
 
-Task<uint64_t> read_cumulative_transaction_count(ethdb::Transaction& tx, BlockNum block_number);
-
 Task<intx::uint256> read_total_issued(ethdb::Transaction& tx, BlockNum block_number);
 
 Task<intx::uint256> read_total_burnt(ethdb::Transaction& tx, BlockNum block_number);
-
-Task<intx::uint256> read_cumulative_gas_used(ethdb::Transaction& tx, BlockNum block_number);
 
 }  // namespace silkworm::rpc::core::rawdb

--- a/silkworm/rpc/core/rawdb/chain_test.cpp
+++ b/silkworm/rpc/core/rawdb/chain_test.cpp
@@ -153,43 +153,6 @@ TEST_CASE("read_total_difficulty") {
     }
 }
 
-TEST_CASE("read_cumulative_transaction_count") {
-    silkworm::test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
-    SECTION("block found and matching") {
-        WorkerPool pool{1};
-        test::MockTransaction transaction;
-        const uint64_t block_number{4'000'000};
-        EXPECT_CALL(transaction, get_one(db::table::kCanonicalHashesName, _)).WillOnce(InvokeWithoutArgs([]() -> Task<silkworm::Bytes> { co_return *silkworm::from_hex("9816753229fc0736bf86a5048de4bc9fcdede8c91dadf88c828c76b2281dff"); }));
-        EXPECT_CALL(transaction, get_one(db::table::kBlockBodiesName, _)).WillOnce(InvokeWithoutArgs([]() -> Task<silkworm::Bytes> { co_return kBody; }));
-        auto result = boost::asio::co_spawn(pool, read_cumulative_transaction_count(transaction, block_number), boost::asio::use_future);
-        CHECK(result.get() == 6939740);
-    }
-
-    SECTION("block found empty") {
-        WorkerPool pool{1};
-        test::MockTransaction transaction;
-        const uint64_t block_number{4'000'000};
-        EXPECT_CALL(transaction, get_one(db::table::kCanonicalHashesName, _)).WillOnce(InvokeWithoutArgs([]() -> Task<silkworm::Bytes> { co_return *silkworm::from_hex("9816753229fc0736bf86a5048de4bc9fcdede8c91dadf88c828c76b2281dff"); }));
-        EXPECT_CALL(transaction, get_one(db::table::kBlockBodiesName, _)).WillOnce(InvokeWithoutArgs([]() -> Task<silkworm::Bytes> { co_return silkworm::Bytes{}; }));
-        auto result = boost::asio::co_spawn(pool, read_cumulative_transaction_count(transaction, block_number), boost::asio::use_future);
-#ifdef SILKWORM_SANITIZE  // Avoid comparison against exception message: it triggers a TSAN data race seemingly related to libstdc++ string implementation
-        CHECK_THROWS_AS(result.get(), std::runtime_error);
-#else
-        CHECK_THROWS_MATCHES(result.get(), std::runtime_error, Message("empty block body RLP in read_body"));
-#endif  // SILKWORM_SANITIZE
-    }
-
-    SECTION("block invalid") {
-        WorkerPool pool{1};
-        test::MockTransaction transaction;
-        const uint64_t block_number{4'000'000};
-        EXPECT_CALL(transaction, get_one(db::table::kCanonicalHashesName, _)).WillOnce(InvokeWithoutArgs([]() -> Task<silkworm::Bytes> { co_return *silkworm::from_hex("9816753229fc0736bf86a5048de4bc9fcdede8c91dadf88c828c76b2281dff"); }));
-        EXPECT_CALL(transaction, get_one(db::table::kBlockBodiesName, _)).WillOnce(InvokeWithoutArgs([]() -> Task<silkworm::Bytes> { co_return silkworm::Bytes{0x00, 0x01}; }));
-        auto result = boost::asio::co_spawn(pool, read_cumulative_transaction_count(transaction, block_number), boost::asio::use_future);
-        CHECK_THROWS_AS(result.get(), std::runtime_error);
-    }
-}
-
 TEST_CASE("read_total_issued") {
     silkworm::test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
     WorkerPool pool{1};
@@ -210,29 +173,6 @@ TEST_CASE("read_total_burnt") {
     EXPECT_CALL(transaction, get_one(_, _)).WillOnce(InvokeWithoutArgs([]() -> Task<silkworm::Bytes> { co_return kTotalBurnt; }));
     auto result = boost::asio::co_spawn(pool, read_total_burnt(transaction, block_number), boost::asio::use_future);
     CHECK(result.get() == 5);
-}
-
-TEST_CASE("read_cumulative_gas_used") {
-    silkworm::test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
-    SECTION("read_cumulative_gas_used") {
-        WorkerPool pool{1};
-        test::MockTransaction transaction;
-
-        const uint64_t block_number{20'000};
-        EXPECT_CALL(transaction, get_one(_, _)).WillOnce(InvokeWithoutArgs([]() -> Task<silkworm::Bytes> { co_return kCumulativeGasUsed; }));
-        auto result = boost::asio::co_spawn(pool, read_cumulative_gas_used(transaction, block_number), boost::asio::use_future);
-        CHECK(result.get() == 0x236);
-    }
-
-    SECTION("read_cumulative_gas_used get_one return empty") {
-        WorkerPool pool{1};
-        test::MockTransaction transaction;
-
-        const uint64_t block_number{20'000};
-        EXPECT_CALL(transaction, get_one(_, _)).WillOnce(InvokeWithoutArgs([]() -> Task<silkworm::Bytes> { co_return silkworm::Bytes{}; }));
-        auto result = boost::asio::co_spawn(pool, read_cumulative_gas_used(transaction, block_number), boost::asio::use_future);
-        CHECK(result.get() == 0);
-    }
 }
 
 }  // namespace silkworm::rpc::core::rawdb

--- a/silkworm/rpc/json_rpc/methods.hpp
+++ b/silkworm/rpc/json_rpc/methods.hpp
@@ -121,7 +121,6 @@ inline constexpr const char* k_erigon_getLatestLogs{"erigon_getLatestLogs"};
 inline constexpr const char* k_erigon_getLogsByHash{"erigon_getLogsByHash"};
 inline constexpr const char* k_erigon_forks{"erigon_forks"};
 inline constexpr const char* k_erigon_watchTheBurn{"erigon_watchTheBurn"};
-inline constexpr const char* k_erigon_cumulative_chain_traffic{"erigon_cumulativeChainTraffic"};
 inline constexpr const char* k_erigon_nodeInfo{"erigon_nodeInfo"};
 
 inline constexpr const char* k_parity_getBlockReceipts{"parity_getBlockReceipts"};

--- a/silkworm/rpc/storage/chain_storage.hpp
+++ b/silkworm/rpc/storage/chain_storage.hpp
@@ -115,7 +115,6 @@ class ChainStorage {
     // Task<intx::uint256> read_total_issued(BlockNum block_number);
 
     // Task<intx::uint256> read_total_burnt(BlockNum block_number);
-
 };
 
 }  // namespace silkworm::rpc

--- a/silkworm/rpc/storage/chain_storage.hpp
+++ b/silkworm/rpc/storage/chain_storage.hpp
@@ -116,7 +116,6 @@ class ChainStorage {
 
     // Task<intx::uint256> read_total_burnt(BlockNum block_number);
 
-    // Task<intx::uint256> read_cumulative_gas_used(BlockNum block_number);
 };
 
 }  // namespace silkworm::rpc


### PR DESCRIPTION
The `erigon_cumulativeChainTraffic` API was removed from erigon in release 2.49