### PR TITLE
rpc-performance-tests: preserve the results

### DIFF
--- a/.github/workflows/rpc-performance-tests.yml
+++ b/.github/workflows/rpc-performance-tests.yml
@@ -127,6 +127,11 @@ jobs:
                     --db_version $db_version \
                     --outcome success \
                     --result_file ${{runner.workspace}}/rpc-tests/perf/reports/mainnet/${servers[i-1]}-$method-result.json
+
+                  if [ $? -ne 0 ]; then
+                    failed_test=1
+                    echo "Failure saving test results on DB"
+                  fi
           
                   echo "Execute Latency Percentile HDR Analysis"   
                   cd ${{runner.workspace}}/rpc-tests/perf/reports/mainnet/


### PR DESCRIPTION
Performance tests do not (yet) have a status indicating success or failure based on the result of measurements: the performance numbers are compared manually after the test completion. Furthermore, they do not block PRs.

We are working on automatic regression detection, but in the meantime we think it is useful to signal with a test failure any error in saving the measurements, since this is a crucial part of the test to allow a-posteriori analysis.