### PR TITLE
clang-tidy: fix cppcoreguidelines-prefer-member-initializer

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -29,7 +29,6 @@ Checks: >
   -cppcoreguidelines-missing-std-forward,
   -cppcoreguidelines-non-private-member-variables-in-classes,
   -cppcoreguidelines-owning-memory,
-  -cppcoreguidelines-prefer-member-initializer,
   -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
   -cppcoreguidelines-pro-bounds-constant-array-index,
   -cppcoreguidelines-pro-bounds-pointer-arithmetic,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -26,7 +26,6 @@ Checks: >
   -cppcoreguidelines-avoid-non-const-global-variables,
   -cppcoreguidelines-avoid-reference-coroutine-parameters,
   -cppcoreguidelines-macro-usage,
-  -cppcoreguidelines-macro-to-enum,
   -cppcoreguidelines-missing-std-forward,
   -cppcoreguidelines-non-private-member-variables-in-classes,
   -cppcoreguidelines-owning-memory,

--- a/cmd/state-transition/state_transition.cpp
+++ b/cmd/state-transition/state_transition.cpp
@@ -47,20 +47,15 @@ StateTransition::StateTransition(const std::string& file_path) noexcept {
     auto testObject = baseJson.begin();
     test_name_ = testObject.key();
     test_data_ = testObject.value();
-
-    terminate_on_error_ = false;
-    show_diagnostics_ = false;
 }
 
