### PR TITLE
rpcdaemon: refactoring ContextTestBase as infra test utility

### DIFF
--- a/silkworm/core/common/base.hpp
+++ b/silkworm/core/common/base.hpp
@@ -50,6 +50,8 @@ using BlockNum = uint64_t;
 using BlockNumRange = std::pair<BlockNum, BlockNum>;
 using BlockTime = uint64_t;
 
+inline constexpr BlockNum kEarliestBlockNumber{0ul};
+
 inline constexpr size_t kAddressLength{20};
 
 inline constexpr size_t kHashLength{32};

--- a/silkworm/infra/test_util/context_test_base.cpp
+++ b/silkworm/infra/test_util/context_test_base.cpp
@@ -1,5 +1,5 @@
-#[[
-   Copyright 2022 The Silkworm Authors
+/*
+   Copyright 2023 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -12,18 +12,24 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-]]
+*/
 
-find_package(benchmark REQUIRED)
+#include "context_test_base.hpp"
 
-file(GLOB_RECURSE SILKWORM_BENCHMARK_TESTS CONFIGURE_DEPENDS "${SILKWORM_MAIN_SRC_DIR}/*_benchmark.cpp")
-add_executable(benchmark_test benchmark_test.cpp ${SILKWORM_BENCHMARK_TESTS})
-target_link_libraries(
-  benchmark_test
-  silkworm_infra
-  silkworm_infra_test_util
-  silkworm_node
-  silkworm_rpcdaemon
-  silkworm_rpcdaemon_test_util
-  benchmark::benchmark
-)
+namespace silkworm::test_util {
+
+ContextTestBase::ContextTestBase()
+    : log_guard_{log::Level::kNone},
+      context_{0},
+      io_context_{*context_.io_context()},
+      grpc_context_{*context_.grpc_context()},
+      context_thread_{[&]() { context_.execute_loop(); }} {}
+
+ContextTestBase::~ContextTestBase() {
+    context_.stop();
+    if (context_thread_.joinable()) {
+        context_thread_.join();
+    }
+}
+
+}  // namespace silkworm::test_util

--- a/silkworm/infra/test_util/context_test_base.hpp
+++ b/silkworm/infra/test_util/context_test_base.hpp
@@ -27,7 +27,7 @@
 #include <silkworm/infra/grpc/client/client_context_pool.hpp>
 #include <silkworm/infra/test_util/log.hpp>
 
