### PR TITLE
qa-tests: add latency percentile analysis

### DIFF
--- a/.github/workflows/rpc-performance-tests.yml
+++ b/.github/workflows/rpc-performance-tests.yml
@@ -122,6 +122,12 @@ jobs:
                     --db_version $db_version \
                     --outcome success \
                     --result_file ${{runner.workspace}}/rpc-tests/perf/reports/mainnet/result.json
+          
+                  echo "Execute Latency Percentile HDR Analysis"                                             
+                  python3 $ERIGON_QA_PATH/test_system/qa-tests/rpc-tests/perf_hdr_analysis.py \
+                    --test_name ${servers[i-1]}-$method \
+                    --input_file ${{runner.workspace}}/rpc-tests/perf/reports/mainnet/result.json \
+                    --output_file ${{runner.workspace}}/rpc-tests/perf/reports/mainnet/${servers[i-1]}_$method_latency_hdr_analysis.pdf
                else
                   failed_test=1
                   cd ${{runner.workspace}}/silkworm

--- a/.github/workflows/rpc-performance-tests.yml
+++ b/.github/workflows/rpc-performance-tests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout RPC Tests Repository & Install Requirements
         run: |
           rm -rf ${{runner.workspace}}/rpc-tests
-          git -c advice.detachedHead=false clone --depth 1 --branch v0.8.2 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
+          git -c advice.detachedHead=false clone --depth 1 --branch v0.26.0 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
           cd ${{runner.workspace}}/rpc-tests
           pip3 install -r requirements.txt
 


### PR DESCRIPTION
Create a pdf with plots of the latency percentile distributions (a plot for each qps and repetition).
Data is created with Vegeta option `report -type=hdrplot` (see rpc-tests [v0.26](https://github.com/erigontech/rpc-tests/releases/tag/v0.26.0))

Relevant documentation:
- [HdrHistogram](https://hdrhistogram.github.io/HdrHistogram/)
- [report --typehdrplot](https://github.com/tsenart/vegeta?tab=readme-ov-file#report--typehdrplot)