-StateTransition::StateTransition(const nlohmann::json& json, const bool terminate_on_error, const bool show_diagnostics) noexcept {
+StateTransition::StateTransition(const nlohmann::json& json, const bool terminate_on_error, const bool show_diagnostics) noexcept
+    : terminate_on_error_{terminate_on_error},
+      show_diagnostics_{show_diagnostics} {
     auto testObject = json.begin();
     test_name_ = testObject.key();
     std::cout << test_name_ << ":" << std::endl;
-
     test_data_ = testObject.value();
-
-    terminate_on_error_ = terminate_on_error;
-    show_diagnostics_ = show_diagnostics;
 }
 
 std::string StateTransition::name() {

--- a/cmd/state-transition/state_transition.hpp
+++ b/cmd/state-transition/state_transition.hpp
@@ -36,8 +36,8 @@ class StateTransition {
     std::string test_name_;
     unsigned total_count_{};
     unsigned failed_count_{};
-    bool terminate_on_error_;
-    bool show_diagnostics_;
+    bool terminate_on_error_{false};
+    bool show_diagnostics_{false};
 
     void print_message(const ExpectedState& expected_state, const ExpectedSubState& expected_sub_state, const std::string& message);
     void print_error_message(const ExpectedState& expected_state, const ExpectedSubState& expected_sub_state, const std::string& message);

--- a/cmd/test/backend_kv_test.cpp
+++ b/cmd/test/backend_kv_test.cpp
@@ -94,8 +94,10 @@ class AsyncUnaryCall : public AsyncCall {
     static UnaryStats stats() { return unary_stats_; }
 
     explicit AsyncUnaryCall(grpc::CompletionQueue* queue, StubInterface* stub, CompletionFunc completion_handler = {})
-        : AsyncCall(queue), stub_(stub), completion_handler_(std::move(completion_handler)) {
-        finish_processor_ = [&](bool ok) { process_finish(ok); };
+        : AsyncCall(queue),
+          stub_(stub),
+          finish_processor_([&](bool ok) { process_finish(ok); }),
+          completion_handler_(std::move(completion_handler)) {
     }
 
     void start(const Request& request) {
@@ -164,10 +166,11 @@ class AsyncServerStreamingCall : public AsyncCall {
     static ServerStreamingStats stats() { return server_streaming_stats_; }
 
     explicit AsyncServerStreamingCall(grpc::CompletionQueue* queue, StubInterface* stub)
-        : AsyncCall(queue), stub_(stub) {
-        start_processor_ = [&](bool ok) { process_start(ok); };
-        read_processor_ = [&](bool ok) { process_read(ok); };
-        finish_processor_ = [&](bool ok) { process_finish(ok); };
+        : AsyncCall(queue),
+          start_processor_([&](bool ok) { process_start(ok); }),
+          read_processor_([&](bool ok) { process_read(ok); }),
+          finish_processor_([&](bool ok) { process_finish(ok); }),
+          stub_(stub) {
     }
 
     void start(const Request& request) {
@@ -290,12 +293,13 @@ class AsyncBidirectionalStreamingCall : public AsyncCall {
     static BidirectionalStreamingStats stats() { return bidi_streaming_stats_; }
 
     explicit AsyncBidirectionalStreamingCall(grpc::CompletionQueue* queue, StubInterface* stub)
-        : AsyncCall(queue), stub_(stub) {
-        start_processor_ = [&](bool ok) { process_start(ok); };
-        read_processor_ = [&](bool ok) { process_read(ok); };
-        write_processor_ = [&](bool ok) { process_write(ok); };
-        writes_done_processor_ = [&](bool ok) { process_writes_done(ok); };
-        finish_processor_ = [&](bool ok) { process_finish(ok); };
+        : AsyncCall(queue),
+          start_processor_([&](bool ok) { process_start(ok); }),
+          read_processor_([&](bool ok) { process_read(ok); }),
+          write_processor_([&](bool ok) { process_write(ok); }),
+          writes_done_processor_([&](bool ok) { process_writes_done(ok); }),
+          finish_processor_([&](bool ok) { process_finish(ok); }),
+          stub_(stub) {
     }
 
     void start() {

--- a/silkworm/core/crypto/sha256.c
+++ b/silkworm/core/crypto/sha256.c
@@ -49,8 +49,12 @@
 #define ALWAYS_INLINE
 #endif
 
-#define CHUNK_SIZE 64
-#define TOTAL_LEN_LEN 8
+enum {
+    CHUNK_SIZE = 64
+};
+enum {
+    TOTAL_LEN_LEN = 8
+};
 
 /*
  * Comments from pseudo-code at https://en.wikipedia.org/wiki/SHA-2 are reproduced here.

--- a/silkworm/core/state/intra_block_state.cpp
+++ b/silkworm/core/state/intra_block_state.cpp
@@ -50,11 +50,11 @@ state::Object& IntraBlockState::get_or_create_object(const evmc::address& addres
     auto* obj{get_object(address)};
 
     if (obj == nullptr) {
-        journal_.emplace_back(new state::CreateDelta{address});
+        journal_.emplace_back(std::make_unique<state::CreateDelta>(address));
         obj = &objects_[address];
         obj->current = Account{};
     } else if (obj->current == std::nullopt) {
-        journal_.emplace_back(new state::UpdateDelta{address, *obj});
+        journal_.emplace_back(std::make_unique<state::UpdateDelta>(address, *obj));
         obj->current = Account{};
     }
 
@@ -93,9 +93,9 @@ void IntraBlockState::create_contract(const evmc::address& address) noexcept {
         } else if (prev->initial) {
             prev_incarnation = prev->initial->incarnation;
         }
-        journal_.emplace_back(new state::UpdateDelta{address, *prev});
+        journal_.emplace_back(std::make_unique<state::UpdateDelta>(address, *prev));
     } else {
-        journal_.emplace_back(new state::CreateDelta{address});
+        journal_.emplace_back(std::make_unique<state::CreateDelta>(address));
     }
 
     if (!prev_incarnation || prev_incarnation == 0) {
@@ -112,9 +112,9 @@ void IntraBlockState::create_contract(const evmc::address& address) noexcept {
 
     auto it{storage_.find(address)};
     if (it == storage_.end()) {
-        journal_.emplace_back(new state::StorageCreateDelta{address});
+        journal_.emplace_back(std::make_unique<state::StorageCreateDelta>(address));
     } else {
-        journal_.emplace_back(new state::StorageWipeDelta{address, it->second});
+        journal_.emplace_back(std::make_unique<state::StorageWipeDelta>(address, it->second));
         storage_.erase(address);
     }
 }
@@ -126,14 +126,14 @@ void IntraBlockState::touch(const evmc::address& address) noexcept {
     // and https://github.com/ethereum/EIPs/issues/716
     static constexpr evmc::address kRipemdAddress{0x0000000000000000000000000000000000000003_address};
     if (inserted && address != kRipemdAddress) {
-        journal_.emplace_back(new state::TouchDelta{address});
+        journal_.emplace_back(std::make_unique<state::TouchDelta>(address));
     }
 }
 
 bool IntraBlockState::record_suicide(const evmc::address& address) noexcept {
     const bool inserted{self_destructs_.insert(address).second};
     if (inserted) {
-        journal_.emplace_back(new state::SuicideDelta{address});
+        journal_.emplace_back(std::make_unique<state::SuicideDelta>(address));
     }
     return inserted;
 }
@@ -169,21 +169,21 @@ intx::uint256 IntraBlockState::get_balance(const evmc::address& address) const n
 
 void IntraBlockState::set_balance(const evmc::address& address, const intx::uint256& value) noexcept {
     auto& obj{get_or_create_object(address)};
-    journal_.emplace_back(new state::UpdateBalanceDelta{address, obj.current->balance});
+    journal_.emplace_back(std::make_unique<state::UpdateBalanceDelta>(address, obj.current->balance));
     obj.current->balance = value;
     touch(address);
 }
 
 void IntraBlockState::add_to_balance(const evmc::address& address, const intx::uint256& addend) noexcept {
     auto& obj{get_or_create_object(address)};
-    journal_.emplace_back(new state::UpdateBalanceDelta{address, obj.current->balance});
+    journal_.emplace_back(std::make_unique<state::UpdateBalanceDelta>(address, obj.current->balance));
     obj.current->balance += addend;
     touch(address);
 }
 
 void IntraBlockState::subtract_from_balance(const evmc::address& address, const intx::uint256& subtrahend) noexcept {
     auto& obj{get_or_create_object(address)};
-    journal_.emplace_back(new state::UpdateBalanceDelta{address, obj.current->balance});
+    journal_.emplace_back(std::make_unique<state::UpdateBalanceDelta>(address, obj.current->balance));
     obj.current->balance -= subtrahend;
     touch(address);
 }
@@ -195,7 +195,7 @@ uint64_t IntraBlockState::get_nonce(const evmc::address& address) const noexcept
 
 void IntraBlockState::set_nonce(const evmc::address& address, uint64_t nonce) noexcept {
     auto& obj{get_or_create_object(address)};
-    journal_.emplace_back(new state::UpdateDelta{address, obj});
+    journal_.emplace_back(std::make_unique<state::UpdateDelta>(address, obj));
     obj.current->nonce = nonce;
 }
 
@@ -231,7 +231,7 @@ evmc::bytes32 IntraBlockState::get_code_hash(const evmc::address& address) const
 
 void IntraBlockState::set_code(const evmc::address& address, ByteView code) noexcept {
     auto& obj{get_or_create_object(address)};
-    journal_.emplace_back(new state::UpdateDelta{address, obj});
+    journal_.emplace_back(std::make_unique<state::UpdateDelta>(address, obj));
     obj.current->code_hash = std::bit_cast<evmc_bytes32>(keccak256(code));
 
     // Don't overwrite already existing code so that views of it
@@ -242,7 +242,7 @@ void IntraBlockState::set_code(const evmc::address& address, ByteView code) noex
 evmc_access_status IntraBlockState::access_account(const evmc::address& address) noexcept {
     const bool cold_read{accessed_addresses_.insert(address).second};
     if (cold_read) {
-        journal_.emplace_back(new state::AccountAccessDelta{address});
+        journal_.emplace_back(std::make_unique<state::AccountAccessDelta>(address));
     }
     return cold_read ? EVMC_ACCESS_COLD : EVMC_ACCESS_WARM;
 }
@@ -250,7 +250,7 @@ evmc_access_status IntraBlockState::access_account(const evmc::address& address)
 evmc_access_status IntraBlockState::access_storage(const evmc::address& address, const evmc::bytes32& key) noexcept {
     const bool cold_read{accessed_storage_keys_[address].insert(key).second};
     if (cold_read) {
-        journal_.emplace_back(new state::StorageAccessDelta{address, key});
+        journal_.emplace_back(std::make_unique<state::StorageAccessDelta>(address, key));
     }
     return cold_read ? EVMC_ACCESS_COLD : EVMC_ACCESS_WARM;
 }
@@ -307,7 +307,7 @@ void IntraBlockState::set_storage(const evmc::address& address, const evmc::byte
         return;
     }
     storage_[address].current[key] = value;
-    journal_.emplace_back(new state::StorageChangeDelta{address, key, prev});
+    journal_.emplace_back(std::make_unique<state::StorageChangeDelta>(address, key, prev));
 }
 
 evmc::bytes32 IntraBlockState::get_transient_storage(const evmc::address& addr, const evmc::bytes32& key) {

--- a/silkworm/node/stagedsync/forks/fork.cpp
+++ b/silkworm/node/stagedsync/forks/fork.cpp
@@ -47,9 +47,9 @@ Fork::Fork(BlockId forking_point, db::ROTxnManaged&& main_chain_tx, NodeSettings
       memory_tx_{memory_db_},
       data_model_{memory_tx_},
       pipeline_{&ns},
-      canonical_chain_(memory_tx_) {
-    // actual head
-    current_head_ = forking_point;
+      canonical_chain_(memory_tx_),
+      current_head_{forking_point}  // actual head
+{
     // go down if needed
     if (canonical_chain_.initial_head() != forking_point) {
         reduce_down_to(forking_point);

--- a/silkworm/node/stagedsync/stages/stage_bodies.cpp
+++ b/silkworm/node/stagedsync/stages/stage_bodies.cpp
@@ -32,9 +32,9 @@ BodiesStage::BodyDataModel::BodyDataModel(db::RWTxn& tx, BlockNum bodies_stage_h
       data_model_(tx_),
       chain_config_{chain_config},
       rule_set_{protocol::rule_set_factory(chain_config)},
-      chain_state_{tx} {
-    initial_height_ = bodies_stage_height;
-    highest_height_ = bodies_stage_height;
+      chain_state_{tx},
+      initial_height_{bodies_stage_height},
+      highest_height_{bodies_stage_height} {
 }
 
 BlockNum BodiesStage::BodyDataModel::initial_height() const { return initial_height_; }

--- a/silkworm/node/stagedsync/stages/stage_headers.cpp
+++ b/silkworm/node/stagedsync/stages/stage_headers.cpp
@@ -30,7 +30,8 @@
 
 namespace silkworm::stagedsync {
 
-HeadersStage::HeaderDataModel::HeaderDataModel(db::RWTxn& tx, BlockNum headers_height) : tx_(tx), data_model_(tx) {
+HeadersStage::HeaderDataModel::HeaderDataModel(db::RWTxn& tx, BlockNum headers_height)
+    : tx_(tx), data_model_(tx), previous_height_(headers_height) {
     auto headers_hash = db::read_canonical_hash(tx, headers_height);
     ensure(headers_hash.has_value(),
            [&]() { return "Headers stage, inconsistent canonical table: not found hash at height " + std::to_string(headers_height); });
@@ -42,7 +43,6 @@ HeadersStage::HeaderDataModel::HeaderDataModel(db::RWTxn& tx, BlockNum headers_h
 
     previous_hash_ = *headers_hash;
     previous_td_ = *headers_head_td;
-    previous_height_ = headers_height;
 }
 
 BlockNum HeadersStage::HeaderDataModel::highest_height() const { return previous_height_; }

--- a/silkworm/rpc/commands/ots_api.cpp
+++ b/silkworm/rpc/commands/ots_api.cpp
@@ -932,11 +932,12 @@ Task<ChunkProviderResponse> ChunkProvider::get() {
     co_return ChunkProviderResponse{key_value.value, true, false};
 }
 
-ChunkProvider::ChunkProvider(db::kv::api::Cursor* cursor, const evmc::address& address, bool navigate_forward, db::kv::api::KeyValue first_seek_key_value) {
-    cursor_ = cursor;
-    address_ = address;
-    navigate_forward_ = navigate_forward;
-    first_seek_key_value_ = std::move(first_seek_key_value);
+ChunkProvider::ChunkProvider(db::kv::api::Cursor* cursor, const evmc::address& address,
+                             bool navigate_forward, db::kv::api::KeyValue first_seek_key_value)
+    : cursor_{cursor},
+      address_{address},
+      navigate_forward_{navigate_forward},
+      first_seek_key_value_{std::move(first_seek_key_value)} {
 }
 
 Task<ChunkLocatorResponse> ChunkLocator::get(BlockNum min_block) {
@@ -955,10 +956,10 @@ Task<ChunkLocatorResponse> ChunkLocator::get(BlockNum min_block) {
     }
 }
 
-ChunkLocator::ChunkLocator(db::kv::api::Cursor* cursor, const evmc::address& address, bool navigate_forward) {
-    cursor_ = cursor;
-    address_ = address;
-    navigate_forward_ = navigate_forward;
+ChunkLocator::ChunkLocator(db::kv::api::Cursor* cursor, const evmc::address& address, bool navigate_forward)
+    : cursor_{cursor},
+      address_{address},
+      navigate_forward_{navigate_forward} {
 }
 
 Task<BlockProviderResponse> ForwardBlockProvider::get() {
@@ -1257,11 +1258,10 @@ Task<BlockProviderResponse> FromToBlockProvider::get() {
     co_return BlockProviderResponse{block_num, has_more_from_ || has_more_to_, false};
 }
 
-FromToBlockProvider::FromToBlockProvider(bool is_backwards, BlockProvider* callFromProvider, BlockProvider* callToProvider) {
-    is_backwards_ = is_backwards;
-    callFromProvider_ = callFromProvider;
-    callToProvider_ = callToProvider;
-    initialized_ = false;
+FromToBlockProvider::FromToBlockProvider(bool is_backwards, BlockProvider* callFromProvider, BlockProvider* callToProvider)
+    : is_backwards_{is_backwards},
+      callFromProvider_{callFromProvider},
+      callToProvider_{callToProvider} {
 }
 
 }  // namespace silkworm::rpc::commands

--- a/silkworm/rpc/commands/ots_api.hpp
+++ b/silkworm/rpc/commands/ots_api.hpp
@@ -122,10 +122,12 @@ class ForwardBlockProvider : public BlockProvider {
     void advance_if_needed(BlockNum min_block);
 
   public:
-    ForwardBlockProvider(db::kv::api::Cursor* cursor, const evmc::address& address, BlockNum min_block) : chunk_locator_(cursor, address, true), chunk_provider_() {
-        cursor_ = cursor;
-        address_ = address;
-        min_block_ = min_block;
+    ForwardBlockProvider(db::kv::api::Cursor* cursor, const evmc::address& address, BlockNum min_block)
+        : cursor_(cursor),
+          address_(address),
+          min_block_(min_block),
+          chunk_locator_(cursor, address, true),
+          chunk_provider_() {
     }
 
     Task<BlockProviderResponse> get() override;
@@ -153,11 +155,12 @@ class BackwardBlockProvider : public BlockProvider {
     void reverse_iterator(roaring::Roaring64Map& bitmap);
 
   public:
-    BackwardBlockProvider(db::kv::api::Cursor* cursor, const evmc::address& address, BlockNum max_block) : chunk_locator_(cursor, address, false), chunk_provider_() {
-        cursor_ = cursor;
-        address_ = address;
-        max_block_ = max_block;
-
+    BackwardBlockProvider(db::kv::api::Cursor* cursor, const evmc::address& address, BlockNum max_block)
+        : cursor_(cursor),
+          address_(address),
+          max_block_(max_block),
+          chunk_locator_(cursor, address, false),
+          chunk_provider_() {
         if (max_block_ == 0) {
             max_block_ = std::numeric_limits<BlockNum>::max();
         }

--- a/silkworm/rpc/ethdb/split_cursor.cpp
+++ b/silkworm/rpc/ethdb/split_cursor.cpp
@@ -20,9 +20,12 @@ namespace silkworm::rpc::ethdb {
 
 SplitCursor::SplitCursor(Cursor& inner_cursor, ByteView key, uint64_t match_bits, uint64_t part1_end,
                          uint64_t part2_start, uint64_t part3_start)
-    : inner_cursor_{inner_cursor}, key_{key}, part1_end_{part1_end}, part2_start_{part2_start}, part3_start_{part3_start} {
-    match_bytes_ = (match_bits + 7) / 8;
-
+    : inner_cursor_{inner_cursor},
+      key_{key},
+      part1_end_{part1_end},
+      part2_start_{part2_start},
+      part3_start_{part3_start},
+      match_bytes_{(match_bits + 7) / 8} {
     uint8_t shift_bits = match_bits & 7;
     if (shift_bits != 0) {
         mask_ = static_cast<uint8_t>(0xff << (8 - shift_bits));
@@ -88,9 +91,12 @@ SplittedKeyValue SplitCursor::split_key_value(const KeyValue& kv) {
 
 SplitCursorDupSort::SplitCursorDupSort(CursorDupSort& inner_cursor, ByteView key, ByteView subkey,
                                        uint64_t match_bits, uint64_t part1_end, uint64_t value_offset)
-    : inner_cursor_{inner_cursor}, key_{key}, subkey_{subkey}, part1_end_{part1_end}, value_offset_{value_offset} {
-    match_bytes_ = (match_bits + 7) / 8;
-
+    : inner_cursor_{inner_cursor},
+      key_{key},
+      subkey_{subkey},
+      part1_end_{part1_end},
+      match_bytes_{(match_bits + 7) / 8},
+      value_offset_{value_offset} {
     uint8_t shift_bits = match_bits & 7;
     if (shift_bits != 0) {
         mask_ = static_cast<uint8_t>(0xff << (8 - shift_bits));

--- a/silkworm/sync/internals/chain_elements.hpp
+++ b/silkworm/sync/internals/chain_elements.hpp
@@ -42,11 +42,11 @@ struct Link {
     bool persisted = false;                   // Whether this link comes from the database record
     bool preverified = false;                 // Ancestor of pre-verified header
 
-    Link(BlockHeader h, bool persisted_) {
-        blockHeight = h.number;
-        hash = h.hash();  // save computation
+    Link(BlockHeader h, bool persisted_)
+        : blockHeight{h.number},
+          hash{h.hash()},  // save computation
+          persisted{persisted_} {
         header = std::make_shared<BlockHeader>(std::move(h));
-        persisted = persisted_;
     }
 
     void remove_child(const Link& child) {
@@ -71,12 +71,12 @@ struct Anchor {
     BlockNum lastLinkHeight{0};                // the blockHeight of the last link of the chain bundle anchored to this
     PeerId peerId;
 
-    Anchor(const BlockHeader& header, PeerId p) {
-        parentHash = header.parent_hash;
-        blockHeight = header.number;
-        lastLinkHeight = blockHeight;
-        // timestamp = 0;  // ready to get extended
-        peerId = std::move(p);
+    Anchor(const BlockHeader& header, PeerId p)
+        : parentHash{header.parent_hash},
+          blockHeight{header.number},
+          lastLinkHeight{blockHeight},
+          // timestamp{0},  // ready to get extended
+          peerId{std::move(p)} {
     }
 
     BlockNum chainLength() const { return lastLinkHeight - blockHeight + 1; }

--- a/silkworm/sync/messages/inbound_new_block.cpp
+++ b/silkworm/sync/messages/inbound_new_block.cpp
@@ -25,8 +25,9 @@
 namespace silkworm {
 
 InboundNewBlock::InboundNewBlock(ByteView data, PeerId peer_id)
-    : peerId_(std::move(peer_id)) {
-    reqId_ = Singleton<RandomNumber>::instance().generate_one();  // for trace purposes
+    : peerId_(std::move(peer_id)),
+      reqId_(Singleton<RandomNumber>::instance().generate_one())  // for trace purposes
+{
     success_or_throw(rlp::decode(data, packet_));
     SILK_TRACE << "Received message " << *this;
 }

--- a/silkworm/sync/messages/inbound_new_block_hashes.cpp
+++ b/silkworm/sync/messages/inbound_new_block_hashes.cpp
@@ -31,8 +31,9 @@
 namespace silkworm {
 
 InboundNewBlockHashes::InboundNewBlockHashes(ByteView data, PeerId peer_id)
-    : peerId_(std::move(peer_id)) {
-    reqId_ = Singleton<RandomNumber>::instance().generate_one();  // for trace purposes
+    : peerId_(std::move(peer_id)),
+      reqId_(Singleton<RandomNumber>::instance().generate_one())  // for trace purposes
+{
     success_or_throw(rlp::decode(data, packet_));
     SILK_TRACE << "Received message " << *this;
 }


### PR DESCRIPTION
and also cppcoreguidelines-macro-to-enum