### PR TITLE
rpcdaemon: enum values for protocol error codes

### DIFF
--- a/silkworm/rpc/commands/admin_api.cpp
+++ b/silkworm/rpc/commands/admin_api.cpp
@@ -20,6 +20,7 @@
 
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/rpc/json/types.hpp>
+#include <silkworm/rpc/protocol/errors.hpp>
 
 namespace silkworm::rpc::commands {
 
@@ -34,12 +35,11 @@ Task<void> AdminRpcApi::handle_admin_node_info(const nlohmann::json& request, nl
         }
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, -32000, e.what());
+        reply = make_json_error(request, kServerError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#admin_peers
@@ -49,12 +49,11 @@ Task<void> AdminRpcApi::handle_admin_peers(const nlohmann::json& request, nlohma
         reply = make_json_content(request, peers);
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, -32000, e.what());
+        reply = make_json_error(request, kServerError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
-    co_return;
 }
 
 }  // namespace silkworm::rpc::commands

--- a/silkworm/rpc/commands/engine_api.cpp
+++ b/silkworm/rpc/commands/engine_api.cpp
@@ -103,16 +103,13 @@ Task<void> EngineRpcApi::handle_engine_get_payload_v1(const nlohmann::json& requ
 #ifndef BUILD_COVERAGE
     } catch (const boost::system::system_error& se) {
         SILK_ERROR << "error: \"" << se.code().message() << "\" processing request: " << request.dump();
-        // TODO(canepat) the error code should be se.code().value() here: application-level errors should come from BackEnd
-        reply = make_json_error(request, kUnknownPayload, se.code().message());
+        reply = make_json_error(request, se.code().value(), se.code().message());
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        // TODO(canepat) the error code should be kInternalError here: application-level errors should come from BackEnd
-        reply = make_json_error(request, kUnknownPayload, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        // TODO(canepat) the error code should be kServerError here: application-level errors should come from BackEnd
-        reply = make_json_error(request, kUnknownPayload, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 #endif
 }
@@ -139,16 +136,13 @@ Task<void> EngineRpcApi::handle_engine_get_payload_v2(const nlohmann::json& requ
         reply = make_json_content(request, payload_and_value);
     } catch (const boost::system::system_error& se) {
         SILK_ERROR << "error: \"" << se.code().message() << "\" processing request: " << request.dump();
-        // TODO(canepat) the error code should be se.code().value() here: application-level errors should come from BackEnd
-        reply = make_json_error(request, kUnknownPayload, se.code().message());
+        reply = make_json_error(request, se.code().value(), se.code().message());
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        // TODO(canepat) the error code should be kInternalError here: application-level errors should come from BackEnd
-        reply = make_json_error(request, kUnknownPayload, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        // TODO(canepat) the error code should be kServerError here: application-level errors should come from BackEnd
-        reply = make_json_error(request, kUnknownPayload, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 }
 
@@ -175,16 +169,13 @@ Task<void> EngineRpcApi::handle_engine_get_payload_v3(const nlohmann::json& requ
         reply = make_json_content(request, payload_and_value);
     } catch (const boost::system::system_error& se) {
         SILK_ERROR << "error: \"" << se.code().message() << "\" processing request: " << request.dump();
-        // TODO(canepat) the error code should be se.code().value() here: application-level errors should come from BackEnd
-        reply = make_json_error(request, kUnknownPayload, se.code().message());
+        reply = make_json_error(request, se.code().value(), se.code().message());
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        // TODO(canepat) the error code should be kInternalError here: application-level errors should come from BackEnd
-        reply = make_json_error(request, kUnknownPayload, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        // TODO(canepat) the error code should be kServerError here: application-level errors should come from BackEnd
-        reply = make_json_error(request, kUnknownPayload, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 }
 

--- a/silkworm/rpc/commands/erigon_api_test.cpp
+++ b/silkworm/rpc/commands/erigon_api_test.cpp
@@ -69,7 +69,7 @@ TEST_CASE_METHOD(ErigonRpcApiTest, "ErigonRpcApi::handle_erigon_get_block_by_tim
             })"_json,
             reply));
 
-        std::string expected_rsp{R"({"jsonrpc":"2.0","id":1,"error":{"code":100,"message":"invalid erigon_getBlockByTimestamp params: []"}})"};
+        std::string expected_rsp{R"({"jsonrpc":"2.0","id":1,"error":{"code":-32602,"message":"invalid erigon_getBlockByTimestamp params: []"}})"};
         CHECK(reply == expected_rsp);
     }
     SECTION("request params are incomplete: return error") {
@@ -86,7 +86,7 @@ TEST_CASE_METHOD(ErigonRpcApiTest, "ErigonRpcApi::handle_erigon_get_block_by_tim
             "id":1,
             "error":{"code":100,"message":"invalid erigon_getBlockByTimestamp params: [\"1658865942\"]"}
         })"_json;
-        std::string expected_rsp{R"({"jsonrpc":"2.0","id":1,"error":{"code":100,"message":"invalid erigon_getBlockByTimestamp params: [\"1658865942\"]"}})"};
+        std::string expected_rsp{R"({"jsonrpc":"2.0","id":1,"error":{"code":-32602,"message":"invalid erigon_getBlockByTimestamp params: [\"1658865942\"]"}})"};
         CHECK(reply == expected_rsp);
     }
     SECTION("request 1st param is invalid: return error") {
@@ -140,7 +140,7 @@ TEST_CASE_METHOD(ErigonRpcApiTest, "ErigonRpcApi::handle_erigon_get_header_by_ha
         CHECK(reply == R"({
             "jsonrpc":"2.0",
             "id":1,
-            "error":{"code":100,"message":"invalid erigon_getHeaderByHash params: []"}
+            "error":{"code":-32602,"message":"invalid erigon_getHeaderByHash params: []"}
         })"_json);
     }
 }
@@ -160,7 +160,7 @@ TEST_CASE_METHOD(ErigonRpcApiTest, "ErigonRpcApi::handle_erigon_get_header_by_nu
         CHECK(reply == R"({
             "jsonrpc":"2.0",
             "id":1,
-            "error":{"code":100,"message":"invalid erigon_getHeaderByNumber params: []"}
+            "error":{"code":-32602,"message":"invalid erigon_getHeaderByNumber params: []"}
         })"_json);
     }
 }
@@ -180,7 +180,7 @@ TEST_CASE_METHOD(ErigonRpcApiTest, "ErigonRpcApi::handle_erigon_get_logs_by_hash
         CHECK(reply == R"({
             "jsonrpc":"2.0",
             "id":1,
-            "error":{"code":100,"message":"invalid erigon_getLogsByHash params: []"}
+            "error":{"code":-32602,"message":"invalid erigon_getLogsByHash params: []"}
         })"_json);
     }
 }
@@ -217,7 +217,7 @@ TEST_CASE_METHOD(ErigonRpcApiTest, "ErigonRpcApi::handle_erigon_block_number", "
         CHECK(reply == R"({
             "jsonrpc":"2.0",
             "id":1,
-            "error":{"code":100,"message":"invalid erigon_blockNumber params: [\"earliest\",\"3\"]"} 
+            "error":{"code":-32602,"message":"invalid erigon_blockNumber params: [\"earliest\",\"3\"]"}
         })"_json);
     }
 #endif  // _WIN32

--- a/silkworm/rpc/commands/eth_api.cpp
+++ b/silkworm/rpc/commands/eth_api.cpp
@@ -48,6 +48,7 @@
 #include <silkworm/rpc/core/gas_price_oracle.hpp>
 #include <silkworm/rpc/core/logs_walker.hpp>
 #include <silkworm/rpc/core/receipts.hpp>
