### PR TITLE
db: KV begin_transaction as txn factory

### DIFF
--- a/silkworm/db/kv/api/direct_service.cpp
+++ b/silkworm/db/kv/api/direct_service.cpp
@@ -19,8 +19,12 @@
 #include <gsl/util>
 
 #include "endpoint/state_changes_call.hpp"
+#include "local_transaction.hpp"
 
 namespace silkworm::db::kv::api {
+
+DirectService::DirectService(ServiceRouter router, ::mdbx::env chaindata_env, StateCache* state_cache)
+    : router_{router}, chaindata_env_{std::move(chaindata_env)}, state_cache_{state_cache} {}
 
 // rpc Version(google.protobuf.Empty) returns (types.VersionReply);
 Task<Version> DirectService::version() {
@@ -29,8 +33,7 @@ Task<Version> DirectService::version() {
 
 // rpc Tx(stream Cursor) returns (stream Pair);
 Task<std::unique_ptr<Transaction>> DirectService::begin_transaction() {
-    // TODO(canepat) implement
-    co_return nullptr;
+    co_return std::make_unique<LocalTransaction>(chaindata_env_, state_cache_);
 }
 
 // rpc StateChanges(StateChangeRequest) returns (stream StateChangeBatch);

--- a/silkworm/db/kv/api/direct_service.hpp
+++ b/silkworm/db/kv/api/direct_service.hpp
@@ -16,8 +16,11 @@
 
 #pragma once
 
+#include <silkworm/db/mdbx/mdbx.hpp>
+
 #include "service.hpp"
 #include "service_router.hpp"
+#include "state_cache.hpp"
 
 namespace silkworm::db::kv::api {
 
@@ -25,7 +28,7 @@ namespace silkworm::db::kv::api {
 //! This is used both client-side by 'direct' (i.e. no-gRPC) implementation and server-side by gRPC server.
 class DirectService : public Service {
   public:
-    explicit DirectService(ServiceRouter router) : router_(router) {}
+    explicit DirectService(ServiceRouter router, ::mdbx::env chaindata_env, StateCache* state_cache);
     ~DirectService() override = default;
 
     DirectService(const DirectService&) = delete;
@@ -63,7 +66,14 @@ class DirectService : public Service {
     Task<DomainRangeResult> get_domain_range(const DomainRangeQuery&) override;
 
   private:
+    //! The router to service endpoint implementation
     ServiceRouter router_;
+
+    //! The MDBX chain database
+    ::mdbx::env chaindata_env_;
+
+    //! The local state cache built upon incoming state changes
+    StateCache* state_cache_;
 };
 
 }  // namespace silkworm::db::kv::api

--- a/silkworm/db/kv/api/direct_service_test.cpp
+++ b/silkworm/db/kv/api/direct_service_test.cpp
@@ -19,13 +19,15 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <silkworm/db/test_util/kv_test_base.hpp>
+#include <silkworm/db/test_util/test_database_context.hpp>
 #include <silkworm/infra/test_util/fixture.hpp>
 
 namespace silkworm::db::kv::api {
 
 using namespace silkworm::test_util;
+using test_util::TestDatabaseContext;
 
-struct DirectServiceTest : public test_util::KVTestBase {
+struct DirectServiceTest : public test_util::KVTestBase, TestDatabaseContext {
     Task<void> consumer(std::optional<StateChangeSet> change_set) {
         if (!change_set) co_return;
         change_set_vector.push_back(*change_set);
@@ -33,7 +35,8 @@ struct DirectServiceTest : public test_util::KVTestBase {
 
     StateChangeChannelPtr channel{std::make_shared<StateChangeChannel>(io_context_.get_executor())};
     concurrency::Channel<StateChangesCall> state_changes_calls_channel{io_context_.get_executor()};
-    DirectService service{ServiceRouter{state_changes_calls_channel}};
+    std::unique_ptr<StateCache> state_cache{std::make_unique<CoherentStateCache>()};
+    DirectService service{ServiceRouter{state_changes_calls_channel}, mdbx_env(), state_cache.get()};
     std::vector<StateChangeSet> change_set_vector;
 };
 

--- a/silkworm/db/kv/api/service_router.cpp
+++ b/silkworm/db/kv/api/service_router.cpp
@@ -1,0 +1,48 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "service_router.hpp"
+
+#include <boost/asio/use_awaitable.hpp>
+
+#include <silkworm/infra/concurrency/co_spawn_sw.hpp>
+
+namespace silkworm::db::kv::api {
+
+using namespace boost::asio;
+
+Task<void> StateChangeRunner::run(std::shared_ptr<StateChangeRunner> self) {
+    auto run = self->handle_calls();
+    co_await concurrency::co_spawn(self->strand_, std::move(run), use_awaitable);
+}
+
+StateChangeRunner::StateChangeRunner(const boost::asio::any_io_executor& executor)
+    : state_changes_calls_channel_{executor}, strand_{executor} {}
+
+Task<void> StateChangeRunner::handle_calls() {
+    auto executor = co_await ThisTask::executor;
+
+    // Loop until receive() throws a cancelled exception
+    while (true) {
+        auto call = co_await state_changes_calls_channel_.receive();
+
+        auto state_changes_channel = std::make_shared<StateChangeChannel>(executor);
+
+        call.set_result(state_changes_channel);
+    }
+}
+
+}  // namespace silkworm::db::kv::api

--- a/silkworm/db/kv/api/service_router.hpp
+++ b/silkworm/db/kv/api/service_router.hpp
@@ -16,6 +16,13 @@
 
 #pragma once
 
+#include <memory>
+
+#include <silkworm/infra/concurrency/task.hpp>
+
+#include <boost/asio/any_io_executor.hpp>
+#include <boost/asio/strand.hpp>
+
 #include <silkworm/infra/concurrency/channel.hpp>
 
 #include "endpoint/state_changes_call.hpp"
@@ -24,6 +31,26 @@ namespace silkworm::db::kv::api {
 
 struct ServiceRouter {
     concurrency::Channel<StateChangesCall>& state_changes_calls_channel;
+};
+
+class StateChangeRunner {
+  public:
+    static Task<void> run(std::shared_ptr<StateChangeRunner> self);
+
+    explicit StateChangeRunner(const boost::asio::any_io_executor& executor);
+
+    template <typename T>
+    using Channel = concurrency::Channel<T>;
+
+    Channel<StateChangesCall>& state_changes_calls_channel() {
+        return state_changes_calls_channel_;
+    }
+
+  private:
+    Task<void> handle_calls();
+
+    Channel<StateChangesCall> state_changes_calls_channel_;
+    boost::asio::strand<boost::asio::any_io_executor> strand_;
 };
 
 }  // namespace silkworm::db::kv::api

--- a/silkworm/db/kv/grpc/client/remote_client.hpp
+++ b/silkworm/db/kv/grpc/client/remote_client.hpp
@@ -21,11 +21,13 @@
 
 #include <agrpc/detail/forward.hpp>
 
+#include <silkworm/db/chain/remote_chain_storage.hpp>
 #include <silkworm/infra/grpc/client/client_context_pool.hpp>
 #include <silkworm/interfaces/remote/kv.grpc.pb.h>
 
 #include "../../api/client.hpp"
 #include "../../api/service.hpp"
+#include "../../api/state_cache.hpp"
 
 namespace silkworm::db::kv::grpc::client {
 
@@ -35,10 +37,16 @@ struct RemoteClient : public api::Client {
     RemoteClient(
         const rpc::ChannelFactory& create_channel,
         agrpc::GrpcContext& grpc_context,
+        api::StateCache* state_cache,
+        chain::BlockProvider block_provider,
+        chain::BlockNumberFromTxnHashProvider block_number_from_txn_hash_provider,
         std::function<Task<void>()> on_disconnect = []() -> Task<void> { co_return; });
     RemoteClient(
         std::unique_ptr<::remote::KV::StubInterface> stub,
         agrpc::GrpcContext& grpc_context,
+        api::StateCache* state_cache,
+        chain::BlockProvider block_provider,
+        chain::BlockNumberFromTxnHashProvider block_number_from_txn_hash_provider,
         std::function<Task<void>()> on_disconnect = []() -> Task<void> { co_return; });
     ~RemoteClient() override;
 

--- a/silkworm/db/kv/grpc/client/remote_client_test.cpp
+++ b/silkworm/db/kv/grpc/client/remote_client_test.cpp
@@ -20,6 +20,7 @@
 #include <gmock/gmock.h>
 
 #include <silkworm/core/common/util.hpp>
+#include <silkworm/db/kv/api/state_cache.hpp>
 #include <silkworm/infra/grpc/client/call.hpp>
 #include <silkworm/infra/grpc/test_util/grpc_actions.hpp>
 #include <silkworm/infra/grpc/test_util/grpc_responder.hpp>
@@ -35,7 +36,25 @@ using namespace silkworm::db::kv::test_util;
 namespace proto = ::remote;
 
 using StrictMockKVStub = testing::StrictMock<proto::FixIssue24351_MockKVStub>;
-using RemoteClientTestRunner = TestRunner<RemoteClient, StrictMockKVStub>;
+
+struct RemoteClientTestRunner : public TestRunner<RemoteClient, StrictMockKVStub> {
+    std::unique_ptr<api::StateCache> state_cache{std::make_unique<api::CoherentStateCache>()};
+    // We're not testing blocks here, so we don't care about proper block provider
+    chain::BlockProvider block_provider{
+        [](BlockNum, HashAsSpan, bool, Block&) -> Task<bool> { co_return false; }};
+    // We're not testing blocks here, so we don't care about proper block-number-from-txn-hash provider
+    chain::BlockNumberFromTxnHashProvider block_number_from_txn_hash_provider{
+        [](HashAsSpan) -> Task<BlockNum> { co_return 0; }};
+
+  protected:
+    RemoteClient make_api_client() override {
+        return RemoteClient{std::move(stub_),
+                            grpc_context_,
+                            state_cache.get(),
+                            block_provider,
+                            block_number_from_txn_hash_provider};
+    }
+};
 
 TEST_CASE_METHOD(RemoteClientTestRunner, "KV::HistoryGet", "[node][remote][kv][grpc]") {
     const api::HistoryPointQuery query{};  // input query doesn't matter here, we tweak the reply

--- a/silkworm/db/test_util/test_database_context.hpp
+++ b/silkworm/db/test_util/test_database_context.hpp
@@ -39,6 +39,7 @@ class TestDatabaseContext {
         std::filesystem::remove_all(db_path);
     }
 
+    mdbx::env& mdbx_env() { return db_; }
     mdbx::env_managed& get_mdbx_env() { return db_; }
     db::EnvConfig get_env_config() { return env_config_; }
     silkworm::ChainConfig get_chain_config();


### PR DESCRIPTION
This PR implements the `db::kv::api::Transaction` factory responsibility into the existing KV API clients (both direct and gRPC).

Moreover, the two flavours of KV API clients are now properly created in `rpc::Daemon` at startup.

*TODO*
In case of standalone RpcDaemon, proper running lifecycle and a more polished object composition for KV API direct service is still missing.