### PR TITLE
qa-tests: save latency percentile distribution analysis data in backup directory

### DIFF
--- a/.github/workflows/rpc-performance-tests.yml
+++ b/.github/workflows/rpc-performance-tests.yml
@@ -92,24 +92,25 @@ jobs:
                                         --json-report ./reports/mainnet/result.json \
                                         --testing-daemon ${servers[i-1]}
     
-
                # Capture test runner script exit status
                perf_exit_status=$?
 
-               # Save test results to a directory with timestamp and commit hash
-               cp -r ${{runner.workspace}}/rpc-tests/perf/reports/mainnet $RPC_PAST_TEST_DIR/mainnet_$(date +%Y%m%d_%H%M%S)_perf_$commit
+               # Preserve test results
+               mv ${{runner.workspace}}/rpc-tests/perf/reports/mainnet/result.json ${{runner.workspace}}/rpc-tests/perf/reports/mainnet/${servers[i-1]}-$method-result.json
                
+               # Prepare historical test results directory
+               mkdir -p $RPC_PAST_TEST_DIR/mainnet_$(date +%Y%m%d_%H%M%S)_perf_$commit
+               mkdir -p $RPC_PAST_TEST_DIR/mainnet_$(date +%Y%m%d_%H%M%S)_perf_$commit_bin
+          
                # Detect the pre-built db version
                db_version=$(python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/prod_info.py $ERIGON_DIR/production.ini production erigon_repo_commit) 
                
                # Check test runner script exit status
                if [ $perf_exit_status -eq 0 ]; then
 
