### PR TITLE
capi: depend on silkworm_db rather than silkworm_node

### DIFF
--- a/silkworm/capi/CMakeLists.txt
+++ b/silkworm/capi/CMakeLists.txt
@@ -25,7 +25,7 @@ set(PRIVATE_LIBS
     glaze::glaze
     Microsoft.GSL::GSL
     silkworm_core
-    silkworm_node
+    silkworm_db
     silkworm_sentry
     silkworm_rpcdaemon
 )


### PR DESCRIPTION
silkworm_db is a smaller dependency than silkworm_node