### PR TITLE
db: temporal KV client index_range API via gRPC

### DIFF
--- a/silkworm/db/kv/api/direct_service.cpp
+++ b/silkworm/db/kv/api/direct_service.cpp
@@ -74,12 +74,6 @@ Task<DomainPointResult> DirectService::get_domain(const DomainPointQuery&) {
 
 /** Temporal Range Queries **/
 
-// rpc IndexRange(IndexRangeReq) returns (IndexRangeReply);
-Task<IndexRangeResult> DirectService::get_index_range(const IndexRangeQuery&) {
-    // TODO(canepat) implement
-    co_return IndexRangeResult{};
-}
-
 // rpc HistoryRange(HistoryRangeReq) returns (Pairs);
 Task<HistoryRangeResult> DirectService::get_history_range(const HistoryRangeQuery&) {
     // TODO(canepat) implement

--- a/silkworm/db/kv/api/direct_service.hpp
+++ b/silkworm/db/kv/api/direct_service.hpp
@@ -56,9 +56,6 @@ class DirectService : public Service {
 
     /** Temporal Range Queries **/
 
-    // rpc IndexRange(IndexRangeReq) returns (IndexRangeReply);
-    Task<IndexRangeResult> get_index_range(const IndexRangeQuery&) override;
-
     // rpc HistoryRange(HistoryRangeReq) returns (Pairs);
     Task<HistoryRangeResult> get_history_range(const HistoryRangeQuery&) override;
 

--- a/silkworm/db/kv/api/endpoint/temporal_range.hpp
+++ b/silkworm/db/kv/api/endpoint/temporal_range.hpp
@@ -22,8 +22,12 @@
 #include <silkworm/core/common/bytes.hpp>
 
 #include "common.hpp"
+#include "paginated_sequence.hpp"
 
 namespace silkworm::db::kv::api {
+
+//! Unlimited range size in range queries
+inline constexpr int64_t kUnlimited{-1};
 
 struct IndexRangeQuery {
     TxId tx_id{0};
@@ -32,7 +36,7 @@ struct IndexRangeQuery {
     Timestamp from_timestamp;
     Timestamp to_timestamp;
     bool ascending_order{false};
-    uint64_t limit{0};
+    int64_t limit{kUnlimited};
     uint32_t page_size{0};
     std::string page_token;
 };
@@ -54,7 +58,7 @@ struct HistoryRangeQuery {
     Timestamp from_timestamp;
     Timestamp to_timestamp;
     bool ascending_order{false};
-    uint64_t limit{0};
+    int64_t limit{kUnlimited};
     uint32_t page_size{0};
     std::string page_token;
 };
@@ -67,11 +71,13 @@ struct DomainRangeQuery {
     Bytes from_key;
     Bytes to_key;
     bool ascending_order{false};
-    uint64_t limit{0};
+    int64_t limit{kUnlimited};
     uint32_t page_size{0};
     std::string page_token;
 };
 
 using DomainRangeResult = RangeResult;
+
+using PaginatedTimestamps = PaginatedSequence<Timestamp>;
 
 }  // namespace silkworm::db::kv::api

--- a/silkworm/db/kv/api/local_transaction.cpp
+++ b/silkworm/db/kv/api/local_transaction.cpp
@@ -68,4 +68,12 @@ std::shared_ptr<chain::ChainStorage> LocalTransaction::create_storage() {
     return std::make_shared<chain::LocalChainStorage>(txn_);
 }
 
+Task<PaginatedTimestamps> LocalTransaction::index_range(api::IndexRangeQuery&& /*query*/) {
+    // TODO(canepat) implement using E3-like aggregator abstraction [tx_id_ must be changed]
+    auto paginator = []() mutable -> Task<api::PaginatedTimestamps::PageResult> {
+        co_return api::PaginatedTimestamps::PageResult{};
+    };
+    co_return api::PaginatedTimestamps{std::move(paginator)};
+}
+
 }  // namespace silkworm::db::kv::api

--- a/silkworm/db/kv/api/local_transaction.hpp
+++ b/silkworm/db/kv/api/local_transaction.hpp
@@ -55,6 +55,9 @@ class LocalTransaction : public BaseTransaction {
 
     Task<void> close() override;
 
+    // rpc IndexRange(IndexRangeReq) returns (IndexRangeReply);
+    Task<PaginatedTimestamps> index_range(IndexRangeQuery&& query) override;
+
   private:
     Task<std::shared_ptr<CursorDupSort>> get_cursor(const std::string& table, bool is_cursor_dup_sort);
 

--- a/silkworm/db/kv/api/service.hpp
+++ b/silkworm/db/kv/api/service.hpp
@@ -48,9 +48,6 @@ struct Service {
 
     /** Temporal Range Queries **/
 
-    // rpc IndexRange(IndexRangeReq) returns (IndexRangeReply);
-    virtual Task<IndexRangeResult> get_index_range(const IndexRangeQuery&) = 0;
-
     // rpc HistoryRange(HistoryRangeReq) returns (Pairs);
     virtual Task<HistoryRangeResult> get_history_range(const HistoryRangeQuery&) = 0;
 

--- a/silkworm/db/kv/api/transaction.hpp
+++ b/silkworm/db/kv/api/transaction.hpp
@@ -27,6 +27,7 @@
 
 #include "cursor.hpp"
 #include "endpoint/key_value.hpp"
+#include "endpoint/temporal_range.hpp"
 
 namespace silkworm::db::kv::api {
 
@@ -63,6 +64,11 @@ class Transaction {
     virtual Task<Bytes> get_one(const std::string& table, ByteView key) = 0;
 
     virtual Task<std::optional<Bytes>> get_both_range(const std::string& table, ByteView key, ByteView subkey) = 0;
+
+    /** Temporal Range Queries **/
+
+    // rpc IndexRange(IndexRangeReq) returns (IndexRangeReply);
+    virtual Task<PaginatedTimestamps> index_range(IndexRangeQuery&& query) = 0;
 };
 
 }  // namespace silkworm::db::kv::api

--- a/silkworm/db/kv/grpc/client/endpoint/temporal_range.cpp
+++ b/silkworm/db/kv/grpc/client/endpoint/temporal_range.cpp
@@ -27,11 +27,11 @@ proto::IndexRangeReq index_range_request_from_query(const api::IndexRangeQuery& 
     proto::IndexRangeReq request;
     request.set_tx_id(query.tx_id);
     request.set_table(query.table);
-    request.set_k(to_hex(query.key));
+    request.set_k(query.key.data(), query.key.size());
     request.set_from_ts(query.from_timestamp);
     request.set_to_ts(query.to_timestamp);
     request.set_order_ascend(query.ascending_order);
-    request.set_limit(static_cast<int64_t>(query.limit));
+    request.set_limit(query.limit);
     request.set_page_size(static_cast<int32_t>(query.page_size));
     request.set_page_token(query.page_token);
     return request;
@@ -75,8 +75,8 @@ api::HistoryRangeResult history_range_result_from_response(const proto::Pairs& r
     ::remote::DomainRangeReq request;
     request.set_tx_id(query.tx_id);
     request.set_table(query.table);
-    request.set_from_key(to_hex(query.from_key));
-    request.set_to_key(to_hex(query.to_key));
+    request.set_from_key(query.from_key.data(), query.from_key.size());
+    request.set_to_key(query.to_key.data(), query.to_key.size());
     request.set_order_ascend(query.ascending_order);
     request.set_limit(static_cast<int64_t>(query.limit));
     request.set_page_size(static_cast<int32_t>(query.page_size));

--- a/silkworm/db/kv/grpc/client/endpoint/temporal_range_test.cpp
+++ b/silkworm/db/kv/grpc/client/endpoint/temporal_range_test.cpp
@@ -31,7 +31,7 @@ namespace proto = ::remote;
 
 TEST_CASE("index_range_request_from_query", "[node][remote][kv][grpc]") {
     const Fixtures<api::IndexRangeQuery, proto::IndexRangeReq> fixtures{
-        {{}, {}},
+        {{}, default_proto_index_range_request()},
         {sample_index_range_query(), sample_proto_index_range_request()},
     };
     for (const auto& [query, expected_range_request] : fixtures) {
@@ -68,7 +68,7 @@ TEST_CASE("index_range_result_from_response", "[node][remote][kv][grpc]") {
 
 TEST_CASE("history_range_request_from_query", "[node][remote][kv][grpc]") {
     const Fixtures<api::HistoryRangeQuery, proto::HistoryRangeReq> fixtures{
-        {{}, {}},
+        {{}, default_proto_history_range_request()},
         {sample_history_range_query(), sample_proto_history_range_request()},
     };
     for (const auto& [query, expected_range_request] : fixtures) {
@@ -105,7 +105,7 @@ TEST_CASE("history_range_result_from_response", "[node][remote][kv][grpc]") {
 
 TEST_CASE("domain_range_request_from_query", "[node][remote][kv][grpc]") {
     const Fixtures<api::DomainRangeQuery, proto::DomainRangeReq> fixtures{
-        {{}, {}},
+        {{}, default_proto_domain_range_request()},
         {sample_domain_range_query(), sample_proto_domain_range_request()},
     };
     for (const auto& [query, expected_range_request] : fixtures) {

--- a/silkworm/db/kv/grpc/client/remote_client_test.cpp
+++ b/silkworm/db/kv/grpc/client/remote_client_test.cpp
@@ -112,34 +112,6 @@ TEST_CASE_METHOD(RemoteClientTestRunner, "KV::DomainGet", "[node][remote][kv][gr
     }
 }
 
-/*TEST_CASE_METHOD(RemoteClientTestRunner, "KV::IndexRange", "[node][remote][kv][grpc]") {
-    const api::IndexRangeQuery query{};  // input query doesn't matter here, we tweak the reply
-
-    rpc::test::StrictMockAsyncResponseReader<proto::IndexRangeReply> reader;
-    EXPECT_CALL(*stub_, AsyncIndexRangeRaw).WillOnce(testing::Return(&reader));
-
-    SECTION("call get_index_range and get result") {
-        proto::IndexRangeReply reply{sample_proto_index_range_response()};
-        EXPECT_CALL(reader, Finish).WillOnce(rpc::test::finish_with(grpc_context_, std::move(reply)));
-
-        const api::IndexRangeResult result = run_service_method<&api::Service::get_index_range>(query);
-        CHECK(result.timestamps == std::vector<api::Timestamp>{1234567, 1234568});
-        CHECK(result.next_page_token == "token2");
-    }
-    SECTION("call get_index_range and get empty result") {
-        EXPECT_CALL(reader, Finish).WillOnce(rpc::test::finish_ok(grpc_context_));
-
-        const api::IndexRangeResult result = run_service_method<&api::Service::get_index_range>(query);
-        CHECK(result.timestamps.empty());
-        CHECK(result.next_page_token.empty());
-    }
-    SECTION("call get_index_range and get error") {
-        EXPECT_CALL(reader, Finish).WillOnce(rpc::test::finish_cancelled(grpc_context_));
-
-        CHECK_THROWS_AS((run_service_method<&api::Service::get_index_range>(query)), rpc::GrpcStatusError);
-    }
-}*/
-
 TEST_CASE_METHOD(RemoteClientTestRunner, "KV::HistoryRange", "[node][remote][kv][grpc]") {
     const api::HistoryRangeQuery query{};  // input query doesn't matter here, we tweak the reply
 

--- a/silkworm/db/kv/grpc/client/remote_client_test.cpp
+++ b/silkworm/db/kv/grpc/client/remote_client_test.cpp
@@ -112,7 +112,7 @@ TEST_CASE_METHOD(RemoteClientTestRunner, "KV::DomainGet", "[node][remote][kv][gr
     }
 }
 
-TEST_CASE_METHOD(RemoteClientTestRunner, "KV::IndexRange", "[node][remote][kv][grpc]") {
+/*TEST_CASE_METHOD(RemoteClientTestRunner, "KV::IndexRange", "[node][remote][kv][grpc]") {
     const api::IndexRangeQuery query{};  // input query doesn't matter here, we tweak the reply
 
     rpc::test::StrictMockAsyncResponseReader<proto::IndexRangeReply> reader;
@@ -138,7 +138,7 @@ TEST_CASE_METHOD(RemoteClientTestRunner, "KV::IndexRange", "[node][remote][kv][g
 
         CHECK_THROWS_AS((run_service_method<&api::Service::get_index_range>(query)), rpc::GrpcStatusError);
     }
-}
+}*/
 
 TEST_CASE_METHOD(RemoteClientTestRunner, "KV::HistoryRange", "[node][remote][kv][grpc]") {
     const api::HistoryRangeQuery query{};  // input query doesn't matter here, we tweak the reply

--- a/silkworm/db/kv/grpc/client/remote_transaction.hpp
+++ b/silkworm/db/kv/grpc/client/remote_transaction.hpp
@@ -59,6 +59,9 @@ class RemoteTransaction : public api::BaseTransaction {
 
     Task<void> close() override;
 
+    // rpc IndexRange(IndexRangeReq) returns (IndexRangeReply);
+    Task<api::PaginatedTimestamps> index_range(api::IndexRangeQuery&& query) override;
+
   private:
     Task<std::shared_ptr<api::CursorDupSort>> get_cursor(const std::string& table, bool is_cursor_dup_sort);
 
@@ -66,6 +69,8 @@ class RemoteTransaction : public api::BaseTransaction {
     chain::BlockNumberFromTxnHashProvider block_number_from_txn_hash_provider_;
     std::map<std::string, std::shared_ptr<api::CursorDupSort>> cursors_;
     std::map<std::string, std::shared_ptr<api::CursorDupSort>> dup_cursors_;
+    ::remote::KV::StubInterface& stub_;
+    agrpc::GrpcContext& grpc_context_;
     TxRpc tx_rpc_;
     uint64_t tx_id_{0};
     uint64_t view_id_{0};

--- a/silkworm/db/kv/grpc/client/remote_transaction_test.cpp
+++ b/silkworm/db/kv/grpc/client/remote_transaction_test.cpp
@@ -420,7 +420,7 @@ TEST_CASE_METHOD(RemoteTransactionTest, "RemoteTransaction::index_range", "[rpc]
     SECTION("throw on error") {
         // Set the call expectations:
         // 1. remote::KV::StubInterface::AsyncIndexRangeRaw call succeeds
-        EXPECT_CALL(*stub_, AsyncIndexRangeRaw).WillOnce(Return(index_range_reader_ptr_.get()));
+        EXPECT_CALL(*stub_, AsyncIndexRangeRaw).WillOnce(Return(index_range_reader_ptr_.release()));
         // 2. AsyncResponseReader<>::Finish call fails
         EXPECT_CALL(*index_range_reader_, Finish).WillOnce(test::finish_error_aborted(grpc_context_, ::remote::IndexRangeReply{}));
         // Execute the test: trying to *use* index_range lazy result should throw
@@ -429,7 +429,7 @@ TEST_CASE_METHOD(RemoteTransactionTest, "RemoteTransaction::index_range", "[rpc]
     SECTION("success: empty") {
         // Set the call expectations:
         // 1. remote::KV::StubInterface::AsyncIndexRangeRaw call succeeds
-        EXPECT_CALL(*stub_, AsyncIndexRangeRaw).WillRepeatedly(Return(index_range_reader_ptr_.get()));
+        EXPECT_CALL(*stub_, AsyncIndexRangeRaw).WillRepeatedly(Return(index_range_reader_ptr_.release()));
         // 2. AsyncResponseReader<>::Finish call succeeds 3 times
         EXPECT_CALL(*index_range_reader_, Finish)
             .WillOnce(test::finish_with(grpc_context_, make_index_range_reply({}, /*has_more*/ false)));
@@ -440,7 +440,7 @@ TEST_CASE_METHOD(RemoteTransactionTest, "RemoteTransaction::index_range", "[rpc]
     SECTION("success: one page") {
         // Set the call expectations:
         // 1. remote::KV::StubInterface::AsyncIndexRangeRaw call succeeds
-        EXPECT_CALL(*stub_, AsyncIndexRangeRaw).WillRepeatedly(Return(index_range_reader_ptr_.get()));
+        EXPECT_CALL(*stub_, AsyncIndexRangeRaw).WillRepeatedly(Return(index_range_reader_ptr_.release()));
         // 2. AsyncResponseReader<>::Finish call succeeds
         EXPECT_CALL(*index_range_reader_, Finish)
             .WillOnce(test::finish_with(grpc_context_, make_index_range_reply({19}, /*has_more*/ false)));
@@ -463,7 +463,7 @@ TEST_CASE_METHOD(RemoteTransactionTest, "RemoteTransaction::index_range", "[rpc]
         // 4. AsyncReaderWriter<remote::Cursor, remote::Pair>::Finish call succeeds w/ status OK
         EXPECT_CALL(reader_writer_, Finish).WillOnce(test::finish_streaming_ok(grpc_context_));
         // 5. remote::KV::StubInterface::AsyncIndexRangeRaw call succeeds
-        EXPECT_CALL(*stub_, AsyncIndexRangeRaw).WillRepeatedly(Return(index_range_reader_ptr_.get()));
+        EXPECT_CALL(*stub_, AsyncIndexRangeRaw).WillRepeatedly(Return(index_range_reader_ptr_.release()));
         // 6. AsyncResponseReader<>::Finish call succeeds 3 times
         EXPECT_CALL(*index_range_reader_, Finish)
             .WillOnce(test::finish_with(grpc_context_, make_index_range_reply({1, 2, 3}, /*has_more*/ true)))

--- a/silkworm/db/kv/grpc/test_util/sample_protos.hpp
+++ b/silkworm/db/kv/grpc/test_util/sample_protos.hpp
@@ -18,7 +18,9 @@
 
 #include <string>
 
+#include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/common/bytes_to_string.hpp>
+#include <silkworm/core/common/util.hpp>
 #include <silkworm/infra/grpc/common/conversion.hpp>
 #include <silkworm/interfaces/remote/kv.pb.h>
 
@@ -28,6 +30,14 @@
 namespace silkworm::db::kv::test_util {
 
 namespace proto = ::remote;
+
+inline std::string ascii_from_hex(const std::string& hex) {
+    const std::optional<Bytes> bytes{from_hex(hex)};
+    if (!bytes) {
+        throw std::runtime_error{"ascii_from_hex"};
+    }
+    return std::string{byte_view_to_string_view(*bytes)};
+}
 
 inline api::HistoryPointQuery sample_history_point_query() {
     return {
@@ -109,11 +119,17 @@ inline api::IndexRangeQuery sample_index_range_query() {
     };
 }
 
+inline proto::IndexRangeReq default_proto_index_range_request() {
+    proto::IndexRangeReq request;
+    request.set_limit(api::kUnlimited);  // default value for type is 0 whilst we're choosing unlimited (-1) in API
+    return request;
+}
+
 inline proto::IndexRangeReq sample_proto_index_range_request() {
     proto::IndexRangeReq request;
     request.set_tx_id(1);
     request.set_table("AAA");
-    request.set_k("0011ff");
+    request.set_k(ascii_from_hex("0011ff"));
     request.set_from_ts(1234567);
     request.set_to_ts(1234967);
     request.set_order_ascend(true);
@@ -149,6 +165,12 @@ inline api::HistoryRangeQuery sample_history_range_query() {
         .page_size = 100,
         .page_token = "token1",
     };
+}
+
+inline proto::HistoryRangeReq default_proto_history_range_request() {
+    proto::HistoryRangeReq request;
+    request.set_limit(api::kUnlimited);  // default value for type is 0 whilst we're choosing unlimited (-1) in API
+    return request;
 }
 
 inline proto::HistoryRangeReq sample_proto_history_range_request() {
@@ -195,12 +217,18 @@ inline api::DomainRangeQuery sample_domain_range_query() {
     };
 }
 
+inline proto::DomainRangeReq default_proto_domain_range_request() {
+    proto::DomainRangeReq request;
+    request.set_limit(api::kUnlimited);  // default value for type is 0 whilst we're choosing unlimited (-1) in API
+    return request;
+}
+
 inline proto::DomainRangeReq sample_proto_domain_range_request() {
     proto::DomainRangeReq request;
     request.set_tx_id(1);
     request.set_table("AAA");
-    request.set_from_key("0011aa");
-    request.set_to_key("0011ff");
+    request.set_from_key(ascii_from_hex("0011aa"));
+    request.set_to_key(ascii_from_hex("0011ff"));
     request.set_order_ascend(true);
     request.set_limit(1'000);
     request.set_page_size(100);

--- a/silkworm/db/test_util/kv_test_base.hpp
+++ b/silkworm/db/test_util/kv_test_base.hpp
@@ -56,6 +56,7 @@ struct KVTestBase : public silkworm::test_util::ContextTestBase {
     using StrictMockKVStub = testing::StrictMock<remote::MockKVStub>;
     using StrictMockKVTxAsyncReaderWriter = rpc::test::StrictMockAsyncReaderWriter<remote::Cursor, remote::Pair>;
     using StrictMockKVStateChangesAsyncReader = rpc::test::StrictMockAsyncReader<remote::StateChangeBatch>;
+    using StrictMockKVIndexRangeAsyncResponseReader = rpc::test::StrictMockAsyncResponseReader<::remote::IndexRangeReply>;
 
     //! Mocked stub of gRPC KV interface
     std::unique_ptr<StrictMockKVStub> stub_{std::make_unique<StrictMockKVStub>()};
@@ -69,6 +70,11 @@ struct KVTestBase : public silkworm::test_util::ContextTestBase {
     std::unique_ptr<StrictMockKVStateChangesAsyncReader> statechanges_reader_ptr_{
         std::make_unique<StrictMockKVStateChangesAsyncReader>()};
     StrictMockKVStateChangesAsyncReader* statechanges_reader_{statechanges_reader_ptr_.get()};
+
+    //! Mocked response reader for IndexRange server streaming RPC of gRPC KV interface
+    std::unique_ptr<StrictMockKVIndexRangeAsyncResponseReader> index_range_reader_ptr_{
+        std::make_unique<StrictMockKVIndexRangeAsyncResponseReader>()};
+    StrictMockKVIndexRangeAsyncResponseReader* index_range_reader_{index_range_reader_ptr_.get()};
 };
 
 }  // namespace silkworm::db::test_util

--- a/silkworm/db/test_util/kv_test_base.hpp
+++ b/silkworm/db/test_util/kv_test_base.hpp
@@ -56,7 +56,6 @@ struct KVTestBase : public silkworm::test_util::ContextTestBase {
     using StrictMockKVStub = testing::StrictMock<remote::MockKVStub>;
     using StrictMockKVTxAsyncReaderWriter = rpc::test::StrictMockAsyncReaderWriter<remote::Cursor, remote::Pair>;
     using StrictMockKVStateChangesAsyncReader = rpc::test::StrictMockAsyncReader<remote::StateChangeBatch>;
-    using StrictMockKVIndexRangeAsyncResponseReader = rpc::test::StrictMockAsyncResponseReader<::remote::IndexRangeReply>;
 
     //! Mocked stub of gRPC KV interface
     std::unique_ptr<StrictMockKVStub> stub_{std::make_unique<StrictMockKVStub>()};
@@ -70,11 +69,6 @@ struct KVTestBase : public silkworm::test_util::ContextTestBase {
     std::unique_ptr<StrictMockKVStateChangesAsyncReader> statechanges_reader_ptr_{
         std::make_unique<StrictMockKVStateChangesAsyncReader>()};
     StrictMockKVStateChangesAsyncReader* statechanges_reader_{statechanges_reader_ptr_.get()};
-
-    //! Mocked response reader for IndexRange server streaming RPC of gRPC KV interface
-    std::unique_ptr<StrictMockKVIndexRangeAsyncResponseReader> index_range_reader_ptr_{
-        std::make_unique<StrictMockKVIndexRangeAsyncResponseReader>()};
-    StrictMockKVIndexRangeAsyncResponseReader* index_range_reader_{index_range_reader_ptr_.get()};
 };
 
 }  // namespace silkworm::db::test_util

--- a/silkworm/db/test_util/mock_transaction.hpp
+++ b/silkworm/db/test_util/mock_transaction.hpp
@@ -46,6 +46,7 @@ class MockTransaction : public kv::api::Transaction {
     MOCK_METHOD((Task<Bytes>), get_one, (const std::string&, ByteView), (override));
     MOCK_METHOD((Task<std::optional<Bytes>>), get_both_range,
                 (const std::string&, ByteView, ByteView), (override));
+    MOCK_METHOD((Task<kv::api::PaginatedTimestamps>), index_range, (kv::api::IndexRangeQuery&&), (override));
 };
 
 }  // namespace silkworm::db::test_util

--- a/silkworm/infra/grpc/client/call.hpp
+++ b/silkworm/infra/grpc/client/call.hpp
@@ -52,7 +52,7 @@ class GrpcStatusError : public std::runtime_error {
 template <class Stub, class Request, class Response>
 Task<Response> unary_rpc(
     agrpc::detail::ClientUnaryRequest<Stub, Request, grpc::ClientAsyncResponseReaderInterface<Response>> rpc,
-    std::unique_ptr<Stub>& stub,
+    Stub& stub,
     Request request,
     agrpc::GrpcContext& grpc_context,
     boost::asio::cancellation_slot* cancellation_slot = nullptr) {
@@ -131,7 +131,7 @@ using DisconnectHook = std::function<Task<void>()>;
 template <class Stub, class Request, class Response>
 Task<Response> unary_rpc_with_retries(
     agrpc::detail::ClientUnaryRequest<Stub, Request, grpc::ClientAsyncResponseReaderInterface<Response>> rpc,
-    std::unique_ptr<Stub>& stub,
+    Stub& stub,
     Request request,
     agrpc::GrpcContext& grpc_context,
     DisconnectHook& on_disconnect,

--- a/silkworm/infra/grpc/client/call_test.cpp
+++ b/silkworm/infra/grpc/client/call_test.cpp
@@ -47,7 +47,7 @@ struct CallTest : public silkworm::test_util::ContextTestBase {
         agrpc::GrpcContext& grpc_context) {
         const auto this_thread_id{std::this_thread::get_id()};
         CHECK(io_context_.get_executor().running_in_this_thread());
-        const auto response = co_await unary_rpc(rpc, stub, request, grpc_context);
+        const auto response = co_await unary_rpc(rpc, *stub, request, grpc_context);
         CHECK(io_context_.get_executor().running_in_this_thread());
         CHECK(this_thread_id == std::this_thread::get_id());
         co_return response;
@@ -138,7 +138,7 @@ TEST_CASE_METHOD(CallTest, "Unary gRPC cancelling: unary_rpc", "[grpc][client]")
 
     // Execute the test: start and then cancel async Version RPC execution
     auto version_reply = spawn(unary_rpc(&proto::KV::StubInterface::AsyncVersion,
-                                         stub,
+                                         *stub,
                                          google::protobuf::Empty{},
                                          grpc_context_,
                                          &cancellation_slot));

--- a/silkworm/infra/grpc/common/errors.cpp
+++ b/silkworm/infra/grpc/common/errors.cpp
@@ -1,0 +1,84 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "errors.hpp"
+
+#include <string>
+
+namespace silkworm::rpc {
+
+// avoid GCC non-virtual-dtor warning
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
+
+// NOLINTNEXTLINE(cppcoreguidelines-virtual-class-destructor)
+class GrpcStatusCodeErrorCategory final : public boost::system::error_category {
+  public:
+    [[nodiscard]] const char* name() const noexcept override {
+        return "rpc::GrpcStatusCodeErrorCategory";
+    };
+
+    [[nodiscard]] std::string message(int ev) const override {
+        switch (static_cast<::grpc::StatusCode>(ev)) {
+            case ::grpc::StatusCode::CANCELLED:
+                return "the operation was cancelled (typically by the caller)";
+            case ::grpc::StatusCode::UNKNOWN:
+                return "unknown error";
+            case ::grpc::StatusCode::INVALID_ARGUMENT:
+                return "client specified an invalid argument";
+            case ::grpc::StatusCode::DEADLINE_EXCEEDED:
+                return "deadline expired before operation could complete";
+            case ::grpc::StatusCode::NOT_FOUND:
+                return "some requested entity was not found";
+            case ::grpc::StatusCode::ALREADY_EXISTS:
+                return "some entity that we attempted to create already exists";
+            case ::grpc::StatusCode::PERMISSION_DENIED:
+                return "the caller does not have permission to execute the specified operation";
+            case ::grpc::StatusCode::UNAUTHENTICATED:
+                return "the request does not have valid authentication credentials for the operation";
+            case ::grpc::StatusCode::RESOURCE_EXHAUSTED:
+                return "some resource has been exhausted";
+            case ::grpc::StatusCode::FAILED_PRECONDITION:
+                return "operation was rejected because the system is not in a state required for the operation execution";
+            case ::grpc::StatusCode::ABORTED:
+                return "the operation was aborted";
+            case ::grpc::StatusCode::OUT_OF_RANGE:
+                return "operation was attempted past the valid range";
+            case ::grpc::StatusCode::UNIMPLEMENTED:
+                return "operation is not implemented or not supported/enabled in this service";
+            case ::grpc::StatusCode::INTERNAL:
+                return "internal error";
+            case ::grpc::StatusCode::UNAVAILABLE:
+                return "the service is currently unavailable";
+            case ::grpc::StatusCode::DATA_LOSS:
+                return "unrecoverable data loss or corruption";
+            default:
+                return "unexpected error occurred";
+        }
+    }
+
+    static GrpcStatusCodeErrorCategory instance;
+};
+
+#pragma GCC diagnostic pop
+
+GrpcStatusCodeErrorCategory GrpcStatusCodeErrorCategory::instance;
+
+boost::system::error_code to_system_code(::grpc::StatusCode status_code) {
+    return {static_cast<int>(status_code), GrpcStatusCodeErrorCategory::instance};
+}
+
+}  // namespace silkworm::rpc

--- a/silkworm/infra/grpc/common/errors.hpp
+++ b/silkworm/infra/grpc/common/errors.hpp
@@ -16,24 +16,13 @@
 
 #pragma once
 
-#include <cstdint>
-#include <string>
-#include <utility>
-#include <vector>
+#include <boost/system/system_error.hpp>
+#include <grpcpp/grpcpp.h>
 
-#include <silkworm/core/common/bytes.hpp>
+namespace silkworm::rpc {
 
-namespace silkworm::db::kv::api {
+//! \details To raise a boost::system::system_error exception:
+//! \code throw boost::system::system_error{rpc::to_system_code(grpc_status_code)};
+boost::system::error_code to_system_code(::grpc::StatusCode);
 
-using TxId = uint64_t;
-using Timestamp = int64_t;
-using TimestampRange = std::pair<Timestamp, Timestamp>;
-
-using ListOfBytes = std::vector<Bytes>;
-using ListOfTimestamp = std::vector<Timestamp>;
-
-using Domain = uint16_t;
-using History = std::string_view;
-using InvertedIndex = std::string_view;
-
-}  // namespace silkworm::db::kv::api
+}  // namespace silkworm::rpc

--- a/silkworm/node/execution/grpc/client/remote_client.cpp
+++ b/silkworm/node/execution/grpc/client/remote_client.cpp
@@ -55,7 +55,7 @@ class RemoteClientImpl final : public api::Service {
     // rpc InsertBlocks(InsertBlocksRequest) returns(InsertionResult);
     Task<api::InsertionResult> insert_blocks(const api::Blocks& blocks) override {
         auto request = insertion_request_from_blocks(blocks);
-        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncInsertBlocks, stub_, std::move(request), grpc_context_);
+        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncInsertBlocks, *stub_, std::move(request), grpc_context_);
         co_return insertion_result_from_response(reply);
     }
 
@@ -64,14 +64,14 @@ class RemoteClientImpl final : public api::Service {
     // rpc ValidateChain(ValidationRequest) returns(ValidationReceipt);
     Task<api::ValidationResult> validate_chain(api::BlockNumAndHash number_and_hash) override {
         auto request = request_from_block_num_and_hash(number_and_hash);
-        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncValidateChain, stub_, std::move(request), grpc_context_);
+        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncValidateChain, *stub_, std::move(request), grpc_context_);
         co_return validation_result_from_response(reply);
     }
 
     // rpc UpdateForkChoice(ForkChoice) returns(ForkChoiceReceipt);
     Task<api::ForkChoiceResult> update_fork_choice(const api::ForkChoice& fork_choice) override {
         auto request = request_from_fork_choice(fork_choice);
-        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncUpdateForkChoice, stub_, std::move(request), grpc_context_);
+        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncUpdateForkChoice, *stub_, std::move(request), grpc_context_);
         co_return fork_choice_result_from_response(reply);
     }
 
@@ -80,14 +80,14 @@ class RemoteClientImpl final : public api::Service {
     // rpc AssembleBlock(AssembleBlockRequest) returns(AssembleBlockResponse);
     Task<api::AssembleBlockResult> assemble_block(const api::BlockUnderConstruction& block) override {
         auto request = assemble_request_from_block(block);
-        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncAssembleBlock, stub_, std::move(request), grpc_context_);
+        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncAssembleBlock, *stub_, std::move(request), grpc_context_);
         co_return assemble_result_from_response(reply);
     }
 
     // rpc GetAssembledBlock(GetAssembledBlockRequest) returns(GetAssembledBlockResponse);
     Task<api::AssembledBlockResult> get_assembled_block(api::PayloadId id) override {
         auto request = get_assembled_request_from_payload_id(id);
-        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncGetAssembledBlock, stub_, std::move(request), grpc_context_);
+        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncGetAssembledBlock, *stub_, std::move(request), grpc_context_);
         co_return get_assembled_result_from_response(reply);
     }
 
@@ -96,35 +96,35 @@ class RemoteClientImpl final : public api::Service {
     // rpc CurrentHeader(google.protobuf.Empty) returns(GetHeaderResponse);
     Task<std::optional<BlockHeader>> current_header() override {
         google::protobuf::Empty request;
-        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncCurrentHeader, stub_, std::move(request), grpc_context_);
+        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncCurrentHeader, *stub_, std::move(request), grpc_context_);
         co_return header_from_response(reply);
     }
 
     // rpc GetTD(GetSegmentRequest) returns(GetTDResponse);
     Task<std::optional<TotalDifficulty>> get_td(api::BlockNumberOrHash number_or_hash) override {
         auto request = request_from_block_number_or_hash(number_or_hash);
-        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncGetTD, stub_, std::move(request), grpc_context_);
+        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncGetTD, *stub_, std::move(request), grpc_context_);
         co_return total_difficulty_from_response(reply);
     }
 
     // rpc GetHeader(GetSegmentRequest) returns(GetHeaderResponse);
     Task<std::optional<BlockHeader>> get_header(api::BlockNumberOrHash number_or_hash) override {
         auto request = request_from_block_number_or_hash(number_or_hash);
-        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncGetHeader, stub_, std::move(request), grpc_context_);
+        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncGetHeader, *stub_, std::move(request), grpc_context_);
         co_return header_from_response(reply);
     }
 
     // rpc GetBody(GetSegmentRequest) returns(GetBodyResponse);
     Task<std::optional<BlockBody>> get_body(api::BlockNumberOrHash number_or_hash) override {
         auto request = request_from_block_number_or_hash(number_or_hash);
-        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncGetBody, stub_, std::move(request), grpc_context_);
+        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncGetBody, *stub_, std::move(request), grpc_context_);
         co_return body_from_response(reply);
     }
 
     // rpc HasBlock(GetSegmentRequest) returns(HasBlockResponse);
     Task<bool> has_block(api::BlockNumberOrHash number_or_hash) override {
         auto request = request_from_block_number_or_hash(number_or_hash);
-        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncHasBlock, stub_, std::move(request), grpc_context_);
+        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncHasBlock, *stub_, std::move(request), grpc_context_);
         co_return reply.has_block();
     }
 
@@ -133,14 +133,14 @@ class RemoteClientImpl final : public api::Service {
     // rpc GetBodiesByRange(GetBodiesByRangeRequest) returns(GetBodiesBatchResponse);
     Task<api::BlockBodies> get_bodies_by_range(BlockNumRange range) override {
         auto request = bodies_request_from_block_range(range);
-        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncGetBodiesByRange, stub_, std::move(request), grpc_context_);
+        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncGetBodiesByRange, *stub_, std::move(request), grpc_context_);
         co_return block_bodies_from_response(reply);
     }
 
     // rpc GetBodiesByHashes(GetBodiesByHashesRequest) returns(GetBodiesBatchResponse);
     Task<api::BlockBodies> get_bodies_by_hashes(const api::BlockHashes& hashes) override {
         auto request = bodies_request_from_block_hashes(hashes);
-        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncGetBodiesByHashes, stub_, std::move(request), grpc_context_);
+        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncGetBodiesByHashes, *stub_, std::move(request), grpc_context_);
         co_return block_bodies_from_response(reply);
     }
 
@@ -149,21 +149,21 @@ class RemoteClientImpl final : public api::Service {
     // rpc IsCanonicalHash(types.H256) returns(IsCanonicalResponse);
     Task<bool> is_canonical_hash(Hash block_hash) override {
         auto request = h256_from_block_hash(block_hash);
-        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncIsCanonicalHash, stub_, std::move(request), grpc_context_);
+        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncIsCanonicalHash, *stub_, std::move(request), grpc_context_);
         co_return reply.canonical();
     }
 
     // rpc GetHeaderHashNumber(types.H256) returns(GetHeaderHashNumberResponse);
     Task<std::optional<BlockNum>> get_header_hash_number(Hash block_hash) override {
         auto request = h256_from_block_hash(block_hash);
-        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncGetHeaderHashNumber, stub_, std::move(request), grpc_context_);
+        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncGetHeaderHashNumber, *stub_, std::move(request), grpc_context_);
         co_return block_number_from_response(reply);
     }
 
     // rpc GetForkChoice(google.protobuf.Empty) returns(ForkChoice);
     Task<api::ForkChoice> get_fork_choice() override {
         google::protobuf::Empty request;
-        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncGetForkChoice, stub_, std::move(request), grpc_context_);
+        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncGetForkChoice, *stub_, std::move(request), grpc_context_);
         co_return fork_choice_from_response(reply);
     }
 
@@ -172,14 +172,14 @@ class RemoteClientImpl final : public api::Service {
     // rpc Ready(google.protobuf.Empty) returns(ReadyResponse);
     Task<bool> ready() override {
         google::protobuf::Empty request;
-        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncReady, stub_, std::move(request), grpc_context_);
+        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncReady, *stub_, std::move(request), grpc_context_);
         co_return reply.ready();
     }
 
     // rpc FrozenBlocks(google.protobuf.Empty) returns(FrozenBlocksResponse);
     Task<uint64_t> frozen_blocks() override {
         google::protobuf::Empty request;
-        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncFrozenBlocks, stub_, std::move(request), grpc_context_);
+        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncFrozenBlocks, *stub_, std::move(request), grpc_context_);
         co_return reply.frozen_blocks();
     }
 

--- a/silkworm/rpc/commands/debug_api_test.cpp
+++ b/silkworm/rpc/commands/debug_api_test.cpp
@@ -38,6 +38,7 @@
 #if !defined(__clang__)
 #include <silkworm/rpc/stagedsync/stages.hpp>
 #endif  // !defined(__clang__)
+#include <silkworm/rpc/test_util/dummy_transaction.hpp>
 
 namespace silkworm::rpc::commands {
 
@@ -211,10 +212,7 @@ class DummyTransaction : public db::kv::api::BaseTransaction {
     }
 
     Task<db::kv::api::PaginatedTimestamps> index_range(db::kv::api::IndexRangeQuery&& query) override {
-        auto paginator = [query = std::move(query)]() mutable -> Task<db::kv::api::PaginatedTimestamps::PageResult> {
-            co_return db::kv::api::PaginatedTimestamps::PageResult{};
-        };
-        co_return db::kv::api::PaginatedTimestamps{std::move(paginator)};
+        co_return db::kv::api::PaginatedTimestamps{test::empty_paginator(std::move(query))};
     }
 
   private:

--- a/silkworm/rpc/commands/debug_api_test.cpp
+++ b/silkworm/rpc/commands/debug_api_test.cpp
@@ -210,6 +210,13 @@ class DummyTransaction : public db::kv::api::BaseTransaction {
         co_return;
     }
 
+    Task<db::kv::api::PaginatedTimestamps> index_range(db::kv::api::IndexRangeQuery&& query) override {
+        auto paginator = [query = std::move(query)]() mutable -> Task<db::kv::api::PaginatedTimestamps::PageResult> {
+            co_return db::kv::api::PaginatedTimestamps::PageResult{};
+        };
+        co_return db::kv::api::PaginatedTimestamps{std::move(paginator)};
+    }
+
   private:
     inline static uint64_t next_tx_id{0};
     inline static uint64_t next_view_id{0};

--- a/silkworm/rpc/core/account_dumper_test.cpp
+++ b/silkworm/rpc/core/account_dumper_test.cpp
@@ -199,6 +199,13 @@ class DummyTransaction : public BaseTransaction {
         co_return;
     }
 
+    Task<db::kv::api::PaginatedTimestamps> index_range(db::kv::api::IndexRangeQuery&& query) override {
+        auto paginator = [query = std::move(query)]() mutable -> Task<db::kv::api::PaginatedTimestamps::PageResult> {
+            co_return db::kv::api::PaginatedTimestamps::PageResult{};
+        };
+        co_return db::kv::api::PaginatedTimestamps{std::move(paginator)};
+    }
+
   private:
     const nlohmann::json& json_;
 };

--- a/silkworm/rpc/core/account_dumper_test.cpp
+++ b/silkworm/rpc/core/account_dumper_test.cpp
@@ -29,6 +29,7 @@
 #include <silkworm/db/kv/api/base_transaction.hpp>
 #include <silkworm/db/kv/api/cursor.hpp>
 #include <silkworm/rpc/ethdb/database.hpp>
+#include <silkworm/rpc/test_util/dummy_transaction.hpp>
 
 namespace silkworm::rpc {
 
@@ -200,10 +201,7 @@ class DummyTransaction : public BaseTransaction {
     }
 
     Task<db::kv::api::PaginatedTimestamps> index_range(db::kv::api::IndexRangeQuery&& query) override {
-        auto paginator = [query = std::move(query)]() mutable -> Task<db::kv::api::PaginatedTimestamps::PageResult> {
-            co_return db::kv::api::PaginatedTimestamps::PageResult{};
-        };
-        co_return db::kv::api::PaginatedTimestamps{std::move(paginator)};
+        co_return db::kv::api::PaginatedTimestamps{test::empty_paginator(std::move(query))};
     }
 
   private:

--- a/silkworm/rpc/core/account_walker_test.cpp
+++ b/silkworm/rpc/core/account_walker_test.cpp
@@ -198,6 +198,13 @@ class DummyTransaction : public BaseTransaction {
         co_return;
     }
 
+    Task<db::kv::api::PaginatedTimestamps> index_range(db::kv::api::IndexRangeQuery&& query) override {
+        auto paginator = [query = std::move(query)]() mutable -> Task<db::kv::api::PaginatedTimestamps::PageResult> {
+            co_return db::kv::api::PaginatedTimestamps::PageResult{};
+        };
+        co_return db::kv::api::PaginatedTimestamps{std::move(paginator)};
+    }
+
   private:
     const nlohmann::json& json_;
 };

--- a/silkworm/rpc/core/account_walker_test.cpp
+++ b/silkworm/rpc/core/account_walker_test.cpp
@@ -31,6 +31,7 @@
 #include <silkworm/db/kv/api/cursor.hpp>
 #include <silkworm/rpc/common/worker_pool.hpp>
 #include <silkworm/rpc/ethdb/database.hpp>
+#include <silkworm/rpc/test_util/dummy_transaction.hpp>
 
 namespace silkworm::rpc {
 
@@ -199,10 +200,7 @@ class DummyTransaction : public BaseTransaction {
     }
 
     Task<db::kv::api::PaginatedTimestamps> index_range(db::kv::api::IndexRangeQuery&& query) override {
-        auto paginator = [query = std::move(query)]() mutable -> Task<db::kv::api::PaginatedTimestamps::PageResult> {
-            co_return db::kv::api::PaginatedTimestamps::PageResult{};
-        };
-        co_return db::kv::api::PaginatedTimestamps{std::move(paginator)};
+        co_return db::kv::api::PaginatedTimestamps{test::empty_paginator(std::move(query))};
     }
 
   private:

--- a/silkworm/rpc/core/storage_walker_test.cpp
+++ b/silkworm/rpc/core/storage_walker_test.cpp
@@ -198,6 +198,13 @@ class DummyTransaction : public BaseTransaction {
         co_return;
     }
 
+    Task<db::kv::api::PaginatedTimestamps> index_range(db::kv::api::IndexRangeQuery&& query) override {
+        auto paginator = [query = std::move(query)]() mutable -> Task<db::kv::api::PaginatedTimestamps::PageResult> {
+            co_return db::kv::api::PaginatedTimestamps::PageResult{};
+        };
+        co_return db::kv::api::PaginatedTimestamps{std::move(paginator)};
+    }
+
   private:
     const nlohmann::json& json_;
 };

--- a/silkworm/rpc/core/storage_walker_test.cpp
+++ b/silkworm/rpc/core/storage_walker_test.cpp
@@ -31,6 +31,7 @@
 #include <silkworm/db/kv/api/cursor.hpp>
 #include <silkworm/rpc/common/worker_pool.hpp>
 #include <silkworm/rpc/ethdb/database.hpp>
+#include <silkworm/rpc/test_util/dummy_transaction.hpp>
 
 namespace silkworm::rpc {
 
@@ -199,10 +200,7 @@ class DummyTransaction : public BaseTransaction {
     }
 
     Task<db::kv::api::PaginatedTimestamps> index_range(db::kv::api::IndexRangeQuery&& query) override {
-        auto paginator = [query = std::move(query)]() mutable -> Task<db::kv::api::PaginatedTimestamps::PageResult> {
-            co_return db::kv::api::PaginatedTimestamps::PageResult{};
-        };
-        co_return db::kv::api::PaginatedTimestamps{std::move(paginator)};
+        co_return db::kv::api::PaginatedTimestamps{test::empty_paginator(std::move(query))};
     }
 
   private:

--- a/silkworm/rpc/test_util/dummy_transaction.hpp
+++ b/silkworm/rpc/test_util/dummy_transaction.hpp
@@ -32,6 +32,12 @@
 
 namespace silkworm::rpc::test {
 
+inline db::kv::api::PaginatedTimestamps::Paginator empty_paginator(db::kv::api::IndexRangeQuery&& query) {
+    return [query = std::move(query)]() mutable -> Task<db::kv::api::PaginatedTimestamps::PageResult> {
+        co_return db::kv::api::PaginatedTimestamps::PageResult{};
+    };
+}
+
 //! This dummy transaction just gives you the same cursor over and over again.
 class DummyTransaction : public db::kv::api::BaseTransaction {
   public:
@@ -65,10 +71,7 @@ class DummyTransaction : public db::kv::api::BaseTransaction {
     Task<void> close() override { co_return; }
 
     Task<db::kv::api::PaginatedTimestamps> index_range(db::kv::api::IndexRangeQuery&& query) override {
-        auto paginator = [query = std::move(query)]() mutable -> Task<db::kv::api::PaginatedTimestamps::PageResult> {
-            co_return db::kv::api::PaginatedTimestamps::PageResult{};
-        };
-        co_return db::kv::api::PaginatedTimestamps{std::move(paginator)};
+        co_return db::kv::api::PaginatedTimestamps{empty_paginator(std::move(query))};
     }
 
   private:

--- a/silkworm/rpc/test_util/dummy_transaction.hpp
+++ b/silkworm/rpc/test_util/dummy_transaction.hpp
@@ -22,46 +22,61 @@
 
 #include <silkworm/infra/concurrency/task.hpp>
 
+#include <silkworm/db/chain/remote_chain_storage.hpp>
 #include <silkworm/db/kv/api/base_transaction.hpp>
 #include <silkworm/db/kv/api/cursor.hpp>
 #include <silkworm/db/state/remote_state.hpp>
 #include <silkworm/rpc/common/util.hpp>
+#include <silkworm/rpc/ethdb/kv/backend_providers.hpp>
+#include <silkworm/rpc/test_util/mock_back_end.hpp>
 
 namespace silkworm::rpc::test {
 
 //! This dummy transaction just gives you the same cursor over and over again.
-class DummyTransaction : public ethdb::BaseTransaction {
+class DummyTransaction : public db::kv::api::BaseTransaction {
   public:
-    explicit DummyTransaction(uint64_t view_id, std::shared_ptr<ethdb::CursorDupSort> cursor)
-        : BaseTransaction(nullptr), view_id_(view_id), cursor_(std::move(cursor)) {}
+    explicit DummyTransaction(uint64_t tx_id,
+                              uint64_t view_id,
+                              std::shared_ptr<db::kv::api::Cursor> cursor,
+                              std::shared_ptr<db::kv::api::CursorDupSort> cursor_dup_sort)
+        : BaseTransaction(nullptr), tx_id_(tx_id), view_id_(view_id), cursor_(std::move(cursor)), cursor_dup_sort_(std::move(cursor_dup_sort)) {}
 
     [[nodiscard]] uint64_t tx_id() const override { return tx_id_; }
     [[nodiscard]] uint64_t view_id() const override { return view_id_; }
 
     Task<void> open() override { co_return; }
 
-    Task<std::shared_ptr<ethdb::Cursor>> cursor(const std::string& /*table*/) override {
+    Task<std::shared_ptr<db::kv::api::Cursor>> cursor(const std::string& /*table*/) override {
         co_return cursor_;
     }
 
-    Task<std::shared_ptr<ethdb::CursorDupSort>> cursor_dup_sort(const std::string& /*table*/) override {
-        co_return cursor_;
+    Task<std::shared_ptr<db::kv::api::CursorDupSort>> cursor_dup_sort(const std::string& /*table*/) override {
+        co_return cursor_dup_sort_;
     }
 
-    std::shared_ptr<silkworm::State> create_state(boost::asio::any_io_executor& executor, const ChainStorage& storage, BlockNum block_number) override {
-        return std::make_shared<silkworm::rpc::state::RemoteState>(executor, *this, storage, block_number);
+    std::shared_ptr<silkworm::State> create_state(boost::asio::any_io_executor& executor, const db::chain::ChainStorage& storage, BlockNum block_number) override {
+        return std::make_shared<db::state::RemoteState>(executor, *this, storage, block_number);
     }
 
-    std::shared_ptr<ChainStorage> create_storage() override {
-        return nullptr;
+    std::shared_ptr<db::chain::ChainStorage> create_storage() override {
+        return std::make_shared<db::chain::RemoteChainStorage>(*this, ethdb::kv::block_provider(&backend_), ethdb::kv::block_number_from_txn_hash_provider(&backend_));
     }
 
     Task<void> close() override { co_return; }
 
+    Task<db::kv::api::PaginatedTimestamps> index_range(db::kv::api::IndexRangeQuery&& query) override {
+        auto paginator = [query = std::move(query)]() mutable -> Task<db::kv::api::PaginatedTimestamps::PageResult> {
+            co_return db::kv::api::PaginatedTimestamps::PageResult{};
+        };
+        co_return db::kv::api::PaginatedTimestamps{std::move(paginator)};
+    }
+
   private:
-    uint64_t tx_id_{1};
+    uint64_t tx_id_;
     uint64_t view_id_;
-    std::shared_ptr<ethdb::CursorDupSort> cursor_;
+    std::shared_ptr<db::kv::api::Cursor> cursor_;
+    std::shared_ptr<db::kv::api::CursorDupSort> cursor_dup_sort_;
+    test::BackEndMock backend_;
 };
 
 }  // namespace silkworm::rpc::test

--- a/silkworm/sentry/grpc/client/sentry_client.cpp
+++ b/silkworm/sentry/grpc/client/sentry_client.cpp
@@ -79,13 +79,13 @@ class SentryClientImpl final : public api::Service {
     // rpc SetStatus(StatusData) returns (SetStatusReply);
     Task<void> set_status(eth::StatusData status_data) override {
         proto::StatusData request = interfaces::proto_status_data_from_status_data(status_data);
-        co_await sw_rpc::unary_rpc_with_retries(&Stub::AsyncSetStatus, stub_, std::move(request), grpc_context_, on_disconnect_, *channel_, "sentry");
+        co_await sw_rpc::unary_rpc_with_retries(&Stub::AsyncSetStatus, *stub_, std::move(request), grpc_context_, on_disconnect_, *channel_, "sentry");
     }
 
     // rpc HandShake(google.protobuf.Empty) returns (HandShakeReply);
     Task<uint8_t> handshake() override {
         google::protobuf::Empty request;
-        proto::HandShakeReply reply = co_await sw_rpc::unary_rpc_with_retries(&Stub::AsyncHandShake, stub_, std::move(request), grpc_context_, on_disconnect_, *channel_, "sentry");
+        proto::HandShakeReply reply = co_await sw_rpc::unary_rpc_with_retries(&Stub::AsyncHandShake, *stub_, std::move(request), grpc_context_, on_disconnect_, *channel_, "sentry");
         uint8_t result = interfaces::eth_version_from_protocol(reply.protocol());
         co_return result;
     }
@@ -93,7 +93,7 @@ class SentryClientImpl final : public api::Service {
     // rpc NodeInfo(google.protobuf.Empty) returns(types.NodeInfoReply);
     Task<NodeInfos> node_infos() override {
         google::protobuf::Empty request;
-        types::NodeInfoReply reply = co_await sw_rpc::unary_rpc_with_retries(&Stub::AsyncNodeInfo, stub_, std::move(request), grpc_context_, on_disconnect_, *channel_, "sentry");
+        types::NodeInfoReply reply = co_await sw_rpc::unary_rpc_with_retries(&Stub::AsyncNodeInfo, *stub_, std::move(request), grpc_context_, on_disconnect_, *channel_, "sentry");
         auto result = interfaces::node_info_from_proto_node_info(reply);
         co_return NodeInfos{result};
     }
@@ -104,7 +104,7 @@ class SentryClientImpl final : public api::Service {
         request.mutable_data()->CopyFrom(interfaces::outbound_data_from_message(message));
         request.mutable_peer_id()->CopyFrom(interfaces::peer_id_from_public_key(public_key));
 
-        proto::SentPeers reply = co_await sw_rpc::unary_rpc_with_retries(&Stub::AsyncSendMessageById, stub_, std::move(request), grpc_context_, on_disconnect_, *channel_, "sentry");
+        proto::SentPeers reply = co_await sw_rpc::unary_rpc_with_retries(&Stub::AsyncSendMessageById, *stub_, std::move(request), grpc_context_, on_disconnect_, *channel_, "sentry");
         auto result = interfaces::peer_keys_from_sent_peers_ids(reply);
         co_return result;
     }
@@ -115,7 +115,7 @@ class SentryClientImpl final : public api::Service {
         request.mutable_data()->CopyFrom(interfaces::outbound_data_from_message(message));
         request.set_max_peers(max_peers);
 
-        proto::SentPeers reply = co_await sw_rpc::unary_rpc_with_retries(&Stub::AsyncSendMessageToRandomPeers, stub_, std::move(request), grpc_context_, on_disconnect_, *channel_, "sentry");
+        proto::SentPeers reply = co_await sw_rpc::unary_rpc_with_retries(&Stub::AsyncSendMessageToRandomPeers, *stub_, std::move(request), grpc_context_, on_disconnect_, *channel_, "sentry");
         auto result = interfaces::peer_keys_from_sent_peers_ids(reply);
         co_return result;
     }
@@ -123,7 +123,7 @@ class SentryClientImpl final : public api::Service {
     // rpc SendMessageToAll(OutboundMessageData) returns (SentPeers);
     Task<PeerKeys> send_message_to_all(Message message) override {
         proto::OutboundMessageData request = interfaces::outbound_data_from_message(message);
-        proto::SentPeers reply = co_await sw_rpc::unary_rpc_with_retries(&Stub::AsyncSendMessageToAll, stub_, std::move(request), grpc_context_, on_disconnect_, *channel_, "sentry");
+        proto::SentPeers reply = co_await sw_rpc::unary_rpc_with_retries(&Stub::AsyncSendMessageToAll, *stub_, std::move(request), grpc_context_, on_disconnect_, *channel_, "sentry");
         auto result = interfaces::peer_keys_from_sent_peers_ids(reply);
         co_return result;
     }
@@ -136,7 +136,7 @@ class SentryClientImpl final : public api::Service {
         // request.set_min_block()
         request.set_max_peers(max_peers);
 
-        proto::SentPeers reply = co_await sw_rpc::unary_rpc_with_retries(&Stub::AsyncSendMessageByMinBlock, stub_, std::move(request), grpc_context_, on_disconnect_, *channel_, "sentry");
+        proto::SentPeers reply = co_await sw_rpc::unary_rpc_with_retries(&Stub::AsyncSendMessageByMinBlock, *stub_, std::move(request), grpc_context_, on_disconnect_, *channel_, "sentry");
         auto result = interfaces::peer_keys_from_sent_peers_ids(reply);
         co_return result;
     }
@@ -147,7 +147,7 @@ class SentryClientImpl final : public api::Service {
         request.mutable_peer_id()->CopyFrom(interfaces::peer_id_from_public_key(public_key));
         // TODO: set_min_block
         // request.set_min_block()
-        co_await sw_rpc::unary_rpc_with_retries(&Stub::AsyncPeerMinBlock, stub_, std::move(request), grpc_context_, on_disconnect_, *channel_, "sentry");
+        co_await sw_rpc::unary_rpc_with_retries(&Stub::AsyncPeerMinBlock, *stub_, std::move(request), grpc_context_, on_disconnect_, *channel_, "sentry");
     }
 
     // rpc Messages(MessagesRequest) returns (stream InboundMessage);
@@ -179,7 +179,7 @@ class SentryClientImpl final : public api::Service {
     // rpc Peers(google.protobuf.Empty) returns (PeersReply);
     Task<PeerInfos> peers() override {
         google::protobuf::Empty request;
-        proto::PeersReply reply = co_await sw_rpc::unary_rpc_with_retries(&Stub::AsyncPeers, stub_, std::move(request), grpc_context_, on_disconnect_, *channel_, "sentry");
+        proto::PeersReply reply = co_await sw_rpc::unary_rpc_with_retries(&Stub::AsyncPeers, *stub_, std::move(request), grpc_context_, on_disconnect_, *channel_, "sentry");
         auto result = interfaces::peer_infos_from_proto_peers_reply(reply);
         co_return result;
     }
@@ -187,7 +187,7 @@ class SentryClientImpl final : public api::Service {
     // rpc PeerCount(PeerCountRequest) returns (PeerCountReply);
     Task<size_t> peer_count() override {
         proto::PeerCountRequest request;
-        proto::PeerCountReply reply = co_await sw_rpc::unary_rpc_with_retries(&Stub::AsyncPeerCount, stub_, std::move(request), grpc_context_, on_disconnect_, *channel_, "sentry");
+        proto::PeerCountReply reply = co_await sw_rpc::unary_rpc_with_retries(&Stub::AsyncPeerCount, *stub_, std::move(request), grpc_context_, on_disconnect_, *channel_, "sentry");
         auto result = static_cast<size_t>(reply.count());
         co_return result;
     }
@@ -196,7 +196,7 @@ class SentryClientImpl final : public api::Service {
     Task<std::optional<PeerInfo>> peer_by_id(EccPublicKey public_key) override {
         proto::PeerByIdRequest request;
         request.mutable_peer_id()->CopyFrom(interfaces::peer_id_from_public_key(public_key));
-        proto::PeerByIdReply reply = co_await sw_rpc::unary_rpc_with_retries(&Stub::AsyncPeerById, stub_, std::move(request), grpc_context_, on_disconnect_, *channel_, "sentry");
+        proto::PeerByIdReply reply = co_await sw_rpc::unary_rpc_with_retries(&Stub::AsyncPeerById, *stub_, std::move(request), grpc_context_, on_disconnect_, *channel_, "sentry");
         auto result = interfaces::peer_info_opt_from_proto_peer_reply(reply);
         co_return result;
     }
@@ -206,7 +206,7 @@ class SentryClientImpl final : public api::Service {
         proto::PenalizePeerRequest request;
         request.mutable_peer_id()->CopyFrom(interfaces::peer_id_from_public_key(public_key));
         request.set_penalty(proto::PenaltyKind::Kick);
-        co_await sw_rpc::unary_rpc_with_retries(&Stub::AsyncPenalizePeer, stub_, std::move(request), grpc_context_, on_disconnect_, *channel_, "sentry");
+        co_await sw_rpc::unary_rpc_with_retries(&Stub::AsyncPenalizePeer, *stub_, std::move(request), grpc_context_, on_disconnect_, *channel_, "sentry");
     }
 
     // rpc PeerEvents(PeerEventsRequest) returns (stream PeerEvent);


### PR DESCRIPTION
This PR implements temporal KV `index_range` API in gRPC client. The following interface changes become necessary:

- first of all, the declaration of such API must be moved from `api::Service` to `api::Transaction`, as the input `api::IndexRangeQuery` always needs to specify the `tx_id`, i.e. the unique identifier of the enclosing db transaction
- then, the return type becomes `api::PaginatedTimestamps`, which is a sequence of timestamps paginated by using the `api::PaginatedSequence<T>` abstraction introduced in #2186

*Extras*
- `cmd`: add `kv_index_range` command in `grpc_toolbox` to allow testing _IndexRange_ KV RPC wrt Erigon3
- `infra`: relax parameter type from `std::unique_ptr<Stub>&` to `Stub&` in `unary_rpc` function to allow easy usage of `::remote::MockKVStub` in unit tests
- `infra`: add utility function translating `::grpc::StatusCode` into `boost::system::error_code`
- `infra`: add utility functions to produce gRPC status codes in unit tests
- `rpc`: refactor `engine_api_test` module to use `DummyTransaction` test utility