-                  # temporary: removes previous binary test
-                  rm -rf ${{runner.workspace}}/last_execution_test/*
-                  # save all vegeta binary report on specific area (last_execution_test) reference are saved on (reference_test_result) 
+                  # save all vegeta binary report
                   echo "Save current vegeta binary files"
-                  cp -r ${{runner.workspace}}/rpc-tests/perf/reports/bin ${{runner.workspace}}/last_execution_test/
+                  cp -r ${{runner.workspace}}/rpc-tests/perf/reports/bin $RPC_PAST_TEST_DIR/mainnet_$(date +%Y%m%d_%H%M%S)_perf_$commit_bin
 
                   echo "Save test result on DB"
                   cd ${{runner.workspace}}/silkworm                                             
@@ -122,15 +123,14 @@ jobs:
                     --runner ${{ runner.name }} \
                     --db_version $db_version \
                     --outcome success \
-                    --result_file ${{runner.workspace}}/rpc-tests/perf/reports/mainnet/result.json
+                    --result_file ${{runner.workspace}}/rpc-tests/perf/reports/mainnet/${servers[i-1]}-$method-result.json
           
                   echo "Execute Latency Percentile HDR Analysis"   
                   cd ${{runner.workspace}}/rpc-tests/perf/reports/mainnet/
                   python3 $ERIGON_QA_PATH/test_system/qa-tests/rpc-tests/perf_hdr_analysis.py \
                     --test_name ${servers[i-1]}-$method \
                     --input_file ./result.json \
-                    --output_file ./${servers[i-1]}-${method}-latency_hdr_analysis.pdf                  
-                  cp -r . $RPC_PAST_TEST_DIR/mainnet_$(date +%Y%m%d_%H%M%S)_perf_$commit
+                    --output_file ./${servers[i-1]}-${method}-latency_hdr_analysis.pdf                                    
                else
                   failed_test=1
                   cd ${{runner.workspace}}/silkworm
@@ -144,6 +144,8 @@ jobs:
                      --db_version $db_version \
                      --outcome failure
                fi
+               # Save test results to a directory with timestamp and commit hash
+               cp -r ${{runner.workspace}}/rpc-tests/perf/reports/mainnet $RPC_PAST_TEST_DIR/mainnet_$(date +%Y%m%d_%H%M%S)_perf_$commit
             done
 
           }
@@ -158,7 +160,7 @@ jobs:
           run_perf mainnet eth_getTransactionByHash stress_test_eth_getTransactionByHash_13M 1:1,100:30,1000:20,10000:20
           run_perf mainnet eth_getTransactionReceipt stress_test_eth_getTransactionReceipt_14M 1:1,100:30,1000:20,5000:20,10000:20,20000:20
           run_perf mainnet eth_createAccessList stress_test_eth_createAccessList_16M 1:1,100:30,1000:20,10000:20,20000:20
-
+          
           if [ $failed_test -eq 0 ]; then
                   echo "TEST_RESULT=success" >> "$GITHUB_OUTPUT"
                   echo "Tests completed successfully"
@@ -204,7 +206,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: test-results
-          path: ${{runner.workspace}}/rpc-tests/perf/reports/mainnet
+          path: $RPC_PAST_TEST_DIR/mainnet_$(date +%Y%m%d_%H%M%S)_perf_$commit
 
       - name: Action for Success
         if: steps.test_step.outputs.TEST_RESULT == 'success'

--- a/.github/workflows/rpc-performance-tests.yml
+++ b/.github/workflows/rpc-performance-tests.yml
@@ -67,6 +67,10 @@ jobs:
           failed_test=0
           commit=$(git -C ${{runner.workspace}}/silkworm rev-parse --short HEAD)
           
+          # Prepare historical test results directory
+          mkdir -p $RPC_PAST_TEST_DIR/mainnet_$(date +%Y%m%d_%H%M%S)_perf_$commit
+          mkdir -p $RPC_PAST_TEST_DIR/mainnet_bin
+          
           run_perf () {
             servers=("silkworm" "erigon")
             for i in 1 2
@@ -96,11 +100,7 @@ jobs:
                perf_exit_status=$?
 
                # Preserve test results
-               mv ${{runner.workspace}}/rpc-tests/perf/reports/mainnet/result.json ${{runner.workspace}}/rpc-tests/perf/reports/mainnet/${servers[i-1]}-$method-result.json
-               
-               # Prepare historical test results directory
-               mkdir -p $RPC_PAST_TEST_DIR/mainnet_$(date +%Y%m%d_%H%M%S)_perf_$commit
-               mkdir -p $RPC_PAST_TEST_DIR/mainnet_$(date +%Y%m%d_%H%M%S)_perf_$commit_bin
+               mv ${{runner.workspace}}/rpc-tests/perf/reports/mainnet/result.json ${{runner.workspace}}/rpc-tests/perf/reports/mainnet/${servers[i-1]}-$method-result.json              
           
                # Detect the pre-built db version
                db_version=$(python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/prod_info.py $ERIGON_DIR/production.ini production erigon_repo_commit) 
@@ -110,7 +110,7 @@ jobs:
 
                   # save all vegeta binary report
                   echo "Save current vegeta binary files"
-                  cp -r ${{runner.workspace}}/rpc-tests/perf/reports/bin $RPC_PAST_TEST_DIR/mainnet_$(date +%Y%m%d_%H%M%S)_perf_$commit_bin
+                  cp -r ${{runner.workspace}}/rpc-tests/perf/reports/bin $RPC_PAST_TEST_DIR/mainnet_bin
 
                   echo "Save test result on DB"
                   cd ${{runner.workspace}}/silkworm                                             

--- a/.github/workflows/rpc-performance-tests.yml
+++ b/.github/workflows/rpc-performance-tests.yml
@@ -65,6 +65,7 @@ jobs:
         run: |
           set +e # Disable exit on error
           failed_test=0
+          commit=$(git -C ${{runner.workspace}}/silkworm rev-parse --short HEAD)
           
           run_perf () {
             servers=("silkworm" "erigon")
@@ -96,7 +97,7 @@ jobs:
                perf_exit_status=$?
 
                # Save test results to a directory with timestamp and commit hash
-               cp -r ${{runner.workspace}}/rpc-tests/perf/reports/mainnet $RPC_PAST_TEST_DIR/mainnet_$(date +%Y%m%d_%H%M%S)_perf_$(git -C ${{runner.workspace}}/silkworm rev-parse --short HEAD)
+               cp -r ${{runner.workspace}}/rpc-tests/perf/reports/mainnet $RPC_PAST_TEST_DIR/mainnet_$(date +%Y%m%d_%H%M%S)_perf_$commit
                
                # Detect the pre-built db version
                db_version=$(python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/prod_info.py $ERIGON_DIR/production.ini production erigon_repo_commit) 
@@ -123,11 +124,13 @@ jobs:
                     --outcome success \
                     --result_file ${{runner.workspace}}/rpc-tests/perf/reports/mainnet/result.json
           
-                  echo "Execute Latency Percentile HDR Analysis"                                             
+                  echo "Execute Latency Percentile HDR Analysis"   
+                  cd ${{runner.workspace}}/rpc-tests/perf/reports/mainnet/
                   python3 $ERIGON_QA_PATH/test_system/qa-tests/rpc-tests/perf_hdr_analysis.py \
                     --test_name ${servers[i-1]}-$method \
-                    --input_file ${{runner.workspace}}/rpc-tests/perf/reports/mainnet/result.json \
-                    --output_file ${{runner.workspace}}/rpc-tests/perf/reports/mainnet/${servers[i-1]}-${method}-latency_hdr_analysis.pdf
+                    --input_file ./result.json \
+                    --output_file ./${servers[i-1]}-${method}-latency_hdr_analysis.pdf                  
+                  cp -r . $RPC_PAST_TEST_DIR/mainnet_$(date +%Y%m%d_%H%M%S)_perf_$commit
                else
                   failed_test=1
                   cd ${{runner.workspace}}/silkworm


### PR DESCRIPTION
Protect output files from being overwritten. 
Save the analysis results to the history directory. 