### PR TITLE
Infra: fix regression in unit tests when executed directly on terminal console

### DIFF
--- a/silkworm/infra/common/log_test.cpp
+++ b/silkworm/infra/common/log_test.cpp
@@ -135,14 +135,16 @@ TEST_CASE("LogBuffer", "[silkworm][common][log]") {
     }
 
     SECTION("Settings disables colorized output depending on TTY") {
+        const bool is_terminal = is_terminal_stdout() && is_terminal_stderr();
+
         // Default output is NOT colorized on non-TTY terminal
         LogBuffer_ForTest<Level::kInfo>{"test0", {"key1", "value1", "key2", "value2"}};  // temporary log object, flush on dtor
         const auto cerr_output0{string_cerr.str()};
         CHECK(absl::StrContains(cerr_output0, "test0"));
-        CHECK(absl::StrContains(cerr_output0, key_value("key1", "value1")));
-        CHECK(absl::StrContains(cerr_output0, key_value("key2", "value2")));
-        CHECK(!absl::StrContains(cerr_output0, prettified_key_value("key1", "value1")));
-        CHECK(!absl::StrContains(cerr_output0, prettified_key_value("key2", "value2")));
+        CHECK(absl::StrContains(cerr_output0, key_value("key1", "value1")) == !is_terminal);
+        CHECK(absl::StrContains(cerr_output0, key_value("key2", "value2")) == !is_terminal);
+        CHECK(absl::StrContains(cerr_output0, prettified_key_value("key1", "value1")) == is_terminal);
+        CHECK(absl::StrContains(cerr_output0, prettified_key_value("key2", "value2")) == is_terminal);
 
         // Reset cerr replacement stream
         string_cerr.str("");
@@ -156,10 +158,10 @@ TEST_CASE("LogBuffer", "[silkworm][common][log]") {
         LogBuffer_ForTest<Level::kInfo>{"test2", {"key3", "value3", "key4", "value4"}};  // temporary log object, flush on dtor
         const auto cerr_output2{string_cerr.str()};
         CHECK(absl::StrContains(cerr_output2, "test2"));
-        CHECK(absl::StrContains(cerr_output2, key_value("key3", "value3")));
-        CHECK(absl::StrContains(cerr_output2, key_value("key4", "value4")));
-        CHECK(!absl::StrContains(cerr_output2, prettified_key_value("key3", "value3")));
-        CHECK(!absl::StrContains(cerr_output2, prettified_key_value("key4", "value4")));
+        CHECK(absl::StrContains(cerr_output2, key_value("key3", "value3")) == !is_terminal);
+        CHECK(absl::StrContains(cerr_output2, key_value("key4", "value4")) == !is_terminal);
+        CHECK(absl::StrContains(cerr_output2, prettified_key_value("key3", "value3")) == is_terminal);
+        CHECK(absl::StrContains(cerr_output2, prettified_key_value("key4", "value4")) == is_terminal);
     }
 
     SECTION("Settings disable colorized output if log file present") {

--- a/silkworm/infra/concurrency/context_pool.cpp
+++ b/silkworm/infra/concurrency/context_pool.cpp
@@ -56,6 +56,7 @@ void Context::execute_loop() {
 }
 
 void Context::stop() {
+    work_.reset();
     io_context_->stop();
 }
 

--- a/silkworm/infra/concurrency/context_pool.cpp
+++ b/silkworm/infra/concurrency/context_pool.cpp
@@ -17,6 +17,7 @@
 #include "context_pool.hpp"
 
 #include <thread>
+#include <utility>
 
 #include <boost/asio/post.hpp>
 #include <boost/asio/thread_pool.hpp>
@@ -56,7 +57,6 @@ void Context::execute_loop() {
 }
 
 void Context::stop() {
-    work_.reset();
     io_context_->stop();
 }
 
@@ -65,7 +65,7 @@ void Context::execute_loop_single_threaded(IdleStrategy&& idle_strategy) {
     SILK_DEBUG << "Single-thread execution loop start [" << std::this_thread::get_id() << "]";
     while (!io_context_->stopped()) {
         std::size_t work_count = io_context_->poll();
-        idle_strategy.idle(work_count);
+        std::forward<IdleStrategy>(idle_strategy).idle(work_count);
     }
     SILK_DEBUG << "Single-thread execution loop end [" << std::this_thread::get_id() << "]";
 }

--- a/silkworm/infra/concurrency/context_pool_test.cpp
+++ b/silkworm/infra/concurrency/context_pool_test.cpp
@@ -146,6 +146,21 @@ TEST_CASE("ContextPool", "[silkworm][concurrency][Context]") {
         context_pool.stop();
         CHECK_NOTHROW(context_pool.join());
     }
+
+    SECTION("stop/start w/o contexts") {
+        ContextPool context_pool{2};
+        REQUIRE(context_pool.num_contexts() == 0);
+        CHECK_NOTHROW(context_pool.stop());
+        CHECK_NOTHROW(context_pool.start());
+    }
+
+    SECTION("stop/start w/ contexts") {
+        ContextPool context_pool{2};
+        context_pool.add_context(Context{0, WaitMode::blocking});
+        context_pool.add_context(Context{1, WaitMode::blocking});
+        CHECK_NOTHROW(context_pool.stop());
+        CHECK_NOTHROW(context_pool.start());
+    }
 }
 #endif  // SILKWORM_SANITIZE
 


### PR DESCRIPTION
This PR fixes a some failing checks in `infra` unit tests when executed directly on terminal console

*Extras*
- remove one clang tidy warning
- add a couple more tests
