### PR TITLE
db: use ByteView in KV StateCache

### DIFF
--- a/silkworm/db/kv/api/base_transaction.cpp
+++ b/silkworm/db/kv/api/base_transaction.cpp
@@ -55,15 +55,13 @@ Task<Bytes> BaseTransaction::get_one_impl_with_cache(const std::string& table, B
         if (table == db::table::kPlainStateName) {
             std::shared_ptr<StateView> view = state_cache_->get_view(*this);
             if (view != nullptr) {
-                // TODO(canepat) remove key copy changing DatabaseReader interface
-                const auto value = co_await view->get(silkworm::Bytes{key.data(), key.size()});
+                const auto value = co_await view->get(key);
                 co_return value ? *value : silkworm::Bytes{};
             }
         } else if (table == db::table::kCodeName) {
             std::shared_ptr<StateView> view = state_cache_->get_view(*this);
             if (view != nullptr) {
-                // TODO(canepat) remove key copy changing DatabaseReader interface
-                const auto value = co_await view->get_code(silkworm::Bytes{key.data(), key.size()});
+                const auto value = co_await view->get_code(key);
                 co_return value ? *value : silkworm::Bytes{};
             }
         }

--- a/silkworm/db/kv/api/state_cache.hpp
+++ b/silkworm/db/kv/api/state_cache.hpp
@@ -40,9 +40,9 @@ class StateView {
   public:
     virtual ~StateView() = default;
 
-    virtual Task<std::optional<Bytes>> get(const Bytes& key) = 0;
+    virtual Task<std::optional<Bytes>> get(ByteView key) = 0;
 
-    virtual Task<std::optional<Bytes>> get_code(const Bytes& key) = 0;
+    virtual Task<std::optional<Bytes>> get_code(ByteView key) = 0;
 };
 
 class StateCache {
@@ -95,9 +95,9 @@ class CoherentStateView : public StateView {
     CoherentStateView(const CoherentStateView&) = delete;
     CoherentStateView& operator=(const CoherentStateView&) = delete;
 
-    Task<std::optional<Bytes>> get(const Bytes& key) override;
+    Task<std::optional<Bytes>> get(ByteView key) override;
 
-    Task<std::optional<Bytes>> get_code(const Bytes& key) override;
+    Task<std::optional<Bytes>> get_code(ByteView key) override;
 
   private:
     Transaction& txn_;
@@ -134,10 +134,10 @@ class CoherentStateCache : public StateCache {
     void process_code_change(CoherentStateRoot* root, StateViewId view_id, const remote::AccountChange& change);
     void process_delete_change(CoherentStateRoot* root, StateViewId view_id, const remote::AccountChange& change);
     void process_storage_change(CoherentStateRoot* root, StateViewId view_id, const remote::AccountChange& change);
-    bool add(const KeyValue& kv, CoherentStateRoot* root, StateViewId view_id);
-    bool add_code(const KeyValue& kv, CoherentStateRoot* root, StateViewId view_id);
-    Task<std::optional<Bytes>> get(const Bytes& key, Transaction& txn);
-    Task<std::optional<Bytes>> get_code(const Bytes& key, Transaction& txn);
+    bool add(KeyValue&& kv, CoherentStateRoot* root, StateViewId view_id);
+    bool add_code(KeyValue&& kv, CoherentStateRoot* root, StateViewId view_id);
+    Task<std::optional<Bytes>> get(ByteView key, Transaction& txn);
+    Task<std::optional<Bytes>> get_code(ByteView key, Transaction& txn);
     CoherentStateRoot* get_root(StateViewId view_id);
     CoherentStateRoot* advance_root(StateViewId view_id);
     void evict_roots(StateViewId next_view_id);


### PR DESCRIPTION
This PR contains a small refactoring in `kv::api::StateCache` following the move from `rpc` to `db` module made in #2136 