+#include <silkworm/rpc/protocol/errors.hpp>
 #include <silkworm/rpc/stagedsync/stages.hpp>
 
 namespace silkworm::rpc::commands {
@@ -63,14 +64,13 @@ Task<void> EthereumRpcApi::handle_eth_block_number(const nlohmann::json& request
         reply = make_json_content(request, to_quantity(block_height));
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_chainid
@@ -83,14 +83,13 @@ Task<void> EthereumRpcApi::handle_eth_chain_id(const nlohmann::json& request, nl
         reply = make_json_content(request, to_quantity(chain_config.chain_id));
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_protocolversion
@@ -100,13 +99,11 @@ Task<void> EthereumRpcApi::handle_eth_protocol_version(const nlohmann::json& req
         reply = make_json_content(request, to_quantity(protocol_version));
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, -32000, e.what());
+        reply = make_json_error(request, kServerError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
-
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_syncing
@@ -133,14 +130,13 @@ Task<void> EthereumRpcApi::handle_eth_syncing(const nlohmann::json& request, nlo
         }
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_gasprice
@@ -171,14 +167,13 @@ Task<void> EthereumRpcApi::handle_eth_gas_price(const nlohmann::json& request, n
         }
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_getblockbyhash
@@ -187,7 +182,7 @@ Task<void> EthereumRpcApi::handle_eth_get_block_by_hash(const nlohmann::json& re
     if (params.size() != 2) {
         auto error_msg = "invalid eth_getBlockByHash params: " + params.dump();
         SILK_ERROR << error_msg;
-        make_glaze_json_error(request, 100, error_msg, reply);
+        make_glaze_json_error(request, kInvalidParams, error_msg, reply);
         co_return;
     }
     auto block_hash = params[0].get<evmc::bytes32>();
@@ -212,14 +207,13 @@ Task<void> EthereumRpcApi::handle_eth_get_block_by_hash(const nlohmann::json& re
         make_glaze_json_null_content(request, reply);
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        make_glaze_json_error(request, 100, e.what(), reply);
+        make_glaze_json_error(request, kInternalError, e.what(), reply);
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        make_glaze_json_error(request, 100, "unexpected exception", reply);
+        make_glaze_json_error(request, kServerError, "unexpected exception", reply);
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_getblockbynumber
@@ -228,7 +222,7 @@ Task<void> EthereumRpcApi::handle_eth_get_block_by_number(const nlohmann::json& 
     if (params.size() != 2) {
         auto error_msg = "invalid eth_getBlockByNumber params: " + params.dump();
         SILK_ERROR << error_msg;
-        make_glaze_json_error(request, 100, error_msg, reply);
+        make_glaze_json_error(request, kInvalidParams, error_msg, reply);
         co_return;
     }
     const auto block_id = params[0].get<std::string>();
@@ -254,14 +248,13 @@ Task<void> EthereumRpcApi::handle_eth_get_block_by_number(const nlohmann::json& 
         make_glaze_json_null_content(request, reply);
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        make_glaze_json_error(request, 100, e.what(), reply);
+        make_glaze_json_error(request, kInternalError, e.what(), reply);
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        make_glaze_json_error(request, 100, "unexpected exception", reply);
+        make_glaze_json_error(request, kServerError, "unexpected exception", reply);
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_getblocktransactioncountbyhash
@@ -270,7 +263,7 @@ Task<void> EthereumRpcApi::handle_eth_get_block_transaction_count_by_hash(const 
     if (params.size() != 1) {
         auto error_msg = "invalid eth_getBlockTransactionCountByHash params: " + params.dump();
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, 100, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
         co_return;
     }
     auto block_hash = params[0].get<evmc::bytes32>();
@@ -291,14 +284,13 @@ Task<void> EthereumRpcApi::handle_eth_get_block_transaction_count_by_hash(const 
         reply = make_json_content(request, 0x0);
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_getblocktransactioncountbynumber
@@ -307,7 +299,7 @@ Task<void> EthereumRpcApi::handle_eth_get_block_transaction_count_by_number(cons
     if (params.size() != 1) {
         auto error_msg = "invalid eth_getBlockTransactionCountByNumber params: " + params.dump();
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, 100, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
         co_return;
     }
     const auto block_id = params[0].get<std::string>();
@@ -329,14 +321,13 @@ Task<void> EthereumRpcApi::handle_eth_get_block_transaction_count_by_number(cons
         reply = make_json_content(request, 0x0);
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_getunclebyblockhashandindex
@@ -345,7 +336,7 @@ Task<void> EthereumRpcApi::handle_eth_get_uncle_by_block_hash_and_index(const nl
     if (params.size() != 2) {
         auto error_msg = "invalid eth_getUncleByBlockHashAndIndex params: " + params.dump();
         SILK_ERROR << error_msg;
-        make_glaze_json_error(request, 100, error_msg, reply);
+        make_glaze_json_error(request, kInvalidParams, error_msg, reply);
         co_return;
     }
     const auto block_hash = params[0].get<evmc::bytes32>();
@@ -385,14 +376,13 @@ Task<void> EthereumRpcApi::handle_eth_get_uncle_by_block_hash_and_index(const nl
         make_glaze_json_null_content(request, reply);
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        make_glaze_json_error(request, 100, e.what(), reply);
+        make_glaze_json_error(request, kInternalError, e.what(), reply);
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        make_glaze_json_error(request, 100, "unexpected exception", reply);
+        make_glaze_json_error(request, kServerError, "unexpected exception", reply);
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_getunclebyblocknumberandindex
@@ -401,7 +391,7 @@ Task<void> EthereumRpcApi::handle_eth_get_uncle_by_block_number_and_index(const 
     if (params.size() != 2) {
         auto error_msg = "invalid eth_getUncleByBlockNumberAndIndex params: " + params.dump();
         SILK_ERROR << error_msg;
-        make_glaze_json_error(request, 100, error_msg, reply);
+        make_glaze_json_error(request, kInvalidParams, error_msg, reply);
         co_return;
     }
     const auto block_id = params[0].get<std::string>();
@@ -441,14 +431,13 @@ Task<void> EthereumRpcApi::handle_eth_get_uncle_by_block_number_and_index(const 
         make_glaze_json_null_content(request, reply);
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        make_glaze_json_error(request, 100, e.what(), reply);
+        make_glaze_json_error(request, kInternalError, e.what(), reply);
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        make_glaze_json_error(request, 100, "unexpected exception", reply);
+        make_glaze_json_error(request, kServerError, "unexpected exception", reply);
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_getunclecountbyblockhash
@@ -457,7 +446,7 @@ Task<void> EthereumRpcApi::handle_eth_get_uncle_count_by_block_hash(const nlohma
     if (params.size() != 1) {
         auto error_msg = "invalid eth_getUncleCountByBlockHash params: " + params.dump();
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, 100, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
         co_return;
     }
     auto block_hash = params[0].get<evmc::bytes32>();
@@ -476,14 +465,13 @@ Task<void> EthereumRpcApi::handle_eth_get_uncle_count_by_block_hash(const nlohma
         reply = make_json_content(request, to_quantity(ommers));
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_getunclecountbyblocknumber
@@ -492,7 +480,7 @@ Task<void> EthereumRpcApi::handle_eth_get_uncle_count_by_block_number(const nloh
     if (params.size() != 1) {
         auto error_msg = "invalid eth_getUncleCountByBlockNumber params: " + params.dump();
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, 100, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
         co_return;
     }
     const auto block_id = params[0].get<std::string>();
@@ -513,14 +501,13 @@ Task<void> EthereumRpcApi::handle_eth_get_uncle_count_by_block_number(const nloh
         reply = make_json_content(request, to_quantity(ommers));
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_gettransactionbyhash
@@ -529,7 +516,7 @@ Task<void> EthereumRpcApi::handle_eth_get_transaction_by_hash(const nlohmann::js
     if (params.size() != 1) {
         auto error_msg = "invalid eth_getTransactionByHash params: " + params.dump();
         SILK_ERROR << error_msg;
-        make_glaze_json_error(request, 100, error_msg, reply);
+        make_glaze_json_error(request, kInvalidParams, error_msg, reply);
         co_return;
     }
     auto transaction_hash = params[0].get<evmc::bytes32>();
@@ -568,14 +555,13 @@ Task<void> EthereumRpcApi::handle_eth_get_transaction_by_hash(const nlohmann::js
         make_glaze_json_null_content(request, reply);
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        make_glaze_json_error(request, 100, e.what(), reply);
+        make_glaze_json_error(request, kInternalError, e.what(), reply);
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        make_glaze_json_error(request, 100, "unexpected exception", reply);
+        make_glaze_json_error(request, kServerError, "unexpected exception", reply);
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_getrawtransactionbyhash
@@ -584,7 +570,7 @@ Task<void> EthereumRpcApi::handle_eth_get_raw_transaction_by_hash(const nlohmann
     if (params.size() != 1) {
         auto error_msg = "invalid eth_getRawTransactionByHash params: " + params.dump();
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, 100, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
         co_return;
     }
     const auto transaction_hash = params[0].get<evmc::bytes32>();
@@ -615,14 +601,13 @@ Task<void> EthereumRpcApi::handle_eth_get_raw_transaction_by_hash(const nlohmann
         reply = make_json_content(request, rlp);
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_gettransactionbyblockhashandindex
@@ -631,7 +616,7 @@ Task<void> EthereumRpcApi::handle_eth_get_transaction_by_block_hash_and_index(co
     if (params.size() != 2) {
         auto error_msg = "invalid eth_getTransactionByBlockHashAndIndex params: " + params.dump();
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, 100, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
         co_return;
     }
     const auto block_hash = params[0].get<evmc::bytes32>();
@@ -663,14 +648,13 @@ Task<void> EthereumRpcApi::handle_eth_get_transaction_by_block_hash_and_index(co
         reply = make_json_content(request, nullptr);
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_getrawtransactionbyblockhashandindex
@@ -679,7 +663,7 @@ Task<void> EthereumRpcApi::handle_eth_get_raw_transaction_by_block_hash_and_inde
     if (params.size() != 2) {
         auto error_msg = "invalid eth_getRawTransactionByBlockHashAndIndex params: " + params.dump();
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, 100, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
         co_return;
     }
     const auto block_hash = params[0].get<evmc::bytes32>();
@@ -713,14 +697,13 @@ Task<void> EthereumRpcApi::handle_eth_get_raw_transaction_by_block_hash_and_inde
         reply = make_json_content(request, rlp);
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_gettransactionbyblocknumberandindex
@@ -729,7 +712,7 @@ Task<void> EthereumRpcApi::handle_eth_get_transaction_by_block_number_and_index(
     if (params.size() != 2) {
         auto error_msg = "invalid eth_getTransactionByBlockNumberAndIndex params: " + params.dump();
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, 100, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
         co_return;
     }
     const auto block_id = params[0].get<std::string>();
@@ -764,14 +747,13 @@ Task<void> EthereumRpcApi::handle_eth_get_transaction_by_block_number_and_index(
         reply = make_json_content(request, rlp);
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_getrawtransactionbyblocknumberandindex
@@ -780,7 +762,7 @@ Task<void> EthereumRpcApi::handle_eth_get_raw_transaction_by_block_number_and_in
     if (params.size() != 2) {
         auto error_msg = "invalid eth_getRawTransactionByBlockNumberAndIndex params: " + params.dump();
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, 100, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
         co_return;
     }
     const auto block_id = params[0].get<std::string>();
@@ -815,14 +797,13 @@ Task<void> EthereumRpcApi::handle_eth_get_raw_transaction_by_block_number_and_in
         reply = make_json_content(request, rlp);
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_gettransactionreceipt
@@ -831,7 +812,7 @@ Task<void> EthereumRpcApi::handle_eth_get_transaction_receipt(const nlohmann::js
     if (params.size() != 1) {
         auto error_msg = "invalid eth_getTransactionReceipt params: " + params.dump();
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, 100, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
         co_return;
     }
     auto transaction_hash = params[0].get<evmc::bytes32>();
@@ -878,11 +859,10 @@ Task<void> EthereumRpcApi::handle_eth_get_transaction_receipt(const nlohmann::js
         reply = make_json_content(request, {});
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_estimategas
@@ -891,7 +871,7 @@ Task<void> EthereumRpcApi::handle_eth_estimate_gas(const nlohmann::json& request
     if (params.size() != 1) {
         auto error_msg = "invalid eth_estimateGas params: " + params.dump();
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, 100, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
         co_return;
     }
     const auto call = params[0].get<Call>();
@@ -939,14 +919,13 @@ Task<void> EthereumRpcApi::handle_eth_estimate_gas(const nlohmann::json& request
         }
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_getbalance
@@ -955,7 +934,7 @@ Task<void> EthereumRpcApi::handle_eth_get_balance(const nlohmann::json& request,
     if (params.size() != 2) {
         auto error_msg = "invalid eth_getBalance params: " + params.dump();
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, 100, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
         co_return;
     }
     const auto address = params[0].get<evmc::address>();
@@ -975,14 +954,13 @@ Task<void> EthereumRpcApi::handle_eth_get_balance(const nlohmann::json& request,
         reply = make_json_content(request, "0x" + (account ? intx::hex(account->balance) : "0"));
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_getcode
@@ -991,7 +969,7 @@ Task<void> EthereumRpcApi::handle_eth_get_code(const nlohmann::json& request, nl
     if (params.size() != 2) {
         auto error_msg = "invalid eth_getCode params: " + params.dump();
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, 100, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
         co_return;
     }
     const auto address = params[0].get<evmc::address>();
@@ -1016,14 +994,13 @@ Task<void> EthereumRpcApi::handle_eth_get_code(const nlohmann::json& request, nl
         }
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_gettransactioncount
@@ -1032,7 +1009,7 @@ Task<void> EthereumRpcApi::handle_eth_get_transaction_count(const nlohmann::json
     if (params.size() != 2) {
         auto error_msg = "invalid eth_getTransactionCount params: " + params.dump();
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, 100, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
         co_return;
     }
     const auto address = params[0].get<evmc::address>();
@@ -1056,14 +1033,13 @@ Task<void> EthereumRpcApi::handle_eth_get_transaction_count(const nlohmann::json
         }
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_getstorageat
@@ -1072,7 +1048,7 @@ Task<void> EthereumRpcApi::handle_eth_get_storage_at(const nlohmann::json& reque
     if (params.size() != 3 || !is_valid_address(params[0].get<std::string>())) {
         const auto error_msg = "invalid eth_getStorageAt params: " + params.dump();
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, 100, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
         co_return;
     }
     const auto address = params[0].get<evmc::address>();
@@ -1080,7 +1056,7 @@ Task<void> EthereumRpcApi::handle_eth_get_storage_at(const nlohmann::json& reque
     if (!is_valid_hex(position) || position.length() > 2 + kHashLength * 2) {
         const auto error_msg = "invalid position in eth_getStorageAt params: " + params.dump();
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, 100, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
         co_return;
     }
     const auto location = bytes32_from_hex(position);
@@ -1105,14 +1081,13 @@ Task<void> EthereumRpcApi::handle_eth_get_storage_at(const nlohmann::json& reque
         }
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_call
@@ -1120,14 +1095,14 @@ Task<void> EthereumRpcApi::handle_eth_call(const nlohmann::json& request, std::s
     if (!request.contains("params")) {
         auto error_msg = "missing value for required argument 0";
         SILK_ERROR << error_msg << request.dump();
-        make_glaze_json_error(request, -32602, error_msg, reply);
+        make_glaze_json_error(request, kInvalidParams, error_msg, reply);
         co_return;
     }
     const auto& params = request["params"];
     if (params.size() != 2) {
         auto error_msg = "invalid eth_call params: " + params.dump();
         SILK_ERROR << error_msg;
-        make_glaze_json_error(request, -32602, error_msg, reply);
+        make_glaze_json_error(request, kInvalidParams, error_msg, reply);
         co_return;
     }
     const auto call = params[0].get<Call>();
@@ -1160,21 +1135,20 @@ Task<void> EthereumRpcApi::handle_eth_call(const nlohmann::json& request, std::s
         } else {
             const auto error_message = execution_result.error_message();
             if (execution_result.data.empty()) {
-                make_glaze_json_error(request, -32000, error_message, reply);
+                make_glaze_json_error(request, kServerError, error_message, reply);
             } else {
                 make_glaze_json_error(request, RevertError{{3, error_message}, execution_result.data}, reply);
             }
         }
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        make_glaze_json_error(request, 100, e.what(), reply);
+        make_glaze_json_error(request, kInternalError, e.what(), reply);
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        make_glaze_json_error(request, 100, "unexpected exception", reply);
+        make_glaze_json_error(request, kServerError, "unexpected exception", reply);
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_callMany
@@ -1182,7 +1156,7 @@ Task<void> EthereumRpcApi::handle_eth_call_many(const nlohmann::json& request, n
     if (!request.contains("params")) {
         auto error_msg = "missing value for required arguments";
         SILK_ERROR << error_msg << request.dump();
-        reply = make_json_error(request, -32602, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
 
         co_return;
     }
@@ -1190,7 +1164,7 @@ Task<void> EthereumRpcApi::handle_eth_call_many(const nlohmann::json& request, n
     if (params.size() < 2) {
         auto error_msg = "invalid eth_callMany params: " + params.dump();
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, -32602, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
         co_return;
     }
 
@@ -1199,7 +1173,7 @@ Task<void> EthereumRpcApi::handle_eth_call_many(const nlohmann::json& request, n
     if (bundles.empty()) {
         const auto error_msg = "invalid eth_callMany bundle list: " + params.dump();
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, 100, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
 
         co_return;
     }
@@ -1227,20 +1201,19 @@ Task<void> EthereumRpcApi::handle_eth_call_many(const nlohmann::json& request, n
         const auto result = co_await executor.execute(bundles, simulation_context, accounts_overrides, timeout);
 
         if (result.error) {
-            reply = make_json_error(request, -32000, result.error.value());
+            reply = make_json_error(request, kServerError, result.error.value());
         } else {
             reply = make_json_content(request, result.results);
         }
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_maxpriorityfeepergas
@@ -1264,14 +1237,13 @@ Task<void> EthereumRpcApi::handle_eth_max_priority_fee_per_gas(const nlohmann::j
         reply = make_json_content(request, to_quantity(gas_price));
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 // https://geth.ethereum.org/docs/rpc/ns-eth#eth_createaccesslist
@@ -1280,7 +1252,7 @@ Task<void> EthereumRpcApi::handle_eth_create_access_list(const nlohmann::json& r
     if (params.size() != 2 && params.size() != 3) {
         auto error_msg = "invalid eth_createAccessList params: " + params.dump();
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, 100, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
         co_return;
     }
     const auto call = params[0].get<Call>();
@@ -1344,7 +1316,7 @@ Task<void> EthereumRpcApi::handle_eth_create_access_list(const nlohmann::json& r
                 tracers, /* refund */ true, /* gasBailout */ false);
 
             if (execution_result.pre_check_error) {
-                reply = make_json_error(request, -32000, execution_result.pre_check_error.value());
+                reply = make_json_error(request, kServerError, execution_result.pre_check_error.value());
                 break;
             }
             const AccessList& current_access_list = tracer->get_access_list();
@@ -1368,14 +1340,13 @@ Task<void> EthereumRpcApi::handle_eth_create_access_list(const nlohmann::json& r
         reply = make_json_content(request, {});
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 // https://docs.flashbots.net/flashbots-auction/miners/mev-geth-spec/v06-rpc/eth_callBundle
@@ -1384,7 +1355,7 @@ Task<void> EthereumRpcApi::handle_eth_call_bundle(const nlohmann::json& request,
     if (params.size() != 3) {
         auto error_msg = "invalid eth_callBundle params: " + params.dump();
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, 100, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
         co_return;
     }
 
@@ -1395,7 +1366,7 @@ Task<void> EthereumRpcApi::handle_eth_call_bundle(const nlohmann::json& request,
     if (tx_hash_list.empty()) {
         const auto error_msg = "invalid eth_callBundle hash list: " + params.dump();
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, 100, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
         co_return;
     }
 
@@ -1429,7 +1400,7 @@ Task<void> EthereumRpcApi::handle_eth_call_bundle(const nlohmann::json& request,
             if (!tx_with_block) {
                 const auto error_msg = "invalid transaction hash";
                 SILK_ERROR << error_msg;
-                reply = make_json_error(request, 100, error_msg);
+                reply = make_json_error(request, kInvalidParams, error_msg);
                 break;
             }
 
@@ -1438,7 +1409,7 @@ Task<void> EthereumRpcApi::handle_eth_call_bundle(const nlohmann::json& request,
                     return tx->create_state(io_executor, storage, block_num);
                 });
             if (execution_result.pre_check_error) {
-                reply = make_json_error(request, -32000, execution_result.pre_check_error.value());
+                reply = make_json_error(request, kServerError, execution_result.pre_check_error.value());
                 error = true;
                 break;
             }
@@ -1446,7 +1417,7 @@ Task<void> EthereumRpcApi::handle_eth_call_bundle(const nlohmann::json& request,
             if ((clock_time::since(start_time) / 1000000) > timeout) {
                 const auto error_msg = "execution aborted (timeout)";
                 SILK_ERROR << error_msg;
-                reply = make_json_error(request, -32000, error_msg);
+                reply = make_json_error(request, kServerError, error_msg);
                 error = true;
                 break;
             }
@@ -1470,14 +1441,13 @@ Task<void> EthereumRpcApi::handle_eth_call_bundle(const nlohmann::json& request,
         reply = make_json_content(request, {});
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_newfilter
@@ -1486,7 +1456,7 @@ Task<void> EthereumRpcApi::handle_eth_new_filter(const nlohmann::json& request, 
     if (params.size() != 1) {
         auto error_msg = "invalid eth_newFilter params: " + params.dump();
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, 100, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
         co_return;
     }
     auto filter = params[0].get<StoredFilter>();
@@ -1494,7 +1464,7 @@ Task<void> EthereumRpcApi::handle_eth_new_filter(const nlohmann::json& request, 
 
     if ((filter.from_block && filter.from_block.value() == core::kPendingBlockId) ||
         (filter.to_block && filter.to_block.value() == core::kPendingBlockId)) {
-        reply = make_json_error(request, -32002, "pending logs not supported");
+        reply = make_json_error(request, kInvalidParams, "pending logs not supported");
         co_return;
     }
 
@@ -1512,21 +1482,19 @@ Task<void> EthereumRpcApi::handle_eth_new_filter(const nlohmann::json& request, 
         if (filter_id) {
             reply = make_json_content(request, filter_id.value());
         } else {
-            reply = make_json_error(request, -32000, "TODO");
+            reply = make_json_error(request, kServerError, "TODO");
         }
     } catch (const std::invalid_argument& iv) {
         reply = make_json_content(request, {});
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_newblockfilter
@@ -1537,14 +1505,13 @@ Task<void> EthereumRpcApi::handle_eth_new_block_filter(const nlohmann::json& req
         reply = make_json_content(request, to_quantity(0));
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_newpendingtransactionfilter
@@ -1555,14 +1522,13 @@ Task<void> EthereumRpcApi::handle_eth_new_pending_transaction_filter(const nlohm
         reply = make_json_content(request, to_quantity(0));
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_getfilterlogs
@@ -1571,7 +1537,7 @@ Task<void> EthereumRpcApi::handle_eth_get_filter_logs(const nlohmann::json& requ
     if (params.size() != 1) {
         auto error_msg = "invalid eth_getFilterLogs params: " + params.dump();
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, 100, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
         co_return;
     }
     auto filter_id = params[0].get<std::string>();
@@ -1579,7 +1545,7 @@ Task<void> EthereumRpcApi::handle_eth_get_filter_logs(const nlohmann::json& requ
 
     const auto filter_ref = filter_storage_->get_filter(filter_id);
     if (!filter_ref) {
-        reply = make_json_error(request, -32000, "filter not found");
+        reply = make_json_error(request, kServerError, "filter not found");
         co_return;
     }
 
@@ -1605,15 +1571,13 @@ Task<void> EthereumRpcApi::handle_eth_get_filter_logs(const nlohmann::json& requ
         reply = make_json_content(request, {});
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_getfilterchanges
@@ -1622,7 +1586,7 @@ Task<void> EthereumRpcApi::handle_eth_get_filter_changes(const nlohmann::json& r
     if (params.size() != 1) {
         auto error_msg = "invalid eth_getFilterChanges params: " + params.dump();
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, 100, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
         co_return;
     }
     auto filter_id = params[0].get<std::string>();
@@ -1631,7 +1595,7 @@ Task<void> EthereumRpcApi::handle_eth_get_filter_changes(const nlohmann::json& r
     const auto filter_opt = filter_storage_->get_filter(filter_id);
 
     if (!filter_opt) {
-        reply = make_json_error(request, -32000, "filter not found");
+        reply = make_json_error(request, kServerError, "filter not found");
         co_return;
     }
 
@@ -1657,14 +1621,13 @@ Task<void> EthereumRpcApi::handle_eth_get_filter_changes(const nlohmann::json& r
         reply = make_json_content(request, logs);
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_uninstallfilter
@@ -1684,8 +1647,6 @@ Task<void> EthereumRpcApi::handle_eth_uninstall_filter(const nlohmann::json& req
     SILK_TRACE << "Removing filter " << (success ? "succeeded" : "failed") << ", storage size: " << filter_storage_->size();
 
     reply = make_json_content(request, success);
-
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_getlogs
@@ -1693,14 +1654,14 @@ Task<void> EthereumRpcApi::handle_eth_get_logs(const nlohmann::json& request, st
     if (!request.contains("params")) {
         auto error_msg = "missing value for required argument 0";
         SILK_ERROR << error_msg << request.dump();
-        make_glaze_json_error(request, -32602, error_msg, reply);
+        make_glaze_json_error(request, kInvalidParams, error_msg, reply);
         co_return;
     }
     auto params = request["params"];
     if (params.size() > 1) {
         auto error_msg = "too many arguments, want at most 1";
         SILK_ERROR << error_msg << request.dump();
-        make_glaze_json_error(request, -32602, error_msg, reply);
+        make_glaze_json_error(request, kInvalidParams, error_msg, reply);
         co_return;
     }
 
@@ -1729,14 +1690,13 @@ Task<void> EthereumRpcApi::handle_eth_get_logs(const nlohmann::json& request, st
         make_glaze_json_content(request, log, reply);
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        make_glaze_json_error(request, 100, e.what(), reply);
+        make_glaze_json_error(request, kInternalError, e.what(), reply);
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        make_glaze_json_error(request, 100, "unexpected exception", reply);
+        make_glaze_json_error(request, kServerError, "unexpected exception", reply);
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_sendrawtransaction
@@ -1745,7 +1705,7 @@ Task<void> EthereumRpcApi::handle_eth_send_raw_transaction(const nlohmann::json&
     if (params.size() != 1) {
         auto error_msg = "invalid eth_sendRawTransaction params: " + params.dump();
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, 100, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
         co_return;
     }
     const auto encoded_tx_string = params[0].get<std::string>();
@@ -1753,7 +1713,7 @@ Task<void> EthereumRpcApi::handle_eth_send_raw_transaction(const nlohmann::json&
     if (!encoded_tx_bytes.has_value()) {
         const auto error_msg = "invalid eth_sendRawTransaction encoded tx: " + encoded_tx_string;
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, -32602, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
         co_return;
     }
     silkworm::ByteView encoded_tx_view{*encoded_tx_bytes};
@@ -1762,7 +1722,7 @@ Task<void> EthereumRpcApi::handle_eth_send_raw_transaction(const nlohmann::json&
     if (!decoding_result) {
         const auto error_msg = decoding_result_to_string(decoding_result.error());
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, -32000, error_msg);
+        reply = make_json_error(request, kServerError, error_msg);
         co_return;
     }
 
@@ -1771,14 +1731,14 @@ Task<void> EthereumRpcApi::handle_eth_send_raw_transaction(const nlohmann::json&
     if (!check_tx_fee_less_cap(kTxFeeCap, txn.max_fee_per_gas, txn.gas_limit)) {
         const auto error_msg = "tx fee exceeds the configured cap";
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, -32000, error_msg);
+        reply = make_json_error(request, kServerError, error_msg);
         co_return;
     }
 
     if (!is_replay_protected(txn)) {
         const auto error_msg = "only replay-protected (EIP-155) transactions allowed over RPC";
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, -32000, error_msg);
+        reply = make_json_error(request, kServerError, error_msg);
         co_return;
     }
 
@@ -1786,14 +1746,14 @@ Task<void> EthereumRpcApi::handle_eth_send_raw_transaction(const nlohmann::json&
     const auto result = co_await tx_pool_->add_transaction(encoded_tx);
     if (!result.success) {
         SILK_ERROR << "cannot add transaction: " << result.error_descr;
-        reply = make_json_error(request, -32000, result.error_descr);
+        reply = make_json_error(request, kServerError, result.error_descr);
         co_return;
     }
 
     if (!txn.sender()) {
         const auto error_msg = "cannot recover sender";
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, -32000, error_msg);
+        reply = make_json_error(request, kServerError, error_msg);
         co_return;
     }
 
@@ -1807,8 +1767,6 @@ Task<void> EthereumRpcApi::handle_eth_send_raw_transaction(const nlohmann::json&
     }
 
     reply = make_json_content(request, hash);
-
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_sendtransaction
@@ -1819,14 +1777,13 @@ Task<void> EthereumRpcApi::handle_eth_send_transaction(const nlohmann::json& req
         reply = make_json_content(request, to_quantity(0));
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_signtransaction
@@ -1837,14 +1794,13 @@ Task<void> EthereumRpcApi::handle_eth_sign_transaction(const nlohmann::json& req
         reply = make_json_content(request, to_quantity(0));
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_getproof
@@ -1855,14 +1811,13 @@ Task<void> EthereumRpcApi::handle_eth_get_proof(const nlohmann::json& request, n
         reply = make_json_content(request, to_quantity(0));
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_mining
@@ -1872,16 +1827,14 @@ Task<void> EthereumRpcApi::handle_eth_mining(const nlohmann::json& request, nloh
         reply = make_json_content(request, mining_result.enabled && mining_result.running);
     } catch (const boost::system::system_error& se) {
         SILK_ERROR << "error: \"" << se.code().message() << "\" processing request: " << request.dump();
-        reply = make_json_error(request, -32000, se.code().message());
+        reply = make_json_error(request, kServerError, se.code().message());
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, -32000, e.what());
+        reply = make_json_error(request, kServerError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
-
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_coinbase
@@ -1891,16 +1844,14 @@ Task<void> EthereumRpcApi::handle_eth_coinbase(const nlohmann::json& request, nl
         reply = make_json_content(request, coinbase_address);
     } catch (const boost::system::system_error& se) {
         SILK_ERROR << "error: \"" << se.code().message() << "\" processing request: " << request.dump();
-        reply = make_json_error(request, -32000, se.code().message());
+        reply = make_json_error(request, kServerError, se.code().message());
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, -32000, e.what());
+        reply = make_json_error(request, kServerError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
-
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_hashrate
@@ -1910,16 +1861,14 @@ Task<void> EthereumRpcApi::handle_eth_hashrate(const nlohmann::json& request, nl
         reply = make_json_content(request, to_quantity(hash_rate));
     } catch (const boost::system::system_error& se) {
         SILK_ERROR << "error: \"" << se.code().message() << "\" processing request: " << request.dump();
-        reply = make_json_error(request, -32000, se.code().message());
+        reply = make_json_error(request, kServerError, se.code().message());
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, -32000, e.what());
+        reply = make_json_error(request, kServerError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
-
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_submithashrate
@@ -1928,7 +1877,7 @@ Task<void> EthereumRpcApi::handle_eth_submit_hashrate(const nlohmann::json& requ
     if (params.size() != 2) {
         const auto error_msg = "invalid eth_submitHashrate params: " + params.dump();
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, 100, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
         co_return;
     }
 
@@ -1939,16 +1888,14 @@ Task<void> EthereumRpcApi::handle_eth_submit_hashrate(const nlohmann::json& requ
         reply = make_json_content(request, success);
     } catch (const boost::system::system_error& se) {
         SILK_ERROR << "error: \"" << se.code().message() << "\" processing request: " << request.dump();
-        reply = make_json_error(request, -32000, se.code().message());
+        reply = make_json_error(request, kServerError, se.code().message());
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, -32000, e.what());
+        reply = make_json_error(request, kServerError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
-
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_getwork
@@ -1963,16 +1910,14 @@ Task<void> EthereumRpcApi::handle_eth_get_work(const nlohmann::json& request, nl
         reply = make_json_content(request, current_work);
     } catch (const boost::system::system_error& se) {
         SILK_ERROR << "error: \"" << se.code().message() << "\" processing request: " << request.dump();
-        reply = make_json_error(request, -32000, se.code().message());
+        reply = make_json_error(request, kServerError, se.code().message());
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, -32000, e.what());
+        reply = make_json_error(request, kServerError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
-
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_submitwork
@@ -1981,7 +1926,7 @@ Task<void> EthereumRpcApi::handle_eth_submit_work(const nlohmann::json& request,
     if (params.size() != 3) {
         const auto error_msg = "invalid eth_submitWork params: " + params.dump();
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, 100, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
         co_return;
     }
 
@@ -1999,16 +1944,14 @@ Task<void> EthereumRpcApi::handle_eth_submit_work(const nlohmann::json& request,
         reply = make_json_content(request, success);
     } catch (const boost::system::system_error& se) {
         SILK_ERROR << "error: \"" << se.code().message() << "\" processing request: " << request.dump();
-        reply = make_json_error(request, -32000, se.code().message());
+        reply = make_json_error(request, kServerError, se.code().message());
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, -32000, e.what());
+        reply = make_json_error(request, kServerError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
-
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_subscribe
@@ -2019,14 +1962,13 @@ Task<void> EthereumRpcApi::handle_eth_subscribe(const nlohmann::json& request, n
         reply = make_json_content(request, to_quantity(0));
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_unsubscribe
@@ -2037,14 +1979,13 @@ Task<void> EthereumRpcApi::handle_eth_unsubscribe(const nlohmann::json& request,
         reply = make_json_content(request, to_quantity(0));
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#eth_feehistory
@@ -2103,20 +2044,19 @@ Task<void> EthereumRpcApi::handle_fee_history(const nlohmann::json& request, nlo
         const auto fee_history = co_await oracle.fee_history(block_number, block_count, reward_percentiles);
 
         if (fee_history.error) {
-            reply = make_json_error(request, -32000, fee_history.error.value());
+            reply = make_json_error(request, kServerError, fee_history.error.value());
         } else {
             reply = make_json_content(request, fee_history);
         }
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 }  // namespace silkworm::rpc::commands

--- a/silkworm/rpc/commands/net_api.cpp
+++ b/silkworm/rpc/commands/net_api.cpp
@@ -20,6 +20,7 @@
 
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/rpc/json/types.hpp>
+#include <silkworm/rpc/protocol/errors.hpp>
 
 namespace silkworm::rpc::commands {
 
@@ -37,10 +38,10 @@ Task<void> NetRpcApi::handle_net_peer_count(const nlohmann::json& request, nlohm
         reply = make_json_content(request, to_quantity(peer_count));
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, -32000, e.what());
+        reply = make_json_error(request, kServerError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 }
 
@@ -51,10 +52,10 @@ Task<void> NetRpcApi::handle_net_version(const nlohmann::json& request, nlohmann
         reply = make_json_content(request, std::to_string(net_version));
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, -32000, e.what());
+        reply = make_json_error(request, kServerError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 }
 

--- a/silkworm/rpc/commands/ots_api.cpp
+++ b/silkworm/rpc/commands/ots_api.cpp
@@ -36,6 +36,7 @@
 #include <silkworm/rpc/core/evm_trace.hpp>
 #include <silkworm/rpc/core/receipts.hpp>
 #include <silkworm/rpc/json/types.hpp>
+#include <silkworm/rpc/protocol/errors.hpp>
 
 namespace silkworm::rpc::commands {
 
@@ -53,7 +54,7 @@ Task<void> OtsRpcApi::handle_ots_has_code(const nlohmann::json& request, nlohman
     if (params.size() != 2) {
         const auto error_msg = "invalid ots_hasCode params: " + params.dump();
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, 100, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
         co_return;
     }
     const auto address = params[0].get<evmc::address>();
@@ -81,14 +82,13 @@ Task<void> OtsRpcApi::handle_ots_has_code(const nlohmann::json& request, nlohman
         }
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 Task<void> OtsRpcApi::handle_ots_get_block_details(const nlohmann::json& request, nlohmann::json& reply) {
@@ -96,7 +96,7 @@ Task<void> OtsRpcApi::handle_ots_get_block_details(const nlohmann::json& request
     if (params.size() != 1) {
         auto error_msg = "invalid handle_ots_getBlockDetails params: " + params.dump();
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, 100, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
         co_return;
     }
     const auto block_id = params[0].is_string() ? params[0].get<std::string>() : to_quantity(params[0].get<uint64_t>());
@@ -131,14 +131,13 @@ Task<void> OtsRpcApi::handle_ots_get_block_details(const nlohmann::json& request
         reply = make_json_content(request, nlohmann::detail::value_t::null);
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 Task<void> OtsRpcApi::handle_ots_get_block_details_by_hash(const nlohmann::json& request, nlohmann::json& reply) {
@@ -146,7 +145,7 @@ Task<void> OtsRpcApi::handle_ots_get_block_details_by_hash(const nlohmann::json&
     if (params.size() != 1) {
         auto error_msg = "invalid ots_getBlockDetailsByHash params: " + params.dump();
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, 100, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
         co_return;
     }
     auto block_hash = params[0].get<evmc::bytes32>();
@@ -181,14 +180,13 @@ Task<void> OtsRpcApi::handle_ots_get_block_details_by_hash(const nlohmann::json&
         reply = make_json_content(request, {});
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 Task<void> OtsRpcApi::handle_ots_get_block_transactions(const nlohmann::json& request, nlohmann::json& reply) {
@@ -196,7 +194,7 @@ Task<void> OtsRpcApi::handle_ots_get_block_transactions(const nlohmann::json& re
     if (params.size() != 3) {
         auto error_msg = "invalid ots_getBlockTransactions params: " + params.dump();
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, 100, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
         co_return;
     }
 
@@ -258,14 +256,13 @@ Task<void> OtsRpcApi::handle_ots_get_block_transactions(const nlohmann::json& re
         reply = make_json_content(request, {});
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 Task<void> OtsRpcApi::handle_ots_get_transaction_by_sender_and_nonce(const nlohmann::json& request, nlohmann::json& reply) {
@@ -273,7 +270,7 @@ Task<void> OtsRpcApi::handle_ots_get_transaction_by_sender_and_nonce(const nlohm
     if (params.size() != 2) {
         const auto error_msg = "invalid ots_getTransactionBySenderAndNonce params: " + params.dump();
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, 100, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
         co_return;
     }
 
@@ -369,14 +366,13 @@ Task<void> OtsRpcApi::handle_ots_get_transaction_by_sender_and_nonce(const nlohm
         reply = make_json_content(request, nlohmann::detail::value_t::null);
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 Task<void> OtsRpcApi::handle_ots_get_contract_creator(const nlohmann::json& request, nlohmann::json& reply) {
@@ -384,7 +380,7 @@ Task<void> OtsRpcApi::handle_ots_get_contract_creator(const nlohmann::json& requ
     if (params.size() != 1) {
         const auto error_msg = "invalid ots_getContractCreator params: " + params.dump();
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, 100, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
         co_return;
     }
 
@@ -508,14 +504,13 @@ Task<void> OtsRpcApi::handle_ots_get_contract_creator(const nlohmann::json& requ
         reply = make_json_content(request, nlohmann::detail::value_t::null);
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 Task<void> OtsRpcApi::handle_ots_trace_transaction(const nlohmann::json& request, nlohmann::json& reply) {
@@ -523,7 +518,7 @@ Task<void> OtsRpcApi::handle_ots_trace_transaction(const nlohmann::json& request
     if (params.size() != 1) {
         const auto error_msg = "invalid ots_traceTransaction params: " + params.dump();
         SILK_ERROR << error_msg << "\n";
-        reply = make_json_error(request, 100, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
         co_return;
     }
 
@@ -541,7 +536,7 @@ Task<void> OtsRpcApi::handle_ots_trace_transaction(const nlohmann::json& request
 
         if (!transaction_with_block.has_value()) {
             const auto error_msg = "transaction 0x" + silkworm::to_hex(transaction_hash) + " not found";
-            reply = make_json_error(request, -32000, error_msg);
+            reply = make_json_error(request, kServerError, error_msg);
             co_await tx->close();  // RAII not (yet) available with coroutines
             co_return;
         }
@@ -555,14 +550,13 @@ Task<void> OtsRpcApi::handle_ots_trace_transaction(const nlohmann::json& request
         reply = make_json_content(request, nlohmann::detail::value_t::null);
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 Task<void> OtsRpcApi::handle_ots_get_transaction_error(const nlohmann::json& request, nlohmann::json& reply) {
@@ -570,7 +564,7 @@ Task<void> OtsRpcApi::handle_ots_get_transaction_error(const nlohmann::json& req
     if (params.size() != 1) {
         const auto error_msg = "invalid ots_getTransactionError params: " + params.dump();
         SILK_ERROR << error_msg << "\n";
-        reply = make_json_error(request, 100, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
         co_return;
     }
 
@@ -588,7 +582,7 @@ Task<void> OtsRpcApi::handle_ots_get_transaction_error(const nlohmann::json& req
 
         if (!transaction_with_block.has_value()) {
             const auto error_msg = "transaction 0x" + silkworm::to_hex(transaction_hash) + " not found";
-            reply = make_json_error(request, -32000, error_msg);
+            reply = make_json_error(request, kServerError, error_msg);
             co_await tx->close();
             co_return;
         }
@@ -602,14 +596,13 @@ Task<void> OtsRpcApi::handle_ots_get_transaction_error(const nlohmann::json& req
         reply = make_json_content(request, nlohmann::detail::value_t::null);
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 Task<void> OtsRpcApi::handle_ots_get_internal_operations(const nlohmann::json& request, nlohmann::json& reply) {
@@ -617,7 +610,7 @@ Task<void> OtsRpcApi::handle_ots_get_internal_operations(const nlohmann::json& r
     if (params.size() != 1) {
         const auto error_msg = "invalid ots_getInternalOperations params: " + params.dump();
         SILK_ERROR << error_msg << "\n";
-        reply = make_json_error(request, 100, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
         co_return;
     }
 
@@ -635,7 +628,7 @@ Task<void> OtsRpcApi::handle_ots_get_internal_operations(const nlohmann::json& r
 
         if (!transaction_with_block.has_value()) {
             const auto error_msg = "transaction 0x" + silkworm::to_hex(transaction_hash) + " not found";
-            reply = make_json_error(request, -32000, error_msg);
+            reply = make_json_error(request, kServerError, error_msg);
             co_await tx->close();
             co_return;
         }
@@ -649,14 +642,13 @@ Task<void> OtsRpcApi::handle_ots_get_internal_operations(const nlohmann::json& r
         reply = make_json_content(request, nlohmann::detail::value_t::null);
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 Task<void> OtsRpcApi::handle_ots_search_transactions_before(const nlohmann::json& request, nlohmann::json& reply) {
@@ -664,7 +656,7 @@ Task<void> OtsRpcApi::handle_ots_search_transactions_before(const nlohmann::json
     if (params.size() != 3) {
         const auto error_msg = "invalid ots_search_transactions_before params: " + params.dump();
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, 100, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
         co_return;
     }
 
@@ -677,7 +669,7 @@ Task<void> OtsRpcApi::handle_ots_search_transactions_before(const nlohmann::json
     if (page_size > kMaxPageSize) {
         auto error_msg = "max allowed page size: " + std::to_string(kMaxPageSize);
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, -32000, error_msg);
+        reply = make_json_error(request, kServerError, error_msg);
         co_return;
     }
 
@@ -732,14 +724,13 @@ Task<void> OtsRpcApi::handle_ots_search_transactions_before(const nlohmann::json
         reply = make_json_content(request, nlohmann::detail::value_t::null);
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 Task<void> OtsRpcApi::handle_ots_search_transactions_after(const nlohmann::json& request, nlohmann::json& reply) {
@@ -747,7 +738,7 @@ Task<void> OtsRpcApi::handle_ots_search_transactions_after(const nlohmann::json&
     if (params.size() != 3) {
         const auto error_msg = "invalid handle_ots_search_transactions_after params: " + params.dump();
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, 100, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
         co_return;
     }
 
@@ -760,7 +751,7 @@ Task<void> OtsRpcApi::handle_ots_search_transactions_after(const nlohmann::json&
     if (page_size > kMaxPageSize) {
         auto error_msg = "max allowed page size: " + std::to_string(kMaxPageSize);
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, -32000, error_msg);
+        reply = make_json_error(request, kServerError, error_msg);
         co_return;
     }
 
@@ -820,14 +811,13 @@ Task<void> OtsRpcApi::handle_ots_search_transactions_after(const nlohmann::json&
         reply = make_json_content(request, nlohmann::detail::value_t::null);
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 Task<bool> OtsRpcApi::trace_blocks(
@@ -873,7 +863,6 @@ Task<void> OtsRpcApi::trace_block(db::kv::api::Transaction& tx, BlockNum block_n
 
     trace::TraceCallExecutor executor{*block_cache_, *chain_storage, workers_, tx};
     co_await executor.trace_touch_block(*block_with_hash, search_addr, extended_block.get_block_size(), *total_difficulty, receipts, results);
-    co_return;
 }
 
 IssuanceDetails OtsRpcApi::get_issuance(const silkworm::ChainConfig& config, const silkworm::BlockWithHash& block) {

--- a/silkworm/rpc/commands/parity_api.cpp
+++ b/silkworm/rpc/commands/parity_api.cpp
@@ -30,6 +30,7 @@
 #include <silkworm/rpc/core/cached_chain.hpp>
 #include <silkworm/rpc/core/receipts.hpp>
 #include <silkworm/rpc/json/types.hpp>
+#include <silkworm/rpc/protocol/errors.hpp>
 
 namespace silkworm::rpc::commands {
 
@@ -41,7 +42,7 @@ Task<void> ParityRpcApi::handle_parity_get_block_receipts(const nlohmann::json& 
     if (params.size() != 1) {
         auto error_msg = "invalid parity_getBlockReceipts params: " + params.dump();
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, 100, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
         co_return;
     }
     const auto block_id = params[0].get<std::string>();
@@ -72,14 +73,13 @@ Task<void> ParityRpcApi::handle_parity_get_block_receipts(const nlohmann::json& 
         reply = make_json_content(request, {});
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 Task<void> ParityRpcApi::handle_parity_list_storage_keys(const nlohmann::json& request, nlohmann::json& reply) {
@@ -87,7 +87,7 @@ Task<void> ParityRpcApi::handle_parity_list_storage_keys(const nlohmann::json& r
     if (params.size() < 2) {
         auto error_msg = "invalid parity_listStorageKeys params: " + params.dump();
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, 100, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
         co_return;
     }
     const auto address = params[0].get<evmc::address>();
@@ -139,14 +139,13 @@ Task<void> ParityRpcApi::handle_parity_list_storage_keys(const nlohmann::json& r
         reply = make_json_content(request, {});
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, 100, e.what());
+        reply = make_json_error(request, kInternalError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
 
     co_await tx->close();  // RAII not (yet) available with coroutines
-    co_return;
 }
 
 }  // namespace silkworm::rpc::commands

--- a/silkworm/rpc/commands/rpc_api_table_test.cpp
+++ b/silkworm/rpc/commands/rpc_api_table_test.cpp
@@ -1,0 +1,141 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "rpc_api_table.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <silkworm/rpc/common/constants.hpp>
+#include <silkworm/rpc/json_rpc/methods.hpp>
+
+namespace silkworm::rpc::commands {
+
+TEST_CASE("RpcApiTable empty spec", "[rpc][api]") {
+    CHECK_NOTHROW(RpcApiTable{""});
+}
+
+//! Check if API table contains specified method in any form
+static bool has_method(const RpcApiTable& t, const std::string& m) {
+    return t.find_json_handler(m) || t.find_json_glaze_handler(m) || t.find_stream_handler(m);
+}
+
+//! Check if specified method is present or not in API table
+static bool check_method(const RpcApiTable& table, const std::string& method, const bool present) {
+    return has_method(table, method) == present;
+}
+
+// These presence checks should always mirror the content of docs/JSON-RPC-API.md
+
+//! Ensure *supported* admin namespace subset is present or not
+static void check_admin_namespace(const RpcApiTable& table, bool present) {
+    CHECK(check_method(table, json_rpc::method::k_admin_nodeInfo, present));
+    CHECK(check_method(table, json_rpc::method::k_admin_peers, present));
+}
+
+//! Ensure *supported* net namespace subset is present or not
+static void check_net_namespace(const RpcApiTable& table, bool present) {
+    CHECK(check_method(table, json_rpc::method::k_net_listening, present));
+    CHECK(check_method(table, json_rpc::method::k_net_peerCount, present));
+    CHECK(check_method(table, json_rpc::method::k_net_version, present));
+}
+
+//! Ensure *supported* eth namespace subset is present or not
+static void check_eth_namespace(const RpcApiTable& table, bool present) {
+    CHECK(check_method(table, json_rpc::method::k_eth_blockNumber, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_chainId, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_protocolVersion, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_syncing, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_gasPrice, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_getUncleByBlockHashAndIndex, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_getUncleByBlockNumberAndIndex, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_getUncleCountByBlockHash, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_getUncleCountByBlockNumber, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_getTransactionByHash, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_getTransactionByBlockHashAndIndex, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_getRawTransactionByHash, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_getRawTransactionByBlockHashAndIndex, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_getRawTransactionByBlockNumberAndIndex, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_getTransactionByBlockNumberAndIndex, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_getTransactionReceipt, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_estimateGas, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_getBalance, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_getCode, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_getTransactionCount, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_getStorageAt, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_call, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_callMany, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_callBundle, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_createAccessList, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_newFilter, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_newBlockFilter, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_newPendingTransactionFilter, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_getFilterLogs, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_getFilterChanges, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_uninstallFilter, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_getLogs, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_sendRawTransaction, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_sendTransaction, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_signTransaction, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_getProof, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_mining, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_coinbase, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_hashrate, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_submitHashrate, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_getWork, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_submitWork, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_subscribe, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_unsubscribe, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_getBlockByHash, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_getBlockTransactionCountByHash, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_getBlockByNumber, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_getBlockTransactionCountByNumber, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_getBlockReceipts, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_getTransactionReceiptsByBlock, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_maxPriorityFeePerGas, present));
+    CHECK(check_method(table, json_rpc::method::k_eth_feeHistory, present));
+}
+
+//! Ensure *supported* web3 namespace subset is present or not
+static void check_web3_namespace(const RpcApiTable& table, bool present) {
+    CHECK(check_method(table, json_rpc::method::k_web3_clientVersion, present));
+    CHECK(check_method(table, json_rpc::method::k_web3_sha3, present));
+}
+
+TEST_CASE("RpcApiTable admin spec", "[rpc][api]") {
+    RpcApiTable table{kAdminApiNamespace};
+    check_admin_namespace(table, true);
+    check_eth_namespace(table, false);
+    check_net_namespace(table, false);
+    check_web3_namespace(table, false);
+}
+
+TEST_CASE("RpcApiTable eth spec", "[rpc][api]") {
+    RpcApiTable table{kEthApiNamespace};
+    check_admin_namespace(table, false);
+    check_eth_namespace(table, true);
+    check_net_namespace(table, false);
+    check_web3_namespace(table, false);
+}
+
+TEST_CASE("RpcApiTable default spec", "[rpc][api]") {
+    RpcApiTable table{kDefaultEth1ApiSpec};
+    check_admin_namespace(table, true);
+    check_eth_namespace(table, true);
+    check_net_namespace(table, true);
+    check_web3_namespace(table, true);
+}
+
+}  // namespace silkworm::rpc::commands

--- a/silkworm/rpc/commands/web3_api.cpp
+++ b/silkworm/rpc/commands/web3_api.cpp
@@ -22,6 +22,7 @@
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/rpc/common/util.hpp>
 #include <silkworm/rpc/json/types.hpp>
+#include <silkworm/rpc/protocol/errors.hpp>
 
 namespace silkworm::rpc::commands {
 
@@ -32,12 +33,11 @@ Task<void> Web3RpcApi::handle_web3_client_version(const nlohmann::json& request,
         reply = make_json_content(request, client_version);
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
-        reply = make_json_error(request, -32000, e.what());
+        reply = make_json_error(request, kServerError, e.what());
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
-        reply = make_json_error(request, 100, "unexpected exception");
+        reply = make_json_error(request, kServerError, "unexpected exception");
     }
-    co_return;
 }
 
 // https://eth.wiki/json-rpc/API#web3_sha3
@@ -46,21 +46,20 @@ Task<void> Web3RpcApi::handle_web3_sha3(const nlohmann::json& request, nlohmann:
     if (params.size() != 1) {
         auto error_msg = "invalid web3_sha3 params: " + params.dump();
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, 100, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
         co_return;
     }
     const auto input_string = params[0].get<std::string>();
-    const auto optional_input_bytes = silkworm::from_hex(input_string);
+    const auto optional_input_bytes = from_hex(input_string);
     if (!optional_input_bytes) {
         auto error_msg = "invalid input: " + input_string;
         SILK_ERROR << error_msg;
-        reply = make_json_error(request, 100, error_msg);
+        reply = make_json_error(request, kInvalidParams, error_msg);
         co_return;
     }
     auto eth_hash = hash_of(optional_input_bytes.value());
     const auto output = "0x" + silkworm::to_hex({eth_hash.bytes, silkworm::kHashLength});
     reply = make_json_content(request, output);
-    co_return;
 }
 
 }  // namespace silkworm::rpc::commands

--- a/silkworm/rpc/core/estimate_gas_oracle_test.cpp
+++ b/silkworm/rpc/core/estimate_gas_oracle_test.cpp
@@ -196,7 +196,9 @@ TEST_CASE("estimate gas") {
 
     SECTION("Call empty, alternatively succeeds and fails with intrinsic") {
         ExecutionResult expect_result_ok{.error_code = evmc_status_code::EVMC_SUCCESS};
-        ExecutionResult expect_result_fail_pre_check{.pre_check_error = "intrinsic ", .pre_check_error_code = kIntrinsicGasTooLow};
+        ExecutionResult expect_result_fail_pre_check{
+            .pre_check_error = "intrinsic ",
+            .pre_check_error_code = PreCheckErrorCode::kIntrinsicGasTooLow};
         ExecutionResult expect_result_fail{.error_code = evmc_status_code::EVMC_OUT_OF_GAS};
         EXPECT_CALL(estimate_gas_oracle, try_execution(_, _, _))
             .Times(14)
@@ -417,7 +419,9 @@ TEST_CASE("estimate gas") {
     }
 
     SECTION("Call fail, try exception") {
-        ExecutionResult expect_result_fail_pre_check{.pre_check_error = "insufficient funds", .pre_check_error_code = kInsufficientFunds};
+        ExecutionResult expect_result_fail_pre_check{
+            .pre_check_error = "insufficient funds",
+            .pre_check_error_code = PreCheckErrorCode::kInsufficientFunds};
         ExecutionResult expect_result_fail{.error_code = evmc_status_code::EVMC_OUT_OF_GAS};
         call.gas = kTxGas * 2;
         call.gas_price = intx::uint256{20'000};
@@ -442,7 +446,9 @@ TEST_CASE("estimate gas") {
 
     SECTION("Call fail, try exception with data") {
         auto data = *silkworm::from_hex("2ac3c1d3e24b45c6c310534bc2dd84b5ed576335");
-        ExecutionResult expect_result_fail_pre_check{.pre_check_error = "insufficient funds", .pre_check_error_code = kInsufficientFunds};
+        ExecutionResult expect_result_fail_pre_check{
+            .pre_check_error = "insufficient funds",
+            .pre_check_error_code = PreCheckErrorCode::kInsufficientFunds};
         ExecutionResult expect_result_fail{.error_code = evmc_status_code::EVMC_OUT_OF_GAS, .data = data};
         call.gas = kTxGas * 2;
         call.gas_price = intx::uint256{20'000};
@@ -466,7 +472,9 @@ TEST_CASE("estimate gas") {
     }
 
     SECTION("Call fail-EVMC_INVALID_INSTRUCTION, try exception") {
-        ExecutionResult expect_result_fail_pre_check{.pre_check_error = "insufficient funds", .pre_check_error_code = kInsufficientFunds};
+        ExecutionResult expect_result_fail_pre_check{
+            .pre_check_error = "insufficient funds",
+            .pre_check_error_code = PreCheckErrorCode::kInsufficientFunds};
         ExecutionResult expect_result_fail{.error_code = evmc_status_code::EVMC_INVALID_INSTRUCTION};
         call.gas = kTxGas * 2;
         call.gas_price = intx::uint256{20'000};

--- a/silkworm/rpc/core/evm_executor.hpp
+++ b/silkworm/rpc/core/evm_executor.hpp
@@ -40,7 +40,7 @@
 
 namespace silkworm::rpc {
 
-enum PreCheckErrorCode {
+enum class PreCheckErrorCode {
     kFeeCapLessThanBlockFeePerGas,
     kInsufficientFunds,
     kInternalError,

--- a/silkworm/rpc/json_rpc/request_handler_test.cpp
+++ b/silkworm/rpc/json_rpc/request_handler_test.cpp
@@ -59,7 +59,7 @@ TEST_CASE_METHOD(test_util::RpcApiE2ETest, "check handle_request method return f
         "jsonrpc":"2.0",
         "id":3,
         "error":{
-             "code":100,
+             "code":-32602,
              "message":"invalid eth_getBlockByNumber params: []"
         }
     })"_json);


### PR DESCRIPTION
This PR adds usage of enumeration values for protocol error codes in JSON RPC API implementations, using the following rules:
- all existing error code values have been kept unchanged, except for 100 (which is invalid error code)
- existing error codes hard-coded to 100 have been mapped to `kInvalidParams = -32602`, `kInternalError = -32603` or `kServerError = -32000` depending on the context

*Extras*
- remove unnecessary `co_return` at the end of API handlers
- add some unit tests for API handler dispatching