### PR TITLE
db: temporal KV client domain_range API via gRPC

### DIFF
--- a/cmd/dev/README.md
+++ b/cmd/dev/README.md
@@ -172,9 +172,9 @@ cmd/dev/snapshots --tool lookup_txn --snapshot_file v1-001500-002000-transaction
 
 Silkworm keeps recent chain data in MDBX database for faster access.
 
-### The `toolbox` tool
+### The `db_toolbox` tool
 
-The `toolbox` tool is a collection of utilities to perform operations on Silkworm MDBX database.
+The `db_toolbox` tool is a collection of utilities to perform operations on Silkworm MDBX database.
 
 #### Synopsis
 
@@ -183,23 +183,56 @@ The `toolbox` tool is a collection of utilities to perform operations on Silkwor
 Dump the database table layout and stats
 
 ```
-cmd/dev/toolbox --datadir ~/Library/Silkworm/ tables
+cmd/dev/db_toolbox --datadir ~/Library/Silkworm/ tables
 ```
 
 Dump the progress of sync stages (i.e. content of SyncStage table)
 
 ```
-cmd/dev/toolbox --datadir ~/Library/Silkworm/ stages
+cmd/dev/db_toolbox --datadir ~/Library/Silkworm/ stages
 ```
 
 Clear content (i.e. delete all the rows) in LogAddressIndex and LogTopicIndex tables
 
 ```
-cmd/dev/toolbox --datadir ~/Library/Silkworm/ --exclusive clear --names LogAddressIndex LogTopicIndex
+cmd/dev/db_toolbox --datadir ~/Library/Silkworm/ --exclusive clear --names LogAddressIndex LogTopicIndex
 ```
 
 Reset the LogIndex stage progress to zero
 
 ```
-cmd/dev/toolbox --datadir ~/Library/Silkworm/ --exclusive stage-set --name LogIndex --height 0
+cmd/dev/db_toolbox --datadir ~/Library/Silkworm/ --exclusive stage-set --name LogIndex --height 0
+```
+
+## gRPC Toolbox
+
+### Overview
+
+Silkworm RPCDaemon may run in standalone mode using gRPC interfaces to communicate to other components.
+
+### The `grpc_toolbox` tool
+
+The `db_toolbox` tool is a collection of utilities to query the KV/ETHBACKEND gRPC interface of Erigon/Silkworm.
+
+#### Synopsis
+
+#### Examples
+
+Print the number of timestamps in which the specified account has changed state
+
+```
+cmd/dev/grpc_toolbox kv_index_range --table AccountsHistoryIdx --key 0x616a3E55a20dD54CC9fBb63D8333D89c275c9D90
+```
+
+Print the first 10 changes in account state history using verbose mode (i.e. print keys and values)
+
+```
+cmd/dev/grpc_toolbox kv_history_range --table AccountsHistory --limit 10 --verbose
+```
+
+Print the first 10 changes in account state for the specified key range using verbose mode (i.e. print keys and values)
+
+```
+cmd/dev/grpc_toolbox kv_domain_range --table accounts --from_key 0x616a3E55a20dD54CC9fBb63D8333D89c275c9D90 \
+--to_key 0x716a3E55a20dD54CC9fBb63D8333D89c275c9D90 --timestamp 100000000 --limit 10 --verbose
 ```

--- a/cmd/dev/grpc_toolbox.cpp
+++ b/cmd/dev/grpc_toolbox.cpp
@@ -687,13 +687,15 @@ int kv_seek_both(const std::string& target, const std::string& table_name, silkw
 }
 
 ABSL_FLAG(std::string, key, "", "key as hex string w/o leading 0x");
-// ABSL_FLAG(LogLevel, log_verbosity, LogLevel::Critical, "logging level as string");
 ABSL_FLAG(std::string, seekkey, "", "seek key as hex string w/o leading 0x");
 ABSL_FLAG(std::string, subkey, "", "subkey as hex string w/o leading 0x");
 ABSL_FLAG(std::string, tool, "", "gRPC remote interface tool name as string");
 ABSL_FLAG(std::string, target, kDefaultPrivateApiAddr, "Silkworm location as string <address>:<port>");
 ABSL_FLAG(std::string, table, "", "database table name as string");
 ABSL_FLAG(int, limit, -1, "max number of items returned by Temporal KV range queries");
