### PR TITLE
rpcdaemon: rename json_rpc::JsonRpcValidator

### DIFF
--- a/docs/fuzzer.md
+++ b/docs/fuzzer.md
@@ -36,7 +36,7 @@ To help with analysing a single request you can run the diagnostic tool:
 ```
 
 ## Trophies
-1.	Various validation errors which led to the introduction of `JsonRpcValidator`
+1.	Various validation errors which led to the introduction of `rpc::json_rpc::Validator`
 2.	BlockNum accepting ill-formatted numbers, e.g. `5x5`
 3.	`{"jsonrpc":"2.0","id":1,"method":"eth_feeHistory","params":["0x1A","0x2",[95,99]]}` - triggers ASAN error
 

--- a/silkworm/rpc/daemon.cpp
+++ b/silkworm/rpc/daemon.cpp
@@ -247,7 +247,7 @@ Daemon::Daemon(DaemonSettings settings, std::optional<mdbx::env> chaindata_env)
     compatibility::set_erigon_json_api_compatibility_required(settings_.erigon_json_rpc_compatibility);
 
     // Load JSON RPC specification for Ethereum API
-    rpc::json_rpc::JsonRpcValidator::load_specification();
+    rpc::json_rpc::Validator::load_specification();
 }
 
 void Daemon::add_private_services() {

--- a/silkworm/rpc/json_rpc/request_handler.cpp
+++ b/silkworm/rpc/json_rpc/request_handler.cpp
@@ -119,7 +119,7 @@ nlohmann::json RequestHandler::prevalidate_and_parse(const std::string& request)
     return nlohmann::json::parse(request);
 }
 
-JsonRpcValidationResult RequestHandler::is_valid_jsonrpc(const nlohmann::json& request_json) {
+ValidationResult RequestHandler::is_valid_jsonrpc(const nlohmann::json& request_json) {
     return json_rpc_validator_.validate(request_json);
 }
 

--- a/silkworm/rpc/json_rpc/request_handler.hpp
+++ b/silkworm/rpc/json_rpc/request_handler.hpp
@@ -55,7 +55,7 @@ class RequestHandler : public rpc::RequestHandler {
 
   private:
     nlohmann::json prevalidate_and_parse(const std::string& request);
-    JsonRpcValidationResult is_valid_jsonrpc(const nlohmann::json& request_json);
+    ValidationResult is_valid_jsonrpc(const nlohmann::json& request_json);
 
     Task<void> handle_request(
         commands::RpcApiTable::HandleMethod handler,
@@ -73,7 +73,7 @@ class RequestHandler : public rpc::RequestHandler {
 
     const commands::RpcApiTable& rpc_api_table_;
 
-    JsonRpcValidator json_rpc_validator_;
+    Validator json_rpc_validator_;
 
     std::shared_ptr<InterfaceLog> ifc_log_;
 };

--- a/silkworm/rpc/json_rpc/validator.hpp
+++ b/silkworm/rpc/json_rpc/validator.hpp
@@ -25,26 +25,26 @@
 
 namespace silkworm::rpc::json_rpc {
 
-using JsonRpcValidationResult = tl::expected<void, std::string>;
+using ValidationResult = tl::expected<void, std::string>;
 
-class JsonRpcValidator {
+class Validator {
   public:
     static void load_specification();
     static const std::string& openrpc_version() { return openrpc_version_; }
 
-    JsonRpcValidationResult validate(const nlohmann::json& request);
+    ValidationResult validate(const nlohmann::json& request);
 
   private:
-    JsonRpcValidationResult check_request_fields(const nlohmann::json& request);
-    JsonRpcValidationResult validate_params(const nlohmann::json& request);
-    JsonRpcValidationResult validate_schema(const nlohmann::json& value, const nlohmann::json& schema);
-    JsonRpcValidationResult validate_type(const nlohmann::json& value, const nlohmann::json& schema);
-    JsonRpcValidationResult validate_string(const nlohmann::json& string, const nlohmann::json& schema);
-    JsonRpcValidationResult validate_array(const nlohmann::json& array, const nlohmann::json& schema);
-    JsonRpcValidationResult validate_object(const nlohmann::json& object, const nlohmann::json& schema);
-    JsonRpcValidationResult validate_boolean(const nlohmann::json& boolean);
-    JsonRpcValidationResult validate_number(const nlohmann::json& number);
-    JsonRpcValidationResult validate_null(const nlohmann::json& value);
+    ValidationResult check_request_fields(const nlohmann::json& request);
+    ValidationResult validate_params(const nlohmann::json& request);
+    ValidationResult validate_schema(const nlohmann::json& value, const nlohmann::json& schema);
+    ValidationResult validate_type(const nlohmann::json& value, const nlohmann::json& schema);
+    ValidationResult validate_string(const nlohmann::json& string, const nlohmann::json& schema);
+    ValidationResult validate_array(const nlohmann::json& array, const nlohmann::json& schema);
+    ValidationResult validate_object(const nlohmann::json& object, const nlohmann::json& schema);
+    ValidationResult validate_boolean(const nlohmann::json& boolean);
+    ValidationResult validate_number(const nlohmann::json& number);
+    ValidationResult validate_null(const nlohmann::json& value);
 
     inline static std::string openrpc_version_;
     inline static std::map<std::string, nlohmann::json> method_specs_;

--- a/silkworm/rpc/json_rpc/validator_benchmark.cpp
+++ b/silkworm/rpc/json_rpc/validator_benchmark.cpp
@@ -21,7 +21,7 @@
 
 #include "validator.hpp"
 
-static silkworm::rpc::json_rpc::JsonRpcValidator validator{};
+static silkworm::rpc::json_rpc::Validator validator{};
 
 const nlohmann::json requests[2] = {
     {

--- a/silkworm/rpc/json_rpc/validator_test.cpp
+++ b/silkworm/rpc/json_rpc/validator_test.cpp
@@ -24,19 +24,19 @@
 
 namespace silkworm::rpc::json_rpc {
 
-//! Ensure JSON RPC spec has been loaded before creating JsonRpcValidator instance
-static JsonRpcValidator create_validator_for_test() {
-    JsonRpcValidator::load_specification();
+//! Ensure JSON RPC spec has been loaded before creating Validator instance
+static Validator create_validator_for_test() {
+    Validator::load_specification();
     return {};
 }
 
-TEST_CASE("JsonRpcValidator loads spec in constructor", "[rpc][http][json_rpc_validator]") {
-    REQUIRE_NOTHROW(JsonRpcValidator::load_specification());
-    CHECK(JsonRpcValidator::openrpc_version() == "1.2.4");
+TEST_CASE("Validator loads spec in constructor", "[rpc][json_rpc][validator]") {
+    REQUIRE_NOTHROW(Validator::load_specification());
+    CHECK(Validator::openrpc_version() == "1.2.4");
 }
 
-TEST_CASE("JsonRpcValidator validates request fields", "[rpc][http][json_rpc_validator]") {
-    JsonRpcValidator validator{create_validator_for_test()};
+TEST_CASE("Validator validates request fields", "[rpc][json_rpc][validator]") {
+    Validator validator{create_validator_for_test()};
 
     nlohmann::json request = {
         {"jsonrpc", "2.0"},
@@ -45,19 +45,19 @@ TEST_CASE("JsonRpcValidator validates request fields", "[rpc][http][json_rpc_val
         {"id", 1},
     };
 
-    JsonRpcValidationResult result = validator.validate(request);
+    ValidationResult result = validator.validate(request);
     CHECK(result);
 }
 
-TEST_CASE("JsonRpcValidator detects missing request field", "[rpc][http][json_rpc_validator]") {
-    JsonRpcValidator validator{create_validator_for_test()};
+TEST_CASE("Validator detects missing request field", "[rpc][json_rpc][validator]") {
+    Validator validator{create_validator_for_test()};
 
     nlohmann::json request = {
         {"method", "eth_getBlockByNumber"},
         {"params", {"0x0", true}},
         {"id", 1},
     };
-    JsonRpcValidationResult result = validator.validate(request);
+    ValidationResult result = validator.validate(request);
     CHECK(!result);
     CHECK(result.error() == "Request not valid, required fields: jsonrpc,id,method,params");
 
@@ -80,8 +80,8 @@ TEST_CASE("JsonRpcValidator detects missing request field", "[rpc][http][json_rp
     CHECK(result.error() == "Request not valid, required fields: jsonrpc,id,method,params");
 }
 
-TEST_CASE("JsonRpcValidator validates invalid request fields", "[rpc][http][json_rpc_validator]") {
-    JsonRpcValidator validator{create_validator_for_test()};
+TEST_CASE("Validator validates invalid request fields", "[rpc][json_rpc][validator]") {
+    Validator validator{create_validator_for_test()};
 
     nlohmann::json request = {
         {"jsonrpc", 2},
@@ -90,7 +90,7 @@ TEST_CASE("JsonRpcValidator validates invalid request fields", "[rpc][http][json
         {"id", 1},
     };
 
-    JsonRpcValidationResult result = validator.validate(request);
+    ValidationResult result = validator.validate(request);
     CHECK(!result);
     CHECK(result.error() == "Invalid field: jsonrpc");
 
@@ -125,8 +125,8 @@ TEST_CASE("JsonRpcValidator validates invalid request fields", "[rpc][http][json
     CHECK(result.error() == "Invalid field: id");
 }
 
-TEST_CASE("JsonRpcValidator accepts missing params field", "[rpc][http][json_rpc_validator]") {
-    JsonRpcValidator validator{create_validator_for_test()};
+TEST_CASE("Validator accepts missing params field", "[rpc][json_rpc][validator]") {
+    Validator validator{create_validator_for_test()};
 
     nlohmann::json request = {
         {"jsonrpc", "2.0"},
@@ -134,12 +134,12 @@ TEST_CASE("JsonRpcValidator accepts missing params field", "[rpc][http][json_rpc
         {"id", 1},
     };
 
-    JsonRpcValidationResult result = validator.validate(request);
+    ValidationResult result = validator.validate(request);
     CHECK(result);
 }
 
-TEST_CASE("JsonRpcValidator rejects missing params field if required", "[rpc][http][json_rpc_validator]") {
-    JsonRpcValidator validator{create_validator_for_test()};
+TEST_CASE("Validator rejects missing params field if required", "[rpc][json_rpc][validator]") {
+    Validator validator{create_validator_for_test()};
 
     nlohmann::json request = {
         {"jsonrpc", "2.0"},
@@ -147,13 +147,13 @@ TEST_CASE("JsonRpcValidator rejects missing params field if required", "[rpc][ht
         {"id", 1},
     };
 
-    JsonRpcValidationResult result = validator.validate(request);
+    ValidationResult result = validator.validate(request);
     CHECK(!result);
     CHECK(result.error() == "Missing required parameter: Block");
 }
 
-TEST_CASE("JsonRpcValidator detects unknown fields", "[rpc][http][json_rpc_validator]") {
-    JsonRpcValidator validator{create_validator_for_test()};
+TEST_CASE("Validator detects unknown fields", "[rpc][json_rpc][validator]") {
+    Validator validator{create_validator_for_test()};
 
     nlohmann::json request = {
         {"unknown", "2.0"},
@@ -162,13 +162,13 @@ TEST_CASE("JsonRpcValidator detects unknown fields", "[rpc][http][json_rpc_valid
         {"id", 1},
     };
 
-    JsonRpcValidationResult result = validator.validate(request);
+    ValidationResult result = validator.validate(request);
     CHECK(!result);
     CHECK(result.error() == "Invalid field: unknown");
 }
 
-TEST_CASE("JsonRpcValidator accepts missing optional parameter", "[rpc][http][json_rpc_validator]") {
-    JsonRpcValidator validator{create_validator_for_test()};
+TEST_CASE("Validator accepts missing optional parameter", "[rpc][json_rpc][validator]") {
+    Validator validator{create_validator_for_test()};
 
     const auto request = R"({
         "jsonrpc":"2.0",
@@ -185,12 +185,12 @@ TEST_CASE("JsonRpcValidator accepts missing optional parameter", "[rpc][http][js
         ]
     })"_json;
 
-    JsonRpcValidationResult result = validator.validate(request);
+    ValidationResult result = validator.validate(request);
     CHECK(result);
 }
 
-TEST_CASE("JsonRpcValidator validates string parameter", "[rpc][http][json_rpc_validator]") {
-    JsonRpcValidator validator{create_validator_for_test()};
+TEST_CASE("Validator validates string parameter", "[rpc][json_rpc][validator]") {
+    Validator validator{create_validator_for_test()};
 
     nlohmann::json request = {
         {"jsonrpc", "2.0"},
@@ -198,7 +198,7 @@ TEST_CASE("JsonRpcValidator validates string parameter", "[rpc][http][json_rpc_v
         {"params", nlohmann::json::array({"0xaa0", "latest"})},
         {"id", 1},
     };
-    JsonRpcValidationResult result = validator.validate(request);
+    ValidationResult result = validator.validate(request);
     CHECK(!result);
     CHECK(result.error() == "Invalid string pattern: 0xaa0 in spec: Address");
 
@@ -253,8 +253,8 @@ TEST_CASE("JsonRpcValidator validates string parameter", "[rpc][http][json_rpc_v
     CHECK(result.error() == "Invalid string: 123 in spec: Address");
 }
 
-TEST_CASE("JsonRpcValidator validates optional parameter if provided", "[rpc][http][json_rpc_validator]") {
-    JsonRpcValidator validator{create_validator_for_test()};
+TEST_CASE("Validator validates optional parameter if provided", "[rpc][json_rpc][validator]") {
+    Validator validator{create_validator_for_test()};
 
     nlohmann::json request = {
         {"jsonrpc", "2.0"},
@@ -262,12 +262,12 @@ TEST_CASE("JsonRpcValidator validates optional parameter if provided", "[rpc][ht
         {"params", {"0xaa00000000000000000000000000000000000000", "not-valid-param"}},
         {"id", 1},
     };
-    JsonRpcValidationResult result = validator.validate(request);
+    ValidationResult result = validator.validate(request);
     CHECK(!result);
 }
 
-TEST_CASE("JsonRpcValidator validates enum", "[rpc][http][json_rpc_validator]") {
-    JsonRpcValidator validator{create_validator_for_test()};
+TEST_CASE("Validator validates enum", "[rpc][json_rpc][validator]") {
+    Validator validator{create_validator_for_test()};
 
     nlohmann::json request = {
         {"jsonrpc", "2.0"},
@@ -275,7 +275,7 @@ TEST_CASE("JsonRpcValidator validates enum", "[rpc][http][json_rpc_validator]") 
         {"params", {"0xaa00000000000000000000000000000000000000", "earliest"}},
         {"id", 1},
     };
-    JsonRpcValidationResult result = validator.validate(request);
+    ValidationResult result = validator.validate(request);
     CHECK(result);
     request = {
         {"jsonrpc", "2.0"},
@@ -297,8 +297,8 @@ TEST_CASE("JsonRpcValidator validates enum", "[rpc][http][json_rpc_validator]") 
     CHECK(!result);
 }
 
-TEST_CASE("JsonRpcValidator validates hash", "[rpc][http][json_rpc_validator]") {
-    JsonRpcValidator validator{create_validator_for_test()};
+TEST_CASE("Validator validates hash", "[rpc][json_rpc][validator]") {
+    Validator validator{create_validator_for_test()};
 
     nlohmann::json request = {
         {"jsonrpc", "2.0"},
@@ -306,7 +306,7 @@ TEST_CASE("JsonRpcValidator validates hash", "[rpc][http][json_rpc_validator]") 
         {"params", {"0xaa00000000000000000000000000000000000000", "0x76734e0205d8c4b711990ab957e86d3dc56d129600e60750552c95448a449794"}},
         {"id", 1},
     };
-    JsonRpcValidationResult result = validator.validate(request);
+    ValidationResult result = validator.validate(request);
     CHECK(result);
     request = {
         {"jsonrpc", "2.0"},
@@ -318,15 +318,15 @@ TEST_CASE("JsonRpcValidator validates hash", "[rpc][http][json_rpc_validator]") 
     CHECK(!result);
 }
 
-TEST_CASE("JsonRpcValidator validates array", "[rpc][http][json_rpc_validator]") {
-    JsonRpcValidator validator{create_validator_for_test()};
+TEST_CASE("Validator validates array", "[rpc][json_rpc][validator]") {
+    Validator validator{create_validator_for_test()};
 
     nlohmann::json request = {
         {"jsonrpc", "2.0"},
         {"id", 1},
         {"method", "eth_getProof"},
         {"params", {"0xaa00000000000000000000000000000000000000", {"0x01", "0x02"}, "0x3"}}};
-    JsonRpcValidationResult result = validator.validate(request);
+    ValidationResult result = validator.validate(request);
     CHECK(result);
 
     request = {
@@ -338,8 +338,8 @@ TEST_CASE("JsonRpcValidator validates array", "[rpc][http][json_rpc_validator]")
     CHECK(!result);
 }
 
-TEST_CASE("JsonRpcValidator validates object", "[rpc][http][json_rpc_validator]") {
-    JsonRpcValidator validator{create_validator_for_test()};
+TEST_CASE("Validator validates object", "[rpc][json_rpc][validator]") {
+    Validator validator{create_validator_for_test()};
 
     nlohmann::json request = {
         {"jsonrpc", "2.0"},
@@ -350,7 +350,7 @@ TEST_CASE("JsonRpcValidator validates object", "[rpc][http][json_rpc_validator]"
                        {"terminalBlockHash", "0x76734e0205d8c4b711990ab957e86d3dc56d129600e60750552c95448a449794"},
                        {"terminalBlockNumber", "0x1"},
                    }}}};
-    JsonRpcValidationResult result = validator.validate(request);
+    ValidationResult result = validator.validate(request);
     CHECK(result);
 
     request = {
@@ -413,8 +413,8 @@ TEST_CASE("JsonRpcValidator validates object", "[rpc][http][json_rpc_validator]"
     CHECK(!result);
 }
 
-TEST_CASE("JsonRpcValidator validates uppercase hex value", "[rpc][http][json_rpc_validator]") {
-    JsonRpcValidator validator{create_validator_for_test()};
+TEST_CASE("Validator validates uppercase hex value", "[rpc][json_rpc][validator]") {
+    Validator validator{create_validator_for_test()};
 
     nlohmann::json request = {
         {"jsonrpc", "2.0"},
@@ -423,12 +423,12 @@ TEST_CASE("JsonRpcValidator validates uppercase hex value", "[rpc][http][json_rp
         {"id", 1},
     };
 
-    JsonRpcValidationResult result = validator.validate(request);
+    ValidationResult result = validator.validate(request);
     CHECK(result);
 }
 
-TEST_CASE("JsonRpcValidator validates `data` field", "[rpc][http][json_rpc_validator]") {
-    JsonRpcValidator validator{create_validator_for_test()};
+TEST_CASE("Validator validates `data` field", "[rpc][json_rpc][validator]") {
+    Validator validator{create_validator_for_test()};
 
     nlohmann::json request = {
         {"jsonrpc", "2.0"},
@@ -437,12 +437,12 @@ TEST_CASE("JsonRpcValidator validates `data` field", "[rpc][http][json_rpc_valid
         {"id", 1},
     };
 
-    JsonRpcValidationResult result = validator.validate(request);
+    ValidationResult result = validator.validate(request);
     CHECK(result);
 }
 
-TEST_CASE("JsonRpcValidator validates nested arrays", "[rpc][http][json_rpc_validator]") {
-    JsonRpcValidator validator{create_validator_for_test()};
+TEST_CASE("Validator validates nested arrays", "[rpc][json_rpc][validator]") {
+    Validator validator{create_validator_for_test()};
 
     auto request1 = R"({
             "jsonrpc":"2.0",
@@ -457,7 +457,7 @@ TEST_CASE("JsonRpcValidator validates nested arrays", "[rpc][http][json_rpc_vali
             ],
             "id":3
     })"_json;
-    JsonRpcValidationResult result1 = validator.validate(request1);
+    ValidationResult result1 = validator.validate(request1);
     CHECK(result1);
 
     auto request2 = R"({
@@ -473,7 +473,7 @@ TEST_CASE("JsonRpcValidator validates nested arrays", "[rpc][http][json_rpc_vali
             ],
             "id":3
     })"_json;
-    JsonRpcValidationResult result2 = validator.validate(request2);
+    ValidationResult result2 = validator.validate(request2);
     CHECK(result2);
 
     auto request3 = R"({
@@ -492,12 +492,12 @@ TEST_CASE("JsonRpcValidator validates nested arrays", "[rpc][http][json_rpc_vali
             ],
             "id":3
     })"_json;
-    JsonRpcValidationResult result3 = validator.validate(request3);
+    ValidationResult result3 = validator.validate(request3);
     CHECK(result3);
 }
 
-TEST_CASE("JsonRpcValidator validates spec test request", "[rpc][http][json_rpc_validator]") {
-    JsonRpcValidator validator{create_validator_for_test()};
+TEST_CASE("Validator validates spec test request", "[rpc][json_rpc][validator]") {
+    Validator validator{create_validator_for_test()};
 
     const auto tests_dir = db::test_util::get_tests_dir();
     for (const auto& test_file : std::filesystem::recursive_directory_iterator(tests_dir)) {
@@ -519,8 +519,8 @@ TEST_CASE("JsonRpcValidator validates spec test request", "[rpc][http][json_rpc_
     }
 }
 
-TEST_CASE("JsonRpcValidator engine_newPayloadV3: patch blobGasUsed regex", "[rpc][http][json_rpc_validator]") {
-    JsonRpcValidator validator{create_validator_for_test()};
+TEST_CASE("Validator engine_newPayloadV3: patch blobGasUsed regex", "[rpc][json_rpc][validator]") {
+    Validator validator{create_validator_for_test()};
 
     // blobGasUsed regex at commit 5849052: "^0x([1-9a-f]+[0-9a-f]{0,15})|0$" does not work for input "blobGasUsed":"0x0"
     // blobGasUsed regex patch: "^0x([1-9a-f]+[0-9a-f]*|0)$"
@@ -552,12 +552,12 @@ TEST_CASE("JsonRpcValidator engine_newPayloadV3: patch blobGasUsed regex", "[rpc
             "0x705d84b4afc89d063429e34886b51a2d8844862acca72d9192ea5f1d0903dd21"
         ]
     })"_json;
-    JsonRpcValidationResult result = validator.validate(request);
+    ValidationResult result = validator.validate(request);
     CHECK(result);
 }
 
-TEST_CASE("JsonRpcValidator engine_newPayloadV3: patch gasUsed regex", "[rpc][http][json_rpc_validator]") {
-    JsonRpcValidator validator{create_validator_for_test()};
+TEST_CASE("Validator engine_newPayloadV3: patch gasUsed regex", "[rpc][json_rpc][validator]") {
+    Validator validator{create_validator_for_test()};
 
     // gasUsed regex at commit 5849052: "^0x([1-9a-f]+[0-9a-f]{0,15})|0$" does not work for input "gasUsed":"0x0"
     // gasUsed regex patch: "^0x([1-9a-f]+[0-9a-f]*|0)$"
@@ -589,12 +589,12 @@ TEST_CASE("JsonRpcValidator engine_newPayloadV3: patch gasUsed regex", "[rpc][ht
             "0xc3e3a313cb5b0e746326f0958cc5cbd931c5ccf9f6dde99e3ab0bd5d2c05d92a"
         ]
     })"_json;
-    JsonRpcValidationResult result = validator.validate(request);
+    ValidationResult result = validator.validate(request);
     CHECK(result);
 }
 
-TEST_CASE("JsonRpcValidator engine_forkchoiceUpdatedV3: null payloadAttributes param", "[rpc][http][json_rpc_validator]") {
-    JsonRpcValidator validator{create_validator_for_test()};
+TEST_CASE("Validator engine_forkchoiceUpdatedV3: null payloadAttributes param", "[rpc][json_rpc][validator]") {
+    Validator validator{create_validator_for_test()};
 
     // Payload attributes at commit 5849052 does NOT allow for null value
     auto request = R"({
@@ -610,12 +610,12 @@ TEST_CASE("JsonRpcValidator engine_forkchoiceUpdatedV3: null payloadAttributes p
             null
         ]
     })"_json;
-    JsonRpcValidationResult result = validator.validate(request);
+    ValidationResult result = validator.validate(request);
     CHECK(result);
 }
 
-TEST_CASE("JsonRpcValidator engine_forkchoiceUpdatedV3: missing payloadAttributes param", "[rpc][http][json_rpc_validator]") {
-    JsonRpcValidator validator{create_validator_for_test()};
+TEST_CASE("Validator engine_forkchoiceUpdatedV3: missing payloadAttributes param", "[rpc][json_rpc][validator]") {
+    Validator validator{create_validator_for_test()};
 
     auto request = R"({
         "jsonrpc":"2.0",
@@ -629,7 +629,7 @@ TEST_CASE("JsonRpcValidator engine_forkchoiceUpdatedV3: missing payloadAttribute
             }
         ]
     })"_json;
-    JsonRpcValidationResult result = validator.validate(request);
+    ValidationResult result = validator.validate(request);
     CHECK(result);
 }
 

--- a/silkworm/rpc/test_util/api_test_database.hpp
+++ b/silkworm/rpc/test_util/api_test_database.hpp
@@ -114,7 +114,7 @@ class RpcApiE2ETest : public db::test_util::TestDatabaseContext, RpcApiTestBase<
     explicit RpcApiE2ETest() : RpcApiTestBase<RequestHandler_ForTest>(get_mdbx_env()) {
         // Ensure JSON RPC spec has been loaded into the validator
         if (!jsonrpc_spec_loaded) {
-            json_rpc::JsonRpcValidator::load_specification();
+            json_rpc::Validator::load_specification();
             jsonrpc_spec_loaded = true;
         }
     }


### PR DESCRIPTION
Avoid repetition in `json_rpc::JsonRpcValidator` renaming it as `json_rpc::Validator`