### PR TITLE
db: snapshots freezer

### DIFF
--- a/silkworm/db/access_layer.hpp
+++ b/silkworm/db/access_layer.hpp
@@ -30,6 +30,7 @@
 #include <silkworm/core/chain/config.hpp>
 #include <silkworm/core/types/account.hpp>
 #include <silkworm/core/types/block.hpp>
+#include <silkworm/core/types/block_body_for_storage.hpp>
 #include <silkworm/core/types/hash.hpp>
 #include <silkworm/core/types/receipt.hpp>
 #include <silkworm/db/mdbx/mdbx.hpp>
@@ -109,6 +110,10 @@ void write_canonical_header_hash(RWTxn& txn, const uint8_t (&hash)[kHashLength],
                              bool read_senders, BlockBody& out);
 [[nodiscard]] bool read_body(ROTxn& txn, const evmc::bytes32& hash, BlockNum bn, BlockBody& body);
 [[nodiscard]] bool read_body(ROTxn& txn, const evmc::bytes32& hash, BlockBody& body);
+[[nodiscard]] bool read_canonical_body(ROTxn& txn, BlockNum block_number, bool read_senders, BlockBody& body);
+
+[[nodiscard]] std::optional<BlockBodyForStorage> read_body_for_storage(ROTxn& txn, const Bytes& key);
+[[nodiscard]] std::optional<BlockBodyForStorage> read_canonical_body_for_storage(ROTxn& txn, BlockNum height);
 
 //! \brief Read the canonical block at specified height
 [[nodiscard]] bool read_canonical_block(ROTxn& txn, BlockNum height, Block& block);

--- a/silkworm/db/bodies/body_snapshot_freezer.cpp
+++ b/silkworm/db/bodies/body_snapshot_freezer.cpp
@@ -1,0 +1,37 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "body_snapshot_freezer.hpp"
+
+#include <stdexcept>
+
+#include <silkworm/db/access_layer.hpp>
+
+#include "body_snapshot.hpp"
+
+namespace silkworm::db {
+
+void BodySnapshotFreezer::copy(ROTxn& txn, BlockNumRange range, snapshots::SnapshotFileWriter& file_writer) const {
+    snapshots::BodySnapshotWriter writer{file_writer};
+    auto out = writer.out();
+    for (BlockNum i = range.first; i < range.second; i++) {
+        auto value_opt = read_canonical_body_for_storage(txn, i);
+        if (!value_opt) throw std::runtime_error{"BodySnapshotFreezer::copy missing body for block " + std::to_string(i)};
+        *out++ = *value_opt;
+    }
+}
+
+}  // namespace silkworm::db

--- a/silkworm/db/bodies/body_snapshot_freezer.hpp
+++ b/silkworm/db/bodies/body_snapshot_freezer.hpp
@@ -16,16 +16,14 @@
 
 #pragma once
 