+ABSL_FLAG(std::string, from_key, "", "start lookup key as hex string w/o leading 0x");
+ABSL_FLAG(std::string, to_key, "", "end lookup key as hex string w/o leading 0x");
+ABSL_FLAG(int64_t, timestamp, -1, "history timestamp for Temporal KV domain_range query");
 ABSL_FLAG(uint32_t, timeout, kDefaultTimeout.count(), "gRPC call timeout as integer");
 ABSL_FLAG(bool, verbose, false, "verbose output");
 
@@ -902,6 +904,34 @@ Task<void> kv_history_range_query(const std::shared_ptr<db::kv::api::Service>& k
     }
 }
 
+Task<void> kv_domain_range_query(const std::shared_ptr<db::kv::api::Service>& kv_service,
+                                 db::kv::api::DomainRangeQuery&& query,
+                                 const bool verbose) {
+    try {
+        auto tx = co_await kv_service->begin_transaction();
+        std::cout << "KV DomainRange -> " << query.table << " limit=" << query.limit << "\n";
+        auto paginated_result = co_await tx->domain_range(std::move(query));
+        auto it = co_await paginated_result.begin();
+        std::cout << "KV DomainRange <- #keys and #values: ";
+        int count{0};
+        std::vector<db::kv::api::KeyValue> keys_and_values;
+        while (it != paginated_result.end()) {
+            keys_and_values.emplace_back(*it);
+            ++count;
+            co_await ++it;
+        }
+        std::cout << count << "\n";
+        if (verbose) {
+            for (const auto& key_value_pair : keys_and_values) {
+                std::cout << "k=" << to_hex(key_value_pair.key) << " v=" << to_hex(key_value_pair.value) << "\n";
+            }
+        }
+        co_await tx->close();
+    } catch (const std::exception& e) {
+        std::cout << "KV DomainRange <- error: " << e.what() << "\n";
+    }
+}
+
 template <typename Q>
 using TKVQueryFunc = Task<void> (*)(const std::shared_ptr<db::kv::api::Service>&, Q&&, bool);
 
@@ -1025,6 +1055,64 @@ int kv_history_range() {
     return execute_temporal_kv_query(target, kv_history_range_query, std::move(query), verbose);
 }
 
