### PR TITLE
db: paginated sequence for temporal KV API

### DIFF
--- a/silkworm/db/kv/api/endpoint/paginated_sequence.hpp
+++ b/silkworm/db/kv/api/endpoint/paginated_sequence.hpp
@@ -69,7 +69,7 @@ class PaginatedSequence {
       private:
         Paginator& next_page_provider_;
         PageResult current_;
-        Page::const_iterator it_;  // empty i.e. sentinel value
+        typename Page::const_iterator it_;  // empty i.e. sentinel value
     };
 
     explicit PaginatedSequence(Paginator next_page_provider) noexcept

--- a/silkworm/db/kv/api/endpoint/paginated_sequence.hpp
+++ b/silkworm/db/kv/api/endpoint/paginated_sequence.hpp
@@ -73,7 +73,7 @@ class PaginatedSequence {
     };
 
     explicit PaginatedSequence(Paginator next_page_provider) noexcept
-        : next_page_provider_(next_page_provider) {}
+        : next_page_provider_(std::move(next_page_provider)) {}
 
     Task<Iterator> begin() {
         auto current = co_await next_page_provider_();

--- a/silkworm/db/kv/api/endpoint/paginated_sequence.hpp
+++ b/silkworm/db/kv/api/endpoint/paginated_sequence.hpp
@@ -17,7 +17,6 @@
 #pragma once
 
 #include <functional>
-#include <iostream>
 #include <optional>
 #include <vector>
 
@@ -25,6 +24,7 @@
 
 namespace silkworm::db::kv::api {
 
+//! Sequence of values produced by pagination using some asynchronous page provider function.
 template <typename T>
 class PaginatedSequence {
   public:

--- a/silkworm/db/kv/api/endpoint/paginated_sequence.hpp
+++ b/silkworm/db/kv/api/endpoint/paginated_sequence.hpp
@@ -1,0 +1,91 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <functional>
+#include <iostream>
+#include <optional>
+#include <vector>
+
+#include <silkworm/infra/concurrency/task.hpp>
+
+namespace silkworm::db::kv::api {
+
+template <typename T>
+class PaginatedSequence {
+  public:
+    using Page = std::vector<T>;
+    struct PageResult {
+        Page values;
+        bool has_more{false};
+    };
+    using Paginator = std::function<Task<PageResult>()>;
+
+    class Iterator {
+      public:
+        T operator*() {
+            return std::move(*it_);
+        }
+
+        Task<void> operator++() {
+            ++it_;
+            if (it_ == current_.values.cend()) {
+                if (current_.has_more) {
+                    current_ = co_await next_page_provider_();
+                    it_ = current_.values.cbegin();
+                } else {
+                    it_ = typename Page::const_iterator();  // empty i.e. sentinel value
+                }
+            }
+        }
+
+        bool operator==(const Iterator& other) const noexcept {
+            return it_ == other.it_;
+        }
+
+        bool operator!=(const Iterator& other) const noexcept {
+            return !(*this == other);
+        }
+
+        Iterator(Paginator& next_page_provider, PageResult current) noexcept
+            : next_page_provider_(next_page_provider), current_(std::move(current)), it_{current_.values.cbegin()} {}
+        Iterator(Paginator& next_page_provider) noexcept
+            : next_page_provider_(next_page_provider) {}
+
+      private:
+        Paginator& next_page_provider_;
+        PageResult current_;
+        Page::const_iterator it_;  // empty i.e. sentinel value
+    };
+
+    explicit PaginatedSequence(Paginator next_page_provider) noexcept
+        : next_page_provider_(next_page_provider) {}
+
+    Task<Iterator> begin() {
+        auto current = co_await next_page_provider_();
+        co_return Iterator{next_page_provider_, std::move(current)};
+    }
+
+    Iterator end() noexcept {
+        return Iterator{next_page_provider_};
+    }
+
+  private:
+    Paginator next_page_provider_;
+};
+
+}  // namespace silkworm::db::kv::api

--- a/silkworm/db/kv/api/endpoint/paginated_sequence.hpp
+++ b/silkworm/db/kv/api/endpoint/paginated_sequence.hpp
@@ -88,4 +88,15 @@ class PaginatedSequence {
     Paginator next_page_provider_;
 };
 
+template <typename T>
+Task<std::vector<T>> paginated_to_vector(PaginatedSequence<T>& paginated) {
+    std::vector<T> all_values;
+    auto it = co_await paginated.begin();
+    while (it != paginated.end()) {
+        all_values.emplace_back(*it);
+        co_await ++it;
+    }
+    co_return all_values;
+}
+
 }  // namespace silkworm::db::kv::api

--- a/silkworm/db/kv/api/endpoint/paginated_sequence_benchmark.cpp
+++ b/silkworm/db/kv/api/endpoint/paginated_sequence_benchmark.cpp
@@ -1,0 +1,190 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "paginated_sequence.hpp"
+
+#include <benchmark/benchmark.h>
+
+#include <silkworm/infra/test_util/context_test_base.hpp>
+
+namespace silkworm::db::kv::api {
+
+using PaginatedUint64 = PaginatedSequence<uint64_t>;
+
+struct PaginatedSequenceBenchTest : public test_util::ContextTestBase {
+};
+
+template <typename TSequence>
+TSequence make_paginated_sequence(const std::size_t page_size, const std::size_t n) {
+    const std::size_t num_pages = n / page_size + (n % page_size ? 1 : 0);
+    const std::size_t last_page_size = n % page_size ? n % page_size : page_size;
+    typename TSequence::Paginator paginator = [=]() -> Task<typename TSequence::PageResult> {
+        static std::size_t count{0};
+        const bool has_more = ++count < num_pages;
+        typename TSequence::Page p(has_more ? page_size : last_page_size, 0);
+        co_return typename TSequence::PageResult{std::move(p), has_more};
+    };
+    return TSequence{std::move(paginator)};
+}
+
+Task<std::size_t> paginated_sequence_iteration(PaginatedUint64& paginated) {
+    std::size_t accumulator{0};
+    auto it = co_await paginated.begin();
+    while (it != paginated.end()) {
+        accumulator += *it;
+        co_await ++it;
+    }
+    co_return accumulator;
+}
+
+static void benchmark_paginated_sequence_iteration(benchmark::State& state) {
+    const auto page_size = static_cast<std::size_t>(state.range(0));
+    const auto n = static_cast<std::size_t>(state.range(1));
+
+    PaginatedSequenceBenchTest test;
+    auto paginated_sequence = make_paginated_sequence<PaginatedUint64>(page_size, n);
+    for ([[maybe_unused]] auto _ : state) {
+        const auto result = test.spawn_and_wait(paginated_sequence_iteration(paginated_sequence));
+        benchmark::DoNotOptimize(result);
+    }
+}
+
+BENCHMARK(benchmark_paginated_sequence_iteration)->Args({100, 1'001});
+BENCHMARK(benchmark_paginated_sequence_iteration)->Args({100, 10'001});
+BENCHMARK(benchmark_paginated_sequence_iteration)->Args({100, 100'001});
+
+BENCHMARK(benchmark_paginated_sequence_iteration)->Args({1'000, 1'001});
+BENCHMARK(benchmark_paginated_sequence_iteration)->Args({1'000, 10'001});
+BENCHMARK(benchmark_paginated_sequence_iteration)->Args({1'000, 100'001});
+
+BENCHMARK(benchmark_paginated_sequence_iteration)->Args({10'000, 10'001});
+BENCHMARK(benchmark_paginated_sequence_iteration)->Args({10'000, 100'001});
+BENCHMARK(benchmark_paginated_sequence_iteration)->Args({10'000, 1'000'001});
+
+BENCHMARK(benchmark_paginated_sequence_iteration)->Args({100'000, 100'001});
+BENCHMARK(benchmark_paginated_sequence_iteration)->Args({100'000, 1'000'001});
+
+template <typename T>
+class PaginatedSequence2 {
+  public:
+    using Page = std::vector<T>;
+    struct PageResult {
+        Page values;
+        bool has_more{false};
+    };
+    using Paginator = std::function<Task<PageResult>()>;
+
+    class Iterator {
+      public:
+        T operator*() {
+            return std::move(*it_);
+        }
+
+        bool operator++() {
+            ++it_;
+            if (it_ == current_.values.cend()) {
+                if (current_.has_more) {
+                    return true;
+                } else {
+                    it_ = typename Page::const_iterator();  // empty i.e. sentinel value
+                }
+            }
+            return false;
+        }
+
+        Task<void> next_page() {
+            current_ = co_await next_page_provider_();
+            it_ = current_.values.cbegin();
+        }
+
+        bool operator==(const Iterator& other) const noexcept {
+            return it_ == other.it_;
+        }
+
+        bool operator!=(const Iterator& other) const noexcept {
+            return !(*this == other);
+        }
+
+        Iterator(Paginator& next_page_provider, PageResult current) noexcept
+            : next_page_provider_(next_page_provider), current_(std::move(current)), it_{current_.values.cbegin()} {}
+        Iterator(Paginator& next_page_provider) noexcept
+            : next_page_provider_(next_page_provider) {}
+
+      private:
+        Paginator& next_page_provider_;
+        PageResult current_;
+        typename Page::const_iterator it_;  // empty i.e. sentinel value
+    };
+
+    explicit PaginatedSequence2(Paginator next_page_provider) noexcept
+        : next_page_provider_(std::move(next_page_provider)) {}
+
+    Task<Iterator> begin() {
+        auto current = co_await next_page_provider_();
+        co_return Iterator{next_page_provider_, std::move(current)};
+    }
+
+    Iterator end() noexcept {
+        return Iterator{next_page_provider_};
+    }
+
+  private:
+    Paginator next_page_provider_;
+};
+
+using Paginated2Uint64 = PaginatedSequence2<uint64_t>;
+
+Task<std::size_t> paginated_sequence_2_iteration(Paginated2Uint64& paginated) {
+    std::size_t accumulator{0};
+    auto it = co_await paginated.begin();
+    while (it != paginated.end()) {
+        accumulator += *it;
+        const bool next_page = ++it;
+        if (next_page) {
+            co_await it.next_page();
+        }
+    }
+    co_return accumulator;
+}
+
+static void benchmark_paginated_sequence_2_iteration(benchmark::State& state) {
+    const auto page_size = static_cast<std::size_t>(state.range(0));
+    const auto n = static_cast<std::size_t>(state.range(1));
+
+    PaginatedSequenceBenchTest test;
+    auto paginated_sequence = make_paginated_sequence<Paginated2Uint64>(page_size, n);
+    for ([[maybe_unused]] auto _ : state) {
+        const auto result = test.spawn_and_wait(paginated_sequence_2_iteration(paginated_sequence));
+        benchmark::DoNotOptimize(result);
+    }
+}
+
+BENCHMARK(benchmark_paginated_sequence_2_iteration)->Args({100, 1'001});
+BENCHMARK(benchmark_paginated_sequence_2_iteration)->Args({100, 10'001});
+BENCHMARK(benchmark_paginated_sequence_2_iteration)->Args({100, 100'001});
+
+BENCHMARK(benchmark_paginated_sequence_2_iteration)->Args({1'000, 1'001});
+BENCHMARK(benchmark_paginated_sequence_2_iteration)->Args({1'000, 10'001});
+BENCHMARK(benchmark_paginated_sequence_2_iteration)->Args({1'000, 100'001});
+
+BENCHMARK(benchmark_paginated_sequence_2_iteration)->Args({10'000, 10'001});
+BENCHMARK(benchmark_paginated_sequence_2_iteration)->Args({10'000, 100'001});
+BENCHMARK(benchmark_paginated_sequence_2_iteration)->Args({10'000, 1'000'001});
+
+BENCHMARK(benchmark_paginated_sequence_2_iteration)->Args({100'000, 100'001});
+BENCHMARK(benchmark_paginated_sequence_2_iteration)->Args({100'000, 1'000'001});
+
+}  // namespace silkworm::db::kv::api

--- a/silkworm/db/kv/api/endpoint/paginated_sequence_benchmark.cpp
+++ b/silkworm/db/kv/api/endpoint/paginated_sequence_benchmark.cpp
@@ -14,11 +14,11 @@
    limitations under the License.
 */
 
-#include "paginated_sequence.hpp"
-
 #include <benchmark/benchmark.h>
 
 #include <silkworm/infra/test_util/context_test_base.hpp>
+
+#include "paginated_sequence.hpp"
 
 namespace silkworm::db::kv::api {
 

--- a/silkworm/db/kv/api/endpoint/paginated_sequence_benchmark.cpp
+++ b/silkworm/db/kv/api/endpoint/paginated_sequence_benchmark.cpp
@@ -77,6 +77,9 @@ BENCHMARK(benchmark_paginated_sequence_iteration)->Args({10'000, 1'000'001});
 BENCHMARK(benchmark_paginated_sequence_iteration)->Args({100'000, 100'001});
 BENCHMARK(benchmark_paginated_sequence_iteration)->Args({100'000, 1'000'001});
 
+// Modified version of PaginatedSequence to check performance tradeoffs w/ different impl
+// - PaginatedSequence: async operator++ (more convenient at call site)
+// - PaginatedSequence2: sync operator++ plus async next_page
 template <typename T>
 class PaginatedSequence2 {
   public:

--- a/silkworm/db/kv/api/endpoint/paginated_sequence_test.cpp
+++ b/silkworm/db/kv/api/endpoint/paginated_sequence_test.cpp
@@ -27,23 +27,12 @@ using PaginatedUint64 = PaginatedSequence<uint64_t>;
 struct PaginatedSequenceTest : public test_util::ContextTestBase {
 };
 
-template <typename T>
-Task<std::vector<T>> to_vector(PaginatedSequence<T>& paginated) {
-    std::vector<T> all_values;
-    auto it = co_await paginated.begin();
-    while (it != paginated.end()) {
-        all_values.emplace_back(*it);
-        co_await ++it;
-    }
-    co_return all_values;
-}
-
 TEST_CASE_METHOD(PaginatedSequenceTest, "paginated_sequence: empty uint64 sequence", "[db][kv][api][paginated_sequence]") {
     PaginatedUint64::Paginator paginator = []() -> Task<PaginatedUint64::PageResult> {
         co_return PaginatedUint64::PageResult{};  // has_more=false as default
     };
     PaginatedUint64 paginated{paginator};
-    CHECK(spawn_and_wait(to_vector(paginated)).empty());
+    CHECK(spawn_and_wait(paginated_to_vector(paginated)).empty());
 }
 
 TEST_CASE_METHOD(PaginatedSequenceTest, "paginated_sequence: non-empty uint64 sequence", "[db][kv][api][paginated_sequence]") {
@@ -61,7 +50,7 @@ TEST_CASE_METHOD(PaginatedSequenceTest, "paginated_sequence: non-empty uint64 se
         }
     };
     PaginatedUint64 paginated{paginator};
-    CHECK(spawn_and_wait(to_vector(paginated)) == std::vector<uint64_t>{1, 2, 3, 4, 5, 6, 7});
+    CHECK(spawn_and_wait(paginated_to_vector(paginated)) == std::vector<uint64_t>{1, 2, 3, 4, 5, 6, 7});
 }
 
 TEST_CASE_METHOD(PaginatedSequenceTest, "paginated_sequence: error", "[db][kv][api][paginated_sequence]") {
@@ -79,7 +68,7 @@ TEST_CASE_METHOD(PaginatedSequenceTest, "paginated_sequence: error", "[db][kv][a
         }
     };
     PaginatedUint64 paginated{paginator};
-    CHECK_THROWS_AS(spawn_and_wait(to_vector(paginated)), std::runtime_error);
+    CHECK_THROWS_AS(spawn_and_wait(paginated_to_vector(paginated)), std::runtime_error);
 }
 
 }  // namespace silkworm::db::kv::api

--- a/silkworm/db/kv/api/endpoint/paginated_sequence_test.cpp
+++ b/silkworm/db/kv/api/endpoint/paginated_sequence_test.cpp
@@ -30,8 +30,10 @@ struct PaginatedSequenceTest : public test_util::ContextTestBase {
 template <typename T>
 Task<std::vector<T>> to_vector(PaginatedSequence<T>& paginated) {
     std::vector<T> all_values;
-    for (auto it = co_await paginated.begin(); it != paginated.end(); co_await ++it) {
+    auto it = co_await paginated.begin();
+    while (it != paginated.end()) {
         all_values.emplace_back(*it);
+        co_await ++it;
     }
     co_return all_values;
 }

--- a/silkworm/db/kv/api/endpoint/paginated_sequence_test.cpp
+++ b/silkworm/db/kv/api/endpoint/paginated_sequence_test.cpp
@@ -18,7 +18,6 @@
 
 #include <catch2/catch_test_macros.hpp>
 
-#include <silkworm/core/common/assert.hpp>
 #include <silkworm/infra/test_util/context_test_base.hpp>
 
 namespace silkworm::db::kv::api {
@@ -52,9 +51,8 @@ TEST_CASE_METHOD(PaginatedSequenceTest, "paginated_sequence: non-empty uint64 se
             case 1: co_return PaginatedUint64::PageResult{PaginatedUint64::Page{1, 2, 3}, /*has_more=*/true};
             case 2: co_return PaginatedUint64::PageResult{PaginatedUint64::Page{4, 5, 6}, /*has_more=*/true};
             case 3: co_return PaginatedUint64::PageResult{PaginatedUint64::Page{7}, /*has_more=*/false};
-            default: SILKWORM_ASSERT(false);
+            default: throw std::logic_error{"unexpected call to paginator"};
         }
-        co_return PaginatedUint64::PageResult{};
     };
     PaginatedUint64 paginated{paginator};
     CHECK(spawn_and_wait(to_vector(paginated)) == std::vector<uint64_t>{1, 2, 3, 4, 5, 6, 7});
@@ -66,10 +64,9 @@ TEST_CASE_METHOD(PaginatedSequenceTest, "paginated_sequence: error", "[db][kv][a
         switch (++count) {
             case 1: co_return PaginatedUint64::PageResult{PaginatedUint64::Page{1, 2, 3}, /*has_more=*/true};
             case 2: co_return PaginatedUint64::PageResult{PaginatedUint64::Page{4, 5, 6}, /*has_more=*/true};
-            case 3: throw std::runtime_error{"pagination error"};
-            default: SILKWORM_ASSERT(false);
+            case 3: throw std::runtime_error{"error during pagination"};
+            default: throw std::logic_error{"unexpected call to paginator"};
         }
-        co_return PaginatedUint64::PageResult{};
     };
     PaginatedUint64 paginated{paginator};
     CHECK_THROWS_AS(spawn_and_wait(to_vector(paginated)), std::runtime_error);

--- a/silkworm/db/kv/api/endpoint/paginated_sequence_test.cpp
+++ b/silkworm/db/kv/api/endpoint/paginated_sequence_test.cpp
@@ -48,10 +48,14 @@ TEST_CASE_METHOD(PaginatedSequenceTest, "paginated_sequence: non-empty uint64 se
     PaginatedUint64::Paginator paginator = []() -> Task<PaginatedUint64::PageResult> {
         static int count{0};
         switch (++count) {
-            case 1: co_return PaginatedUint64::PageResult{PaginatedUint64::Page{1, 2, 3}, /*has_more=*/true};
-            case 2: co_return PaginatedUint64::PageResult{PaginatedUint64::Page{4, 5, 6}, /*has_more=*/true};
-            case 3: co_return PaginatedUint64::PageResult{PaginatedUint64::Page{7}, /*has_more=*/false};
-            default: throw std::logic_error{"unexpected call to paginator"};
+            case 1:
+                co_return PaginatedUint64::PageResult{PaginatedUint64::Page{1, 2, 3}, /*has_more=*/true};
+            case 2:
+                co_return PaginatedUint64::PageResult{PaginatedUint64::Page{4, 5, 6}, /*has_more=*/true};
+            case 3:
+                co_return PaginatedUint64::PageResult{PaginatedUint64::Page{7}, /*has_more=*/false};
+            default:
+                throw std::logic_error{"unexpected call to paginator"};
         }
     };
     PaginatedUint64 paginated{paginator};
@@ -62,10 +66,14 @@ TEST_CASE_METHOD(PaginatedSequenceTest, "paginated_sequence: error", "[db][kv][a
     PaginatedUint64::Paginator paginator = []() -> Task<PaginatedUint64::PageResult> {
         static int count{0};
         switch (++count) {
-            case 1: co_return PaginatedUint64::PageResult{PaginatedUint64::Page{1, 2, 3}, /*has_more=*/true};
-            case 2: co_return PaginatedUint64::PageResult{PaginatedUint64::Page{4, 5, 6}, /*has_more=*/true};
-            case 3: throw std::runtime_error{"error during pagination"};
-            default: throw std::logic_error{"unexpected call to paginator"};
+            case 1:
+                co_return PaginatedUint64::PageResult{PaginatedUint64::Page{1, 2, 3}, /*has_more=*/true};
+            case 2:
+                co_return PaginatedUint64::PageResult{PaginatedUint64::Page{4, 5, 6}, /*has_more=*/true};
+            case 3:
+                throw std::runtime_error{"error during pagination"};
+            default:
+                throw std::logic_error{"unexpected call to paginator"};
         }
     };
     PaginatedUint64 paginated{paginator};

--- a/silkworm/db/kv/api/endpoint/paginated_sequence_test.cpp
+++ b/silkworm/db/kv/api/endpoint/paginated_sequence_test.cpp
@@ -1,0 +1,78 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "paginated_sequence.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <silkworm/core/common/assert.hpp>
+#include <silkworm/infra/test_util/context_test_base.hpp>
+
+namespace silkworm::db::kv::api {
+
+using PaginatedUint64 = PaginatedSequence<uint64_t>;
+
+struct PaginatedSequenceTest : public test_util::ContextTestBase {
+};
+
+template <typename T>
+Task<std::vector<T>> to_vector(PaginatedSequence<T>& paginated) {
+    std::vector<T> all_values;
+    for (auto it = co_await paginated.begin(); it != paginated.end(); co_await ++it) {
+        all_values.emplace_back(*it);
+    }
+    co_return all_values;
+}
+
+TEST_CASE_METHOD(PaginatedSequenceTest, "paginated_sequence: empty uint64 sequence", "[db][kv][api][paginated_sequence]") {
+    PaginatedUint64::Paginator paginator = []() -> Task<PaginatedUint64::PageResult> {
+        co_return PaginatedUint64::PageResult{};  // has_more=false as default
+    };
+    PaginatedUint64 paginated{paginator};
+    CHECK(spawn_and_wait(to_vector(paginated)).empty());
+}
+
+TEST_CASE_METHOD(PaginatedSequenceTest, "paginated_sequence: non-empty uint64 sequence", "[db][kv][api][paginated_sequence]") {
+    PaginatedUint64::Paginator paginator = []() -> Task<PaginatedUint64::PageResult> {
+        static int count{0};
+        switch (++count) {
+            case 1: co_return PaginatedUint64::PageResult{PaginatedUint64::Page{1, 2, 3}, /*has_more=*/true};
+            case 2: co_return PaginatedUint64::PageResult{PaginatedUint64::Page{4, 5, 6}, /*has_more=*/true};
+            case 3: co_return PaginatedUint64::PageResult{PaginatedUint64::Page{7}, /*has_more=*/false};
+            default: SILKWORM_ASSERT(false);
+        }
+        co_return PaginatedUint64::PageResult{};
+    };
+    PaginatedUint64 paginated{paginator};
+    CHECK(spawn_and_wait(to_vector(paginated)) == std::vector<uint64_t>{1, 2, 3, 4, 5, 6, 7});
+}
+
+TEST_CASE_METHOD(PaginatedSequenceTest, "paginated_sequence: error", "[db][kv][api][paginated_sequence]") {
+    PaginatedUint64::Paginator paginator = []() -> Task<PaginatedUint64::PageResult> {
+        static int count{0};
+        switch (++count) {
+            case 1: co_return PaginatedUint64::PageResult{PaginatedUint64::Page{1, 2, 3}, /*has_more=*/true};
+            case 2: co_return PaginatedUint64::PageResult{PaginatedUint64::Page{4, 5, 6}, /*has_more=*/true};
+            case 3: throw std::runtime_error{"pagination error"};
+            default: SILKWORM_ASSERT(false);
+        }
+        co_return PaginatedUint64::PageResult{};
+    };
+    PaginatedUint64 paginated{paginator};
+    CHECK_THROWS_AS(spawn_and_wait(to_vector(paginated)), std::runtime_error);
+}
+
+}  // namespace silkworm::db::kv::api


### PR DESCRIPTION
This PR introduces support for a hand-crafted paginated sequence of values to be used in the definition of `temporal KV` API endpoints. Such abstraction allows user code to navigate a paginated contiguous sequence of values without bothering about pagination at call site.

If performance measurements in standalone mode (i.e. direct KV client) will show significant overhead caused by this approach, we can relax this requirement to hide pagination at call site and try to obtain faster code.

*Design Alternatives*
We're going to use this abstraction for both direct and gRPC KV client implementations and we cannot block the coroutine scheduler in gRPC case, so we do need a common asynchronous interface definition. This requirement (which could be challenged if performance results are not satisfactory) excludes usage of a C++ iterator.
Hence, I have considered the following alternative options:
- C++23 `std::generator` reference [implementation](https://github.com/lewissbaker/generator): not feasible because it does not allow usage of `co_await` within the generator coroutine
- asynchronous generator based on C++20 coroutines: some examples exists [here](https://github.com/facebook/folly/blob/main/folly/coro/AsyncGenerator.h) and [here](https://gist.github.com/Serikov/b28115e3b13a7c0ec45ab76468ddb0bd), which however do not play nicely with Asio. Another feasible option could be [`cobalt` implementation](https://github.com/boostorg/cobalt/blob/develop/include/boost/cobalt/detail/generator.hpp), which is based on and is compatible with Asio, but it would require to add a new dependency and using other companion `cobalt` abstractions just for one class: this seems too much.
- experimental Asio [coro](https://github.com/chriskohlhoff/asio/blob/master/asio/include/asio/experimental/coro.hpp) abstraction acting as task/generator/awaitable: this looks promising but it's still experimental so there are [substantial issues](https://github.com/chriskohlhoff/asio/issues?q=is%3Aissue+is%3Aopen+experimental%3A%3Acoro+) and again would require a large refactoring in our codebase.


*Notes*
Evaluating usage of Cobalt could be interesting as a research sub-project, so I've opened #2185