### PR TITLE
rpc-integration-tests: avoid saving unuseful result

### DIFF
--- a/.github/workflows/rpc-integration-tests.yml
+++ b/.github/workflows/rpc-integration-tests.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout Silkworm Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: "0"
@@ -108,12 +108,6 @@ jobs:
         with:
           name: test-results
           path: ${{runner.workspace}}/rpc-tests/integration/mainnet/results/
-
-      - name: Save test results
-        working-directory: ${{runner.workspace}}/silkworm
-        env:
-          TEST_RESULT: ${{ steps.test_step.outputs.TEST_RESULT }}
-        run: python3 $ERIGON_QA_PATH/test_system/qa-tests/uploads/upload_test_results.py --repo silkworm --branch ${{ github.ref_name }} --commit $(git rev-parse HEAD) --test_name rpc-integration-tests --chain mainnet --outcome $TEST_RESULT #--result_file ${{runner.workspace}}/rpc-tests/integration/mainnet/result.json
 
       - name: Action for Success
         if: steps.test_step.outputs.TEST_RESULT == 'success'


### PR DESCRIPTION
Currently, integration tests only save the outcome on the database: success or failure, and no other information.
Since integration tests are necessary for a PR to be accepted, it is not very useful to save the outcome on the database. This also blocks a PR in case of failure of saving, blocking the developers' work.

This PR removes the "save  results" task.