+int kv_domain_range() {
+    const auto target{absl::GetFlag(FLAGS_target)};
+    if (target.empty() || !absl::StrContains(target, ":")) {
+        std::cerr << "Parameter target is invalid: [" << target << "]\n";
+        std::cerr << "Use --target flag to specify the location of Erigon running instance in <host>:<port> format\n";
+        return -1;
+    }
+
+    const auto table_name{absl::GetFlag(FLAGS_table)};
+    if (table_name.empty()) {
+        std::cerr << "Parameter table is invalid: [" << table_name << "]\n";
+        std::cerr << "Use --table flag to specify the name of Erigon database table\n";
+        return -1;
+    }
+
+    const auto from_key{absl::GetFlag(FLAGS_from_key)};
+    const auto from_key_bytes = silkworm::from_hex(from_key);
+    if (from_key.empty() || !from_key_bytes.has_value()) {
+        std::cerr << "Parameter from_key is invalid: [" << from_key << "]\n";
+        std::cerr << "Use --from_key flag to specify the start key in key-value table lookup as hex string\n";
+        return -1;
+    }
+
+    const auto to_key{absl::GetFlag(FLAGS_to_key)};
+    const auto to_key_bytes = silkworm::from_hex(to_key);
+    if (to_key.empty() || !to_key_bytes.has_value()) {
+        std::cerr << "Parameter to_key is invalid: [" << to_key << "]\n";
+        std::cerr << "Use --to_key flag to specify the end key in key-value table lookup as hex string\n";
+        return -1;
+    }
+
+    const auto timestamp{absl::GetFlag(FLAGS_timestamp)};
+    if (timestamp < -1) {
+        std::cerr << "Parameter timestamp is invalid: [" << timestamp << "]\n";
+        std::cerr << "Use --timestamp flag to specify the history timestamp for TKV domain_range query (-1 means latest)\n";
+        return -1;
+    }
+
+    const auto limit{absl::GetFlag(FLAGS_limit)};
+    if (limit < -1) {
+        std::cerr << "Parameter limit is invalid: [" << limit << "]\n";
+        std::cerr << "Use --limit flag to specify the max number of items returned by TKV queries (-1 means no limit)\n";
+        return -1;
+    }
+
+    const auto verbose{absl::GetFlag(FLAGS_verbose)};
+
+    db::kv::api::DomainRangeQuery query{
+        .table = table_name,
+        .from_key = *from_key_bytes,
+        .to_key = *to_key_bytes,
+        .timestamp = timestamp > -1 ? std::make_optional(timestamp) : std::nullopt,
+        .ascending_order = true,
+        .limit = limit,
+    };
+    return execute_temporal_kv_query(target, kv_domain_range_query, std::move(query), verbose);
+}
+
 int main(int argc, char* argv[]) {
     absl::SetProgramUsageMessage(
         "Execute specified internal gRPC I/F tool:\n"
@@ -1036,7 +1124,8 @@ int main(int argc, char* argv[]) {
         "\tkv_seek_async_callback\t\tquery using SEEK the Erigon/Silkworm Key-Value (KV) remote interface to database\n"
         "\tkv_seek_both\t\t\tquery using SEEK_BOTH the Erigon/Silkworm Key-Value (KV) remote interface to database\n"
         "\tkv_index_range\t\tquery using INDEX_RANGE the Erigon/Silkworm Key-Value (KV) remote interface to database\n"
-        "\tkv_history_range\t\tquery using HISTORY_RANGE the Erigon/Silkworm Key-Value (KV) remote interface to database\n");
+        "\tkv_history_range\t\tquery using HISTORY_RANGE the Erigon/Silkworm Key-Value (KV) remote interface to database\n"
+        "\tkv_domain_range\t\tquery using DOMAIN_RANGE the Erigon/Silkworm Key-Value (KV) remote interface to database\n");
     const auto positional_args = absl::ParseCommandLine(argc, argv);
     if (positional_args.size() < 2) {
         std::cerr << "No gRPC tool specified as first positional argument\n\n";
@@ -1073,6 +1162,9 @@ int main(int argc, char* argv[]) {
     }
     if (tool == "kv_history_range") {
         return kv_history_range();
+    }
+    if (tool == "kv_domain_range") {
+        return kv_domain_range();
     }
 
     std::cerr << "Unknown tool " << tool << " specified as first argument\n\n";

--- a/silkworm/db/kv/api/direct_service.cpp
+++ b/silkworm/db/kv/api/direct_service.cpp
@@ -72,12 +72,4 @@ Task<DomainPointResult> DirectService::get_domain(const DomainPointQuery&) {
     co_return DomainPointResult{};
 }
 
-/** Temporal Range Queries **/
-
-// rpc DomainRange(DomainRangeReq) returns (Pairs);
-Task<DomainRangeResult> DirectService::get_domain_range(const DomainRangeQuery&) {
-    // TODO(canepat) implement
-    co_return DomainRangeResult{};
-}
-
 }  // namespace silkworm::db::kv::api

--- a/silkworm/db/kv/api/direct_service.hpp
+++ b/silkworm/db/kv/api/direct_service.hpp
@@ -54,11 +54,6 @@ class DirectService : public Service {
     // rpc DomainGet(DomainGetReq) returns (DomainGetReply);
     Task<DomainPointResult> get_domain(const DomainPointQuery&) override;
 
-    /** Temporal Range Queries **/
-
-    // rpc DomainRange(DomainRangeReq) returns (Pairs);
-    Task<DomainRangeResult> get_domain_range(const DomainRangeQuery&) override;
-
   private:
     //! The router to service endpoint implementation
     ServiceRouter router_;

--- a/silkworm/db/kv/api/endpoint/temporal_point.hpp
+++ b/silkworm/db/kv/api/endpoint/temporal_point.hpp
@@ -41,7 +41,7 @@ struct DomainPointQuery {
     TxId tx_id{0};
     std::string table;
     Bytes key;
-    std::optional<Timestamp> timestamp{0};  // not present means 'latest state' (no history lookup)
+    std::optional<Timestamp> timestamp;  // not present means 'latest state' (no history lookup)
     Bytes sub_key;
 };
 

--- a/silkworm/db/kv/api/endpoint/temporal_range.hpp
+++ b/silkworm/db/kv/api/endpoint/temporal_range.hpp
@@ -70,6 +70,7 @@ struct DomainRangeQuery {
     std::string table;
     Bytes from_key;
     Bytes to_key;
+    std::optional<Timestamp> timestamp;  // not present means 'latest state' (no history lookup)
     bool ascending_order{false};
     int64_t limit{kUnlimited};
     uint32_t page_size{0};

--- a/silkworm/db/kv/api/local_transaction.cpp
+++ b/silkworm/db/kv/api/local_transaction.cpp
@@ -86,4 +86,13 @@ Task<PaginatedKeysValues> LocalTransaction::history_range(HistoryRangeQuery&& /*
     co_return api::PaginatedKeysValues{std::move(paginator)};
 }
 
+// NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
+Task<PaginatedKeysValues> LocalTransaction::domain_range(DomainRangeQuery&& /*query*/) {
+    // TODO(canepat) implement using E3-like aggregator abstraction [tx_id_ must be changed]
+    auto paginator = []() mutable -> Task<api::PaginatedKeysValues::PageResult> {
+        co_return api::PaginatedKeysValues::PageResult{};
+    };
+    co_return api::PaginatedKeysValues{std::move(paginator)};
+}
+
 }  // namespace silkworm::db::kv::api

--- a/silkworm/db/kv/api/local_transaction.hpp
+++ b/silkworm/db/kv/api/local_transaction.hpp
@@ -61,6 +61,9 @@ class LocalTransaction : public BaseTransaction {
     // rpc HistoryRange(HistoryRangeReq) returns (Pairs);
     Task<PaginatedKeysValues> history_range(HistoryRangeQuery&& query) override;
 
+    // rpc DomainRange(DomainRangeReq) returns (Pairs);
+    Task<PaginatedKeysValues> domain_range(DomainRangeQuery&& query) override;
+
   private:
     Task<std::shared_ptr<CursorDupSort>> get_cursor(const std::string& table, bool is_cursor_dup_sort);
 

--- a/silkworm/db/kv/api/service.hpp
+++ b/silkworm/db/kv/api/service.hpp
@@ -45,11 +45,6 @@ struct Service {
 
     // rpc DomainGet(DomainGetReq) returns (DomainGetReply);
     virtual Task<DomainPointResult> get_domain(const DomainPointQuery&) = 0;
-
-    /** Temporal Range Queries **/
-
-    // rpc DomainRange(DomainRangeReq) returns (Pairs);
-    virtual Task<DomainRangeResult> get_domain_range(const DomainRangeQuery&) = 0;
 };
 
 }  // namespace silkworm::db::kv::api

--- a/silkworm/db/kv/api/transaction.hpp
+++ b/silkworm/db/kv/api/transaction.hpp
@@ -72,6 +72,9 @@ class Transaction {
 
     // rpc HistoryRange(HistoryRangeReq) returns (Pairs);
     virtual Task<PaginatedKeysValues> history_range(HistoryRangeQuery&& query) = 0;
+
+    // rpc DomainRange(DomainRangeReq) returns (Pairs);
+    virtual Task<PaginatedKeysValues> domain_range(DomainRangeQuery&& query) = 0;
 };
 
 }  // namespace silkworm::db::kv::api

--- a/silkworm/db/kv/grpc/client/endpoint/temporal_point_test.cpp
+++ b/silkworm/db/kv/grpc/client/endpoint/temporal_point_test.cpp
@@ -63,7 +63,6 @@ TEST_CASE("history_get_result_from_response", "[node][remote][kv][grpc]") {
 
 TEST_CASE("domain_get_request_from_query", "[node][remote][kv][grpc]") {
     const Fixtures<api::DomainPointQuery, proto::DomainGetReq> fixtures{
-        {{}, {}},
         {sample_domain_point_query(), sample_proto_domain_point_request()},
     };
     for (const auto& [query, expected_point_request] : fixtures) {

--- a/silkworm/db/kv/grpc/client/endpoint/temporal_range.cpp
+++ b/silkworm/db/kv/grpc/client/endpoint/temporal_range.cpp
@@ -78,6 +78,11 @@ api::HistoryRangeResult history_range_result_from_response(const proto::Pairs& r
     request.set_table(query.table);
     request.set_from_key(query.from_key.data(), query.from_key.size());
     request.set_to_key(query.to_key.data(), query.to_key.size());
+    if (query.timestamp) {
+        request.set_ts(static_cast<uint64_t>(*query.timestamp));
+    } else {
+        request.set_latest(true);
+    }
     request.set_order_ascend(query.ascending_order);
     request.set_limit(static_cast<int64_t>(query.limit));
     request.set_page_size(static_cast<int32_t>(query.page_size));

--- a/silkworm/db/kv/grpc/client/endpoint/temporal_range_test.cpp
+++ b/silkworm/db/kv/grpc/client/endpoint/temporal_range_test.cpp
@@ -116,6 +116,7 @@ TEST_CASE("domain_range_request_from_query", "[node][remote][kv][grpc]") {
             CHECK(range_request.table() == expected_range_request.table());
             CHECK(range_request.from_key() == expected_range_request.from_key());
             CHECK(range_request.to_key() == expected_range_request.to_key());
+            CHECK(range_request.ts() == expected_range_request.ts());
             CHECK(range_request.order_ascend() == expected_range_request.order_ascend());
             CHECK(range_request.limit() == expected_range_request.limit());
             CHECK(range_request.page_size() == expected_range_request.page_size());

--- a/silkworm/db/kv/grpc/client/remote_client.cpp
+++ b/silkworm/db/kv/grpc/client/remote_client.cpp
@@ -153,15 +153,6 @@ class RemoteClientImpl final : public api::Service {
         co_return domain_get_result_from_response(reply);
     }
 
-    /** Temporal Range Queries **/
-
-    // rpc DomainRange(DomainRangeReq) returns (Pairs);
-    Task<api::DomainRangeResult> get_domain_range(const api::DomainRangeQuery& query) override {
-        auto request = domain_range_request_from_query(query);
-        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncDomainRange, *stub_, std::move(request), grpc_context_);
-        co_return domain_range_result_from_response(reply);
-    }
-
     void set_min_backoff_timeout(const std::chrono::milliseconds& min_backoff_timeout) {
         min_backoff_timeout_ = min_backoff_timeout;
     }

--- a/silkworm/db/kv/grpc/client/remote_transaction.hpp
+++ b/silkworm/db/kv/grpc/client/remote_transaction.hpp
@@ -65,6 +65,9 @@ class RemoteTransaction : public api::BaseTransaction {
     // rpc HistoryRange(HistoryRangeReq) returns (Pairs);
     Task<api::PaginatedKeysValues> history_range(api::HistoryRangeQuery&& query) override;
 
+    // rpc DomainRange(DomainRangeReq) returns (Pairs);
+    Task<api::PaginatedKeysValues> domain_range(api::DomainRangeQuery&& query) override;
+
   private:
     Task<std::shared_ptr<api::CursorDupSort>> get_cursor(const std::string& table, bool is_cursor_dup_sort);
 

--- a/silkworm/db/kv/grpc/client/remote_transaction_test.cpp
+++ b/silkworm/db/kv/grpc/client/remote_transaction_test.cpp
@@ -602,7 +602,7 @@ TEST_CASE_METHOD(RemoteTransactionTest, "RemoteTransaction::domain_range", "[rpc
         // that involve compiler-generated constructors binding references to pr-values seems to trigger this bug:
         // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100611
         api::DomainRangeQuery query;
-        auto paginated_keys_and_values = co_await remote_tx_.history_range(std::move(query));
+        auto paginated_keys_and_values = co_await remote_tx_.domain_range(std::move(query));
 #else
         auto paginated_keys_and_values = co_await remote_tx_.domain_range(api::DomainRangeQuery{});
 #endif  // #if __GNUC__ < 13 && !defined(__clang__)

--- a/silkworm/db/kv/grpc/client/remote_transaction_test.cpp
+++ b/silkworm/db/kv/grpc/client/remote_transaction_test.cpp
@@ -495,7 +495,7 @@ TEST_CASE_METHOD(RemoteTransactionTest, "RemoteTransaction::index_range", "[rpc]
     }
 }
 
-static proto::Pairs make_history_range_reply(const std::vector<api::KeyValue>& keys_and_values, bool has_more) {
+static proto::Pairs make_key_value_range_reply(const std::vector<api::KeyValue>& keys_and_values, bool has_more) {
     proto::Pairs reply;
     for (const auto& kv : keys_and_values) {
         reply.add_keys(bytes_to_string(kv.key));
@@ -538,7 +538,7 @@ TEST_CASE_METHOD(RemoteTransactionTest, "RemoteTransaction::history_range", "[rp
         EXPECT_CALL(*stub_, AsyncHistoryRangeRaw).WillRepeatedly(Return(&reader));
         // 2. AsyncResponseReader<>::Finish call succeeds 3 times
         EXPECT_CALL(reader, Finish)
-            .WillOnce(test::finish_with(grpc_context_, make_history_range_reply({}, /*has_more*/ false)));
+            .WillOnce(test::finish_with(grpc_context_, make_key_value_range_reply({}, /*has_more*/ false)));
 
         // Execute the test: call index_range and flatten the data matches the expected data
         CHECK(spawn_and_wait(flatten_history_range).empty());
@@ -549,7 +549,7 @@ TEST_CASE_METHOD(RemoteTransactionTest, "RemoteTransaction::history_range", "[rp
         EXPECT_CALL(*stub_, AsyncHistoryRangeRaw).WillRepeatedly(Return(&reader));
         // 2. AsyncResponseReader<>::Finish call succeeds
         EXPECT_CALL(reader, Finish)
-            .WillOnce(test::finish_with(grpc_context_, make_history_range_reply({kv1}, /*has_more*/ false)));
+            .WillOnce(test::finish_with(grpc_context_, make_key_value_range_reply({kv1}, /*has_more*/ false)));
 
         // Execute the test: call index_range and flatten the data matches the expected data
         CHECK(spawn_and_wait(flatten_history_range) == std::vector<api::KeyValue>{kv1});
@@ -572,9 +572,9 @@ TEST_CASE_METHOD(RemoteTransactionTest, "RemoteTransaction::history_range", "[rp
         EXPECT_CALL(*stub_, AsyncHistoryRangeRaw).WillRepeatedly(Return(&reader));
         // 6. AsyncResponseReader<>::Finish call succeeds 3 times
         EXPECT_CALL(reader, Finish)
-            .WillOnce(test::finish_with(grpc_context_, make_history_range_reply({kv1, kv2}, /*has_more*/ true)))
-            .WillOnce(test::finish_with(grpc_context_, make_history_range_reply({kv2, kv1}, /*has_more*/ true)))
-            .WillOnce(test::finish_with(grpc_context_, make_history_range_reply({kv3}, /*has_more*/ false)));
+            .WillOnce(test::finish_with(grpc_context_, make_key_value_range_reply({kv1, kv2}, /*has_more*/ true)))
+            .WillOnce(test::finish_with(grpc_context_, make_key_value_range_reply({kv2, kv1}, /*has_more*/ true)))
+            .WillOnce(test::finish_with(grpc_context_, make_key_value_range_reply({kv3}, /*has_more*/ false)));
 
         // Execute the test preconditions:
         // open a new transaction w/ expected transaction ID
@@ -584,6 +584,92 @@ TEST_CASE_METHOD(RemoteTransactionTest, "RemoteTransaction::history_range", "[rp
 
         // Execute the test: call index_range and flatten the data matches the expected data
         CHECK(spawn_and_wait(flatten_history_range) == std::vector<api::KeyValue>{kv1, kv2, kv2, kv1, kv3});
+
+        // Execute the test postconditions:
+        // close the transaction succeeds
+        CHECK_NOTHROW(spawn_and_wait(remote_tx_.close()));
+    }
+}
+
+TEST_CASE_METHOD(RemoteTransactionTest, "RemoteTransaction::domain_range", "[rpc][ethdb][kv][remote_transaction]") {
+    const api::KeyValue kv1{*from_hex("0011FF0011AA"), *from_hex("0011")};
+    const api::KeyValue kv2{*from_hex("0011FF0011BB"), *from_hex("0022")};
+    const api::KeyValue kv3{*from_hex("0011FF0011CC"), *from_hex("0033")};
+
+    auto flatten_domain_range = [&]() -> Task<std::vector<api::KeyValue>> {
+#if __GNUC__ < 13 && !defined(__clang__)  // Clang compiler defines __GNUC__ as well
+        // Before GCC 13, we must avoid passing api::DomainRangeQuery as temporary because co_await-ing expressions
+        // that involve compiler-generated constructors binding references to pr-values seems to trigger this bug:
+        // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100611
+        api::DomainRangeQuery query;
+        auto paginated_keys_and_values = co_await remote_tx_.history_range(std::move(query));
+#else
+        auto paginated_keys_and_values = co_await remote_tx_.domain_range(api::DomainRangeQuery{});
+#endif  // #if __GNUC__ < 13 && !defined(__clang__)
+        co_return co_await paginated_to_vector(paginated_keys_and_values);
+    };
+    rpc::test::StrictMockAsyncResponseReader<proto::Pairs> reader;
+    SECTION("throw on error") {
+        // Set the call expectations:
+        // 1. remote::KV::StubInterface::AsyncDomainRangeRaw call succeeds
+        EXPECT_CALL(*stub_, AsyncDomainRangeRaw).WillOnce(Return(&reader));
+        // 2. AsyncResponseReader<>::Finish call fails
+        EXPECT_CALL(reader, Finish).WillOnce(test::finish_error_aborted(grpc_context_, proto::Pairs{}));
+        // Execute the test: trying to *use* index_range lazy result should throw
+        CHECK_THROWS_AS(spawn_and_wait(flatten_domain_range), boost::system::system_error);
+    }
+    SECTION("success: empty") {
+        // Set the call expectations:
+        // 1. remote::KV::StubInterface::AsyncDomainRangeRaw call succeeds
+        EXPECT_CALL(*stub_, AsyncDomainRangeRaw).WillRepeatedly(Return(&reader));
+        // 2. AsyncResponseReader<>::Finish call succeeds 3 times
+        EXPECT_CALL(reader, Finish)
+            .WillOnce(test::finish_with(grpc_context_, make_key_value_range_reply({}, /*has_more*/ false)));
+
+        // Execute the test: call index_range and flatten the data matches the expected data
+        CHECK(spawn_and_wait(flatten_domain_range).empty());
+    }
+    SECTION("success: one page") {
+        // Set the call expectations:
+        // 1. remote::KV::StubInterface::AsyncDomainRangeRaw call succeeds
+        EXPECT_CALL(*stub_, AsyncDomainRangeRaw).WillRepeatedly(Return(&reader));
+        // 2. AsyncResponseReader<>::Finish call succeeds
+        EXPECT_CALL(reader, Finish)
+            .WillOnce(test::finish_with(grpc_context_, make_key_value_range_reply({kv1}, /*has_more*/ false)));
+
+        // Execute the test: call index_range and flatten the data matches the expected data
+        CHECK(spawn_and_wait(flatten_domain_range) == std::vector<api::KeyValue>{kv1});
+    }
+    SECTION("success: more than one page") {
+        // Set the call expectations: [just once let's do the whole procedure by calling Tx first]
+        // 1. remote::KV::StubInterface::PrepareAsyncTxRaw call succeeds
+        expect_request_async_tx(/*ok=*/true);
+        // 2. AsyncReaderWriter<remote::Cursor, remote::Pair>::Read calls succeed w/ specified transaction and cursor IDs
+        remote::Pair tx_id_pair{make_fake_tx_created_pair()};
+        remote::Pair cursor_id_pair;
+        cursor_id_pair.set_cursor_id(0x23);
+        EXPECT_CALL(reader_writer_, Read)
+            .WillOnce(test::read_success_with(grpc_context_, tx_id_pair));
+        // 3. AsyncReaderWriter<remote::Cursor, remote::Pair>::WritesDone call succeeds
+        EXPECT_CALL(reader_writer_, WritesDone).WillOnce(test::writes_done_success(grpc_context_));
+        // 4. AsyncReaderWriter<remote::Cursor, remote::Pair>::Finish call succeeds w/ status OK
+        EXPECT_CALL(reader_writer_, Finish).WillOnce(test::finish_streaming_ok(grpc_context_));
+        // 5. remote::KV::StubInterface::AsyncDomainRangeRaw call succeeds
+        EXPECT_CALL(*stub_, AsyncDomainRangeRaw).WillRepeatedly(Return(&reader));
+        // 6. AsyncResponseReader<>::Finish call succeeds 3 times
+        EXPECT_CALL(reader, Finish)
+            .WillOnce(test::finish_with(grpc_context_, make_key_value_range_reply({kv1, kv2}, /*has_more*/ true)))
+            .WillOnce(test::finish_with(grpc_context_, make_key_value_range_reply({kv2, kv1}, /*has_more*/ true)))
+            .WillOnce(test::finish_with(grpc_context_, make_key_value_range_reply({kv3}, /*has_more*/ false)));
+
+        // Execute the test preconditions:
+        // open a new transaction w/ expected transaction ID
+        REQUIRE_NOTHROW(spawn_and_wait(remote_tx_.open()));
+        REQUIRE(ensure_fake_tx_created_tx_id(remote_tx_));
+        REQUIRE(ensure_fake_tx_created_view_id(remote_tx_));
+
+        // Execute the test: call index_range and flatten the data matches the expected data
+        CHECK(spawn_and_wait(flatten_domain_range) == std::vector<api::KeyValue>{kv1, kv2, kv2, kv1, kv3});
 
         // Execute the test postconditions:
         // close the transaction succeeds

--- a/silkworm/db/kv/grpc/test_util/sample_protos.hpp
+++ b/silkworm/db/kv/grpc/test_util/sample_protos.hpp
@@ -210,6 +210,7 @@ inline api::DomainRangeQuery sample_domain_range_query() {
         .table = "AAA",
         .from_key = {0x00, 0x11, 0xaa},
         .to_key = {0x00, 0x11, 0xff},
+        .timestamp = 180'000'000,
         .ascending_order = true,
         .limit = 1'000,
         .page_size = 100,
@@ -229,6 +230,7 @@ inline proto::DomainRangeReq sample_proto_domain_range_request() {
     request.set_table("AAA");
     request.set_from_key(ascii_from_hex("0011aa"));
     request.set_to_key(ascii_from_hex("0011ff"));
+    request.set_ts(180'000'000);
     request.set_order_ascend(true);
     request.set_limit(1'000);
     request.set_page_size(100);

--- a/silkworm/db/test_util/mock_transaction.hpp
+++ b/silkworm/db/test_util/mock_transaction.hpp
@@ -48,6 +48,7 @@ class MockTransaction : public kv::api::Transaction {
                 (const std::string&, ByteView, ByteView), (override));
     MOCK_METHOD((Task<kv::api::PaginatedTimestamps>), index_range, (kv::api::IndexRangeQuery&&), (override));
     MOCK_METHOD((Task<kv::api::PaginatedKeysValues>), history_range, (kv::api::HistoryRangeQuery&&), (override));
+    MOCK_METHOD((Task<kv::api::PaginatedKeysValues>), domain_range, (kv::api::DomainRangeQuery&&), (override));
 };
 
 }  // namespace silkworm::db::test_util

--- a/silkworm/rpc/commands/debug_api_test.cpp
+++ b/silkworm/rpc/commands/debug_api_test.cpp
@@ -221,6 +221,11 @@ class DummyTransaction : public db::kv::api::BaseTransaction {
         co_return test::empty_paginated_keys_and_values();
     }
 
+    // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
+    Task<db::kv::api::PaginatedKeysValues> domain_range(db::kv::api::DomainRangeQuery&& /*query*/) override {
+        co_return test::empty_paginated_keys_and_values();
+    }
+
   private:
     inline static uint64_t next_tx_id{0};
     inline static uint64_t next_view_id{0};

--- a/silkworm/rpc/core/account_dumper_test.cpp
+++ b/silkworm/rpc/core/account_dumper_test.cpp
@@ -210,6 +210,11 @@ class DummyTransaction : public BaseTransaction {
         co_return test::empty_paginated_keys_and_values();
     }
 
+    // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
+    Task<db::kv::api::PaginatedKeysValues> domain_range(db::kv::api::DomainRangeQuery&& /*query*/) override {
+        co_return test::empty_paginated_keys_and_values();
+    }
+
   private:
     const nlohmann::json& json_;
 };

--- a/silkworm/rpc/core/account_walker_test.cpp
+++ b/silkworm/rpc/core/account_walker_test.cpp
@@ -209,6 +209,11 @@ class DummyTransaction : public BaseTransaction {
         co_return test::empty_paginated_keys_and_values();
     }
 
+    // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
+    Task<db::kv::api::PaginatedKeysValues> domain_range(db::kv::api::DomainRangeQuery&& /*query*/) override {
+        co_return test::empty_paginated_keys_and_values();
+    }
+
   private:
     const nlohmann::json& json_;
 };

--- a/silkworm/rpc/core/storage_walker_test.cpp
+++ b/silkworm/rpc/core/storage_walker_test.cpp
@@ -209,6 +209,11 @@ class DummyTransaction : public BaseTransaction {
         co_return test::empty_paginated_keys_and_values();
     }
 
+    // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
+    Task<db::kv::api::PaginatedKeysValues> domain_range(db::kv::api::DomainRangeQuery&& /*query*/) override {
+        co_return test::empty_paginated_keys_and_values();
+    }
+
   private:
     const nlohmann::json& json_;
 };

--- a/silkworm/rpc/test_util/dummy_transaction.hpp
+++ b/silkworm/rpc/test_util/dummy_transaction.hpp
@@ -90,6 +90,11 @@ class DummyTransaction : public db::kv::api::BaseTransaction {
         co_return empty_paginated_keys_and_values();
     }
 
+    // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
+    Task<db::kv::api::PaginatedKeysValues> domain_range(db::kv::api::DomainRangeQuery&& /*query*/) override {
+        co_return test::empty_paginated_keys_and_values();
+    }
+
   private:
     uint64_t tx_id_;
     uint64_t view_id_;


### PR DESCRIPTION
This PR implements temporal KV `domain_range` API in gRPC client. The following interface changes become necessary:

- first of all, the declaration of such API must be moved from `api::Service` to `api::Transaction`, as the input `api::DomainRangeQuery` always needs to specify the `tx_id`, i.e. the unique identifier of the enclosing db transaction
- then, the return type becomes `api::PaginatedKeysValues`, which is a sequence of keys and values paginated by using the existing `api::PaginatedSequencePair<K, V>` abstraction

*Extras*
- `cmd`: add `kv_domain_range` command in `grpc_toolbox` to allow testing _DomainRange_ KV RPC wrt Erigon3