### PR TITLE
rpcdaemon: remove optional in read chain config

### DIFF
--- a/silkworm/rpc/commands/engine_api.cpp
+++ b/silkworm/rpc/commands/engine_api.cpp
@@ -318,25 +318,24 @@ Task<void> EngineRpcApi::handle_engine_new_payload_v2(const nlohmann::json& requ
 #endif
         const auto storage{tx->create_storage()};
         const auto config{co_await storage->read_chain_config()};
-        ensure(config.has_value(), "execution layer has invalid configuration");
-        ensure(config->shanghai_time.has_value(), "execution layer has no Shanghai timestamp in configuration");
+        ensure(config.shanghai_time.has_value(), "execution layer has no Shanghai timestamp in configuration");
 
         // We MUST check that CL has sent the expected ExecutionPayload version [Specification for params]
-        if (payload.timestamp < config->shanghai_time && payload.version != ExecutionPayload::V1) {
+        if (payload.timestamp < config.shanghai_time && payload.version != ExecutionPayload::V1) {
             const auto error_msg = "consensus layer must use ExecutionPayloadV1 if timestamp lower than Shanghai";
             SILK_ERROR << error_msg;
             reply = make_json_error(request, kInvalidParams, error_msg);
             co_await tx->close();
             co_return;
         }
-        if (payload.timestamp >= config->shanghai_time && payload.version != ExecutionPayload::V2) {
+        if (payload.timestamp >= config.shanghai_time && payload.version != ExecutionPayload::V2) {
             const auto error_msg = "consensus layer must use ExecutionPayloadV2 if timestamp greater or equal to Shanghai";
             SILK_ERROR << error_msg;
             reply = make_json_error(request, kInvalidParams, error_msg);
             co_await tx->close();
             co_return;
         }
-        if (config->cancun_time && payload.timestamp >= config->cancun_time) {
+        if (config.cancun_time && payload.timestamp >= config.cancun_time) {
             const auto error_msg = "consensus layer must use ExecutionPayloadV3 if timestamp greater or equal to Cancun";
             SILK_ERROR << error_msg;
             reply = make_json_error(request, kUnsupportedFork, error_msg);
@@ -382,12 +381,11 @@ Task<void> EngineRpcApi::handle_engine_new_payload_v3(const nlohmann::json& requ
 #endif
         const auto storage{tx->create_storage()};
         const auto config{co_await storage->read_chain_config()};
-        ensure(config.has_value(), "execution layer has invalid configuration");
-        ensure(config->shanghai_time.has_value(), "execution layer has no Shanghai timestamp in configuration");
-        ensure(config->cancun_time.has_value(), "execution layer has no Cancun timestamp in configuration");
+        ensure(config.shanghai_time.has_value(), "execution layer has no Shanghai timestamp in configuration");
+        ensure(config.cancun_time.has_value(), "execution layer has no Cancun timestamp in configuration");
 
         // We MUST check that CL has sent the expected ExecutionPayload version [Specification for params]
-        if (payload.timestamp >= config->cancun_time && payload.version != ExecutionPayload::V3) {
+        if (payload.timestamp >= config.cancun_time && payload.version != ExecutionPayload::V3) {
             const auto error_msg = "consensus layer must use ExecutionPayloadV3 if timestamp greater or equal to Cancun";
             SILK_ERROR << error_msg;
             reply = make_json_error(request, kUnsupportedFork, error_msg);
@@ -581,13 +579,12 @@ Task<void> EngineRpcApi::handle_engine_exchange_transition_configuration_v1(cons
 #endif
         const auto storage{tx->create_storage()};
         const auto config{co_await storage->read_chain_config()};
-        ensure(config.has_value(), "execution layer has invalid configuration");
-        ensure(config->terminal_total_difficulty.has_value(), "execution layer does not have terminal total difficulty");
+        ensure(config.terminal_total_difficulty.has_value(), "execution layer does not have terminal total difficulty");
 
         // We SHOULD check for any configuration mismatch except `terminalBlockNumber` [Specification 2.]
-        if (config->terminal_total_difficulty != cl_configuration.terminal_total_difficulty) {
+        if (config.terminal_total_difficulty != cl_configuration.terminal_total_difficulty) {
             SILK_ERROR << "execution layer has the incorrect terminal total difficulty, expected: "
-                       << cl_configuration.terminal_total_difficulty << " got: " << config->terminal_total_difficulty.value();
+                       << cl_configuration.terminal_total_difficulty << " got: " << config.terminal_total_difficulty.value();
             reply = make_json_error(request, kInvalidParams, "consensus layer terminal total difficulty does not match");
             co_await tx->close();
             co_return;
@@ -602,7 +599,7 @@ Task<void> EngineRpcApi::handle_engine_exchange_transition_configuration_v1(cons
 
         // We MUST respond with configurable setting values set according to EIP-3675 [Specification 1.]
         const TransitionConfiguration transition_configuration{
-            .terminal_total_difficulty = config->terminal_total_difficulty.value(),
+            .terminal_total_difficulty = config.terminal_total_difficulty.value(),
             .terminal_block_hash = kZeroHash,  // terminal_block_hash removed from chain_config, return zero
             .terminal_block_number = 0         // terminal_block_number removed from chain_config, return zero
         };

--- a/silkworm/rpc/commands/ots_api.cpp
+++ b/silkworm/rpc/commands/ots_api.cpp
@@ -108,7 +108,7 @@ Task<void> OtsRpcApi::handle_ots_get_block_details(const nlohmann::json& request
         const auto block_with_hash = co_await core::read_block_by_number(*block_cache_, *chain_storage, block_number);
         if (block_with_hash) {
             const auto total_difficulty{co_await chain_storage->read_total_difficulty(block_with_hash->hash, block_number)};
-            ensure_post_condition(total_difficulty.has_value(), [&]() { return "no difficulty for block number=" + std::to_string(block_number); });
+            ensure(total_difficulty.has_value(), [&]() { return "no total difficulty for block: " + std::to_string(block_number); });
             const Block extended_block{block_with_hash, *total_difficulty, false};
             const auto block_size = extended_block.get_block_size();
             const BlockDetails block_details{block_size, block_with_hash->hash, block_with_hash->block.header, *total_difficulty,
@@ -116,8 +116,7 @@ Task<void> OtsRpcApi::handle_ots_get_block_details(const nlohmann::json& request
                                              block_with_hash->block.withdrawals};
             const auto receipts = co_await core::get_receipts(*tx, *block_with_hash);
             const auto chain_config = co_await chain_storage->read_chain_config();
-            ensure(chain_config.has_value(), "cannot read chain config");
-            const IssuanceDetails issuance = get_issuance(*chain_config, *block_with_hash);
+            const IssuanceDetails issuance = get_issuance(chain_config, *block_with_hash);
             const intx::uint256 total_fees = get_block_fees(*block_with_hash, receipts);
             const BlockDetailsResponse block_details_response{block_details, issuance, total_fees};
             reply = make_json_content(request, block_details_response);
@@ -159,7 +158,7 @@ Task<void> OtsRpcApi::handle_ots_get_block_details_by_hash(const nlohmann::json&
         if (block_with_hash) {
             const auto block_number = block_with_hash->block.header.number;
             const auto total_difficulty{co_await chain_storage->read_total_difficulty(block_with_hash->hash, block_number)};
-            ensure_post_condition(total_difficulty.has_value(), [&]() { return "no difficulty for block number=" + std::to_string(block_number); });
+            ensure(total_difficulty.has_value(), [&]() { return "no total difficulty for block: " + std::to_string(block_number); });
             const Block extended_block{block_with_hash, *total_difficulty, false};
             const auto block_size = extended_block.get_block_size();
             const BlockDetails block_details{block_size, block_with_hash->hash, block_with_hash->block.header, *total_difficulty,
@@ -167,8 +166,7 @@ Task<void> OtsRpcApi::handle_ots_get_block_details_by_hash(const nlohmann::json&
                                              block_with_hash->block.withdrawals};
             const auto receipts = co_await core::get_receipts(*tx, *block_with_hash);
             const auto chain_config = co_await chain_storage->read_chain_config();
-            ensure(chain_config.has_value(), "cannot read chain config");
-            const IssuanceDetails issuance = get_issuance(*chain_config, *block_with_hash);
+            const IssuanceDetails issuance = get_issuance(chain_config, *block_with_hash);
             const intx::uint256 total_fees = get_block_fees(*block_with_hash, receipts);
             const BlockDetailsResponse block_details_response{block_details, issuance, total_fees};
             reply = make_json_content(request, block_details_response);
@@ -214,7 +212,7 @@ Task<void> OtsRpcApi::handle_ots_get_block_transactions(const nlohmann::json& re
         const auto block_with_hash = co_await core::read_block_by_number(*block_cache_, *chain_storage, block_number);
         if (block_with_hash) {
             const auto total_difficulty{co_await chain_storage->read_total_difficulty(block_with_hash->hash, block_number)};
-            ensure_post_condition(total_difficulty.has_value(), [&]() { return "no difficulty for block number=" + std::to_string(block_number); });
+            ensure(total_difficulty.has_value(), [&]() { return "no total difficulty for block: " + std::to_string(block_number); });
             const Block extended_block{block_with_hash, *total_difficulty, false};
             auto receipts = co_await core::get_receipts(*tx, *block_with_hash);
             auto block_size = extended_block.get_block_size();
@@ -866,7 +864,7 @@ Task<void> OtsRpcApi::trace_block(ethdb::Transaction& tx, BlockNum block_number,
     }
 
     const auto total_difficulty{co_await chain_storage->read_total_difficulty(block_with_hash->hash, block_number)};
-    ensure_post_condition(total_difficulty.has_value(), [&]() { return "no difficulty for block number=" + std::to_string(block_number); });
+    ensure(total_difficulty.has_value(), [&]() { return "no total difficulty for block: " + std::to_string(block_number); });
     const auto receipts = co_await core::get_receipts(tx, *block_with_hash);
     const Block extended_block{block_with_hash, *total_difficulty, false};
 

--- a/silkworm/rpc/core/call_many.cpp
+++ b/silkworm/rpc/core/call_many.cpp
@@ -156,9 +156,7 @@ Task<CallManyResult> CallExecutor::execute(
         co_return result;
     }
 
-    const auto chain_config_ptr = co_await chain_storage->read_chain_config();
-    ensure(chain_config_ptr.has_value(), "cannot read chain config");
-
+    const auto chain_config = co_await chain_storage->read_chain_config();
     const auto block_with_hash = co_await rpc::core::read_block_by_number_or_hash(block_cache_, *chain_storage, transaction_, context.block_number);
     if (!block_with_hash) {
         throw std::invalid_argument("read_block_by_number_or_hash: block not found");
@@ -170,7 +168,7 @@ Task<CallManyResult> CallExecutor::execute(
 
     auto this_executor = co_await boost::asio::this_coro::executor;
     result = co_await async_task(workers_.executor(), [&]() -> CallManyResult {
-        return executes_all_bundles(*chain_config_ptr,
+        return executes_all_bundles(chain_config,
                                     *chain_storage,
                                     block_with_hash,
                                     bundles,

--- a/silkworm/rpc/core/estimate_gas_oracle.cpp
+++ b/silkworm/rpc/core/estimate_gas_oracle.cpp
@@ -39,7 +39,7 @@ Task<intx::uint256> EstimateGasOracle::estimate_gas(const Call& call, const silk
     } else {
         const auto header = co_await block_header_provider_(block_number);
         if (!header) {
-            throw EstimateGasException{-1, "invalid header"};
+            throw EstimateGasException{-1, "header " + std::to_string(block_number) + " not found"};
         }
 
         hi = header->gas_limit;

--- a/silkworm/rpc/core/estimate_gas_oracle_test.cpp
+++ b/silkworm/rpc/core/estimate_gas_oracle_test.cpp
@@ -86,10 +86,12 @@ TEST_CASE("estimate gas") {
 
     silkworm::Account kAccount{0, kBalance};
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-capturing-lambda-coroutines)
     BlockHeaderProvider block_header_provider = [&kBlockHeader](BlockNum /*block_number*/) -> Task<std::optional<BlockHeader>> {
         co_return kBlockHeader;
     };
 
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-capturing-lambda-coroutines)
     AccountReader account_reader = [&kAccount](const evmc::address& /*address*/, BlockNum /*block_number*/) -> Task<std::optional<silkworm::Account>> {
         co_return kAccount;
     };

--- a/silkworm/rpc/core/evm_debug.cpp
+++ b/silkworm/rpc/core/evm_debug.cpp
@@ -382,12 +382,11 @@ Task<void> DebugExecutor::execute(json::Stream& stream, const ChainStorage& stor
 
     SILK_DEBUG << "execute: block_number: " << block_number << " #txns: " << transactions.size() << " config: " << config_;
 
-    const auto chain_config_ptr = co_await storage.read_chain_config();
-    ensure(chain_config_ptr.has_value(), "cannot read chain config");
+    const auto chain_config = co_await storage.read_chain_config();
     auto current_executor = co_await boost::asio::this_coro::executor;
     co_await async_task(workers_.executor(), [&]() -> void {
         auto state = tx_.create_state(current_executor, storage, block_number - 1);
-        EVMExecutor executor{*chain_config_ptr, workers_, state};
+        EVMExecutor executor{chain_config, workers_, state};
 
         for (std::uint64_t idx = 0; idx < transactions.size(); idx++) {
             rpc::Transaction txn{block.transactions[idx]};
@@ -441,12 +440,11 @@ Task<void> DebugExecutor::execute(
                << " index: " << std::dec << index
                << " config: " << config_;
 
-    const auto chain_config_ptr = co_await storage.read_chain_config();
-    ensure(chain_config_ptr.has_value(), "cannot read chain config");
+    const auto chain_config = co_await storage.read_chain_config();
     auto current_executor = co_await boost::asio::this_coro::executor;
     co_await async_task(workers_.executor(), [&]() {
         auto state = tx_.create_state(current_executor, storage, block_number);
-        EVMExecutor executor{*chain_config_ptr, workers_, state};
+        EVMExecutor executor{chain_config, workers_, state};
 
         for (auto idx{0}; idx < index; idx++) {
             silkworm::Transaction txn{block.transactions[std::size_t(idx)]};
@@ -493,13 +491,11 @@ Task<void> DebugExecutor::execute(
                << " transaction_index: " << std::dec << transaction_index
                << " config: " << config_;
 
-    const auto chain_config_ptr = co_await storage.read_chain_config();
-    ensure(chain_config_ptr.has_value(), "cannot read chain config");
-
+    const auto chain_config = co_await storage.read_chain_config();
     auto current_executor = co_await boost::asio::this_coro::executor;
     co_await async_task(workers_.executor(), [&]() {
         auto state = tx_.create_state(current_executor, storage, block.header.number);
-        EVMExecutor executor{*chain_config_ptr, workers_, state};
+        EVMExecutor executor{chain_config, workers_, state};
 
         for (auto idx{0}; idx < transaction_index; idx++) {
             silkworm::Transaction txn{block_transactions[std::size_t(idx)]};

--- a/silkworm/rpc/core/rawdb/chain.cpp
+++ b/silkworm/rpc/core/rawdb/chain.cpp
@@ -75,10 +75,11 @@ Task<evmc::bytes32> read_head_header_hash(ethdb::Transaction& tx) {
     const silkworm::Bytes kHeadHeaderKey = silkworm::bytes_of_string(db::table::kHeadHeaderName);
     const auto value = co_await tx.get_one(db::table::kHeadHeaderName, kHeadHeaderKey);
     if (value.empty()) {
-        throw std::invalid_argument{"empty head header hash value in read_head_header_hash"};
+        throw std::runtime_error{"empty head header hash value in read_head_header_hash"};
     }
     const auto head_header_hash{silkworm::to_bytes32(value)};
     SILK_DEBUG << "head header hash: " << silkworm::to_hex(head_header_hash);
     co_return head_header_hash;
 }
+
 }  // namespace silkworm::rpc::core::rawdb

--- a/silkworm/rpc/json/types.cpp
+++ b/silkworm/rpc/json/types.cpp
@@ -164,7 +164,7 @@ std::string to_quantity(uint64_t number) {
     return "0x" + to_hex_no_leading_zeros(number);
 }
 
-std::string to_quantity(intx::uint256 number) {
+std::string to_quantity(const intx::uint256& number) {
     if (number == 0) {
         return "0x0";
     }

--- a/silkworm/rpc/json/types.hpp
+++ b/silkworm/rpc/json/types.hpp
@@ -119,7 +119,7 @@ std::string to_hex(uint64_t number);
 std::string to_hex_no_leading_zeros(uint64_t number);
 std::string to_hex_no_leading_zeros(silkworm::ByteView bytes);
 std::string to_quantity(uint64_t number);
-std::string to_quantity(intx::uint256 number);
+std::string to_quantity(const intx::uint256& number);
 std::string to_quantity(silkworm::ByteView bytes);
 
 void to_quantity(std::span<char> hex_bytes, uint64_t number);

--- a/silkworm/rpc/storage/chain_storage.hpp
+++ b/silkworm/rpc/storage/chain_storage.hpp
@@ -16,8 +16,6 @@
 
 #pragma once
 
-#include <optional>
-
 #include <silkworm/infra/concurrency/task.hpp>
 
 #include <silkworm/core/common/base.hpp>
@@ -33,7 +31,7 @@ class ChainStorage {
     virtual ~ChainStorage() = default;
 
     //! Read the current chain configuration parameters
-    [[nodiscard]] virtual Task<std::optional<ChainConfig>> read_chain_config() const = 0;
+    [[nodiscard]] virtual Task<ChainConfig> read_chain_config() const = 0;
 
     //! Get the highest block number
     [[nodiscard]] virtual Task<BlockNum> highest_block_number() const = 0;

--- a/silkworm/rpc/storage/local_chain_storage.cpp
+++ b/silkworm/rpc/storage/local_chain_storage.cpp
@@ -25,8 +25,12 @@ namespace silkworm::rpc {
 
 LocalChainStorage::LocalChainStorage(db::ROTxn& txn) : data_model_{txn} {}
 
-Task<std::optional<ChainConfig>> LocalChainStorage::read_chain_config() const {
-    co_return data_model_.read_chain_config();
+Task<ChainConfig> LocalChainStorage::read_chain_config() const {
+    const auto chain_config{data_model_.read_chain_config()};
+    if (!chain_config) {
+        throw std::runtime_error{"empty chain config data in storage"};
+    }
+    co_return *chain_config;
 }
 
 Task<BlockNum> LocalChainStorage::highest_block_number() const {

--- a/silkworm/rpc/storage/local_chain_storage.hpp
+++ b/silkworm/rpc/storage/local_chain_storage.hpp
@@ -30,7 +30,7 @@ class LocalChainStorage : public ChainStorage {
     explicit LocalChainStorage(db::ROTxn& txn);
     ~LocalChainStorage() override = default;
 
-    [[nodiscard]] Task<std::optional<ChainConfig>> read_chain_config() const override;
+    [[nodiscard]] Task<ChainConfig> read_chain_config() const override;
 
     [[nodiscard]] Task<BlockNum> highest_block_number() const override;
 
@@ -42,9 +42,7 @@ class LocalChainStorage : public ChainStorage {
     Task<bool> read_block(BlockNum number, bool read_senders, silkworm::Block& block) const override;
 
     [[nodiscard]] Task<std::optional<BlockHeader>> read_header(BlockNum number, HashAsArray hash) const override;
-
     [[nodiscard]] Task<std::optional<BlockHeader>> read_header(BlockNum number, const Hash& hash) const override;
-
     [[nodiscard]] Task<std::optional<BlockHeader>> read_header(const Hash& hash) const override;
 
     [[nodiscard]] Task<std::vector<BlockHeader>> read_sibling_headers(BlockNum number) const override;

--- a/silkworm/rpc/storage/remote_chain_storage.hpp
+++ b/silkworm/rpc/storage/remote_chain_storage.hpp
@@ -38,7 +38,7 @@ class RemoteChainStorage : public ChainStorage {
                        BlockNumberFromTxnHashProvider block_number_from_txn_hash_provider);
     ~RemoteChainStorage() override = default;
 
-    [[nodiscard]] Task<std::optional<silkworm::ChainConfig>> read_chain_config() const override;
+    [[nodiscard]] Task<silkworm::ChainConfig> read_chain_config() const override;
 
     [[nodiscard]] Task<BlockNum> highest_block_number() const override;
 

--- a/silkworm/rpc/storage/remote_chain_storage_test.cpp
+++ b/silkworm/rpc/storage/remote_chain_storage_test.cpp
@@ -86,10 +86,8 @@ TEST_CASE_METHOD(RemoteChainStorageTest, "read_chain_config") {
             co_return kChainConfig;
         }));
         const auto chain_config = spawn_and_wait(storage.read_chain_config());
-        CHECK(chain_config.has_value());
-        if (chain_config) {
-            CHECK(chain_config->genesis_hash == 0x439816753229fc0736bf86a5048de4bc9fcdede8c91dadf88c828c76b2281dff_bytes32);
-            CHECK(chain_config->to_json() == R"({
+        CHECK(chain_config.genesis_hash == 0x439816753229fc0736bf86a5048de4bc9fcdede8c91dadf88c828c76b2281dff_bytes32);
+        CHECK(chain_config.to_json() == R"({
                 "berlinBlock":12244000,
                 "byzantiumBlock":4370000,
                 "chainId":1,
@@ -105,7 +103,6 @@ TEST_CASE_METHOD(RemoteChainStorageTest, "read_chain_config") {
                 "muirGlacierBlock":9200000,
                 "petersburgBlock":7280000
             })"_json);
-        }
     }
 }
 

--- a/silkworm/rpc/test_util/mock_chain_storage.hpp
+++ b/silkworm/rpc/test_util/mock_chain_storage.hpp
@@ -32,9 +32,7 @@ namespace silkworm::rpc::test {
 
 class MockChainStorage : public silkworm::rpc::ChainStorage {
   public:
-    MOCK_METHOD((Task<std::optional<silkworm::ChainConfig>>), read_chain_config, (), (const override));
-
-    MOCK_METHOD((Task<std::optional<ChainId>>), read_chain_id, (), (const override));
+    MOCK_METHOD((Task<silkworm::ChainConfig>), read_chain_config, (), (const override));
 
     MOCK_METHOD((Task<BlockNum>), highest_block_number, (), (const override));
 


### PR DESCRIPTION
This PR removes `std::optional` from the returned type of `ChainStorage::read_chain_config` and raises an exception in case of missing chain configuration.

Fixes #2103

*Extras*
- change the type of exception raised by `read_head_header_hash`
- pass `into::uint256` by reference in `to_quantity`