-namespace silkworm::rpc::test {
+namespace silkworm::test_util {
 
 class ContextTestBase {
   public:
@@ -50,10 +50,10 @@ class ContextTestBase {
     ~ContextTestBase();
 
     silkworm::test_util::SetLogVerbosityGuard log_guard_;
-    ClientContext context_;
+    rpc::ClientContext context_;
     boost::asio::io_context& io_context_;
     agrpc::GrpcContext& grpc_context_;
     std::thread context_thread_;
 };
 
-}  // namespace silkworm::rpc::test
+}  // namespace silkworm::test_util

--- a/silkworm/rpc/CMakeLists.txt
+++ b/silkworm/rpc/CMakeLists.txt
@@ -59,4 +59,6 @@ silkworm_library(
   PRIVATE ${SILKWORM_RPCDAEMON_PRIVATE_LIBRARIES}
 )
 
-target_link_libraries(silkworm_rpcdaemon_test PRIVATE silkworm_rpcdaemon_test_util GTest::gmock)
+target_link_libraries(
+  silkworm_rpcdaemon_test PRIVATE silkworm_infra_test_util silkworm_rpcdaemon_test_util GTest::gmock
+)

--- a/silkworm/rpc/commands/engine_api_test.cpp
+++ b/silkworm/rpc/commands/engine_api_test.cpp
@@ -106,14 +106,14 @@ class EngineRpcApi_ForTest : public EngineRpcApi {
 using testing::_;
 using testing::InvokeWithoutArgs;
 
-struct EngineRpcApiTest : public test::JsonApiTestBase<EngineRpcApi_ForTest> {
-    EngineRpcApiTest() : test::JsonApiTestBase<EngineRpcApi_ForTest>() {
+struct EngineRpcApiTest : public test_util::JsonApiTestBase<EngineRpcApi_ForTest> {
+    EngineRpcApiTest() : test_util::JsonApiTestBase<EngineRpcApi_ForTest>() {
         add_private_service<ethdb::Database>(io_context_, std::make_unique<DummyDatabase>(mock_cursor));
         add_shared_service<engine::ExecutionEngine>(io_context_, mock_engine);
         add_private_service<ethbackend::BackEnd>(io_context_, std::make_unique<test::BackEndMock>());
     }
 
-    std::shared_ptr<test::ExecutionEngineMock> mock_engine{std::make_shared<test::ExecutionEngineMock>()};
+    std::shared_ptr<test_util::ExecutionEngineMock> mock_engine{std::make_shared<test_util::ExecutionEngineMock>()};
     std::shared_ptr<test::MockCursor> mock_cursor{std::make_shared<test::MockCursor>()};
 };
 

--- a/silkworm/rpc/commands/erigon_api.cpp
+++ b/silkworm/rpc/commands/erigon_api.cpp
@@ -22,6 +22,7 @@
 
 #include <intx/intx.hpp>
 
+#include <silkworm/core/common/base.hpp>
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/core/protocol/ethash_rule_set.hpp>
 #include <silkworm/core/types/evmc_bytes32.hpp>
@@ -127,7 +128,7 @@ Task<void> ErigonRpcApi::handle_erigon_get_block_by_timestamp(const nlohmann::js
         const auto chain_storage = tx->create_storage();
 
         // Lookup the first and last block headers
-        const auto first_header = co_await chain_storage->read_canonical_header(core::kEarliestBlockNumber);
+        const auto first_header = co_await chain_storage->read_canonical_header(kEarliestBlockNumber);
         const auto head_header_hash = co_await core::rawdb::read_head_header_hash(*tx);
         const auto header_header_block_number = co_await chain_storage->read_block_number(head_header_hash);
         const auto current_header = co_await chain_storage->read_header(*header_header_block_number, head_header_hash);
@@ -138,7 +139,7 @@ Task<void> ErigonRpcApi::handle_erigon_get_block_by_timestamp(const nlohmann::js
         if (current_header->timestamp <= timestamp) {
             block_number = current_block_number;
         } else if (first_header->timestamp >= timestamp) {
-            block_number = core::kEarliestBlockNumber;
+            block_number = kEarliestBlockNumber;
         } else {
             // Good-old binary search to find the lowest block header matching timestamp
             auto matching_block_number = co_await binary_search(current_block_number, [&](uint64_t bn) -> Task<bool> {

--- a/silkworm/rpc/commands/erigon_api_test.cpp
+++ b/silkworm/rpc/commands/erigon_api_test.cpp
@@ -52,7 +52,7 @@ class ErigonRpcApi_ForTest : public ErigonRpcApi {
     }
 };
 
-using ErigonRpcApiTest = test::JsonApiTestBase<ErigonRpcApi_ForTest>;
+using ErigonRpcApiTest = test_util::JsonApiTestBase<ErigonRpcApi_ForTest>;
 
 #ifndef SILKWORM_SANITIZE
 TEST_CASE_METHOD(ErigonRpcApiTest, "ErigonRpcApi::handle_erigon_get_block_by_timestamp", "[rpc][erigon_api]") {

--- a/silkworm/rpc/commands/eth_api_test.cpp
+++ b/silkworm/rpc/commands/eth_api_test.cpp
@@ -24,10 +24,10 @@
 namespace silkworm::rpc::commands {
 
 #ifndef SILKWORM_SANITIZE
-TEST_CASE_METHOD(test::RpcApiE2ETest, "unit: eth_blockNumber succeeds if request well-formed", "[rpc][api]") {
+TEST_CASE_METHOD(test_util::RpcApiE2ETest, "unit: eth_blockNumber succeeds if request well-formed", "[rpc][api]") {
     const auto request = R"({"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]})"_json;
     std::string reply;
-    run<&test::RequestHandler_ForTest::request_and_create_reply>(request, reply);
+    run<&test_util::RequestHandler_ForTest::request_and_create_reply>(request, reply);
     CHECK(nlohmann::json::parse(reply) == R"({
         "jsonrpc":"2.0",
         "id":1,
@@ -35,10 +35,10 @@ TEST_CASE_METHOD(test::RpcApiE2ETest, "unit: eth_blockNumber succeeds if request
     })"_json);
 }
 
-TEST_CASE_METHOD(test::RpcApiE2ETest, "unit: eth_blockNumber fails if request empty", "[rpc][api]") {
+TEST_CASE_METHOD(test_util::RpcApiE2ETest, "unit: eth_blockNumber fails if request empty", "[rpc][api]") {
     const auto request = R"({})"_json;
     std::string reply;
-    run<&test::RequestHandler_ForTest::request_and_create_reply>(request, reply);
+    run<&test_util::RequestHandler_ForTest::request_and_create_reply>(request, reply);
     CHECK(nlohmann::json::parse(reply) == R"({
         "jsonrpc":"2.0",
         "id":null,
@@ -46,7 +46,7 @@ TEST_CASE_METHOD(test::RpcApiE2ETest, "unit: eth_blockNumber fails if request em
     })"_json);
 }
 
-TEST_CASE_METHOD(test::RpcApiE2ETest, "unit: eth_sendRawTransaction fails rlp parsing", "[rpc][api]") {
+TEST_CASE_METHOD(test_util::RpcApiE2ETest, "unit: eth_sendRawTransaction fails rlp parsing", "[rpc][api]") {
     const auto request = R"({
         "jsonrpc": "2.0",
         "id": 1,
@@ -54,7 +54,7 @@ TEST_CASE_METHOD(test::RpcApiE2ETest, "unit: eth_sendRawTransaction fails rlp pa
         "params": ["0xd46ed67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f0724456"]
     })"_json;
     std::string reply;
-    run<&test::RequestHandler_ForTest::request_and_create_reply>(request, reply);
+    run<&test_util::RequestHandler_ForTest::request_and_create_reply>(request, reply);
     CHECK(nlohmann::json::parse(reply) == R"({
         "jsonrpc":"2.0",
         "id":1,
@@ -62,7 +62,7 @@ TEST_CASE_METHOD(test::RpcApiE2ETest, "unit: eth_sendRawTransaction fails rlp pa
     })"_json);
 }
 
-TEST_CASE_METHOD(test::RpcApiE2ETest, "unit: eth_sendRawTransaction fails wrong number digit", "[rpc][api]") {
+TEST_CASE_METHOD(test_util::RpcApiE2ETest, "unit: eth_sendRawTransaction fails wrong number digit", "[rpc][api]") {
     const auto request = R"({
         "jsonrpc": "2.0",
         "id": 1,
@@ -70,7 +70,7 @@ TEST_CASE_METHOD(test::RpcApiE2ETest, "unit: eth_sendRawTransaction fails wrong 
         "params": ["0xd46ed67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445"]
     })"_json;
     std::string reply;
-    run<&test::RequestHandler_ForTest::request_and_create_reply>(request, reply);
+    run<&test_util::RequestHandler_ForTest::request_and_create_reply>(request, reply);
     CHECK(nlohmann::json::parse(reply) == R"({
         "jsonrpc":"2.0",
         "id":1,
@@ -78,10 +78,10 @@ TEST_CASE_METHOD(test::RpcApiE2ETest, "unit: eth_sendRawTransaction fails wrong 
     })"_json);
 }
 
-TEST_CASE_METHOD(test::RpcApiE2ETest, "unit: eth_feeHistory succeeds if request well-formed", "[rpc][api]") {
+TEST_CASE_METHOD(test_util::RpcApiE2ETest, "unit: eth_feeHistory succeeds if request well-formed", "[rpc][api]") {
     const auto request = R"({"jsonrpc":"2.0","id":1,"method":"eth_feeHistory","params":["0x1","0x867A80",[25,75]]})"_json;
     std::string reply;
-    run<&test::RequestHandler_ForTest::request_and_create_reply>(request, reply);
+    run<&test_util::RequestHandler_ForTest::request_and_create_reply>(request, reply);
     CHECK(nlohmann::json::parse(reply) == R"({
         "jsonrpc":"2.0",
         "id":1,
@@ -89,10 +89,10 @@ TEST_CASE_METHOD(test::RpcApiE2ETest, "unit: eth_feeHistory succeeds if request 
     })"_json);
 }
 
-TEST_CASE_METHOD(test::RpcApiE2ETest, "fuzzy: eth_call invalid params", "[rpc][api]") {
+TEST_CASE_METHOD(test_util::RpcApiE2ETest, "fuzzy: eth_call invalid params", "[rpc][api]") {
     const auto request = R"({"jsonrpc":"2.0","id":1,"method":"eth_call","params":[{}, "latest"]})"_json;
     std::string reply;
-    run<&test::RequestHandler_ForTest::request_and_create_reply>(request, reply);
+    run<&test_util::RequestHandler_ForTest::request_and_create_reply>(request, reply);
     CHECK(nlohmann::json::parse(reply) == R"({
         "jsonrpc":"2.0",
         "id":1,
@@ -100,10 +100,10 @@ TEST_CASE_METHOD(test::RpcApiE2ETest, "fuzzy: eth_call invalid params", "[rpc][a
    })"_json);
 }
 
-TEST_CASE_METHOD(test::RpcApiE2ETest, "fuzzy: eth_feeHistory sigsegv invalid input", "[rpc][api]") {
+TEST_CASE_METHOD(test_util::RpcApiE2ETest, "fuzzy: eth_feeHistory sigsegv invalid input", "[rpc][api]") {
     const auto request = R"({"jsonrpc":"2.0","id":1,"method":"eth_feeHistory","params":["5x1","0x2",[95,99]]})"_json;
     std::string reply;
-    run<&test::RequestHandler_ForTest::request_and_create_reply>(request, reply);
+    run<&test_util::RequestHandler_ForTest::request_and_create_reply>(request, reply);
     CHECK(nlohmann::json::parse(reply) == R"({
         "jsonrpc":"2.0",
         "id":1,
@@ -111,10 +111,10 @@ TEST_CASE_METHOD(test::RpcApiE2ETest, "fuzzy: eth_feeHistory sigsegv invalid inp
     })"_json);
 }
 
-TEST_CASE_METHOD(test::RpcApiE2ETest, "fuzzy: eth_feeHistory sigsegv valid input", "[rpc][api]") {
+TEST_CASE_METHOD(test_util::RpcApiE2ETest, "fuzzy: eth_feeHistory sigsegv valid input", "[rpc][api]") {
     const auto request = R"({"jsonrpc":"2.0","id":1,"method":"eth_feeHistory","params":["0x5","0x2",[95,99]]})"_json;
     std::string reply;
-    run<&test::RequestHandler_ForTest::request_and_create_reply>(request, reply);
+    run<&test_util::RequestHandler_ForTest::request_and_create_reply>(request, reply);
     CHECK(nlohmann::json::parse(reply) == R"({
         "jsonrpc":"2.0",
         "id":1,

--- a/silkworm/rpc/commands/parity_api_test.cpp
+++ b/silkworm/rpc/commands/parity_api_test.cpp
@@ -22,10 +22,10 @@
 namespace silkworm::rpc::commands {
 
 #ifndef SILKWORM_SANITIZE
-TEST_CASE_METHOD(test::RpcApiE2ETest, "parity_getBlockReceipts: misnamed 'params' field", "[rpc][api]") {
+TEST_CASE_METHOD(test_util::RpcApiE2ETest, "parity_getBlockReceipts: misnamed 'params' field", "[rpc][api]") {
     const auto request = R"({"jsonrpc":"2.0","id":1,"method":"parity_getBlockReceipts","pirams":["0x0"]})";
     std::string reply;
-    run<&test::RequestHandler_ForTest::handle_request>(request, reply);
+    run<&test_util::RequestHandler_ForTest::handle_request>(request, reply);
     CHECK(nlohmann::json::parse(reply) == R"({
         "jsonrpc":"2.0",
         "id":1,

--- a/silkworm/rpc/commands/rpc_api_test.cpp
+++ b/silkworm/rpc/commands/rpc_api_test.cpp
@@ -29,6 +29,10 @@
 
 namespace silkworm::rpc::commands {
 
+using silkworm::test_util::SetLogVerbosityGuard;
+using test_util::RequestHandler_ForTest;
+using test_util::RpcApiTestBase;
+
 // Function to recursively sort JSON arrays
 void sort_array(nlohmann::json& jsonObj) {  // NOLINT(*-no-recursion)
     if (jsonObj.is_array()) {
@@ -81,7 +85,7 @@ static const std::vector<std::string> subtests_to_ignore = {
 // Exclude tests from sanitizer builds due to ASAN/TSAN warnings inside gRPC library
 #ifndef SILKWORM_SANITIZE
 TEST_CASE("rpc_api io (all files)", "[rpc][rpc_api]") {
-    test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
+    SetLogVerbosityGuard log_guard{log::Level::kNone};
     auto tests_dir = db::test_util::get_tests_dir();
     for (const auto& test_file : std::filesystem::recursive_directory_iterator(tests_dir)) {
         if (!test_file.is_directory() && test_file.path().extension() == ".io") {
@@ -104,7 +108,7 @@ TEST_CASE("rpc_api io (all files)", "[rpc][rpc_api]") {
 
             SECTION("RPC IO test " + group_name + " | " + test_name) {  // NOLINT(*-inefficient-string-concatenation)
                 auto context = db::test_util::TestDatabaseContext();
-                test::RpcApiTestBase<test::RequestHandler_ForTest> test_base{context.get_mdbx_env()};
+                RpcApiTestBase<RequestHandler_ForTest> test_base{context.get_mdbx_env()};
 
                 std::string line_out;
                 std::string line_in;
@@ -118,7 +122,7 @@ TEST_CASE("rpc_api io (all files)", "[rpc][rpc_api]") {
                     auto expected = nlohmann::json::parse(line_in.substr(3));
 
                     std::string response;
-                    test_base.run<&test::RequestHandler_ForTest::request_and_create_reply>(request, response);
+                    test_base.run<&RequestHandler_ForTest::request_and_create_reply>(request, response);
                     INFO("Request:           " << request.dump());
                     INFO("Actual response:   " << response);
                     INFO("Expected response: " << expected.dump());
@@ -135,15 +139,15 @@ TEST_CASE("rpc_api io (all files)", "[rpc][rpc_api]") {
 }
 
 TEST_CASE("rpc_api io (individual)", "[rpc][rpc_api][ignore]") {
-    test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
+    SetLogVerbosityGuard log_guard{log::Level::kNone};
     auto context = db::test_util::TestDatabaseContext();
-    test::RpcApiTestBase<test::RequestHandler_ForTest> test_base{context.get_mdbx_env()};
+    RpcApiTestBase<RequestHandler_ForTest> test_base{context.get_mdbx_env()};
 
     SECTION("sample test") {
         auto request = R"({"jsonrpc":"2.0","id":1,"method":"debug_getRawTransaction","params":["0x74e41d593675913d6d5521f46523f1bd396dff1891bdb35f59be47c7e5e0b34b"]})"_json;
         std::string response;
 
-        test_base.run<&test::RequestHandler_ForTest::request_and_create_reply>(request, response);
+        test_base.run<&RequestHandler_ForTest::request_and_create_reply>(request, response);
         CHECK(nlohmann::json::parse(response) == R"({"jsonrpc":"2.0","id":1,"result":"0xf8678084342770c182520894658bdf435d810c91414ec09147daa6db624063798203e880820a95a0af5fc351b9e457a31f37c84e5cd99dd3c5de60af3de33c6f4160177a2c786a60a0201da7a21046af55837330a2c52fc1543cd4d9ead00ddf178dd96935b607ff9b"})"_json);
     }
 }

--- a/silkworm/rpc/common/async_task_benchmark.cpp
+++ b/silkworm/rpc/common/async_task_benchmark.cpp
@@ -17,7 +17,7 @@
 #include <benchmark/benchmark.h>
 
 #include <silkworm/rpc/common/worker_pool.hpp>
-#include <silkworm/rpc/test_util/context_test_base.hpp>
+#include <silkworm/rpc/test_util/service_context_test_base.hpp>
 
 #include "async_task.hpp"
 
@@ -27,7 +27,7 @@ std::size_t recursive_factorial(std::size_t n) {
     return n == 0 ? 1 : n * recursive_factorial(n - 1);
 }
 
-struct AsyncTaskBenchTest : test::ContextTestBase {
+struct AsyncTaskBenchTest : test_util::ServiceContextTestBase {
 };
 
 template <typename Executor>

--- a/silkworm/rpc/common/async_task_test.cpp
+++ b/silkworm/rpc/common/async_task_test.cpp
@@ -22,11 +22,11 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <silkworm/rpc/common/worker_pool.hpp>
-#include <silkworm/rpc/test_util/context_test_base.hpp>
+#include <silkworm/rpc/test_util/service_context_test_base.hpp>
 
 namespace silkworm::rpc {
 
-struct AsyncTaskTest : test::ContextTestBase {
+struct AsyncTaskTest : test_util::ServiceContextTestBase {
 };
 
 const static std::vector<std::pair<std::size_t, std::size_t>> kTestData = {

--- a/silkworm/rpc/common/binary_search_test.cpp
+++ b/silkworm/rpc/common/binary_search_test.cpp
@@ -21,11 +21,11 @@
 
 #include <catch2/catch_test_macros.hpp>
 
-#include <silkworm/rpc/test_util/context_test_base.hpp>
+#include <silkworm/rpc/test_util/service_context_test_base.hpp>
 
 namespace silkworm::rpc {
 
-struct BinarySearchTest : test::ContextTestBase {
+struct BinarySearchTest : test_util::ServiceContextTestBase {
 };
 
 struct BinaryTestData {

--- a/silkworm/rpc/core/blocks.hpp
+++ b/silkworm/rpc/core/blocks.hpp
@@ -33,8 +33,6 @@ constexpr const char* kFinalizedBlockId{"finalized"};
 constexpr const char* kSafeBlockId{"safe"};
 constexpr const char* kLatestExecutedBlockId{"latestExecuted"};
 
-constexpr BlockNum kEarliestBlockNumber{0ul};
-
 // TODO(canepat) migrate to ChainStorage?
 
 Task<bool> is_latest_block_number(BlockNum block_number, ethdb::Transaction& tx);

--- a/silkworm/rpc/core/estimate_gas_oracle_test.cpp
+++ b/silkworm/rpc/core/estimate_gas_oracle_test.cpp
@@ -39,7 +39,7 @@
 
 namespace silkworm::rpc {
 
-struct RemoteDatabaseTest : test::KVTestBase {
+struct RemoteDatabaseTest : test_util::KVTestBase {
   public:
     // RemoteDatabase holds the KV stub by std::unique_ptr, so we cannot rely on mock stub from base class
     StrictMockKVStub* kv_stub_ = new StrictMockKVStub;

--- a/silkworm/rpc/core/evm_debug_test.cpp
+++ b/silkworm/rpc/core/evm_debug_test.cpp
@@ -28,10 +28,10 @@
 #include <silkworm/rpc/core/remote_state.hpp>
 #include <silkworm/rpc/ethdb/kv/backend_providers.hpp>
 #include <silkworm/rpc/storage/remote_chain_storage.hpp>
-#include <silkworm/rpc/test_util/context_test_base.hpp>
 #include <silkworm/rpc/test_util/mock_back_end.hpp>
 #include <silkworm/rpc/test_util/mock_block_cache.hpp>
 #include <silkworm/rpc/test_util/mock_transaction.hpp>
+#include <silkworm/rpc/test_util/service_context_test_base.hpp>
 #include <silkworm/rpc/types/transaction.hpp>
 
 namespace silkworm::rpc::debug {
@@ -54,7 +54,7 @@ static Bytes kConfigValue{*silkworm::from_hex(
     "223a302c22697374616e62756c426c6f636b223a313536313635312c226265726c696e426c6f636b223a343436303634342c226c6f6e646f6e"
     "426c6f636b223a353036323630352c22636c69717565223a7b22706572696f64223a31352c2265706f6368223a33303030307d7d")};
 
-struct DebugExecutorTest : public test::ContextTestBase {
+struct DebugExecutorTest : public test_util::ServiceContextTestBase {
     test::MockBlockCache cache;
     test::MockTransaction transaction;
     WorkerPool workers{1};

--- a/silkworm/rpc/core/evm_executor_test.cpp
+++ b/silkworm/rpc/core/evm_executor_test.cpp
@@ -31,10 +31,10 @@
 #include <silkworm/rpc/common/util.hpp>
 #include <silkworm/rpc/ethdb/kv/backend_providers.hpp>
 #include <silkworm/rpc/storage/remote_chain_storage.hpp>
-#include <silkworm/rpc/test_util/context_test_base.hpp>
 #include <silkworm/rpc/test_util/dummy_transaction.hpp>
 #include <silkworm/rpc/test_util/mock_back_end.hpp>
 #include <silkworm/rpc/test_util/mock_transaction.hpp>
+#include <silkworm/rpc/test_util/service_context_test_base.hpp>
 #include <silkworm/rpc/types/transaction.hpp>
 
 namespace silkworm::rpc {
@@ -42,7 +42,7 @@ namespace silkworm::rpc {
 using testing::_;
 using testing::InvokeWithoutArgs;
 
-struct EVMExecutorTest : public test::ContextTestBase {
+struct EVMExecutorTest : public test_util::ServiceContextTestBase {
     EVMExecutorTest() {
         pool.start();
     }

--- a/silkworm/rpc/core/evm_trace_test.cpp
+++ b/silkworm/rpc/core/evm_trace_test.cpp
@@ -32,10 +32,10 @@
 #include <silkworm/rpc/core/remote_state.hpp>
 #include <silkworm/rpc/ethdb/kv/backend_providers.hpp>
 #include <silkworm/rpc/storage/remote_chain_storage.hpp>
-#include <silkworm/rpc/test_util/context_test_base.hpp>
 #include <silkworm/rpc/test_util/mock_back_end.hpp>
 #include <silkworm/rpc/test_util/mock_block_cache.hpp>
 #include <silkworm/rpc/test_util/mock_transaction.hpp>
+#include <silkworm/rpc/test_util/service_context_test_base.hpp>
 #include <silkworm/rpc/types/transaction.hpp>
 
 namespace silkworm::rpc::trace {
@@ -58,7 +58,7 @@ static Bytes kConfigValue{*silkworm::from_hex(
     "223a302c22697374616e62756c426c6f636b223a313536313635312c226265726c696e426c6f636b223a343436303634342c226c6f6e646f6e"
     "426c6f636b223a353036323630352c22636c69717565223a7b22706572696f64223a31352c2265706f6368223a33303030307d7d")};
 
-struct TraceCallExecutorTest : public test::ContextTestBase {
+struct TraceCallExecutorTest : public test_util::ServiceContextTestBase {
     test::MockTransaction transaction;
     WorkerPool workers{1};
     test::MockBlockCache block_cache;

--- a/silkworm/rpc/core/remote_state_test.cpp
+++ b/silkworm/rpc/core/remote_state_test.cpp
@@ -27,7 +27,7 @@
 #include <silkworm/core/common/empty_hashes.hpp>
 #include <silkworm/db/tables.hpp>
 #include <silkworm/infra/common/log.hpp>
-#include <silkworm/rpc/test_util/context_test_base.hpp>
+#include <silkworm/infra/test_util/context_test_base.hpp>
 #include <silkworm/rpc/test_util/mock_chain_storage.hpp>
 #include <silkworm/rpc/test_util/mock_transaction.hpp>
 
@@ -38,7 +38,7 @@ using testing::Invoke;
 using testing::InvokeWithoutArgs;
 using testing::Unused;
 
-struct RemoteStateTest : public test::ContextTestBase {
+struct RemoteStateTest : public test_util::ContextTestBase {
     test::MockTransaction transaction;
     boost::asio::any_io_executor current_executor{io_context_.get_executor()};
     test::MockChainStorage chain_storage;

--- a/silkworm/rpc/core/state_reader_test.cpp
+++ b/silkworm/rpc/core/state_reader_test.cpp
@@ -21,10 +21,10 @@
 #include <catch2/catch_test_macros.hpp>
 #include <evmc/evmc.hpp>
 
+#include <silkworm/core/common/base.hpp>
 #include <silkworm/db/tables.hpp>
+#include <silkworm/infra/test_util/context_test_base.hpp>
 #include <silkworm/rpc/common/util.hpp>
-#include <silkworm/rpc/core/blocks.hpp>
-#include <silkworm/rpc/test_util/context_test_base.hpp>
 #include <silkworm/rpc/test_util/mock_transaction.hpp>
 
 namespace silkworm::rpc {
@@ -54,7 +54,7 @@ static const silkworm::Bytes kEncodedStorageHistory{*silkworm::from_hex(
 static const silkworm::Bytes kBinaryCode{*silkworm::from_hex("0x60045e005c60016000555d")};
 static const evmc::bytes32 kCodeHash{0xef722d9baf50b9983c2fce6329c5a43a15b8d5ba79cd792e7199d615be88284d_bytes32};
 
-struct StateReaderTest : public test::ContextTestBase {
+struct StateReaderTest : public test_util::ContextTestBase {
     test::MockTransaction transaction_;
     StateReader state_reader_{transaction_};
 };
@@ -69,7 +69,7 @@ TEST_CASE_METHOD(StateReaderTest, "StateReader::read_account") {
 
         // Execute the test: calling read_account should return no account
         std::optional<silkworm::Account> account;
-        CHECK_NOTHROW(account = spawn_and_wait(state_reader_.read_account(kZeroAddress, core::kEarliestBlockNumber)));
+        CHECK_NOTHROW(account = spawn_and_wait(state_reader_.read_account(kZeroAddress, kEarliestBlockNumber)));
         CHECK(!account);
     }
 
@@ -82,7 +82,7 @@ TEST_CASE_METHOD(StateReaderTest, "StateReader::read_account") {
 
         // Execute the test: calling read_account should return the expected account
         std::optional<silkworm::Account> account;
-        CHECK_NOTHROW(account = spawn_and_wait(state_reader_.read_account(kZeroAddress, core::kEarliestBlockNumber)));
+        CHECK_NOTHROW(account = spawn_and_wait(state_reader_.read_account(kZeroAddress, kEarliestBlockNumber)));
         CHECK(account);
         if (account) {
             CHECK(account->nonce == 2);
@@ -103,7 +103,7 @@ TEST_CASE_METHOD(StateReaderTest, "StateReader::read_account") {
 
         // Execute the test: calling read_account should return expected account
         std::optional<silkworm::Account> account;
-        CHECK_NOTHROW(account = spawn_and_wait(state_reader_.read_account(kZeroAddress, core::kEarliestBlockNumber)));
+        CHECK_NOTHROW(account = spawn_and_wait(state_reader_.read_account(kZeroAddress, kEarliestBlockNumber)));
         CHECK(account);
         if (account) {
             CHECK(account->nonce == 2);
@@ -124,7 +124,7 @@ TEST_CASE_METHOD(StateReaderTest, "StateReader::read_account") {
 
         // Execute the test: calling read_account should return the expected account
         std::optional<silkworm::Account> account;
-        CHECK_NOTHROW(account = spawn_and_wait(state_reader_.read_account(kZeroAddress, core::kEarliestBlockNumber)));
+        CHECK_NOTHROW(account = spawn_and_wait(state_reader_.read_account(kZeroAddress, kEarliestBlockNumber)));
         CHECK(account);
         if (account) {
             CHECK(account->nonce == 12345);
@@ -145,7 +145,7 @@ TEST_CASE_METHOD(StateReaderTest, "StateReader::read_storage") {
 
         // Execute the test: calling read_storage should return empty storage value
         evmc::bytes32 location;
-        CHECK_NOTHROW(location = spawn_and_wait(state_reader_.read_storage(kZeroAddress, 0, kLocationHash, core::kEarliestBlockNumber)));
+        CHECK_NOTHROW(location = spawn_and_wait(state_reader_.read_storage(kZeroAddress, 0, kLocationHash, kEarliestBlockNumber)));
         CHECK(location == evmc::bytes32{});
     }
 
@@ -158,7 +158,7 @@ TEST_CASE_METHOD(StateReaderTest, "StateReader::read_storage") {
 
         // Execute the test: calling read_storage should return expected storage location
         evmc::bytes32 location;
-        CHECK_NOTHROW(location = spawn_and_wait(state_reader_.read_storage(kZeroAddress, 0, kLocationHash, core::kEarliestBlockNumber)));
+        CHECK_NOTHROW(location = spawn_and_wait(state_reader_.read_storage(kZeroAddress, 0, kLocationHash, kEarliestBlockNumber)));
         CHECK(location == silkworm::to_bytes32(kStorageLocation));
     }
 
@@ -167,7 +167,7 @@ TEST_CASE_METHOD(StateReaderTest, "StateReader::read_storage") {
         // 1. DatabaseReader::get call on kStorageHistory returns the storage bitmap
         EXPECT_CALL(transaction_, get(db::table::kStorageHistoryName, _)).WillOnce(InvokeWithoutArgs([]() -> Task<KeyValue> {
             co_return KeyValue{
-                silkworm::db::storage_history_key(kZeroAddress, kLocationHash, core::kEarliestBlockNumber),
+                silkworm::db::storage_history_key(kZeroAddress, kLocationHash, kEarliestBlockNumber),
                 kEncodedStorageHistory};
         }));
         // 2. DatabaseReader::get_both_range call on kPlainAccountChangeSet the storage location value
@@ -175,7 +175,7 @@ TEST_CASE_METHOD(StateReaderTest, "StateReader::read_storage") {
 
         // Execute the test: calling read_storage should return expected storage location
         evmc::bytes32 location;
-        CHECK_NOTHROW(location = spawn_and_wait(state_reader_.read_storage(kZeroAddress, 0, kLocationHash, core::kEarliestBlockNumber)));
+        CHECK_NOTHROW(location = spawn_and_wait(state_reader_.read_storage(kZeroAddress, 0, kLocationHash, kEarliestBlockNumber)));
         CHECK(location == silkworm::to_bytes32(kStorageLocation));
     }
 }

--- a/silkworm/rpc/ethbackend/remote_backend_test.cpp
+++ b/silkworm/rpc/ethbackend/remote_backend_test.cpp
@@ -60,7 +60,7 @@ using evmc::literals::operator""_bytes32;
 
 using StrictMockEthBackendStub = testing::StrictMock<::remote::MockETHBACKENDStub>;
 
-using EthBackendTest = test::GrpcApiTestBase<ethbackend::RemoteBackEnd, StrictMockEthBackendStub>;
+using EthBackendTest = test_util::GrpcApiTestBase<ethbackend::RemoteBackEnd, StrictMockEthBackendStub>;
 
 #ifndef SILKWORM_SANITIZE
 TEST_CASE_METHOD(EthBackendTest, "BackEnd::etherbase", "[silkworm][rpc][ethbackend][backend]") {

--- a/silkworm/rpc/ethdb/kv/remote_cursor_test.cpp
+++ b/silkworm/rpc/ethdb/kv/remote_cursor_test.cpp
@@ -50,7 +50,7 @@ static const silkworm::Bytes kAccountChangeSetKeyBytes{silkworm::bytes_of_string
 static const silkworm::Bytes kAccountChangeSetSubkeyBytes{silkworm::bytes_of_string(kAccountChangeSetSubkey)};
 static const silkworm::Bytes kAccountChangeSetValueBytes{silkworm::bytes_of_string(kAccountChangeSetValue)};
 
-struct RemoteCursorTest : test::KVTestBase {
+struct RemoteCursorTest : test_util::KVTestBase {
     RemoteCursorTest() {
         // Set the call expectations common to all RemoteCursor tests:
         // remote::KV::StubInterface::PrepareAsyncTxRaw call succeeds

--- a/silkworm/rpc/ethdb/kv/remote_database_test.cpp
+++ b/silkworm/rpc/ethdb/kv/remote_database_test.cpp
@@ -29,7 +29,7 @@
 
 namespace silkworm::rpc::ethdb::kv {
 
-struct RemoteDatabaseTest : test::KVTestBase {
+struct RemoteDatabaseTest : test_util::KVTestBase {
     // RemoteDatabase holds the KV stub by std::unique_ptr, so we cannot rely on mock stub from base class
     StrictMockKVStub* kv_stub_ = new StrictMockKVStub;
     CoherentStateCache state_cache_;

--- a/silkworm/rpc/ethdb/kv/remote_transaction_test.cpp
+++ b/silkworm/rpc/ethdb/kv/remote_transaction_test.cpp
@@ -31,7 +31,7 @@ namespace silkworm::rpc::ethdb::kv {
 
 using testing::_;
 
-struct RemoteTransactionTest : test::KVTestBase {
+struct RemoteTransactionTest : test_util::KVTestBase {
     CoherentStateCache state_cache_;
     test::BackEndMock backend;
     RemoteTransaction remote_tx_{*stub_,

--- a/silkworm/rpc/ethdb/kv/state_changes_stream_test.cpp
+++ b/silkworm/rpc/ethdb/kv/state_changes_stream_test.cpp
@@ -58,7 +58,7 @@ TEST_CASE("StateChangesStream::set_registration_interval", "[rpc][ethdb][kv][sta
     CHECK(StateChangesStream::registration_interval() == kDefaultRegistrationInterval);
 }
 
-struct StateChangesStreamTest : test::KVTestBase {
+struct StateChangesStreamTest : test_util::KVTestBase {
     StateChangesStream stream_{context_, stub_.get()};
 };
 

--- a/silkworm/rpc/json/stream_test.cpp
+++ b/silkworm/rpc/json/stream_test.cpp
@@ -22,7 +22,7 @@
 
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/rpc/common/worker_pool.hpp>
-#include <silkworm/rpc/test_util/context_test_base.hpp>
+#include <silkworm/rpc/test_util/service_context_test_base.hpp>
 
 namespace silkworm::rpc::json {
 
@@ -31,7 +31,7 @@ static const nlohmann::json kJsonNull = nlohmann::json::value_t::null;
 static const nlohmann::json kJsonEmptyObject = nlohmann::json::value_t::object;
 static const nlohmann::json kJsonEmptyArray = nlohmann::json::value_t::array;
 
-struct StreamTest : test::ContextTestBase {
+struct StreamTest : test_util::ServiceContextTestBase {
 };
 
 TEST_CASE_METHOD(StreamTest, "json::Stream writing JSON", "[rpc][json]") {

--- a/silkworm/rpc/json_rpc/request_handler_test.cpp
+++ b/silkworm/rpc/json_rpc/request_handler_test.cpp
@@ -23,10 +23,10 @@
 namespace silkworm::rpc::json_rpc {
 
 #ifndef SILKWORM_SANITIZE
-TEST_CASE_METHOD(test::RpcApiE2ETest, "check handle_request no method", "[rpc][handle]") {
+TEST_CASE_METHOD(test_util::RpcApiE2ETest, "check handle_request no method", "[rpc][handle]") {
     const auto request = R"({"jsonrpc":"2.0","id":1})"_json;
     std::string reply;
-    run<&test::RequestHandler_ForTest::request_and_create_reply>(request, reply);
+    run<&test_util::RequestHandler_ForTest::request_and_create_reply>(request, reply);
     CHECK(nlohmann::json::parse(reply) == R"({
         "jsonrpc":"2.0",
         "id":1,
@@ -37,10 +37,10 @@ TEST_CASE_METHOD(test::RpcApiE2ETest, "check handle_request no method", "[rpc][h
     })"_json);
 }
 
-TEST_CASE_METHOD(test::RpcApiE2ETest, "check handle_request invalid method", "[rpc][handle_request]") {
+TEST_CASE_METHOD(test_util::RpcApiE2ETest, "check handle_request invalid method", "[rpc][handle_request]") {
     const auto request = R"({"jsonrpc":"2.0","id":1, "method":"eth_AAA"})"_json;
     std::string reply;
-    run<&test::RequestHandler_ForTest::request_and_create_reply>(request, reply);
+    run<&test_util::RequestHandler_ForTest::request_and_create_reply>(request, reply);
     CHECK(nlohmann::json::parse(reply) == R"({
         "jsonrpc":"2.0",
         "id":1,
@@ -51,10 +51,10 @@ TEST_CASE_METHOD(test::RpcApiE2ETest, "check handle_request invalid method", "[r
     })"_json);
 }
 
-TEST_CASE_METHOD(test::RpcApiE2ETest, "check handle_request method return failed", "[rpc][handle_request]") {
+TEST_CASE_METHOD(test_util::RpcApiE2ETest, "check handle_request method return failed", "[rpc][handle_request]") {
     const auto request = R"({"jsonrpc":"2.0","id":3,"method":"eth_getBlockByNumber","params":[]})"_json;
     std::string reply;
-    run<&test::RequestHandler_ForTest::request_and_create_reply>(request, reply);
+    run<&test_util::RequestHandler_ForTest::request_and_create_reply>(request, reply);
     CHECK(nlohmann::json::parse(reply) == R"({
         "jsonrpc":"2.0",
         "id":3,
@@ -65,13 +65,13 @@ TEST_CASE_METHOD(test::RpcApiE2ETest, "check handle_request method return failed
     })"_json);
 }
 
-TEST_CASE_METHOD(test::RpcApiE2ETest, "check handle_request does not allow nil characters after json object", "[rpc][handle_request]") {
+TEST_CASE_METHOD(test_util::RpcApiE2ETest, "check handle_request does not allow nil characters after json object", "[rpc][handle_request]") {
     // request: {"jsonrpc":"2.0","id":1,"method":"eth_feeHistory","params":["0x1A","0x2",[95,99]]}\0x0H
     constexpr char binary_input_internal[] = {0x7b, 0x22, 0x6a, 0x73, 0x6f, 0x6e, 0x72, 0x70, 0x63, 0x22, 0x3a, 0x22, 0x32, 0x2e, 0x30, 0x22, 0x2c, 0x22, 0x69, 0x64, 0x22, 0x3a, 0x31, 0x2c, 0x22, 0x6d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x22, 0x3a, 0x22, 0x65, 0x74, 0x68, 0x5f, 0x66, 0x65, 0x65, 0x48, 0x69, 0x73, 0x74, 0x6f, 0x72, 0x79, 0x22, 0x2c, 0x22, 0x70, 0x61, 0x72, 0x61, 0x6d, 0x73, 0x22, 0x3a, 0x5b, 0x22, 0x30, 0x78, 0x31, 0x41, 0x22, 0x2c, 0x22, 0x30, 0x78, 0x32, 0x22, 0x2c, 0x5b, 0x39, 0x35, 0x2c, 0x39, 0x39, 0x5d, 0x5d, 0x7d, 0x0, 0x48};
     const std::string_view request_view{&binary_input_internal[0], sizeof(binary_input_internal)};
     const std::string request{request_view};
     std::string reply;
-    run<&test::RequestHandler_ForTest::handle_request>(request, reply);
+    run<&test_util::RequestHandler_ForTest::handle_request>(request, reply);
     CHECK(nlohmann::json::parse(reply) == R"({
         "error": {
             "code": -32601,
@@ -82,13 +82,13 @@ TEST_CASE_METHOD(test::RpcApiE2ETest, "check handle_request does not allow nil c
     })"_json);
 }
 
-TEST_CASE_METHOD(test::RpcApiE2ETest, "check handle_request does not allow nil characters inside json object", "[rpc][handle_request]") {
+TEST_CASE_METHOD(test_util::RpcApiE2ETest, "check handle_request does not allow nil characters inside json object", "[rpc][handle_request]") {
     // request: {"jsonrpc":"2.0","id":1,"method":"eth_feeHistory","params":["0x1A","0x2",[95,99]]\0x0}
     constexpr char binary_input_internal[] = {0x7b, 0x22, 0x6a, 0x73, 0x6f, 0x6e, 0x72, 0x70, 0x63, 0x22, 0x3a, 0x22, 0x32, 0x2e, 0x30, 0x22, 0x2c, 0x22, 0x69, 0x64, 0x22, 0x3a, 0x31, 0x2c, 0x22, 0x6d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x22, 0x3a, 0x22, 0x65, 0x74, 0x68, 0x5f, 0x66, 0x65, 0x65, 0x48, 0x69, 0x73, 0x74, 0x6f, 0x72, 0x79, 0x22, 0x2c, 0x22, 0x70, 0x61, 0x72, 0x61, 0x6d, 0x73, 0x22, 0x3a, 0x5b, 0x22, 0x30, 0x78, 0x31, 0x41, 0x22, 0x2c, 0x22, 0x30, 0x78, 0x32, 0x22, 0x2c, 0x5b, 0x39, 0x35, 0x2c, 0x39, 0x39, 0x5d, 0x5d, 0x0, 0x7d};
     const std::string_view request_view{&binary_input_internal[0], sizeof(binary_input_internal)};
     const std::string request{request_view};
     std::string reply;
-    run<&test::RequestHandler_ForTest::handle_request>(request, reply);
+    run<&test_util::RequestHandler_ForTest::handle_request>(request, reply);
     CHECK(nlohmann::json::parse(reply) == R"({
         "error": {
             "code": -32601,
@@ -99,7 +99,7 @@ TEST_CASE_METHOD(test::RpcApiE2ETest, "check handle_request does not allow nil c
     })"_json);
 }
 
-TEST_CASE_METHOD(test::RpcApiE2ETest, "check handle_request does allow nil characters inside quoted string", "[rpc][handle_request]") {
+TEST_CASE_METHOD(test_util::RpcApiE2ETest, "check handle_request does allow nil characters inside quoted string", "[rpc][handle_request]") {
     // request: {"jsonrpc":"2.0","id":1,"method":"eth_feeHistory\0x0","params":["0x1A","0x2",[95,99]]}
     constexpr char binary_input_internal[] = {
         0x7b, 0x22, 0x6a, 0x73, 0x6f, 0x6e, 0x72, 0x70, 0x63, 0x22, 0x3a, 0x22, 0x32, 0x2e, 0x30, 0x22, 0x2c, 0x22, 0x69, 0x64, 0x22,
@@ -109,7 +109,7 @@ TEST_CASE_METHOD(test::RpcApiE2ETest, "check handle_request does allow nil chara
     const std::string_view request_view{&binary_input_internal[0], sizeof(binary_input_internal)};
     const std::string request{request_view};
     std::string reply;
-    run<&test::RequestHandler_ForTest::handle_request>(request, reply);
+    run<&test_util::RequestHandler_ForTest::handle_request>(request, reply);
     CHECK(nlohmann::json::parse(reply) == R"({
         "error": {
             "code": -32600,
@@ -120,7 +120,7 @@ TEST_CASE_METHOD(test::RpcApiE2ETest, "check handle_request does allow nil chara
     })"_json);
 }
 
-TEST_CASE_METHOD(test::RpcApiE2ETest, "check handle_request does not allow missing params if required", "[rpc][handle_request]") {
+TEST_CASE_METHOD(test_util::RpcApiE2ETest, "check handle_request does not allow missing params if required", "[rpc][handle_request]") {
     // request: {"jsonrpc":"2.0","id":1,"method":"eth_getBlockReceipts"}\012
     constexpr char binary_input_internal[] = {
         0x7b, 0x22, 0x6a, 0x73, 0x6f, 0x6e, 0x72, 0x70, 0x63, 0x22, 0x3a, 0x22, 0x32, 0x2e, 0x30, 0x22, 0x2c, 0x22, 0x69, 0x64, 0x22,
@@ -129,7 +129,7 @@ TEST_CASE_METHOD(test::RpcApiE2ETest, "check handle_request does not allow missi
     const std::string_view request_view{&binary_input_internal[0], sizeof(binary_input_internal)};
     const std::string request{request_view};
     std::string reply;
-    run<&test::RequestHandler_ForTest::handle_request>(request, reply);
+    run<&test_util::RequestHandler_ForTest::handle_request>(request, reply);
     CHECK(nlohmann::json::parse(reply) == R"({
         "error": {
             "code": -32600,

--- a/silkworm/rpc/storage/remote_chain_storage.cpp
+++ b/silkworm/rpc/storage/remote_chain_storage.cpp
@@ -18,10 +18,10 @@
 
 #include <utility>
 
+#include <silkworm/core/common/base.hpp>
 #include <silkworm/db/tables.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/grpc/common/conversion.hpp>
-#include <silkworm/rpc/core/blocks.hpp>
 #include <silkworm/rpc/core/rawdb/chain.hpp>
 
 namespace silkworm::rpc {
@@ -34,7 +34,7 @@ RemoteChainStorage::RemoteChainStorage(ethdb::Transaction& tx,
       block_number_from_txn_hash_provider_{std::move(block_number_from_txn_hash_provider)} {}
 
 Task<std::optional<ChainConfig>> RemoteChainStorage::read_chain_config() const {
-    const auto genesis_block_hash{co_await core::rawdb::read_canonical_block_hash(tx_, core::kEarliestBlockNumber)};
+    const auto genesis_block_hash{co_await core::rawdb::read_canonical_block_hash(tx_, kEarliestBlockNumber)};
     SILK_DEBUG << "rawdb::read_chain_config genesis_block_hash: " << to_hex(genesis_block_hash);
     const ByteView genesis_block_hash_bytes{genesis_block_hash.bytes, kHashLength};
     const auto data{co_await tx_.get_one(db::table::kConfigName, genesis_block_hash_bytes)};

--- a/silkworm/rpc/test_util/api_test_base.hpp
+++ b/silkworm/rpc/test_util/api_test_base.hpp
@@ -20,12 +20,12 @@
 #include <utility>
 
 #include <silkworm/rpc/common/worker_pool.hpp>
-#include <silkworm/rpc/test_util/context_test_base.hpp>
+#include <silkworm/rpc/test_util/service_context_test_base.hpp>
 
-namespace silkworm::rpc::test {
+namespace silkworm::rpc::test_util {
 
 template <typename JsonApi>
-class JsonApiTestBase : public ContextTestBase {
+class JsonApiTestBase : public ServiceContextTestBase {
   public:
     template <auto method, typename... Args>
     auto run(Args&&... args) {
@@ -35,9 +35,9 @@ class JsonApiTestBase : public ContextTestBase {
 };
 
 template <typename JsonApi>
-class JsonApiWithWorkersTestBase : public ContextTestBase {
+class JsonApiWithWorkersTestBase : public ServiceContextTestBase {
   public:
-    explicit JsonApiWithWorkersTestBase() : ContextTestBase(), workers_{1} {}
+    explicit JsonApiWithWorkersTestBase() : ServiceContextTestBase(), workers_{1} {}
 
     template <auto method, typename... Args>
     auto run(Args&&... args) {
@@ -49,7 +49,7 @@ class JsonApiWithWorkersTestBase : public ContextTestBase {
 };
 
 template <typename GrpcApi, typename Stub>
-class GrpcApiTestBase : public ContextTestBase {
+class GrpcApiTestBase : public ServiceContextTestBase {
   public:
     template <auto method, typename... Args>
     auto run(Args&&... args) {
@@ -60,4 +60,4 @@ class GrpcApiTestBase : public ContextTestBase {
     std::unique_ptr<Stub> stub_{std::make_unique<Stub>()};
 };
 
-}  // namespace silkworm::rpc::test
+}  // namespace silkworm::rpc::test_util

--- a/silkworm/rpc/test_util/api_test_database.hpp
+++ b/silkworm/rpc/test_util/api_test_database.hpp
@@ -43,10 +43,10 @@
 #include <silkworm/rpc/ethdb/file/local_database.hpp>
 #include <silkworm/rpc/json_rpc/request_handler.hpp>
 #include <silkworm/rpc/json_rpc/validator.hpp>
-#include <silkworm/rpc/test_util/context_test_base.hpp>
+#include <silkworm/rpc/test_util/service_context_test_base.hpp>
 #include <silkworm/rpc/transport/stream_writer.hpp>
 
-namespace silkworm::rpc::test {
+namespace silkworm::rpc::test_util {
 
 class ChannelForTest : public StreamWriter {
   public:
@@ -77,9 +77,9 @@ class RequestHandler_ForTest : public json_rpc::RequestHandler {
     inline static const std::vector<std::string> allowed_origins;
 };
 
-class LocalContextTestBase : public silkworm::rpc::test::ContextTestBase {
+class LocalContextTestBase : public ServiceContextTestBase {
   public:
-    explicit LocalContextTestBase(ethdb::kv::StateCache* state_cache, mdbx::env& chaindata_env) : ContextTestBase() {
+    explicit LocalContextTestBase(ethdb::kv::StateCache* state_cache, mdbx::env& chaindata_env) : ServiceContextTestBase() {
         add_private_service<ethdb::Database>(io_context_, std::make_unique<ethdb::file::LocalDatabase>(state_cache, chaindata_env));
     }
 };
@@ -121,8 +121,8 @@ class RpcApiE2ETest : public db::test_util::TestDatabaseContext, RpcApiTestBase<
     using RpcApiTestBase<RequestHandler_ForTest>::run;
 
   private:
-    static inline test_util::SetLogVerbosityGuard log_guard_{log::Level::kNone};
+    static inline silkworm::test_util::SetLogVerbosityGuard log_guard_{log::Level::kNone};
     static inline bool jsonrpc_spec_loaded{false};
 };
 
-}  // namespace silkworm::rpc::test
+}  // namespace silkworm::rpc::test_util

--- a/silkworm/rpc/test_util/kv_test_base.hpp
+++ b/silkworm/rpc/test_util/kv_test_base.hpp
@@ -22,13 +22,13 @@
 
 #include <silkworm/infra/grpc/test_util/grpc_responder.hpp>
 #include <silkworm/interfaces/remote/kv_mock.grpc.pb.h>
-#include <silkworm/rpc/test_util/context_test_base.hpp>
+#include <silkworm/rpc/test_util/service_context_test_base.hpp>
 
-namespace silkworm::rpc::test {
+namespace silkworm::rpc::test_util {
 
 using testing::Return;
 
-struct KVTestBase : ContextTestBase {
+struct KVTestBase : ServiceContextTestBase {
     testing::Expectation expect_request_async_tx(bool ok) {
         return expect_request_async_tx(*stub_, ok);
     }
@@ -69,4 +69,4 @@ struct KVTestBase : ContextTestBase {
     StrictMockKVStateChangesAsyncReader* statechanges_reader_{statechanges_reader_ptr_.get()};
 };
 
-}  // namespace silkworm::rpc::test
+}  // namespace silkworm::rpc::test_util

--- a/silkworm/rpc/test_util/mock_execution_engine.hpp
+++ b/silkworm/rpc/test_util/mock_execution_engine.hpp
@@ -27,7 +27,7 @@
 #include <silkworm/rpc/common/util.hpp>
 #include <silkworm/rpc/engine/execution_engine.hpp>
 
-namespace silkworm::rpc::test {
+namespace silkworm::rpc::test_util {
 
 class ExecutionEngineMock : public engine::ExecutionEngine {  // NOLINT
   public:
@@ -38,4 +38,4 @@ class ExecutionEngineMock : public engine::ExecutionEngine {  // NOLINT
     MOCK_METHOD((Task<ExecutionPayloadBodies>), get_payload_bodies_by_range, (BlockNum start, uint64_t count, Msec));
 };
 
-}  // namespace silkworm::rpc::test
+}  // namespace silkworm::rpc::test_util

--- a/silkworm/rpc/test_util/service_context_test_base.cpp
+++ b/silkworm/rpc/test_util/service_context_test_base.cpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2023 The Silkworm Authors
+   Copyright 2024 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-#include "context_test_base.hpp"
+#include "service_context_test_base.hpp"
 
 #include <memory>
 
@@ -30,14 +30,10 @@
 
 #include "mock_execution_engine.hpp"
 
-namespace silkworm::rpc::test {
+namespace silkworm::rpc::test_util {
 
-ContextTestBase::ContextTestBase()
-    : log_guard_{log::Level::kNone},
-      context_{0},
-      io_context_{*context_.io_context()},
-      grpc_context_{*context_.grpc_context()},
-      context_thread_{[&]() { context_.execute_loop(); }} {
+ServiceContextTestBase::ServiceContextTestBase()
+    : ContextTestBase() {
     add_shared_service(io_context_, std::make_shared<BlockCache>());
     add_shared_service(io_context_, std::make_shared<FilterStorage>(1024));
     add_shared_service<ethdb::kv::StateCache>(io_context_, std::make_shared<ethdb::kv::CoherentStateCache>());
@@ -51,11 +47,4 @@ ContextTestBase::ContextTestBase()
     add_private_service<txpool::TransactionPool>(io_context_, std::make_unique<txpool::TransactionPool>(io_context_, grpc_channel, grpc_context_));
 }
 
-ContextTestBase::~ContextTestBase() {
-    context_.stop();
-    if (context_thread_.joinable()) {
-        context_thread_.join();
-    }
-}
-
-}  // namespace silkworm::rpc::test
+}  // namespace silkworm::rpc::test_util

--- a/silkworm/rpc/test_util/service_context_test_base.hpp
+++ b/silkworm/rpc/test_util/service_context_test_base.hpp
@@ -1,0 +1,41 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <chrono>
+#include <utility>
+
+#include <boost/asio/co_spawn.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/use_future.hpp>
+
+#include <silkworm/infra/common/log.hpp>
+#include <silkworm/infra/grpc/client/client_context_pool.hpp>
+#include <silkworm/infra/test_util/context_test_base.hpp>
+#include <silkworm/infra/test_util/log.hpp>
+
+namespace silkworm::rpc::test_util {
+
+using silkworm::test_util::ContextTestBase;
+
+class ServiceContextTestBase : public ContextTestBase {
+  public:
+    ServiceContextTestBase();
+    ~ServiceContextTestBase() = default;
+};
+
+}  // namespace silkworm::rpc::test_util

--- a/silkworm/rpc/transport/stream_writer_test.cpp
+++ b/silkworm/rpc/transport/stream_writer_test.cpp
@@ -21,11 +21,11 @@
 #include <catch2/catch_test_macros.hpp>
 #include <nlohmann/json.hpp>
 
-#include <silkworm/rpc/test_util/context_test_base.hpp>
+#include <silkworm/rpc/test_util/service_context_test_base.hpp>
 
 namespace silkworm::rpc {
 
-struct WriterTest : test::ContextTestBase {
+struct WriterTest : test_util::ServiceContextTestBase {
 };
 
 class JsonChunkWriter : public StreamWriter {

--- a/silkworm/rpc/txpool/miner_test.cpp
+++ b/silkworm/rpc/txpool/miner_test.cpp
@@ -37,7 +37,7 @@ namespace silkworm::rpc::txpool {
 using evmc::literals::operator""_bytes32;
 using StrictMockMiningStub = testing::StrictMock<::txpool::MockMiningStub>;
 
-using MinerTest = test::GrpcApiTestBase<Miner, StrictMockMiningStub>;
+using MinerTest = test_util::GrpcApiTestBase<Miner, StrictMockMiningStub>;
 
 #ifndef SILKWORM_SANITIZE
 TEST_CASE_METHOD(MinerTest, "Miner::get_work", "[rpc][txpool][miner]") {

--- a/silkworm/rpc/txpool/transaction_pool_test.cpp
+++ b/silkworm/rpc/txpool/transaction_pool_test.cpp
@@ -70,7 +70,7 @@ namespace silkworm::rpc::txpool {
 using evmc::literals::operator""_address, evmc::literals::operator""_bytes32;
 using StrictMockTxpoolStub = testing::StrictMock<::txpool::MockTxpoolStub>;
 
-using TransactionPoolTest = test::GrpcApiTestBase<TransactionPool, StrictMockTxpoolStub>;
+using TransactionPoolTest = test_util::GrpcApiTestBase<TransactionPool, StrictMockTxpoolStub>;
 
 #ifndef SILKWORM_SANITIZE
 TEST_CASE_METHOD(TransactionPoolTest, "TransactionPool::add_transaction", "[rpc][txpool][transaction_pool]") {

--- a/silkworm/rpc/types/block.cpp
+++ b/silkworm/rpc/types/block.cpp
@@ -21,6 +21,7 @@
 #include <absl/strings/match.h>
 
 #include <silkworm/core/common/assert.hpp>
+#include <silkworm/core/common/base.hpp>
 #include <silkworm/core/common/endian.hpp>
 #include <silkworm/core/rlp/encode_vector.hpp>
 #include <silkworm/core/types/evmc_bytes32.hpp>
@@ -86,7 +87,7 @@ std::ostream& operator<<(std::ostream& out, const BlockNumberOrHash& bnoh) {
 void BlockNumberOrHash::build(const std::string& bnoh) {
     value_ = uint64_t{0};
     if (bnoh == core::kEarliestBlockId) {
-        value_ = core::kEarliestBlockNumber;
+        value_ = kEarliestBlockNumber;
     } else if (bnoh == core::kLatestBlockId ||
                bnoh == core::kPendingBlockId ||
                bnoh == core::kFinalizedBlockId ||

--- a/silkworm/sync/CMakeLists.txt
+++ b/silkworm/sync/CMakeLists.txt
@@ -44,4 +44,6 @@ silkworm_library(
   PRIVATE ${SILKWORM_SYNC_PRIVATE_LIBS}
 )
 
-target_link_libraries(silkworm_sync_test PRIVATE GTest::gmock silkworm_db_test_util silkworm_rpcdaemon_test_util)
+target_link_libraries(
+  silkworm_sync_test PRIVATE GTest::gmock silkworm_db_test_util silkworm_infra_test_util silkworm_rpcdaemon_test_util
+)

--- a/silkworm/sync/sync_pos_test.cpp
+++ b/silkworm/sync/sync_pos_test.cpp
@@ -25,7 +25,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <gmock/gmock.h>
 
-#include <silkworm/rpc/test_util/context_test_base.hpp>
+#include <silkworm/rpc/test_util/service_context_test_base.hpp>
 #include <silkworm/sync/block_exchange.hpp>
 #include <silkworm/sync/sentry_client.hpp>
 
@@ -34,7 +34,7 @@
 
 namespace silkworm::chainsync {
 
-struct PoSSyncTest : public rpc::test::ContextTestBase {
+struct PoSSyncTest : public rpc::test_util::ServiceContextTestBase {
     SentryClient sentry_client{io_context_.get_executor(), nullptr};  // TODO(canepat) mock
     mdbx::env_managed chaindata_env{};
     db::ROAccess db_access{chaindata_env};


### PR DESCRIPTION
This PR splits `rpc::test:: ContextTestBase` into two different test utility abstractions:

- `silkworm::test_util:: ContextTestBase` in `infra` module
- `silkworm::rpc::test_util::ServiceContextTestBase` in `rpc` module

 in order to remove any dependency of `rpc/storage` package from `rpc/test_util`, as a preparation step to then move `storage` package in `db` module.

After this PR, the only remaining `rpc/storage` dependencies in `rpc` are from `ether::kv::Transaction` and `rpc::test::MockTransaction`, which will be moved together with `storage`.

*Extras*
- move `kEarliestBlockNumber` definition from `rpc` to `core` to break dependency of `rpc/storage` package from `rpc/core`
- rename some namespace `test` as `test_util` for naming consistency