-#include <silkworm/db/snapshots/snapshot_bundle_factory.hpp>
+#include <silkworm/db/snapshot_freezer.hpp>
 
 namespace silkworm::db {
 
-struct SnapshotBundleFactoryImpl : public snapshots::SnapshotBundleFactory {
-    ~SnapshotBundleFactoryImpl() override = default;
-
-    snapshots::SnapshotBundle make(PathByTypeProvider snapshot_path, PathByTypeProvider index_path) const override;
-    snapshots::SnapshotBundle make(const std::filesystem::path& dir_path, BlockNumRange range) const override;
-    std::vector<std::shared_ptr<snapshots::IndexBuilder>> index_builders(const snapshots::SnapshotPath& seg_file) const override;
+class BodySnapshotFreezer : public SnapshotFreezer {
+  public:
+    ~BodySnapshotFreezer() override = default;
+    void copy(ROTxn& txn, BlockNumRange range, snapshots::SnapshotFileWriter& file_writer) const override;
 };
 
 }  // namespace silkworm::db

--- a/silkworm/db/data_migration.cpp
+++ b/silkworm/db/data_migration.cpp
@@ -14,18 +14,18 @@
    limitations under the License.
 */
 
-#pragma once
-
-#include <silkworm/db/snapshots/snapshot_bundle_factory.hpp>
+#include "data_migration.hpp"
 
 namespace silkworm::db {
 
-struct SnapshotBundleFactoryImpl : public snapshots::SnapshotBundleFactory {
-    ~SnapshotBundleFactoryImpl() override = default;
-
-    snapshots::SnapshotBundle make(PathByTypeProvider snapshot_path, PathByTypeProvider index_path) const override;
-    snapshots::SnapshotBundle make(const std::filesystem::path& dir_path, BlockNumRange range) const override;
-    std::vector<std::shared_ptr<snapshots::IndexBuilder>> index_builders(const snapshots::SnapshotPath& seg_file) const override;
-};
+void DataMigration::run() {
+    cleanup();
+    auto command = next_command();
+    if (!command) return;
+    auto result = migrate(std::move(command));
+    index(result);
+    commit(result);
+    cleanup();
+}
 
 }  // namespace silkworm::db

--- a/silkworm/db/freezer.cpp
+++ b/silkworm/db/freezer.cpp
@@ -1,0 +1,150 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "freezer.hpp"
+
+#include <cassert>
+#include <filesystem>
+#include <stdexcept>
+#include <vector>
+
+#include <silkworm/core/common/base.hpp>
+
+#include "access_layer.hpp"
+#include "bodies/body_snapshot_freezer.hpp"
+#include "headers/header_snapshot_freezer.hpp"
+#include "prune_mode.hpp"
+#include "snapshot_freezer.hpp"
+#include "snapshots/path.hpp"
+#include "snapshots/snapshot_bundle.hpp"
+#include "snapshots/snapshot_writer.hpp"
+#include "transactions/txn_snapshot_freezer.hpp"
+
+namespace silkworm::db {
+
+using namespace silkworm::snapshots;
+
+struct FreezerCommand : public DataMigrationCommand {
+    BlockNumRange range;
+
+    FreezerCommand(BlockNumRange range1)
+        : range(std::move(range1)) {}
+    ~FreezerCommand() override = default;
+};
+
+struct FreezerResult : public DataMigrationResult {
+    SnapshotBundle bundle;
+
+    FreezerResult(SnapshotBundle bundle1)
+        : bundle(std::move(bundle1)) {}
+    ~FreezerResult() override = default;
+};
+
+static BlockNum get_tip_num(ROTxn& txn) {
+    auto [num, _] = db::read_canonical_head(txn);
+    return num;
+}
+
+std::unique_ptr<DataMigrationCommand> Freezer::next_command() {
+    BlockNum last_frozen = snapshots_.max_block_available();
+    BlockNum start = (last_frozen > 0) ? last_frozen + 1 : 0;
+    BlockNum end = start + kChunkSize;
+
+    BlockNum tip = [this] {
+        auto db_tx = db_access_.start_ro_tx();
+        return get_tip_num(db_tx);
+    }();
+
+    if (end + kFullImmutabilityThreshold <= tip) {
+        return std::make_unique<FreezerCommand>(FreezerCommand{{start, end}});
+    }
+    return {};
+}
+
+static const SnapshotFreezer& get_snapshot_freezer(SnapshotType type) {
+    static HeaderSnapshotFreezer header_snapshot_freezer;
+    static BodySnapshotFreezer body_snapshot_freezer;
+    static TransactionSnapshotFreezer txn_snapshot_freezer;
+
+    switch (type) {
+        case snapshots::headers:
+            return header_snapshot_freezer;
+        case snapshots::bodies:
+            return body_snapshot_freezer;
+        case snapshots::transactions:
+            return txn_snapshot_freezer;
+        default:
+            assert(false);
+            throw std::runtime_error("invalid type");
+    }
+}
+
+std::shared_ptr<DataMigrationResult> Freezer::migrate(std::unique_ptr<DataMigrationCommand> command) {
+    auto& freezer_command = dynamic_cast<FreezerCommand&>(*command);
+    auto range = freezer_command.range;
+
+    auto bundle = snapshots_.bundle_factory().make(tmp_dir_path_, range);
+    for (auto& snapshot_ref : bundle.snapshots()) {
+        auto path = snapshot_ref.get().path();
+        SnapshotFileWriter file_writer{path, tmp_dir_path_};
+        {
+            auto db_tx = db_access_.start_ro_tx();
+            auto& freezer = get_snapshot_freezer(path.type());
+            freezer.copy(db_tx, range, file_writer);
+        }
+        SnapshotFileWriter::flush(std::move(file_writer));
+    }
+
+    return std::make_shared<FreezerResult>(std::move(bundle));
+}
+
+void Freezer::index(std::shared_ptr<DataMigrationResult> result) {
+    auto& freezer_result = dynamic_cast<FreezerResult&>(*result);
+    auto& bundle = freezer_result.bundle;
+
+    for (auto& snapshot_ref : bundle.snapshots()) {
+        SnapshotPath snapshot_path = snapshot_ref.get().path();
+        auto index_builders = snapshots_.bundle_factory().index_builders(snapshot_path);
+        for (auto& index_builder : index_builders) {
+            index_builder->build();
+        }
+    }
+}
+
+static void move_file(const std::filesystem::path& path, const std::filesystem::path& target_dir_path) {
+    std::filesystem::rename(path, target_dir_path / path.filename());
+}
+
+void Freezer::commit(std::shared_ptr<DataMigrationResult> result) {
+    auto& freezer_result = dynamic_cast<FreezerResult&>(*result);
+    auto& bundle = freezer_result.bundle;
+
+    for (auto& index_ref : bundle.indexes()) {
+        move_file(index_ref.get().path().path(), snapshots_.path());
+    }
+    for (auto& snapshot_ref : bundle.snapshots()) {
+        move_file(snapshot_ref.get().path().path(), snapshots_.path());
+    }
+
+    auto final_bundle = snapshots_.bundle_factory().make(snapshots_.path(), bundle.block_range());
+    snapshots_.add_snapshot_bundle(std::move(final_bundle));
+}
+
+void Freezer::cleanup() {
+    // TODO
+}
+
+}  // namespace silkworm::db

--- a/silkworm/db/freezer.hpp
+++ b/silkworm/db/freezer.hpp
@@ -1,0 +1,49 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include "data_migration.hpp"
+#include "mdbx/mdbx.hpp"
+#include "snapshots/repository.hpp"
+
+namespace silkworm::db {
+
+class Freezer : public DataMigration {
+  public:
+    Freezer(
+        db::ROAccess db_access,
+        snapshots::SnapshotRepository& snapshots,
+        std::filesystem::path tmp_dir_path)
+        : db_access_(std::move(db_access)),
+          snapshots_(snapshots),
+          tmp_dir_path_(std::move(tmp_dir_path)) {}
+
+  private:
+    static constexpr size_t kChunkSize = 1000;
+
+    std::unique_ptr<DataMigrationCommand> next_command() override;
+    std::shared_ptr<DataMigrationResult> migrate(std::unique_ptr<DataMigrationCommand> command) override;
+    void index(std::shared_ptr<DataMigrationResult> result) override;
+    void commit(std::shared_ptr<DataMigrationResult> result) override;
+    void cleanup() override;
+
+    db::ROAccess db_access_;
+    snapshots::SnapshotRepository& snapshots_;
+    std::filesystem::path tmp_dir_path_;
+};
+
+}  // namespace silkworm::db

--- a/silkworm/db/headers/header_snapshot_freezer.cpp
+++ b/silkworm/db/headers/header_snapshot_freezer.cpp
@@ -1,0 +1,37 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "header_snapshot_freezer.hpp"
+
+#include <stdexcept>
+
+#include <silkworm/db/access_layer.hpp>
+
+#include "header_snapshot.hpp"
+
+namespace silkworm::db {
+
+void HeaderSnapshotFreezer::copy(ROTxn& txn, BlockNumRange range, snapshots::SnapshotFileWriter& file_writer) const {
+    snapshots::HeaderSnapshotWriter writer{file_writer};
+    auto out = writer.out();
+    for (BlockNum i = range.first; i < range.second; i++) {
+        auto value_opt = read_canonical_header(txn, i);
+        if (!value_opt) throw std::runtime_error{"HeaderSnapshotFreezer::copy missing header for block " + std::to_string(i)};
+        *out++ = *value_opt;
+    }
+}
+
+}  // namespace silkworm::db

--- a/silkworm/db/headers/header_snapshot_freezer.hpp
+++ b/silkworm/db/headers/header_snapshot_freezer.hpp
@@ -16,16 +16,14 @@
 
 #pragma once
 
-#include <silkworm/db/snapshots/snapshot_bundle_factory.hpp>
+#include <silkworm/db/snapshot_freezer.hpp>
 
 namespace silkworm::db {
 
-struct SnapshotBundleFactoryImpl : public snapshots::SnapshotBundleFactory {
-    ~SnapshotBundleFactoryImpl() override = default;
-
-    snapshots::SnapshotBundle make(PathByTypeProvider snapshot_path, PathByTypeProvider index_path) const override;
-    snapshots::SnapshotBundle make(const std::filesystem::path& dir_path, BlockNumRange range) const override;
-    std::vector<std::shared_ptr<snapshots::IndexBuilder>> index_builders(const snapshots::SnapshotPath& seg_file) const override;
+class HeaderSnapshotFreezer : public SnapshotFreezer {
+  public:
+    ~HeaderSnapshotFreezer() override = default;
+    void copy(ROTxn& txn, BlockNumRange range, snapshots::SnapshotFileWriter& file_writer) const override;
 };
 
 }  // namespace silkworm::db

--- a/silkworm/db/snapshot_freezer.hpp
+++ b/silkworm/db/snapshot_freezer.hpp
@@ -16,16 +16,18 @@
 
 #pragma once
 
-#include <silkworm/db/snapshots/snapshot_bundle_factory.hpp>
+#include <silkworm/core/common/base.hpp>
+
+#include "mdbx/mdbx.hpp"
+#include "snapshots/snapshot_writer.hpp"
 
 namespace silkworm::db {
 
-struct SnapshotBundleFactoryImpl : public snapshots::SnapshotBundleFactory {
-    ~SnapshotBundleFactoryImpl() override = default;
+struct SnapshotFreezer {
+    virtual ~SnapshotFreezer() = default;
 
-    snapshots::SnapshotBundle make(PathByTypeProvider snapshot_path, PathByTypeProvider index_path) const override;
-    snapshots::SnapshotBundle make(const std::filesystem::path& dir_path, BlockNumRange range) const override;
-    std::vector<std::shared_ptr<snapshots::IndexBuilder>> index_builders(const snapshots::SnapshotPath& seg_file) const override;
+    //! Copies data for a block range from db to the snapshot file.
+    virtual void copy(ROTxn& txn, BlockNumRange range, snapshots::SnapshotFileWriter& file_writer) const = 0;
 };
 
 }  // namespace silkworm::db

--- a/silkworm/db/snapshots/repository.hpp
+++ b/silkworm/db/snapshots/repository.hpp
@@ -20,6 +20,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <ranges>
 #include <string>
@@ -53,13 +54,14 @@ class SnapshotRepository {
 
     [[nodiscard]] const SnapshotSettings& settings() const { return settings_; }
     [[nodiscard]] std::filesystem::path path() const { return settings_.repository_dir; }
+    [[nodiscard]] const SnapshotBundleFactory& bundle_factory() const { return *bundle_factory_; }
 
     void reopen_folder();
     void close();
 
     void add_snapshot_bundle(SnapshotBundle bundle);
 
-    [[nodiscard]] std::size_t bundles_count() const { return bundles_.size(); }
+    [[nodiscard]] std::size_t bundles_count() const;
     [[nodiscard]] std::size_t total_snapshots_count() const { return bundles_count() * SnapshotBundle::kSnapshotsCount; }
     [[nodiscard]] std::size_t total_indexes_count() const { return bundles_count() * SnapshotBundle::kIndexesCount; }
 
@@ -99,6 +101,7 @@ class SnapshotRepository {
 
     //! Full snapshot bundles ordered by block_from
     std::map<BlockNum, SnapshotBundle> bundles_;
+    mutable std::mutex bundles_mutex_;
 };
 
 }  // namespace silkworm::snapshots

--- a/silkworm/db/snapshots/snapshot_bundle.cpp
+++ b/silkworm/db/snapshots/snapshot_bundle.cpp
@@ -1,0 +1,44 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "snapshot_bundle.hpp"
+
+#include <silkworm/infra/common/ensure.hpp>
+
+namespace silkworm::snapshots {
+
+void SnapshotBundle::reopen() {
+    for (auto& snapshot_ref : snapshots()) {
+        snapshot_ref.get().reopen_segment();
+        ensure(!snapshot_ref.get().empty(), [&]() {
+            return "invalid empty snapshot " + snapshot_ref.get().fs_path().string();
+        });
+    }
+    for (auto& index_ref : indexes()) {
+        index_ref.get().reopen_index();
+    }
+}
+
+void SnapshotBundle::close() {
+    for (auto& index_ref : indexes()) {
+        index_ref.get().close_index();
+    }
+    for (auto& snapshot_ref : snapshots()) {
+        snapshot_ref.get().close();
+    }
+}
+
+}  // namespace silkworm::snapshots

--- a/silkworm/db/snapshots/snapshot_bundle.hpp
+++ b/silkworm/db/snapshots/snapshot_bundle.hpp
@@ -63,6 +63,23 @@ struct SnapshotBundle {
         };
     }
 
+    std::array<SnapshotType, kSnapshotsCount> snapshot_types() {
+        return {
+            SnapshotType::headers,
+            SnapshotType::bodies,
+            SnapshotType::transactions,
+        };
+    }
+
+    std::array<SnapshotType, kIndexesCount> index_types() {
+        return {
+            SnapshotType::headers,
+            SnapshotType::bodies,
+            SnapshotType::transactions,
+            SnapshotType::transactions_to_block,
+        };
+    }
+
     const Snapshot& snapshot(SnapshotType type) const {
         switch (type) {
             case headers:
@@ -99,6 +116,7 @@ struct SnapshotBundle {
     // assume that all snapshots have the same block range, and use one of them
     BlockNum block_from() const { return header_snapshot.block_from(); }
     BlockNum block_to() const { return header_snapshot.block_to(); }
+    BlockNumRange block_range() const { return {block_from(), block_to()}; }
 
     void reopen();
     void close();

--- a/silkworm/db/snapshots/snapshot_bundle_factory.hpp
+++ b/silkworm/db/snapshots/snapshot_bundle_factory.hpp
@@ -15,9 +15,13 @@
 */
 
 #pragma once
+
+#include <filesystem>
 #include <functional>
 #include <memory>
 #include <vector>
+
+#include <silkworm/core/common/base.hpp>
 
 #include "index_builder.hpp"
 #include "path.hpp"
@@ -31,8 +35,9 @@ struct SnapshotBundleFactory {
 
     using PathByTypeProvider = std::function<SnapshotPath(SnapshotType)>;
     virtual SnapshotBundle make(PathByTypeProvider snapshot_path, PathByTypeProvider index_path) const = 0;
+    virtual SnapshotBundle make(const std::filesystem::path& dir_path, BlockNumRange range) const = 0;
 
-    virtual std::vector<std::shared_ptr<IndexBuilder>> index_builders(SnapshotPath seg_file) const = 0;
+    virtual std::vector<std::shared_ptr<IndexBuilder>> index_builders(const SnapshotPath& seg_file) const = 0;
 };
 
 }  // namespace silkworm::snapshots

--- a/silkworm/db/transactions/txn_snapshot_freezer.cpp
+++ b/silkworm/db/transactions/txn_snapshot_freezer.cpp
@@ -1,0 +1,45 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "txn_snapshot_freezer.hpp"
+
+#include <stdexcept>
+
+#include <silkworm/db/access_layer.hpp>
+
+#include "txn_snapshot.hpp"
+
+namespace silkworm::db {
+
+void TransactionSnapshotFreezer::copy(ROTxn& txn, BlockNumRange range, snapshots::SnapshotFileWriter& file_writer) const {
+    snapshots::TransactionSnapshotWriter writer{file_writer};
+    auto out = writer.out();
+    auto system_tx = snapshots::empty_system_tx();
+
+    for (BlockNum i = range.first; i < range.second; i++) {
+        BlockBody body;
+        bool found = read_canonical_body(txn, i, /* read_senders = */ true, body);
+        if (!found) throw std::runtime_error{"TransactionSnapshotFreezer::copy missing body for block " + std::to_string(i)};
+
+        *out++ = system_tx;
+        for (auto& value : body.transactions) {
+            *out++ = value;
+        }
+        *out++ = system_tx;
+    }
+}
+
+}  // namespace silkworm::db

--- a/silkworm/db/transactions/txn_snapshot_freezer.hpp
+++ b/silkworm/db/transactions/txn_snapshot_freezer.hpp
@@ -16,16 +16,14 @@
 
 #pragma once
 
-#include <silkworm/db/snapshots/snapshot_bundle_factory.hpp>
+#include <silkworm/db/snapshot_freezer.hpp>
 
 namespace silkworm::db {
 
-struct SnapshotBundleFactoryImpl : public snapshots::SnapshotBundleFactory {
-    ~SnapshotBundleFactoryImpl() override = default;
-
-    snapshots::SnapshotBundle make(PathByTypeProvider snapshot_path, PathByTypeProvider index_path) const override;
-    snapshots::SnapshotBundle make(const std::filesystem::path& dir_path, BlockNumRange range) const override;
-    std::vector<std::shared_ptr<snapshots::IndexBuilder>> index_builders(const snapshots::SnapshotPath& seg_file) const override;
+class TransactionSnapshotFreezer : public SnapshotFreezer {
+  public:
+    ~TransactionSnapshotFreezer() override = default;
+    void copy(ROTxn& txn, BlockNumRange range, snapshots::SnapshotFileWriter& file_writer) const override;
 };
 
 }  // namespace silkworm::db

--- a/silkworm/db/transactions/txn_snapshot_word_serializer.hpp
+++ b/silkworm/db/transactions/txn_snapshot_word_serializer.hpp
@@ -44,6 +44,8 @@ void encode_word_from_tx(Bytes& word, const Transaction& tx);
 //! Decode transaction from snapshot word. Format is: tx_hash_1byte + sender_address_20byte + tx_rlp_bytes
 void decode_word_into_tx(ByteView word, Transaction& tx);
 
+Transaction empty_system_tx();
+
 struct TransactionSnapshotWordSerializer : public SnapshotWordSerializer {
     Transaction value;
     Bytes word;


### PR DESCRIPTION
Freezer implements a data migration process from mdbx to snapshots.
Each snapshot type implements a SnapshotFreezer interface to copy the data.
The data migration is implemented. Cleanup and stageloop integration will be implemented later.
DataMigration::run implements a single migration pass, later on we'll run it in a loop with some sleep().

SnapshotRepository thread-safety is improved, but not entirely. We can't rely on a single mutex for repo queries that loop over bundles. This has to be addressed later.