### PR TITLE
db: temporal KV client history_range API via gRPC

### DIFF
--- a/cmd/dev/grpc_toolbox.cpp
+++ b/cmd/dev/grpc_toolbox.cpp
@@ -693,6 +693,7 @@ ABSL_FLAG(std::string, subkey, "", "subkey as hex string w/o leading 0x");
 ABSL_FLAG(std::string, tool, "", "gRPC remote interface tool name as string");
 ABSL_FLAG(std::string, target, kDefaultPrivateApiAddr, "Silkworm location as string <address>:<port>");
 ABSL_FLAG(std::string, table, "", "database table name as string");
+ABSL_FLAG(int, limit, -1, "max number of items returned by Temporal KV range queries");
 ABSL_FLAG(uint32_t, timeout, kDefaultTimeout.count(), "gRPC call timeout as integer");
 ABSL_FLAG(bool, verbose, false, "verbose output");
 
@@ -873,7 +874,39 @@ Task<void> kv_index_range_query(const std::shared_ptr<db::kv::api::Service>& kv_
     }
 }
 
-int kv_index_range_coro(const std::string& target, const std::string& table, const Bytes& key, const bool verbose) {
+Task<void> kv_history_range_query(const std::shared_ptr<db::kv::api::Service>& kv_service,
+                                  db::kv::api::HistoryRangeQuery&& query,
+                                  const bool verbose) {
+    try {
+        auto tx = co_await kv_service->begin_transaction();
+        std::cout << "KV HistoryRange -> " << query.table << " limit=" << query.limit << "\n";
+        auto paginated_result = co_await tx->history_range(std::move(query));
+        auto it = co_await paginated_result.begin();
+        std::cout << "KV HistoryRange <- #keys and #values: ";
+        int count{0};
+        std::vector<db::kv::api::KeyValue> keys_and_values;
+        while (it != paginated_result.end()) {
+            keys_and_values.emplace_back(*it);
+            ++count;
+            co_await ++it;
+        }
+        std::cout << count << "\n";
+        if (verbose) {
+            for (const auto& key_value_pair : keys_and_values) {
+                std::cout << "k=" << to_hex(key_value_pair.key) << " v=" << to_hex(key_value_pair.value) << "\n";
+            }
+        }
+        co_await tx->close();
+    } catch (const std::exception& e) {
+        std::cout << "KV HistoryRange <- error: " << e.what() << "\n";
+    }
+}
+
+template <typename Q>
+using TKVQueryFunc = Task<void> (*)(const std::shared_ptr<db::kv::api::Service>&, Q&&, bool);
+
+template <typename Q>
+int execute_temporal_kv_query(const std::string& target, TKVQueryFunc<Q> query_func, Q&& query, const bool verbose) {
     try {
         ClientContextPool context_pool{1};
         auto& context = context_pool.next_context();
@@ -901,15 +934,9 @@ int kv_index_range_coro(const std::string& target, const std::string& table, con
                                                   rpc::ethdb::kv::block_provider(&eth_backend),
                                                   rpc::ethdb::kv::block_number_from_txn_hash_provider(&eth_backend)};
         auto kv_service = client.service();
-        db::kv::api::IndexRangeQuery query{
-            .table = table,
-            .key = key,
-            .from_timestamp = 0,
-            .to_timestamp = -1,
-            .ascending_order = true,
-        };
+
         // NOLINTNEXTLINE(performance-unnecessary-value-param)
-        boost::asio::co_spawn(*io_context, kv_index_range_query(kv_service, std::move(query), verbose), [&](std::exception_ptr) {
+        boost::asio::co_spawn(*io_context, query_func(kv_service, std::forward<Q>(query), verbose), [&](std::exception_ptr) {
             context_pool.stop();
         });
 
@@ -926,7 +953,7 @@ int kv_index_range() {
     const auto target{absl::GetFlag(FLAGS_target)};
     if (target.empty() || !absl::StrContains(target, ":")) {
         std::cerr << "Parameter target is invalid: [" << target << "]\n";
-        std::cerr << "Use --target flag to specify the location of Erigon running instance\n";
+        std::cerr << "Use --target flag to specify the location of Erigon running instance in <host>:<port> format\n";
         return -1;
     }
 
@@ -941,13 +968,61 @@ int kv_index_range() {
     const auto key_bytes = silkworm::from_hex(key);
     if (key.empty() || !key_bytes.has_value()) {
         std::cerr << "Parameter key is invalid: [" << key << "]\n";
-        std::cerr << "Use --key flag to specify the key in key-value dupsort table\n";
+        std::cerr << "Use --key flag to specify the start key in key-value table as hex string\n";
+        return -1;
+    }
+
+    const auto limit{absl::GetFlag(FLAGS_limit)};
+    if (limit < -1) {
+        std::cerr << "Parameter limit is invalid: [" << limit << "]\n";
+        std::cerr << "Use --limit flag to specify the max number of items returned by TKV queries (-1 means no limit)\n";
         return -1;
     }
 
     const auto verbose{absl::GetFlag(FLAGS_verbose)};
 
-    return kv_index_range_coro(target, table_name, *key_bytes, verbose);
+    db::kv::api::IndexRangeQuery query{
+        .table = table_name,
+        .key = *key_bytes,
+        .from_timestamp = 0,
+        .to_timestamp = -1,
+        .ascending_order = true,
+        .limit = limit};
+    return execute_temporal_kv_query(target, kv_index_range_query, std::move(query), verbose);
+}
+
+int kv_history_range() {
+    const auto target{absl::GetFlag(FLAGS_target)};
+    if (target.empty() || !absl::StrContains(target, ":")) {
+        std::cerr << "Parameter target is invalid: [" << target << "]\n";
+        std::cerr << "Use --target flag to specify the location of Erigon running instance in <host>:<port> format\n";
+        return -1;
+    }
+
+    const auto table_name{absl::GetFlag(FLAGS_table)};
+    if (table_name.empty()) {
+        std::cerr << "Parameter table is invalid: [" << table_name << "]\n";
+        std::cerr << "Use --table flag to specify the name of Erigon database table\n";
+        return -1;
+    }
+
+    const auto limit{absl::GetFlag(FLAGS_limit)};
+    if (limit < -1) {
+        std::cerr << "Parameter limit is invalid: [" << limit << "]\n";
+        std::cerr << "Use --limit flag to specify the max number of items returned by TKV queries (-1 means no limit)\n";
+        return -1;
+    }
+
+    const auto verbose{absl::GetFlag(FLAGS_verbose)};
+
+    db::kv::api::HistoryRangeQuery query{
+        .table = table_name,
+        .from_timestamp = 0,
+        .to_timestamp = -1,  // 1'000'000
+        .ascending_order = true,
+        .limit = limit,
+    };
+    return execute_temporal_kv_query(target, kv_history_range_query, std::move(query), verbose);
 }
 
 int main(int argc, char* argv[]) {
@@ -960,7 +1035,8 @@ int main(int argc, char* argv[]) {
         "\tkv_seek_async\t\t\tquery using SEEK the Erigon/Silkworm Key-Value (KV) remote interface to database\n"
         "\tkv_seek_async_callback\t\tquery using SEEK the Erigon/Silkworm Key-Value (KV) remote interface to database\n"
         "\tkv_seek_both\t\t\tquery using SEEK_BOTH the Erigon/Silkworm Key-Value (KV) remote interface to database\n"
-        "\tkv_index_range\t\tquery using INDEX_RANGE the Erigon/Silkworm Key-Value (KV) remote interface to database\n");
+        "\tkv_index_range\t\tquery using INDEX_RANGE the Erigon/Silkworm Key-Value (KV) remote interface to database\n"
+        "\tkv_history_range\t\tquery using HISTORY_RANGE the Erigon/Silkworm Key-Value (KV) remote interface to database\n");
     const auto positional_args = absl::ParseCommandLine(argc, argv);
     if (positional_args.size() < 2) {
         std::cerr << "No gRPC tool specified as first positional argument\n\n";
@@ -994,6 +1070,9 @@ int main(int argc, char* argv[]) {
     }
     if (tool == "kv_index_range") {
         return kv_index_range();
+    }
+    if (tool == "kv_history_range") {
+        return kv_history_range();
     }
 
     std::cerr << "Unknown tool " << tool << " specified as first argument\n\n";

--- a/silkworm/core/common/bytes_to_string.hpp
+++ b/silkworm/core/common/bytes_to_string.hpp
@@ -39,6 +39,7 @@ ByteView array_to_byte_view(const std::array<unsigned char, Size>& array) {
     return ByteView{reinterpret_cast<const uint8_t*>(array.data()), Size};
 }
 
+inline std::string bytes_to_string(Bytes b) { return {b.begin(), b.end()}; }
 inline std::string_view byte_view_to_string_view(ByteView v) { return {byte_ptr_cast(v.data()), v.length()}; }
 
 }  // namespace silkworm

--- a/silkworm/db/kv/api/direct_service.cpp
+++ b/silkworm/db/kv/api/direct_service.cpp
@@ -74,12 +74,6 @@ Task<DomainPointResult> DirectService::get_domain(const DomainPointQuery&) {
 
 /** Temporal Range Queries **/
 
-// rpc HistoryRange(HistoryRangeReq) returns (Pairs);
-Task<HistoryRangeResult> DirectService::get_history_range(const HistoryRangeQuery&) {
-    // TODO(canepat) implement
-    co_return HistoryRangeResult{};
-}
-
 // rpc DomainRange(DomainRangeReq) returns (Pairs);
 Task<DomainRangeResult> DirectService::get_domain_range(const DomainRangeQuery&) {
     // TODO(canepat) implement

--- a/silkworm/db/kv/api/direct_service.hpp
+++ b/silkworm/db/kv/api/direct_service.hpp
@@ -56,9 +56,6 @@ class DirectService : public Service {
 
     /** Temporal Range Queries **/
 
-    // rpc HistoryRange(HistoryRangeReq) returns (Pairs);
-    Task<HistoryRangeResult> get_history_range(const HistoryRangeQuery&) override;
-
     // rpc DomainRange(DomainRangeReq) returns (Pairs);
     Task<DomainRangeResult> get_domain_range(const DomainRangeQuery&) override;
 

--- a/silkworm/db/kv/api/endpoint/key_value.hpp
+++ b/silkworm/db/kv/api/endpoint/key_value.hpp
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <tuple>
+
 #include <silkworm/core/common/bytes.hpp>
 
 namespace silkworm::db::kv::api {
@@ -23,6 +25,17 @@ namespace silkworm::db::kv::api {
 struct KeyValue {
     Bytes key;
     Bytes value;
+
+    constexpr KeyValue() noexcept = default;
+
+    constexpr KeyValue(Bytes k, Bytes v) : key{std::move(k)}, value{std::move(v)} {}
+
+    // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
+    constexpr KeyValue(Bytes k) : key{std::move(k)} {}
+
+    // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
+    constexpr KeyValue(std::pair<Bytes, Bytes> kv_pair)
+        : key{std::move(kv_pair.first)}, value{std::move(kv_pair.second)} {}
 };
 
 inline bool operator<(const KeyValue& lhs, const KeyValue& rhs) {

--- a/silkworm/db/kv/api/endpoint/key_value.hpp
+++ b/silkworm/db/kv/api/endpoint/key_value.hpp
@@ -26,15 +26,15 @@ struct KeyValue {
     Bytes key;
     Bytes value;
 
-    constexpr KeyValue() noexcept = default;
+    KeyValue() noexcept = default;
 
-    constexpr KeyValue(Bytes k, Bytes v) : key{std::move(k)}, value{std::move(v)} {}
-
-    // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    constexpr KeyValue(Bytes k) : key{std::move(k)} {}
+    KeyValue(Bytes k, Bytes v) : key{std::move(k)}, value{std::move(v)} {}
 
     // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
-    constexpr KeyValue(std::pair<Bytes, Bytes> kv_pair)
+    KeyValue(Bytes k) : key{std::move(k)} {}
+
+    // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
+    KeyValue(std::pair<Bytes, Bytes> kv_pair)
         : key{std::move(kv_pair.first)}, value{std::move(kv_pair.second)} {}
 };
 

--- a/silkworm/db/kv/api/endpoint/paginated_sequence.hpp
+++ b/silkworm/db/kv/api/endpoint/paginated_sequence.hpp
@@ -25,6 +25,8 @@
 
 #include <silkworm/infra/common/ensure.hpp>
 
+#include "key_value.hpp"
+
 namespace silkworm::db::kv::api {
 
 //! Sequence of values produced by pagination using some asynchronous page provider function.
@@ -178,8 +180,8 @@ class PaginatedSequencePair {
 };
 
 template <typename K, typename V>
-Task<std::vector<std::pair<K, V>>> paginated_to_vector(PaginatedSequencePair<K, V>& paginated) {
-    std::vector<std::pair<K, V>> all_keys_and_values;
+Task<std::vector<KeyValue>> paginated_to_vector(PaginatedSequencePair<K, V>& paginated) {
+    std::vector<KeyValue> all_keys_and_values;
     auto it = co_await paginated.begin();
     while (it != paginated.end()) {
         all_keys_and_values.emplace_back(*it);

--- a/silkworm/db/kv/api/endpoint/paginated_sequence.hpp
+++ b/silkworm/db/kv/api/endpoint/paginated_sequence.hpp
@@ -18,9 +18,12 @@
 
 #include <functional>
 #include <optional>
+#include <tuple>
 #include <vector>
 
 #include <silkworm/infra/concurrency/task.hpp>
+
+#include <silkworm/infra/common/ensure.hpp>
 
 namespace silkworm::db::kv::api {
 
@@ -97,6 +100,92 @@ Task<std::vector<T>> paginated_to_vector(PaginatedSequence<T>& paginated) {
         co_await ++it;
     }
     co_return all_values;
+}
+
+//! Sequence of keys and values produced by pagination using some asynchronous page provider function.
+template <typename K, typename V>
+class PaginatedSequencePair {
+  public:
+    using KPage = std::vector<K>;
+    using VPage = std::vector<V>;
+    struct PageResult {
+        KPage keys;
+        VPage values;
+        bool has_more{false};
+    };
+    using Paginator = std::function<Task<PageResult>()>;
+
+    class Iterator {
+      public:
+        std::pair<K, V> operator*() {
+            return {std::move(*key_it_), std::move(*value_it_)};
+        }
+
+        Task<void> operator++() {
+            ++key_it_;
+            ++value_it_;
+            if (key_it_ == current_.keys.cend()) {
+                SILKWORM_ASSERT(value_it_ == current_.values.cend());
+                if (current_.has_more) {
+                    current_ = co_await next_page_provider_();
+                    key_it_ = current_.keys.cbegin();
+                    value_it_ = current_.values.cbegin();
+                } else {
+                    key_it_ = typename KPage::const_iterator();    // empty i.e. sentinel value
+                    value_it_ = typename VPage::const_iterator();  // empty i.e. sentinel value
+                }
+            }
+        }
+
+        bool operator==(const Iterator& other) const noexcept {
+            return key_it_ == other.key_it_ && value_it_ == other.value_it_;
+        }
+
+        bool operator!=(const Iterator& other) const noexcept {
+            return !(*this == other);
+        }
+
+        Iterator(Paginator& next_page_provider, PageResult current) noexcept
+            : next_page_provider_(next_page_provider),
+              current_(std::move(current)),
+              key_it_{current_.keys.cbegin()},
+              value_it_{current_.values.cbegin()} {}
+        explicit Iterator(Paginator& next_page_provider) noexcept
+            : next_page_provider_(next_page_provider) {}
+
+      private:
+        Paginator& next_page_provider_;
+        PageResult current_;
+        typename KPage::const_iterator key_it_;    // empty i.e. sentinel value
+        typename VPage::const_iterator value_it_;  // empty i.e. sentinel value
+    };
+
+    explicit PaginatedSequencePair(Paginator next_page_provider) noexcept
+        : next_page_provider_(std::move(next_page_provider)) {}
+
+    Task<Iterator> begin() {
+        auto current = co_await next_page_provider_();
+        ensure(current.keys.size() == current.values.size(), "PaginatedSequencePair::begin keys/values size mismatch");
+        co_return Iterator{next_page_provider_, std::move(current)};
+    }
+
+    Iterator end() noexcept {
+        return Iterator{next_page_provider_};
+    }
+
+  private:
+    Paginator next_page_provider_;
+};
+
+template <typename K, typename V>
+Task<std::vector<std::pair<K, V>>> paginated_to_vector(PaginatedSequencePair<K, V>& paginated) {
+    std::vector<std::pair<K, V>> all_keys_and_values;
+    auto it = co_await paginated.begin();
+    while (it != paginated.end()) {
+        all_keys_and_values.emplace_back(*it);
+        co_await ++it;
+    }
+    co_return all_keys_and_values;
 }
 
 }  // namespace silkworm::db::kv::api

--- a/silkworm/db/kv/api/endpoint/temporal_range.hpp
+++ b/silkworm/db/kv/api/endpoint/temporal_range.hpp
@@ -79,5 +79,6 @@ struct DomainRangeQuery {
 using DomainRangeResult = RangeResult;
 
 using PaginatedTimestamps = PaginatedSequence<Timestamp>;
+using PaginatedKeysValues = PaginatedSequencePair<Bytes, Bytes>;
 
 }  // namespace silkworm::db::kv::api

--- a/silkworm/db/kv/api/local_transaction.cpp
+++ b/silkworm/db/kv/api/local_transaction.cpp
@@ -77,4 +77,13 @@ Task<PaginatedTimestamps> LocalTransaction::index_range(api::IndexRangeQuery&& /
     co_return api::PaginatedTimestamps{std::move(paginator)};
 }
 
+// NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
+Task<PaginatedKeysValues> LocalTransaction::history_range(HistoryRangeQuery&& /*query*/) {
+    // TODO(canepat) implement using E3-like aggregator abstraction [tx_id_ must be changed]
+    auto paginator = []() mutable -> Task<api::PaginatedKeysValues::PageResult> {
+        co_return api::PaginatedKeysValues::PageResult{};
+    };
+    co_return api::PaginatedKeysValues{std::move(paginator)};
+}
+
 }  // namespace silkworm::db::kv::api

--- a/silkworm/db/kv/api/local_transaction.hpp
+++ b/silkworm/db/kv/api/local_transaction.hpp
@@ -58,6 +58,9 @@ class LocalTransaction : public BaseTransaction {
     // rpc IndexRange(IndexRangeReq) returns (IndexRangeReply);
     Task<PaginatedTimestamps> index_range(IndexRangeQuery&& query) override;
 
+    // rpc HistoryRange(HistoryRangeReq) returns (Pairs);
+    Task<PaginatedKeysValues> history_range(HistoryRangeQuery&& query) override;
+
   private:
     Task<std::shared_ptr<CursorDupSort>> get_cursor(const std::string& table, bool is_cursor_dup_sort);
 

--- a/silkworm/db/kv/api/service.hpp
+++ b/silkworm/db/kv/api/service.hpp
@@ -48,9 +48,6 @@ struct Service {
 
     /** Temporal Range Queries **/
 
-    // rpc HistoryRange(HistoryRangeReq) returns (Pairs);
-    virtual Task<HistoryRangeResult> get_history_range(const HistoryRangeQuery&) = 0;
-
     // rpc DomainRange(DomainRangeReq) returns (Pairs);
     virtual Task<DomainRangeResult> get_domain_range(const DomainRangeQuery&) = 0;
 };

--- a/silkworm/db/kv/api/transaction.hpp
+++ b/silkworm/db/kv/api/transaction.hpp
@@ -69,6 +69,9 @@ class Transaction {
 
     // rpc IndexRange(IndexRangeReq) returns (IndexRangeReply);
     virtual Task<PaginatedTimestamps> index_range(IndexRangeQuery&& query) = 0;
+
+    // rpc HistoryRange(HistoryRangeReq) returns (Pairs);
+    virtual Task<PaginatedKeysValues> history_range(HistoryRangeQuery&& query) = 0;
 };
 
 }  // namespace silkworm::db::kv::api

--- a/silkworm/db/kv/grpc/client/endpoint/temporal_range.cpp
+++ b/silkworm/db/kv/grpc/client/endpoint/temporal_range.cpp
@@ -16,6 +16,7 @@
 
 #include "temporal_range.hpp"
 
+#include <silkworm/core/common/bytes_to_string.hpp>
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/infra/grpc/common/bytes.hpp>
 
@@ -61,11 +62,11 @@ proto::HistoryRangeReq history_range_request_from_query(const api::HistoryRangeQ
 
 api::HistoryRangeResult history_range_result_from_response(const proto::Pairs& response) {
     api::HistoryRangeResult result;
-    for (const auto& hex_key : response.keys()) {
-        rpc::deserialize_hex_as_bytes(hex_key, result.keys);
+    for (const auto& key : response.keys()) {
+        result.keys.emplace_back(string_to_bytes(key));
     }
-    for (const auto& hex_value : response.values()) {
-        rpc::deserialize_hex_as_bytes(hex_value, result.values);
+    for (const auto& value : response.values()) {
+        result.values.emplace_back(string_to_bytes(value));
     }
     result.next_page_token = response.next_page_token();
     return result;

--- a/silkworm/db/kv/grpc/client/remote_client.cpp
+++ b/silkworm/db/kv/grpc/client/remote_client.cpp
@@ -155,13 +155,6 @@ class RemoteClientImpl final : public api::Service {
 
     /** Temporal Range Queries **/
 
-    // rpc HistoryRange(HistoryRangeReq) returns (Pairs);
-    Task<api::HistoryRangeResult> get_history_range(const api::HistoryRangeQuery& query) override {
-        auto request = history_range_request_from_query(query);
-        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncHistoryRange, *stub_, std::move(request), grpc_context_);
-        co_return history_range_result_from_response(reply);
-    }
-
     // rpc DomainRange(DomainRangeReq) returns (Pairs);
     Task<api::DomainRangeResult> get_domain_range(const api::DomainRangeQuery& query) override {
         auto request = domain_range_request_from_query(query);

--- a/silkworm/db/kv/grpc/client/remote_client_test.cpp
+++ b/silkworm/db/kv/grpc/client/remote_client_test.cpp
@@ -112,36 +112,6 @@ TEST_CASE_METHOD(RemoteClientTestRunner, "KV::DomainGet", "[node][remote][kv][gr
     }
 }
 
-/*TEST_CASE_METHOD(RemoteClientTestRunner, "KV::HistoryRange", "[node][remote][kv][grpc]") {
-    const api::HistoryRangeQuery query{};  // input query doesn't matter here, we tweak the reply
-
-    rpc::test::StrictMockAsyncResponseReader<proto::Pairs> reader;
-    EXPECT_CALL(*stub_, AsyncHistoryRangeRaw).WillOnce(testing::Return(&reader));
-
-    SECTION("call get_history_range and get result") {
-        proto::Pairs reply{sample_proto_history_range_response()};
-        EXPECT_CALL(reader, Finish).WillOnce(rpc::test::finish_with(grpc_context_, std::move(reply)));
-
-        const api::HistoryRangeResult result = run_service_method<&api::Service::get_history_range>(query);
-        CHECK(result.keys == std::vector<Bytes>{*from_hex("00110011AA"), *from_hex("00110011BB")});
-        CHECK(result.values == std::vector<Bytes>{*from_hex("00110011EE"), *from_hex("00110011FF")});
-        CHECK(result.next_page_token == "token2");
-    }
-    SECTION("call get_history_range and get empty result") {
-        EXPECT_CALL(reader, Finish).WillOnce(rpc::test::finish_ok(grpc_context_));
-
-        const api::HistoryRangeResult result = run_service_method<&api::Service::get_history_range>(query);
-        CHECK(result.keys.empty());
-        CHECK(result.values.empty());
-        CHECK(result.next_page_token.empty());
-    }
-    SECTION("call get_history_range and get error") {
-        EXPECT_CALL(reader, Finish).WillOnce(rpc::test::finish_cancelled(grpc_context_));
-
-        CHECK_THROWS_AS((run_service_method<&api::Service::get_history_range>(query)), rpc::GrpcStatusError);
-    }
-}*/
-
 TEST_CASE_METHOD(RemoteClientTestRunner, "KV::DomainRange", "[node][remote][kv][grpc]") {
     const api::DomainRangeQuery query{};  // input query doesn't matter here, we tweak the reply
 

--- a/silkworm/db/kv/grpc/client/remote_client_test.cpp
+++ b/silkworm/db/kv/grpc/client/remote_client_test.cpp
@@ -112,7 +112,7 @@ TEST_CASE_METHOD(RemoteClientTestRunner, "KV::DomainGet", "[node][remote][kv][gr
     }
 }
 
-TEST_CASE_METHOD(RemoteClientTestRunner, "KV::HistoryRange", "[node][remote][kv][grpc]") {
+/*TEST_CASE_METHOD(RemoteClientTestRunner, "KV::HistoryRange", "[node][remote][kv][grpc]") {
     const api::HistoryRangeQuery query{};  // input query doesn't matter here, we tweak the reply
 
     rpc::test::StrictMockAsyncResponseReader<proto::Pairs> reader;
@@ -140,7 +140,7 @@ TEST_CASE_METHOD(RemoteClientTestRunner, "KV::HistoryRange", "[node][remote][kv]
 
         CHECK_THROWS_AS((run_service_method<&api::Service::get_history_range>(query)), rpc::GrpcStatusError);
     }
-}
+}*/
 
 TEST_CASE_METHOD(RemoteClientTestRunner, "KV::DomainRange", "[node][remote][kv][grpc]") {
     const api::DomainRangeQuery query{};  // input query doesn't matter here, we tweak the reply

--- a/silkworm/db/kv/grpc/client/remote_transaction.hpp
+++ b/silkworm/db/kv/grpc/client/remote_transaction.hpp
@@ -62,6 +62,9 @@ class RemoteTransaction : public api::BaseTransaction {
     // rpc IndexRange(IndexRangeReq) returns (IndexRangeReply);
     Task<api::PaginatedTimestamps> index_range(api::IndexRangeQuery&& query) override;
 
+    // rpc HistoryRange(HistoryRangeReq) returns (Pairs);
+    Task<api::PaginatedKeysValues> history_range(api::HistoryRangeQuery&& query) override;
+
   private:
     Task<std::shared_ptr<api::CursorDupSort>> get_cursor(const std::string& table, bool is_cursor_dup_sort);
 

--- a/silkworm/db/kv/grpc/client/remote_transaction_test.cpp
+++ b/silkworm/db/kv/grpc/client/remote_transaction_test.cpp
@@ -21,6 +21,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_predicate.hpp>
 
+#include <silkworm/core/common/bytes_to_string.hpp>
 #include <silkworm/db/test_util/kv_test_base.hpp>
 #include <silkworm/infra/grpc/test_util/grpc_actions.hpp>
 #include <silkworm/infra/grpc/test_util/grpc_matcher.hpp>
@@ -404,7 +405,7 @@ TEST_CASE_METHOD(RemoteTransactionTest, "RemoteTransaction::cursor_dup_sort", "[
 #endif  // SILKWORM_SANITIZE
 
 static ::remote::IndexRangeReply make_index_range_reply(const api::ListOfTimestamp& timestamps, bool has_more) {
-    ::remote::IndexRangeReply reply;
+    proto::IndexRangeReply reply;
     for (const auto ts : timestamps) {
         reply.add_timestamps(static_cast<uint64_t>(ts));
     }
@@ -431,7 +432,7 @@ TEST_CASE_METHOD(RemoteTransactionTest, "RemoteTransaction::index_range", "[rpc]
         // 1. remote::KV::StubInterface::AsyncIndexRangeRaw call succeeds
         EXPECT_CALL(*stub_, AsyncIndexRangeRaw).WillOnce(Return(&reader));
         // 2. AsyncResponseReader<>::Finish call fails
-        EXPECT_CALL(reader, Finish).WillOnce(test::finish_error_aborted(grpc_context_, ::remote::IndexRangeReply{}));
+        EXPECT_CALL(reader, Finish).WillOnce(test::finish_error_aborted(grpc_context_, proto::IndexRangeReply{}));
         // Execute the test: trying to *use* index_range lazy result should throw
         CHECK_THROWS_AS(spawn_and_wait(flatten_index_range), boost::system::system_error);
     }
@@ -487,6 +488,102 @@ TEST_CASE_METHOD(RemoteTransactionTest, "RemoteTransaction::index_range", "[rpc]
 
         // Execute the test: call index_range and flatten the data matches the expected data
         CHECK(spawn_and_wait(flatten_index_range) == api::ListOfTimestamp{1, 2, 3, 4, 5, 6, 7});
+
+        // Execute the test postconditions:
+        // close the transaction succeeds
+        CHECK_NOTHROW(spawn_and_wait(remote_tx_.close()));
+    }
+}
+
+static proto::Pairs make_history_range_reply(const std::vector<api::KeyValue>& keys_and_values, bool has_more) {
+    proto::Pairs reply;
+    for (const auto& kv : keys_and_values) {
+        reply.add_keys(bytes_to_string(kv.key));
+        reply.add_values(bytes_to_string(kv.value));
+    }
+    reply.set_next_page_token(has_more ? "token" : "");
+    return reply;
+}
+
+TEST_CASE_METHOD(RemoteTransactionTest, "RemoteTransaction::history_range", "[rpc][ethdb][kv][remote_transaction]") {
+    const api::KeyValue kv1{*from_hex("0011FF0011AA"), *from_hex("0011")};
+    const api::KeyValue kv2{*from_hex("0011FF0011BB"), *from_hex("0022")};
+    const api::KeyValue kv3{*from_hex("0011FF0011CC"), *from_hex("0033")};
+
+    auto flatten_history_range = [&]() -> Task<std::vector<api::KeyValue>> {
+#if __GNUC__ < 13 && !defined(__clang__)  // Clang compiler defines __GNUC__ as well
+        // Before GCC 13, we must avoid passing api::IndexRangeQuery as temporary because co_await-ing expressions
+        // that involve compiler-generated constructors binding references to pr-values seems to trigger this bug:
+        // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100611
+        api::HistoryRangeQuery query;
+        auto paginated_keys_and_values = co_await remote_tx_.history_range(std::move(query));
+#else
+        auto paginated_keys_and_values = co_await remote_tx_.history_range(api::HistoryRangeQuery{});
+#endif  // #if __GNUC__ < 13 && !defined(__clang__)
+        co_return co_await paginated_to_vector(paginated_keys_and_values);
+    };
+    rpc::test::StrictMockAsyncResponseReader<proto::Pairs> reader;
+    SECTION("throw on error") {
+        // Set the call expectations:
+        // 1. remote::KV::StubInterface::AsyncHistoryRangeRaw call succeeds
+        EXPECT_CALL(*stub_, AsyncHistoryRangeRaw).WillOnce(Return(&reader));
+        // 2. AsyncResponseReader<>::Finish call fails
+        EXPECT_CALL(reader, Finish).WillOnce(test::finish_error_aborted(grpc_context_, proto::Pairs{}));
+        // Execute the test: trying to *use* index_range lazy result should throw
+        CHECK_THROWS_AS(spawn_and_wait(flatten_history_range), boost::system::system_error);
+    }
+    SECTION("success: empty") {
+        // Set the call expectations:
+        // 1. remote::KV::StubInterface::AsyncHistoryRangeRaw call succeeds
+        EXPECT_CALL(*stub_, AsyncHistoryRangeRaw).WillRepeatedly(Return(&reader));
+        // 2. AsyncResponseReader<>::Finish call succeeds 3 times
+        EXPECT_CALL(reader, Finish)
+            .WillOnce(test::finish_with(grpc_context_, make_history_range_reply({}, /*has_more*/ false)));
+
+        // Execute the test: call index_range and flatten the data matches the expected data
+        CHECK(spawn_and_wait(flatten_history_range).empty());
+    }
+    SECTION("success: one page") {
+        // Set the call expectations:
+        // 1. remote::KV::StubInterface::AsyncHistoryRangeRaw call succeeds
+        EXPECT_CALL(*stub_, AsyncHistoryRangeRaw).WillRepeatedly(Return(&reader));
+        // 2. AsyncResponseReader<>::Finish call succeeds
+        EXPECT_CALL(reader, Finish)
+            .WillOnce(test::finish_with(grpc_context_, make_history_range_reply({kv1}, /*has_more*/ false)));
+
+        // Execute the test: call index_range and flatten the data matches the expected data
+        CHECK(spawn_and_wait(flatten_history_range) == std::vector<api::KeyValue>{kv1});
+    }
+    SECTION("success: more than one page") {
+        // Set the call expectations: [just once let's do the whole procedure by calling Tx first]
+        // 1. remote::KV::StubInterface::PrepareAsyncTxRaw call succeeds
+        expect_request_async_tx(/*ok=*/true);
+        // 2. AsyncReaderWriter<remote::Cursor, remote::Pair>::Read calls succeed w/ specified transaction and cursor IDs
+        remote::Pair tx_id_pair{make_fake_tx_created_pair()};
+        remote::Pair cursor_id_pair;
+        cursor_id_pair.set_cursor_id(0x23);
+        EXPECT_CALL(reader_writer_, Read)
+            .WillOnce(test::read_success_with(grpc_context_, tx_id_pair));
+        // 3. AsyncReaderWriter<remote::Cursor, remote::Pair>::WritesDone call succeeds
+        EXPECT_CALL(reader_writer_, WritesDone).WillOnce(test::writes_done_success(grpc_context_));
+        // 4. AsyncReaderWriter<remote::Cursor, remote::Pair>::Finish call succeeds w/ status OK
+        EXPECT_CALL(reader_writer_, Finish).WillOnce(test::finish_streaming_ok(grpc_context_));
+        // 5. remote::KV::StubInterface::AsyncHistoryRangeRaw call succeeds
+        EXPECT_CALL(*stub_, AsyncHistoryRangeRaw).WillRepeatedly(Return(&reader));
+        // 6. AsyncResponseReader<>::Finish call succeeds 3 times
+        EXPECT_CALL(reader, Finish)
+            .WillOnce(test::finish_with(grpc_context_, make_history_range_reply({kv1, kv2}, /*has_more*/ true)))
+            .WillOnce(test::finish_with(grpc_context_, make_history_range_reply({kv2, kv1}, /*has_more*/ true)))
+            .WillOnce(test::finish_with(grpc_context_, make_history_range_reply({kv3}, /*has_more*/ false)));
+
+        // Execute the test preconditions:
+        // open a new transaction w/ expected transaction ID
+        REQUIRE_NOTHROW(spawn_and_wait(remote_tx_.open()));
+        REQUIRE(ensure_fake_tx_created_tx_id(remote_tx_));
+        REQUIRE(ensure_fake_tx_created_view_id(remote_tx_));
+
+        // Execute the test: call index_range and flatten the data matches the expected data
+        CHECK(spawn_and_wait(flatten_history_range) == std::vector<api::KeyValue>{kv1, kv2, kv2, kv1, kv3});
 
         // Execute the test postconditions:
         // close the transaction succeeds

--- a/silkworm/db/kv/grpc/test_util/sample_protos.hpp
+++ b/silkworm/db/kv/grpc/test_util/sample_protos.hpp
@@ -188,10 +188,10 @@ inline proto::HistoryRangeReq sample_proto_history_range_request() {
 
 inline proto::Pairs sample_proto_history_range_response() {
     proto::Pairs response;
-    response.add_keys("00110011AA");
-    response.add_keys("00110011BB");
-    response.add_values("00110011EE");
-    response.add_values("00110011FF");
+    response.add_keys(bytes_to_string(*from_hex("00110011AA")));
+    response.add_keys(bytes_to_string(*from_hex("00110011BB")));
+    response.add_values(bytes_to_string(*from_hex("00110011EE")));
+    response.add_values(bytes_to_string(*from_hex("00110011FF")));
     response.set_next_page_token("token2");
     return response;
 }

--- a/silkworm/db/test_util/mock_transaction.hpp
+++ b/silkworm/db/test_util/mock_transaction.hpp
@@ -47,6 +47,7 @@ class MockTransaction : public kv::api::Transaction {
     MOCK_METHOD((Task<std::optional<Bytes>>), get_both_range,
                 (const std::string&, ByteView, ByteView), (override));
     MOCK_METHOD((Task<kv::api::PaginatedTimestamps>), index_range, (kv::api::IndexRangeQuery&&), (override));
+    MOCK_METHOD((Task<kv::api::PaginatedKeysValues>), history_range, (kv::api::HistoryRangeQuery&&), (override));
 };
 
 }  // namespace silkworm::db::test_util

--- a/silkworm/rpc/commands/debug_api_test.cpp
+++ b/silkworm/rpc/commands/debug_api_test.cpp
@@ -211,8 +211,12 @@ class DummyTransaction : public db::kv::api::BaseTransaction {
         co_return;
     }
 
-    Task<db::kv::api::PaginatedTimestamps> index_range(db::kv::api::IndexRangeQuery&& query) override {
-        co_return db::kv::api::PaginatedTimestamps{test::empty_paginator(std::move(query))};
+    Task<db::kv::api::PaginatedTimestamps> index_range(db::kv::api::IndexRangeQuery&& /*query*/) override {
+        co_return test::empty_paginated_timestamps();
+    }
+
+    Task<db::kv::api::PaginatedKeysValues> history_range(db::kv::api::HistoryRangeQuery&& /*query*/) override {
+        co_return test::empty_paginated_keys_and_values();
     }
 
   private:

--- a/silkworm/rpc/core/account_dumper_test.cpp
+++ b/silkworm/rpc/core/account_dumper_test.cpp
@@ -200,8 +200,12 @@ class DummyTransaction : public BaseTransaction {
         co_return;
     }
 
-    Task<db::kv::api::PaginatedTimestamps> index_range(db::kv::api::IndexRangeQuery&& query) override {
-        co_return db::kv::api::PaginatedTimestamps{test::empty_paginator(std::move(query))};
+    Task<db::kv::api::PaginatedTimestamps> index_range(db::kv::api::IndexRangeQuery&& /*query*/) override {
+        co_return test::empty_paginated_timestamps();
+    }
+
+    Task<db::kv::api::PaginatedKeysValues> history_range(db::kv::api::HistoryRangeQuery&& /*query*/) override {
+        co_return test::empty_paginated_keys_and_values();
     }
 
   private:

--- a/silkworm/rpc/core/account_walker_test.cpp
+++ b/silkworm/rpc/core/account_walker_test.cpp
@@ -199,8 +199,12 @@ class DummyTransaction : public BaseTransaction {
         co_return;
     }
 
-    Task<db::kv::api::PaginatedTimestamps> index_range(db::kv::api::IndexRangeQuery&& query) override {
-        co_return db::kv::api::PaginatedTimestamps{test::empty_paginator(std::move(query))};
+    Task<db::kv::api::PaginatedTimestamps> index_range(db::kv::api::IndexRangeQuery&& /*query*/) override {
+        co_return test::empty_paginated_timestamps();
+    }
+
+    Task<db::kv::api::PaginatedKeysValues> history_range(db::kv::api::HistoryRangeQuery&& /*query*/) override {
+        co_return test::empty_paginated_keys_and_values();
     }
 
   private:

--- a/silkworm/rpc/core/storage_walker_test.cpp
+++ b/silkworm/rpc/core/storage_walker_test.cpp
@@ -199,8 +199,12 @@ class DummyTransaction : public BaseTransaction {
         co_return;
     }
 
-    Task<db::kv::api::PaginatedTimestamps> index_range(db::kv::api::IndexRangeQuery&& query) override {
-        co_return db::kv::api::PaginatedTimestamps{test::empty_paginator(std::move(query))};
+    Task<db::kv::api::PaginatedTimestamps> index_range(db::kv::api::IndexRangeQuery&& /*query*/) override {
+        co_return test::empty_paginated_timestamps();
+    }
+
+    Task<db::kv::api::PaginatedKeysValues> history_range(db::kv::api::HistoryRangeQuery&& /*query*/) override {
+        co_return test::empty_paginated_keys_and_values();
     }
 
   private:

--- a/silkworm/rpc/test_util/dummy_transaction.hpp
+++ b/silkworm/rpc/test_util/dummy_transaction.hpp
@@ -32,10 +32,20 @@
 
 namespace silkworm::rpc::test {
 
-inline db::kv::api::PaginatedTimestamps::Paginator empty_paginator(db::kv::api::IndexRangeQuery&& query) {
-    return [query = std::move(query)]() mutable -> Task<db::kv::api::PaginatedTimestamps::PageResult> {
-        co_return db::kv::api::PaginatedTimestamps::PageResult{};
+template <typename Paginated>
+inline Paginated empty_paginated_sequence() {
+    auto paginator = []() -> Task<typename Paginated::PageResult> {
+        co_return typename Paginated::PageResult{};
     };
+    return Paginated{paginator};
+}
+
+inline db::kv::api::PaginatedTimestamps empty_paginated_timestamps() {
+    return empty_paginated_sequence<db::kv::api::PaginatedTimestamps>();
+}
+
+inline db::kv::api::PaginatedKeysValues empty_paginated_keys_and_values() {
+    return empty_paginated_sequence<db::kv::api::PaginatedKeysValues>();
 }
 
 //! This dummy transaction just gives you the same cursor over and over again.
@@ -70,8 +80,12 @@ class DummyTransaction : public db::kv::api::BaseTransaction {
 
     Task<void> close() override { co_return; }
 
-    Task<db::kv::api::PaginatedTimestamps> index_range(db::kv::api::IndexRangeQuery&& query) override {
-        co_return db::kv::api::PaginatedTimestamps{empty_paginator(std::move(query))};
+    Task<db::kv::api::PaginatedTimestamps> index_range(db::kv::api::IndexRangeQuery&& /*query*/) override {
+        co_return empty_paginated_timestamps();
+    }
+
+    Task<db::kv::api::PaginatedKeysValues> history_range(db::kv::api::HistoryRangeQuery&& /*query*/) override {
+        co_return empty_paginated_keys_and_values();
     }
 
   private:


### PR DESCRIPTION
This PR implements temporal KV `history_range` API in gRPC client. The following interface changes become necessary:

- first of all, the declaration of such API must be moved from `api::Service` to `api::Transaction`, as the input `api::HistoryRangeQuery` always needs to specify the `tx_id`, i.e. the unique identifier of the enclosing db transaction
- then, the return type becomes `api::PaginatedKeysValues`, which is a sequence of keys and values paginated by using the new `api::PaginatedSequencePair<K, V>` abstraction

*Extras*
- `cmd`: add `kv_history_range` command in `grpc_toolbox` to allow testing _HistoryRange_ KV RPC wrt Erigon3
- `rpc`: add utility functions to create empty paginators