### PR TITLE
Interfaces: upgrade to 0d10589

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -111,11 +111,12 @@ If you need to update library `lib` in Silkworm submodules to `commit_hash`, the
 ## Updating Internal gRPC Interfaces
 
 If you need to update gRPC protocol definitions (i.e. `.proto` files) and related stubs/skeletons for internal
-[Erigon interfaces][erigon-interfaces], the following procedure  must be applied:
+[Erigon interfaces][erigon-interfaces], the following procedure must be applied:
 
 1. determine the current version used in Erigon as `commit_hash` from [here][erigon-interfaces-version]
 2. cd third_party/erigon-interfaces
-3. git checkout <commit_hash>
+3. git pull
+4. git checkout <commit_hash>
 
 
 ## Updating Snapshots

--- a/silkworm/db/kv/grpc/client/endpoint/temporal_point.cpp
+++ b/silkworm/db/kv/grpc/client/endpoint/temporal_point.cpp
@@ -16,28 +16,26 @@
 
 #include "temporal_point.hpp"
 
+#include <silkworm/core/common/bytes_to_string.hpp>
 #include <silkworm/core/common/util.hpp>
 
 namespace silkworm::db::kv::grpc::client {
 
 namespace proto = ::remote;
 
-proto::HistoryGetReq history_get_request_from_query(const api::HistoryPointQuery& query) {
-    proto::HistoryGetReq request;
+proto::HistorySeekReq history_seek_request_from_query(const api::HistoryPointQuery& query) {
+    proto::HistorySeekReq request;
     request.set_tx_id(query.tx_id);
     request.set_table(query.table);
-    request.set_k(to_hex(query.key));
+    request.set_k(query.key.data(), query.key.size());
     request.set_ts(static_cast<uint64_t>(query.timestamp));
     return request;
 }
 
-api::HistoryPointResult history_get_result_from_response(const proto::HistoryGetReply& response) {
+api::HistoryPointResult history_seek_result_from_response(const proto::HistorySeekReply& response) {
     api::HistoryPointResult result;
     result.success = response.ok();
-    auto hex{from_hex(response.v())};
-    if (hex) {
-        result.value = std::move(*hex);
-    }
+    result.value = string_to_bytes(response.v());
     return result;
 }
 

--- a/silkworm/db/kv/grpc/client/endpoint/temporal_point.hpp
+++ b/silkworm/db/kv/grpc/client/endpoint/temporal_point.hpp
@@ -22,8 +22,8 @@
 
 namespace silkworm::db::kv::grpc::client {
 
-::remote::HistoryGetReq history_get_request_from_query(const api::HistoryPointQuery&);
-api::HistoryPointResult history_get_result_from_response(const ::remote::HistoryGetReply&);
+::remote::HistorySeekReq history_seek_request_from_query(const api::HistoryPointQuery&);
+api::HistoryPointResult history_seek_result_from_response(const ::remote::HistorySeekReply&);
 
 ::remote::DomainGetReq domain_get_request_from_query(const api::DomainPointQuery&);
 api::DomainPointResult domain_get_result_from_response(const ::remote::DomainGetReply&);

--- a/silkworm/db/kv/grpc/client/endpoint/temporal_point_test.cpp
+++ b/silkworm/db/kv/grpc/client/endpoint/temporal_point_test.cpp
@@ -30,13 +30,13 @@ using namespace silkworm::test_util;
 namespace proto = ::remote;
 
 TEST_CASE("history_get_request_from_query", "[node][remote][kv][grpc]") {
-    const Fixtures<api::HistoryPointQuery, proto::HistoryGetReq> fixtures{
+    const Fixtures<api::HistoryPointQuery, proto::HistorySeekReq> fixtures{
         {{}, {}},
-        {sample_history_point_query(), sample_proto_history_point_request()},
+        {sample_history_point_query(), sample_proto_history_seek_request()},
     };
     for (const auto& [query, expected_point_request] : fixtures) {
         SECTION("query: " + std::to_string(query.tx_id)) {
-            const auto& point_request{history_get_request_from_query(query)};
+            const auto& point_request{history_seek_request_from_query(query)};
             // CHECK(point_request == expected_point_request);  // requires operator== in gRPC
             CHECK(point_request.tx_id() == expected_point_request.tx_id());
             CHECK(point_request.table() == expected_point_request.table());
@@ -47,13 +47,13 @@ TEST_CASE("history_get_request_from_query", "[node][remote][kv][grpc]") {
 }
 
 TEST_CASE("history_get_result_from_response", "[node][remote][kv][grpc]") {
-    const Fixtures<proto::HistoryGetReply, api::HistoryPointResult> fixtures{
+    const Fixtures<proto::HistorySeekReply, api::HistoryPointResult> fixtures{
         {{}, {}},
-        {sample_proto_history_get_response(), sample_history_point_result()},
+        {sample_proto_history_seek_response(), sample_history_point_result()},
     };
     for (const auto& [response, expected_point_result] : fixtures) {
         SECTION("ok: " + std::to_string(response.ok())) {
-            const auto& point_result{history_get_result_from_response(response)};
+            const auto& point_result{history_seek_result_from_response(response)};
             // CHECK(point_result == expected_point_result);  // requires operator== in gRPC
             CHECK(point_result.success == expected_point_result.success);
             CHECK(point_result.value == expected_point_result.value);

--- a/silkworm/db/kv/grpc/client/endpoint/temporal_range.cpp
+++ b/silkworm/db/kv/grpc/client/endpoint/temporal_range.cpp
@@ -17,7 +17,6 @@
 #include "temporal_range.hpp"
 
 #include <silkworm/core/common/bytes_to_string.hpp>
-#include <silkworm/core/common/util.hpp>
 #include <silkworm/infra/grpc/common/bytes.hpp>
 
 namespace silkworm::db::kv::grpc::client {

--- a/silkworm/db/kv/grpc/client/remote_client.cpp
+++ b/silkworm/db/kv/grpc/client/remote_client.cpp
@@ -139,11 +139,11 @@ class RemoteClientImpl final : public api::Service {
 
     /** Temporal Point Queries **/
 
-    // rpc HistoryGet(HistoryGetReq) returns (HistoryGetReply);
+    // rpc HistoryGet(HistorySeekReq) returns (HistorySeekReply);
     Task<api::HistoryPointResult> get_history(const api::HistoryPointQuery& query) override {
-        auto request = history_get_request_from_query(query);
-        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncHistoryGet, *stub_, std::move(request), grpc_context_);
-        co_return history_get_result_from_response(reply);
+        auto request = history_seek_request_from_query(query);
+        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncHistorySeek, *stub_, std::move(request), grpc_context_);
+        co_return history_seek_result_from_response(reply);
     }
 
     // rpc DomainGet(DomainGetReq) returns (DomainGetReply);

--- a/silkworm/db/kv/grpc/client/remote_client_test.cpp
+++ b/silkworm/db/kv/grpc/client/remote_client_test.cpp
@@ -56,14 +56,14 @@ struct RemoteClientTestRunner : public TestRunner<RemoteClient, StrictMockKVStub
     }
 };
 
-TEST_CASE_METHOD(RemoteClientTestRunner, "KV::HistoryGet", "[node][remote][kv][grpc]") {
+TEST_CASE_METHOD(RemoteClientTestRunner, "KV::HistorySeek", "[node][remote][kv][grpc]") {
     const api::HistoryPointQuery query{};  // input query doesn't matter here, we tweak the reply
 
-    rpc::test::StrictMockAsyncResponseReader<proto::HistoryGetReply> reader;
-    EXPECT_CALL(*stub_, AsyncHistoryGetRaw).WillOnce(testing::Return(&reader));
+    rpc::test::StrictMockAsyncResponseReader<proto::HistorySeekReply> reader;
+    EXPECT_CALL(*stub_, AsyncHistorySeekRaw).WillOnce(testing::Return(&reader));
 
     SECTION("call get_history and get result") {
-        proto::HistoryGetReply reply{sample_proto_history_get_response()};
+        proto::HistorySeekReply reply{sample_proto_history_seek_response()};
         EXPECT_CALL(reader, Finish).WillOnce(rpc::test::finish_with(grpc_context_, std::move(reply)));
 
         const api::HistoryPointResult result = run_service_method<&api::Service::get_history>(query);

--- a/silkworm/db/kv/grpc/server/kv_calls.cpp
+++ b/silkworm/db/kv/grpc/server/kv_calls.cpp
@@ -724,12 +724,12 @@ Task<void> SnapshotsCall::operator()() {
     SILK_TRACE << "SnapshotsCall END #blocks_files: " << response.blocks_files_size() << " #history_files: " << response.history_files_size();
 }
 
-Task<void> HistoryGetCall::operator()() {
-    SILK_TRACE << "HistoryGetCall START";
-    remote::HistoryGetReply response;
+Task<void> HistorySeekCall::operator()() {
+    SILK_TRACE << "HistorySeekCall START";
+    remote::HistorySeekReply response;
     // TODO(canepat) implement properly
     co_await agrpc::finish(responder_, response, ::grpc::Status::OK);
-    SILK_TRACE << "HistoryGetCall END ok: " << response.ok() << " value: " << response.v();
+    SILK_TRACE << "HistorySeekCall END ok: " << response.ok() << " value: " << response.v();
 }
 
 Task<void> DomainGetCall::operator()() {

--- a/silkworm/db/kv/grpc/server/kv_calls.hpp
+++ b/silkworm/db/kv/grpc/server/kv_calls.hpp
@@ -168,7 +168,7 @@ class SnapshotsCall : public rpc::server::UnaryCall<remote::SnapshotsRequest, re
 
 //! Unary RPC for HistoryGet method of 'kv' gRPC protocol.
 //! rpc HistoryGet(HistoryGetReq) returns (HistoryGetReply);
-class HistoryGetCall : public rpc::server::UnaryCall<remote::HistoryGetReq, remote::HistoryGetReply> {
+class HistorySeekCall : public rpc::server::UnaryCall<remote::HistorySeekReq, remote::HistorySeekReply> {
   public:
     using Base::UnaryCall;
 

--- a/silkworm/db/kv/grpc/server/kv_server.cpp
+++ b/silkworm/db/kv/grpc/server/kv_server.cpp
@@ -66,9 +66,9 @@ void KvServer::register_kv_request_calls(agrpc::GrpcContext* grpc_context) {
                        [](auto&&... args) -> Task<void> {
                            co_await DomainGetCall{std::forward<decltype(args)>(args)...}();
                        });
-    request_repeatedly(*grpc_context, service, &remote::KV::AsyncService::RequestHistoryGet,
+    request_repeatedly(*grpc_context, service, &remote::KV::AsyncService::RequestHistorySeek,
                        [](auto&&... args) -> Task<void> {
-                           co_await HistoryGetCall{std::forward<decltype(args)>(args)...}();
+                           co_await HistorySeekCall{std::forward<decltype(args)>(args)...}();
                        });
     request_repeatedly(*grpc_context, service, &remote::KV::AsyncService::RequestIndexRange,
                        [](auto&&... args) -> Task<void> {

--- a/silkworm/db/kv/grpc/server/kv_server_test.cpp
+++ b/silkworm/db/kv/grpc/server/kv_server_test.cpp
@@ -97,9 +97,9 @@ class KvClient {
         return stub_->Snapshots(&context, request, response);
     }
 
-    grpc::Status history_get(const remote::HistoryGetReq& request, remote::HistoryGetReply* response) {
+    grpc::Status history_seek(const remote::HistorySeekReq& request, remote::HistorySeekReply* response) {
         grpc::ClientContext context;
-        return stub_->HistoryGet(&context, request, response);
+        return stub_->HistorySeek(&context, request, response);
     }
 
     grpc::Status domain_get(const remote::DomainGetReq& request, remote::DomainGetReply* response) {
@@ -654,10 +654,10 @@ TEST_CASE_METHOD(KvEnd2EndTest, "KvServer E2E: KV", "[silkworm][node][rpc]") {
         CHECK(status.ok());
     }
 
-    SECTION("HistoryGet: return value in target history") {
-        remote::HistoryGetReq request;
-        remote::HistoryGetReply response;
-        const auto status = kv_client->history_get(request, &response);
+    SECTION("HistorySeek: return value in target history") {
+        remote::HistorySeekReq request;
+        remote::HistorySeekReply response;
+        const auto status = kv_client->history_seek(request, &response);
         CHECK(status.ok());
     }
 

--- a/silkworm/db/kv/grpc/test_util/sample_protos.hpp
+++ b/silkworm/db/kv/grpc/test_util/sample_protos.hpp
@@ -48,8 +48,8 @@ inline api::HistoryPointQuery sample_history_point_query() {
     };
 }
 
-inline proto::HistoryGetReq sample_proto_history_point_request() {
-    proto::HistoryGetReq request;
+inline proto::HistorySeekReq sample_proto_history_seek_request() {
+    proto::HistorySeekReq request;
     request.set_tx_id(1);
     request.set_table("AAA");
     request.set_k("0011ff");
@@ -57,8 +57,8 @@ inline proto::HistoryGetReq sample_proto_history_point_request() {
     return request;
 }
 
-inline proto::HistoryGetReply sample_proto_history_get_response() {
-    proto::HistoryGetReply response;
+inline proto::HistorySeekReply sample_proto_history_seek_response() {
+    proto::HistorySeekReply response;
     response.set_ok(true);
     response.set_v("ff00ff00");
     return response;

--- a/silkworm/db/kv/grpc/test_util/sample_protos.hpp
+++ b/silkworm/db/kv/grpc/test_util/sample_protos.hpp
@@ -52,7 +52,7 @@ inline proto::HistorySeekReq sample_proto_history_seek_request() {
     proto::HistorySeekReq request;
     request.set_tx_id(1);
     request.set_table("AAA");
-    request.set_k("0011ff");
+    request.set_k(ascii_from_hex("0011ff"));
     request.set_ts(1234567);
     return request;
 }
@@ -60,7 +60,7 @@ inline proto::HistorySeekReq sample_proto_history_seek_request() {
 inline proto::HistorySeekReply sample_proto_history_seek_response() {
     proto::HistorySeekReply response;
     response.set_ok(true);
-    response.set_v("ff00ff00");
+    response.set_v(ascii_from_hex("ff00ff00"));
     return response;
 }
 

--- a/silkworm/infra/grpc/test_util/interfaces/kv_mock_fix24351.grpc.pb.h
+++ b/silkworm/infra/grpc/test_util/interfaces/kv_mock_fix24351.grpc.pb.h
@@ -32,8 +32,8 @@ class FixIssue24351_MockKVStub : public remote::MockKVStub {
   MOCK_METHOD3(PrepareAsyncReceiveStateChanges, ::grpc::ClientAsyncReaderInterface< ::remote::StateChange>*(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq));
   MOCK_METHOD3(AsyncDomainGet, ::grpc::ClientAsyncResponseReaderInterface< ::remote::DomainGetReply>*(::grpc::ClientContext* context, const ::remote::DomainGetReq& request, ::grpc::CompletionQueue* cq));
   MOCK_METHOD3(PrepareAsyncDomainGet, ::grpc::ClientAsyncResponseReaderInterface< ::remote::DomainGetReply>*(::grpc::ClientContext* context, const ::remote::DomainGetReq& request, ::grpc::CompletionQueue* cq));
-  MOCK_METHOD3(AsyncHistoryGet, ::grpc::ClientAsyncResponseReaderInterface< ::remote::HistoryGetReply>*(::grpc::ClientContext* context, const ::remote::HistoryGetReq& request, ::grpc::CompletionQueue* cq));
-  MOCK_METHOD3(PrepareAsyncHistoryGet, ::grpc::ClientAsyncResponseReaderInterface< ::remote::HistoryGetReply>*(::grpc::ClientContext* context, const ::remote::HistoryGetReq& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD3(AsyncHistorySeek, ::grpc::ClientAsyncResponseReaderInterface< ::remote::HistorySeekReply>*(::grpc::ClientContext* context, const ::remote::HistorySeekReq& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD3(PrepareAsyncHistorySeek, ::grpc::ClientAsyncResponseReaderInterface< ::remote::HistorySeekReply>*(::grpc::ClientContext* context, const ::remote::HistorySeekReq& request, ::grpc::CompletionQueue* cq));
   MOCK_METHOD3(AsyncIndexRange, ::grpc::ClientAsyncResponseReaderInterface< ::remote::IndexRangeReply>*(::grpc::ClientContext* context, const ::remote::IndexRangeReq& request, ::grpc::CompletionQueue* cq));
   MOCK_METHOD3(PrepareAsyncIndexRange, ::grpc::ClientAsyncResponseReaderInterface< ::remote::IndexRangeReply>*(::grpc::ClientContext* context, const ::remote::IndexRangeReq& request, ::grpc::CompletionQueue* cq));
   MOCK_METHOD3(AsyncHistoryRange, ::grpc::ClientAsyncResponseReaderInterface< ::remote::Pairs>*(::grpc::ClientContext* context, const ::remote::HistoryRangeReq& request, ::grpc::CompletionQueue* cq));

--- a/silkworm/interfaces/3.21.12/execution/execution.pb.cc
+++ b/silkworm/interfaces/3.21.12/execution/execution.pb.cc
@@ -83,6 +83,7 @@ PROTOBUF_CONSTEXPR Header::Header(
   , /*decltype(_impl_.base_fee_per_gas_)*/nullptr
   , /*decltype(_impl_.withdrawal_hash_)*/nullptr
   , /*decltype(_impl_.parent_beacon_block_root_)*/nullptr
+  , /*decltype(_impl_.requests_root_)*/nullptr
   , /*decltype(_impl_.block_number_)*/uint64_t{0u}
   , /*decltype(_impl_.gas_limit_)*/uint64_t{0u}
   , /*decltype(_impl_.gas_used_)*/uint64_t{0u}
@@ -105,6 +106,7 @@ PROTOBUF_CONSTEXPR BlockBody::BlockBody(
     /*decltype(_impl_.transactions_)*/{}
   , /*decltype(_impl_.uncles_)*/{}
   , /*decltype(_impl_.withdrawals_)*/{}
+  , /*decltype(_impl_.requests_)*/{}
   , /*decltype(_impl_.block_hash_)*/nullptr
   , /*decltype(_impl_.block_number_)*/uint64_t{0u}
   , /*decltype(_impl_._cached_size_)*/{}} {}
@@ -391,6 +393,7 @@ PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORIT
 PROTOBUF_CONSTEXPR FrozenBlocksResponse::FrozenBlocksResponse(
     ::_pbi::ConstantInitialized): _impl_{
     /*decltype(_impl_.frozen_blocks_)*/uint64_t{0u}
+  , /*decltype(_impl_.has_gap_)*/false
   , /*decltype(_impl_._cached_size_)*/{}} {}
 struct FrozenBlocksResponseDefaultTypeInternal {
   PROTOBUF_CONSTEXPR FrozenBlocksResponseDefaultTypeInternal()
@@ -472,6 +475,7 @@ const uint32_t TableStruct_execution_2fexecution_2eproto::offsets[] PROTOBUF_SEC
   PROTOBUF_FIELD_OFFSET(::execution::Header, _impl_.blob_gas_used_),
   PROTOBUF_FIELD_OFFSET(::execution::Header, _impl_.excess_blob_gas_),
   PROTOBUF_FIELD_OFFSET(::execution::Header, _impl_.parent_beacon_block_root_),
+  PROTOBUF_FIELD_OFFSET(::execution::Header, _impl_.requests_root_),
   PROTOBUF_FIELD_OFFSET(::execution::Header, _impl_.aura_step_),
   PROTOBUF_FIELD_OFFSET(::execution::Header, _impl_.aura_seal_),
   ~0u,
@@ -492,10 +496,11 @@ const uint32_t TableStruct_execution_2fexecution_2eproto::offsets[] PROTOBUF_SEC
   ~0u,
   1,
   2,
-  4,
   5,
-  3,
   6,
+  3,
+  4,
+  7,
   0,
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::execution::BlockBody, _internal_metadata_),
@@ -508,6 +513,7 @@ const uint32_t TableStruct_execution_2fexecution_2eproto::offsets[] PROTOBUF_SEC
   PROTOBUF_FIELD_OFFSET(::execution::BlockBody, _impl_.transactions_),
   PROTOBUF_FIELD_OFFSET(::execution::BlockBody, _impl_.uncles_),
   PROTOBUF_FIELD_OFFSET(::execution::BlockBody, _impl_.withdrawals_),
+  PROTOBUF_FIELD_OFFSET(::execution::BlockBody, _impl_.requests_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::execution::Block, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -682,6 +688,7 @@ const uint32_t TableStruct_execution_2fexecution_2eproto::offsets[] PROTOBUF_SEC
   ~0u,  // no _weak_field_map_
   ~0u,  // no _inlined_string_donated_
   PROTOBUF_FIELD_OFFSET(::execution::FrozenBlocksResponse, _impl_.frozen_blocks_),
+  PROTOBUF_FIELD_OFFSET(::execution::FrozenBlocksResponse, _impl_.has_gap_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::execution::HasBlockResponse, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -694,29 +701,29 @@ static const ::_pbi::MigrationSchema schemas[] PROTOBUF_SECTION_VARIABLE(protode
   { 0, -1, -1, sizeof(::execution::ForkChoiceReceipt)},
   { 9, -1, -1, sizeof(::execution::ValidationReceipt)},
   { 18, -1, -1, sizeof(::execution::IsCanonicalResponse)},
-  { 25, 54, -1, sizeof(::execution::Header)},
-  { 77, -1, -1, sizeof(::execution::BlockBody)},
-  { 88, -1, -1, sizeof(::execution::Block)},
-  { 96, 103, -1, sizeof(::execution::GetHeaderResponse)},
-  { 104, 111, -1, sizeof(::execution::GetTDResponse)},
-  { 112, 119, -1, sizeof(::execution::GetBodyResponse)},
-  { 120, 127, -1, sizeof(::execution::GetHeaderHashNumberResponse)},
-  { 128, 136, -1, sizeof(::execution::GetSegmentRequest)},
-  { 138, -1, -1, sizeof(::execution::InsertBlocksRequest)},
-  { 145, 155, -1, sizeof(::execution::ForkChoice)},
-  { 159, -1, -1, sizeof(::execution::InsertionResult)},
-  { 166, -1, -1, sizeof(::execution::ValidationRequest)},
-  { 174, 186, -1, sizeof(::execution::AssembleBlockRequest)},
-  { 192, -1, -1, sizeof(::execution::AssembleBlockResponse)},
-  { 200, -1, -1, sizeof(::execution::GetAssembledBlockRequest)},
-  { 207, -1, -1, sizeof(::execution::AssembledBlockData)},
-  { 216, 224, -1, sizeof(::execution::GetAssembledBlockResponse)},
-  { 226, -1, -1, sizeof(::execution::GetBodiesBatchResponse)},
-  { 233, -1, -1, sizeof(::execution::GetBodiesByHashesRequest)},
-  { 240, -1, -1, sizeof(::execution::GetBodiesByRangeRequest)},
-  { 248, -1, -1, sizeof(::execution::ReadyResponse)},
-  { 255, -1, -1, sizeof(::execution::FrozenBlocksResponse)},
-  { 262, -1, -1, sizeof(::execution::HasBlockResponse)},
+  { 25, 55, -1, sizeof(::execution::Header)},
+  { 79, -1, -1, sizeof(::execution::BlockBody)},
+  { 91, -1, -1, sizeof(::execution::Block)},
+  { 99, 106, -1, sizeof(::execution::GetHeaderResponse)},
+  { 107, 114, -1, sizeof(::execution::GetTDResponse)},
+  { 115, 122, -1, sizeof(::execution::GetBodyResponse)},
+  { 123, 130, -1, sizeof(::execution::GetHeaderHashNumberResponse)},
+  { 131, 139, -1, sizeof(::execution::GetSegmentRequest)},
+  { 141, -1, -1, sizeof(::execution::InsertBlocksRequest)},
+  { 148, 158, -1, sizeof(::execution::ForkChoice)},
+  { 162, -1, -1, sizeof(::execution::InsertionResult)},
+  { 169, -1, -1, sizeof(::execution::ValidationRequest)},
+  { 177, 189, -1, sizeof(::execution::AssembleBlockRequest)},
+  { 195, -1, -1, sizeof(::execution::AssembleBlockResponse)},
+  { 203, -1, -1, sizeof(::execution::GetAssembledBlockRequest)},
+  { 210, -1, -1, sizeof(::execution::AssembledBlockData)},
+  { 219, 227, -1, sizeof(::execution::GetAssembledBlockResponse)},
+  { 229, -1, -1, sizeof(::execution::GetBodiesBatchResponse)},
+  { 236, -1, -1, sizeof(::execution::GetBodiesByHashesRequest)},
+  { 243, -1, -1, sizeof(::execution::GetBodiesByRangeRequest)},
+  { 251, -1, -1, sizeof(::execution::ReadyResponse)},
+  { 258, -1, -1, sizeof(::execution::FrozenBlocksResponse)},
+  { 266, -1, -1, sizeof(::execution::HasBlockResponse)},
 };
 
 static const ::_pb::Message* const file_default_instances[] = {
@@ -759,7 +766,7 @@ const char descriptor_table_protodef_execution_2fexecution_2eproto[] PROTOBUF_SE
   "ExecutionStatus\022&\n\021latest_valid_hash\030\002 \001"
   "(\0132\013.types.H256\022\030\n\020validation_error\030\003 \001("
   "\t\"(\n\023IsCanonicalResponse\022\021\n\tcanonical\030\001 "
-  "\001(\010\"\311\006\n\006Header\022 \n\013parent_hash\030\001 \001(\0132\013.ty"
+  "\001(\010\"\204\007\n\006Header\022 \n\013parent_hash\030\001 \001(\0132\013.ty"
   "pes.H256\022\035\n\010coinbase\030\002 \001(\0132\013.types.H160\022"
   "\037\n\nstate_root\030\003 \001(\0132\013.types.H256\022!\n\014rece"
   "ipt_root\030\004 \001(\0132\013.types.H256\022 \n\nlogs_bloo"
@@ -775,96 +782,99 @@ const char descriptor_table_protodef_execution_2fexecution_2eproto[] PROTOBUF_SE
   "awal_hash\030\022 \001(\0132\013.types.H256H\001\210\001\001\022\032\n\rblo"
   "b_gas_used\030\023 \001(\004H\002\210\001\001\022\034\n\017excess_blob_gas"
   "\030\024 \001(\004H\003\210\001\001\0222\n\030parent_beacon_block_root\030"
-  "\025 \001(\0132\013.types.H256H\004\210\001\001\022\026\n\taura_step\030\026 \001"
-  "(\004H\005\210\001\001\022\026\n\taura_seal\030\027 \001(\014H\006\210\001\001B\023\n\021_base"
-  "_fee_per_gasB\022\n\020_withdrawal_hashB\020\n\016_blo"
-  "b_gas_usedB\022\n\020_excess_blob_gasB\033\n\031_paren"
-  "t_beacon_block_rootB\014\n\n_aura_stepB\014\n\n_au"
-  "ra_seal\"\243\001\n\tBlockBody\022\037\n\nblock_hash\030\001 \001("
-  "\0132\013.types.H256\022\024\n\014block_number\030\002 \001(\004\022\024\n\014"
-  "transactions\030\003 \003(\014\022!\n\006uncles\030\004 \003(\0132\021.exe"
-  "cution.Header\022&\n\013withdrawals\030\005 \003(\0132\021.typ"
-  "es.Withdrawal\"N\n\005Block\022!\n\006header\030\001 \001(\0132\021"
-  ".execution.Header\022\"\n\004body\030\002 \001(\0132\024.execut"
-  "ion.BlockBody\"F\n\021GetHeaderResponse\022&\n\006he"
-  "ader\030\001 \001(\0132\021.execution.HeaderH\000\210\001\001B\t\n\007_h"
-  "eader\"4\n\rGetTDResponse\022\034\n\002td\030\001 \001(\0132\013.typ"
-  "es.H256H\000\210\001\001B\005\n\003_td\"C\n\017GetBodyResponse\022\'"
-  "\n\004body\030\001 \001(\0132\024.execution.BlockBodyH\000\210\001\001B"
-  "\007\n\005_body\"I\n\033GetHeaderHashNumberResponse\022"
-  "\031\n\014block_number\030\001 \001(\004H\000\210\001\001B\017\n\r_block_num"
-  "ber\"t\n\021GetSegmentRequest\022\031\n\014block_number"
-  "\030\001 \001(\004H\000\210\001\001\022$\n\nblock_hash\030\002 \001(\0132\013.types."
-  "H256H\001\210\001\001B\017\n\r_block_numberB\r\n\013_block_has"
-  "h\"7\n\023InsertBlocksRequest\022 \n\006blocks\030\001 \003(\013"
-  "2\020.execution.Block\"\313\001\n\nForkChoice\022$\n\017hea"
-  "d_block_hash\030\001 \001(\0132\013.types.H256\022\017\n\007timeo"
-  "ut\030\002 \001(\004\022.\n\024finalized_block_hash\030\003 \001(\0132\013"
-  ".types.H256H\000\210\001\001\022)\n\017safe_block_hash\030\004 \001("
-  "\0132\013.types.H256H\001\210\001\001B\027\n\025_finalized_block_"
-  "hashB\022\n\020_safe_block_hash\"=\n\017InsertionRes"
-  "ult\022*\n\006result\030\001 \001(\0162\032.execution.Executio"
-  "nStatus\">\n\021ValidationRequest\022\031\n\004hash\030\001 \001"
-  "(\0132\013.types.H256\022\016\n\006number\030\002 \001(\004\"\224\002\n\024Asse"
-  "mbleBlockRequest\022 \n\013parent_hash\030\001 \001(\0132\013."
-  "types.H256\022\021\n\ttimestamp\030\002 \001(\004\022 \n\013prev_ra"
-  "ndao\030\003 \001(\0132\013.types.H256\022,\n\027suggested_fee"
-  "_recipient\030\004 \001(\0132\013.types.H160\022&\n\013withdra"
-  "wals\030\005 \003(\0132\021.types.Withdrawal\0222\n\030parent_"
-  "beacon_block_root\030\006 \001(\0132\013.types.H256H\000\210\001"
-  "\001B\033\n\031_parent_beacon_block_root\"1\n\025Assemb"
-  "leBlockResponse\022\n\n\002id\030\001 \001(\004\022\014\n\004busy\030\002 \001("
-  "\010\"&\n\030GetAssembledBlockRequest\022\n\n\002id\030\001 \001("
-  "\004\"\226\001\n\022AssembledBlockData\0222\n\021execution_pa"
-  "yload\030\001 \001(\0132\027.types.ExecutionPayload\022 \n\013"
-  "block_value\030\002 \001(\0132\013.types.H256\022*\n\014blobs_"
-  "bundle\030\003 \001(\0132\024.types.BlobsBundleV1\"d\n\031Ge"
-  "tAssembledBlockResponse\0220\n\004data\030\001 \001(\0132\035."
-  "execution.AssembledBlockDataH\000\210\001\001\022\014\n\004bus"
-  "y\030\002 \001(\010B\007\n\005_data\">\n\026GetBodiesBatchRespon"
-  "se\022$\n\006bodies\030\001 \003(\0132\024.execution.BlockBody"
-  "\"7\n\030GetBodiesByHashesRequest\022\033\n\006hashes\030\001"
-  " \003(\0132\013.types.H256\"7\n\027GetBodiesByRangeReq"
-  "uest\022\r\n\005start\030\001 \001(\004\022\r\n\005count\030\002 \001(\004\"\036\n\rRe"
-  "adyResponse\022\r\n\005ready\030\001 \001(\010\"-\n\024FrozenBloc"
-  "ksResponse\022\025\n\rfrozen_blocks\030\001 \001(\004\"%\n\020Has"
-  "BlockResponse\022\021\n\thas_block\030\001 \001(\010*q\n\017Exec"
-  "utionStatus\022\013\n\007Success\020\000\022\014\n\010BadBlock\020\001\022\016"
-  "\n\nTooFarAway\020\002\022\022\n\016MissingSegment\020\003\022\025\n\021In"
-  "validForkchoice\020\004\022\010\n\004Busy\020\0052\206\n\n\tExecutio"
-  "n\022J\n\014InsertBlocks\022\036.execution.InsertBloc"
-  "ksRequest\032\032.execution.InsertionResult\022K\n"
-  "\rValidateChain\022\034.execution.ValidationReq"
-  "uest\032\034.execution.ValidationReceipt\022G\n\020Up"
-  "dateForkChoice\022\025.execution.ForkChoice\032\034."
-  "execution.ForkChoiceReceipt\022R\n\rAssembleB"
-  "lock\022\037.execution.AssembleBlockRequest\032 ."
-  "execution.AssembleBlockResponse\022^\n\021GetAs"
-  "sembledBlock\022#.execution.GetAssembledBlo"
-  "ckRequest\032$.execution.GetAssembledBlockR"
-  "esponse\022E\n\rCurrentHeader\022\026.google.protob"
-  "uf.Empty\032\034.execution.GetHeaderResponse\022\?"
-  "\n\005GetTD\022\034.execution.GetSegmentRequest\032\030."
-  "execution.GetTDResponse\022G\n\tGetHeader\022\034.e"
-  "xecution.GetSegmentRequest\032\034.execution.G"
-  "etHeaderResponse\022C\n\007GetBody\022\034.execution."
-  "GetSegmentRequest\032\032.execution.GetBodyRes"
-  "ponse\022E\n\010HasBlock\022\034.execution.GetSegment"
-  "Request\032\033.execution.HasBlockResponse\022Y\n\020"
-  "GetBodiesByRange\022\".execution.GetBodiesBy"
-  "RangeRequest\032!.execution.GetBodiesBatchR"
-  "esponse\022[\n\021GetBodiesByHashes\022#.execution"
-  ".GetBodiesByHashesRequest\032!.execution.Ge"
-  "tBodiesBatchResponse\022>\n\017IsCanonicalHash\022"
-  "\013.types.H256\032\036.execution.IsCanonicalResp"
-  "onse\022J\n\023GetHeaderHashNumber\022\013.types.H256"
-  "\032&.execution.GetHeaderHashNumberResponse"
-  "\022>\n\rGetForkChoice\022\026.google.protobuf.Empt"
-  "y\032\025.execution.ForkChoice\0229\n\005Ready\022\026.goog"
-  "le.protobuf.Empty\032\030.execution.ReadyRespo"
-  "nse\022G\n\014FrozenBlocks\022\026.google.protobuf.Em"
-  "pty\032\037.execution.FrozenBlocksResponseB\027Z\025"
-  "./execution;executionb\006proto3"
+  "\025 \001(\0132\013.types.H256H\004\210\001\001\022\'\n\rrequests_root"
+  "\030\026 \001(\0132\013.types.H256H\005\210\001\001\022\026\n\taura_step\030\027 "
+  "\001(\004H\006\210\001\001\022\026\n\taura_seal\030\030 \001(\014H\007\210\001\001B\023\n\021_bas"
+  "e_fee_per_gasB\022\n\020_withdrawal_hashB\020\n\016_bl"
+  "ob_gas_usedB\022\n\020_excess_blob_gasB\033\n\031_pare"
+  "nt_beacon_block_rootB\020\n\016_requests_rootB\014"
+  "\n\n_aura_stepB\014\n\n_aura_seal\"\265\001\n\tBlockBody"
+  "\022\037\n\nblock_hash\030\001 \001(\0132\013.types.H256\022\024\n\014blo"
+  "ck_number\030\002 \001(\004\022\024\n\014transactions\030\003 \003(\014\022!\n"
+  "\006uncles\030\004 \003(\0132\021.execution.Header\022&\n\013with"
+  "drawals\030\005 \003(\0132\021.types.Withdrawal\022\020\n\010requ"
+  "ests\030\006 \003(\014\"N\n\005Block\022!\n\006header\030\001 \001(\0132\021.ex"
+  "ecution.Header\022\"\n\004body\030\002 \001(\0132\024.execution"
+  ".BlockBody\"F\n\021GetHeaderResponse\022&\n\006heade"
+  "r\030\001 \001(\0132\021.execution.HeaderH\000\210\001\001B\t\n\007_head"
+  "er\"4\n\rGetTDResponse\022\034\n\002td\030\001 \001(\0132\013.types."
+  "H256H\000\210\001\001B\005\n\003_td\"C\n\017GetBodyResponse\022\'\n\004b"
+  "ody\030\001 \001(\0132\024.execution.BlockBodyH\000\210\001\001B\007\n\005"
+  "_body\"I\n\033GetHeaderHashNumberResponse\022\031\n\014"
+  "block_number\030\001 \001(\004H\000\210\001\001B\017\n\r_block_number"
+  "\"t\n\021GetSegmentRequest\022\031\n\014block_number\030\001 "
+  "\001(\004H\000\210\001\001\022$\n\nblock_hash\030\002 \001(\0132\013.types.H25"
+  "6H\001\210\001\001B\017\n\r_block_numberB\r\n\013_block_hash\"7"
+  "\n\023InsertBlocksRequest\022 \n\006blocks\030\001 \003(\0132\020."
+  "execution.Block\"\313\001\n\nForkChoice\022$\n\017head_b"
+  "lock_hash\030\001 \001(\0132\013.types.H256\022\017\n\007timeout\030"
+  "\002 \001(\004\022.\n\024finalized_block_hash\030\003 \001(\0132\013.ty"
+  "pes.H256H\000\210\001\001\022)\n\017safe_block_hash\030\004 \001(\0132\013"
+  ".types.H256H\001\210\001\001B\027\n\025_finalized_block_has"
+  "hB\022\n\020_safe_block_hash\"=\n\017InsertionResult"
+  "\022*\n\006result\030\001 \001(\0162\032.execution.ExecutionSt"
+  "atus\">\n\021ValidationRequest\022\031\n\004hash\030\001 \001(\0132"
+  "\013.types.H256\022\016\n\006number\030\002 \001(\004\"\224\002\n\024Assembl"
+  "eBlockRequest\022 \n\013parent_hash\030\001 \001(\0132\013.typ"
+  "es.H256\022\021\n\ttimestamp\030\002 \001(\004\022 \n\013prev_randa"
+  "o\030\003 \001(\0132\013.types.H256\022,\n\027suggested_fee_re"
+  "cipient\030\004 \001(\0132\013.types.H160\022&\n\013withdrawal"
+  "s\030\005 \003(\0132\021.types.Withdrawal\0222\n\030parent_bea"
+  "con_block_root\030\006 \001(\0132\013.types.H256H\000\210\001\001B\033"
+  "\n\031_parent_beacon_block_root\"1\n\025AssembleB"
+  "lockResponse\022\n\n\002id\030\001 \001(\004\022\014\n\004busy\030\002 \001(\010\"&"
+  "\n\030GetAssembledBlockRequest\022\n\n\002id\030\001 \001(\004\"\226"
+  "\001\n\022AssembledBlockData\0222\n\021execution_paylo"
+  "ad\030\001 \001(\0132\027.types.ExecutionPayload\022 \n\013blo"
+  "ck_value\030\002 \001(\0132\013.types.H256\022*\n\014blobs_bun"
+  "dle\030\003 \001(\0132\024.types.BlobsBundleV1\"d\n\031GetAs"
+  "sembledBlockResponse\0220\n\004data\030\001 \001(\0132\035.exe"
+  "cution.AssembledBlockDataH\000\210\001\001\022\014\n\004busy\030\002"
+  " \001(\010B\007\n\005_data\">\n\026GetBodiesBatchResponse\022"
+  "$\n\006bodies\030\001 \003(\0132\024.execution.BlockBody\"7\n"
+  "\030GetBodiesByHashesRequest\022\033\n\006hashes\030\001 \003("
+  "\0132\013.types.H256\"7\n\027GetBodiesByRangeReques"
+  "t\022\r\n\005start\030\001 \001(\004\022\r\n\005count\030\002 \001(\004\"\036\n\rReady"
+  "Response\022\r\n\005ready\030\001 \001(\010\">\n\024FrozenBlocksR"
+  "esponse\022\025\n\rfrozen_blocks\030\001 \001(\004\022\017\n\007has_ga"
+  "p\030\002 \001(\010\"%\n\020HasBlockResponse\022\021\n\thas_block"
+  "\030\001 \001(\010*q\n\017ExecutionStatus\022\013\n\007Success\020\000\022\014"
+  "\n\010BadBlock\020\001\022\016\n\nTooFarAway\020\002\022\022\n\016MissingS"
+  "egment\020\003\022\025\n\021InvalidForkchoice\020\004\022\010\n\004Busy\020"
+  "\0052\206\n\n\tExecution\022J\n\014InsertBlocks\022\036.execut"
+  "ion.InsertBlocksRequest\032\032.execution.Inse"
+  "rtionResult\022K\n\rValidateChain\022\034.execution"
+  ".ValidationRequest\032\034.execution.Validatio"
+  "nReceipt\022G\n\020UpdateForkChoice\022\025.execution"
+  ".ForkChoice\032\034.execution.ForkChoiceReceip"
+  "t\022R\n\rAssembleBlock\022\037.execution.AssembleB"
+  "lockRequest\032 .execution.AssembleBlockRes"
+  "ponse\022^\n\021GetAssembledBlock\022#.execution.G"
+  "etAssembledBlockRequest\032$.execution.GetA"
+  "ssembledBlockResponse\022E\n\rCurrentHeader\022\026"
+  ".google.protobuf.Empty\032\034.execution.GetHe"
+  "aderResponse\022\?\n\005GetTD\022\034.execution.GetSeg"
+  "mentRequest\032\030.execution.GetTDResponse\022G\n"
+  "\tGetHeader\022\034.execution.GetSegmentRequest"
+  "\032\034.execution.GetHeaderResponse\022C\n\007GetBod"
+  "y\022\034.execution.GetSegmentRequest\032\032.execut"
+  "ion.GetBodyResponse\022E\n\010HasBlock\022\034.execut"
+  "ion.GetSegmentRequest\032\033.execution.HasBlo"
+  "ckResponse\022Y\n\020GetBodiesByRange\022\".executi"
+  "on.GetBodiesByRangeRequest\032!.execution.G"
+  "etBodiesBatchResponse\022[\n\021GetBodiesByHash"
+  "es\022#.execution.GetBodiesByHashesRequest\032"
+  "!.execution.GetBodiesBatchResponse\022>\n\017Is"
+  "CanonicalHash\022\013.types.H256\032\036.execution.I"
+  "sCanonicalResponse\022J\n\023GetHeaderHashNumbe"
+  "r\022\013.types.H256\032&.execution.GetHeaderHash"
+  "NumberResponse\022>\n\rGetForkChoice\022\026.google"
+  ".protobuf.Empty\032\025.execution.ForkChoice\0229"
+  "\n\005Ready\022\026.google.protobuf.Empty\032\030.execut"
+  "ion.ReadyResponse\022G\n\014FrozenBlocks\022\026.goog"
+  "le.protobuf.Empty\032\037.execution.FrozenBloc"
+  "ksResponseB\034Z\032./execution;executionproto"
+  "b\006proto3"
   ;
 static const ::_pbi::DescriptorTable* const descriptor_table_execution_2fexecution_2eproto_deps[2] = {
   &::descriptor_table_google_2fprotobuf_2fempty_2eproto,
@@ -872,7 +882,7 @@ static const ::_pbi::DescriptorTable* const descriptor_table_execution_2fexecuti
 };
 static ::_pbi::once_flag descriptor_table_execution_2fexecution_2eproto_once;
 const ::_pbi::DescriptorTable descriptor_table_execution_2fexecution_2eproto = {
-    false, false, 4629, descriptor_table_protodef_execution_2fexecution_2eproto,
+    false, false, 4728, descriptor_table_protodef_execution_2fexecution_2eproto,
     "execution/execution.proto",
     &descriptor_table_execution_2fexecution_2eproto_once, descriptor_table_execution_2fexecution_2eproto_deps, 2, 26,
     schemas, file_default_instances, TableStruct_execution_2fexecution_2eproto::offsets,
@@ -1677,17 +1687,21 @@ class Header::_Internal {
     (*has_bits)[0] |= 4u;
   }
   static void set_has_blob_gas_used(HasBits* has_bits) {
-    (*has_bits)[0] |= 16u;
+    (*has_bits)[0] |= 32u;
   }
   static void set_has_excess_blob_gas(HasBits* has_bits) {
-    (*has_bits)[0] |= 32u;
+    (*has_bits)[0] |= 64u;
   }
   static const ::types::H256& parent_beacon_block_root(const Header* msg);
   static void set_has_parent_beacon_block_root(HasBits* has_bits) {
     (*has_bits)[0] |= 8u;
   }
+  static const ::types::H256& requests_root(const Header* msg);
+  static void set_has_requests_root(HasBits* has_bits) {
+    (*has_bits)[0] |= 16u;
+  }
   static void set_has_aura_step(HasBits* has_bits) {
-    (*has_bits)[0] |= 64u;
+    (*has_bits)[0] |= 128u;
   }
   static void set_has_aura_seal(HasBits* has_bits) {
     (*has_bits)[0] |= 1u;
@@ -1745,6 +1759,10 @@ Header::_Internal::withdrawal_hash(const Header* msg) {
 const ::types::H256&
 Header::_Internal::parent_beacon_block_root(const Header* msg) {
   return *msg->_impl_.parent_beacon_block_root_;
+}
+const ::types::H256&
+Header::_Internal::requests_root(const Header* msg) {
+  return *msg->_impl_.requests_root_;
 }
 void Header::clear_parent_hash() {
   if (GetArenaForAllocation() == nullptr && _impl_.parent_hash_ != nullptr) {
@@ -1818,6 +1836,10 @@ void Header::clear_parent_beacon_block_root() {
   if (_impl_.parent_beacon_block_root_ != nullptr) _impl_.parent_beacon_block_root_->Clear();
   _impl_._has_bits_[0] &= ~0x00000008u;
 }
+void Header::clear_requests_root() {
+  if (_impl_.requests_root_ != nullptr) _impl_.requests_root_->Clear();
+  _impl_._has_bits_[0] &= ~0x00000010u;
+}
 Header::Header(::PROTOBUF_NAMESPACE_ID::Arena* arena,
                          bool is_message_owned)
   : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
@@ -1845,6 +1867,7 @@ Header::Header(const Header& from)
     , decltype(_impl_.base_fee_per_gas_){nullptr}
     , decltype(_impl_.withdrawal_hash_){nullptr}
     , decltype(_impl_.parent_beacon_block_root_){nullptr}
+    , decltype(_impl_.requests_root_){nullptr}
     , decltype(_impl_.block_number_){}
     , decltype(_impl_.gas_limit_){}
     , decltype(_impl_.gas_used_){}
@@ -1910,6 +1933,9 @@ Header::Header(const Header& from)
   if (from._internal_has_parent_beacon_block_root()) {
     _this->_impl_.parent_beacon_block_root_ = new ::types::H256(*from._impl_.parent_beacon_block_root_);
   }
+  if (from._internal_has_requests_root()) {
+    _this->_impl_.requests_root_ = new ::types::H256(*from._impl_.requests_root_);
+  }
   ::memcpy(&_impl_.block_number_, &from._impl_.block_number_,
     static_cast<size_t>(reinterpret_cast<char*>(&_impl_.aura_step_) -
     reinterpret_cast<char*>(&_impl_.block_number_)) + sizeof(_impl_.aura_step_));
@@ -1938,6 +1964,7 @@ inline void Header::SharedCtor(
     , decltype(_impl_.base_fee_per_gas_){nullptr}
     , decltype(_impl_.withdrawal_hash_){nullptr}
     , decltype(_impl_.parent_beacon_block_root_){nullptr}
+    , decltype(_impl_.requests_root_){nullptr}
     , decltype(_impl_.block_number_){uint64_t{0u}}
     , decltype(_impl_.gas_limit_){uint64_t{0u}}
     , decltype(_impl_.gas_used_){uint64_t{0u}}
@@ -1983,6 +2010,7 @@ inline void Header::SharedDtor() {
   if (this != internal_default_instance()) delete _impl_.base_fee_per_gas_;
   if (this != internal_default_instance()) delete _impl_.withdrawal_hash_;
   if (this != internal_default_instance()) delete _impl_.parent_beacon_block_root_;
+  if (this != internal_default_instance()) delete _impl_.requests_root_;
 }
 
 void Header::SetCachedSize(int size) const {
@@ -2040,7 +2068,7 @@ void Header::Clear() {
     delete _impl_.transaction_hash_;
   }
   _impl_.transaction_hash_ = nullptr;
-  if (cached_has_bits & 0x0000000eu) {
+  if (cached_has_bits & 0x0000001eu) {
     if (cached_has_bits & 0x00000002u) {
       GOOGLE_DCHECK(_impl_.base_fee_per_gas_ != nullptr);
       _impl_.base_fee_per_gas_->Clear();
@@ -2053,11 +2081,15 @@ void Header::Clear() {
       GOOGLE_DCHECK(_impl_.parent_beacon_block_root_ != nullptr);
       _impl_.parent_beacon_block_root_->Clear();
     }
+    if (cached_has_bits & 0x00000010u) {
+      GOOGLE_DCHECK(_impl_.requests_root_ != nullptr);
+      _impl_.requests_root_->Clear();
+    }
   }
   ::memset(&_impl_.block_number_, 0, static_cast<size_t>(
       reinterpret_cast<char*>(&_impl_.nonce_) -
       reinterpret_cast<char*>(&_impl_.block_number_)) + sizeof(_impl_.nonce_));
-  if (cached_has_bits & 0x00000070u) {
+  if (cached_has_bits & 0x000000e0u) {
     ::memset(&_impl_.blob_gas_used_, 0, static_cast<size_t>(
         reinterpret_cast<char*>(&_impl_.aura_step_) -
         reinterpret_cast<char*>(&_impl_.blob_gas_used_)) + sizeof(_impl_.aura_step_));
@@ -2244,18 +2276,26 @@ const char* Header::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
         } else
           goto handle_unusual;
         continue;
-      // optional uint64 aura_step = 22;
+      // optional .types.H256 requests_root = 22;
       case 22:
-        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 176)) {
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 178)) {
+          ptr = ctx->ParseMessage(_internal_mutable_requests_root(), ptr);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      // optional uint64 aura_step = 23;
+      case 23:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 184)) {
           _Internal::set_has_aura_step(&has_bits);
           _impl_.aura_step_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
           CHK_(ptr);
         } else
           goto handle_unusual;
         continue;
-      // optional bytes aura_seal = 23;
-      case 23:
-        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 186)) {
+      // optional bytes aura_seal = 24;
+      case 24:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 194)) {
           auto str = _internal_mutable_aura_seal();
           ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
           CHK_(ptr);
@@ -2431,16 +2471,23 @@ uint8_t* Header::_InternalSerialize(
         _Internal::parent_beacon_block_root(this).GetCachedSize(), target, stream);
   }
 
-  // optional uint64 aura_step = 22;
-  if (_internal_has_aura_step()) {
-    target = stream->EnsureSpace(target);
-    target = ::_pbi::WireFormatLite::WriteUInt64ToArray(22, this->_internal_aura_step(), target);
+  // optional .types.H256 requests_root = 22;
+  if (_internal_has_requests_root()) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(22, _Internal::requests_root(this),
+        _Internal::requests_root(this).GetCachedSize(), target, stream);
   }
 
-  // optional bytes aura_seal = 23;
+  // optional uint64 aura_step = 23;
+  if (_internal_has_aura_step()) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteUInt64ToArray(23, this->_internal_aura_step(), target);
+  }
+
+  // optional bytes aura_seal = 24;
   if (_internal_has_aura_seal()) {
     target = stream->WriteBytesMaybeAliased(
-        23, this->_internal_aura_seal(), target);
+        24, this->_internal_aura_seal(), target);
   }
 
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
@@ -2466,7 +2513,7 @@ size_t Header::ByteSizeLong() const {
         this->_internal_extra_data());
   }
 
-  // optional bytes aura_seal = 23;
+  // optional bytes aura_seal = 24;
   cached_has_bits = _impl_._has_bits_[0];
   if (cached_has_bits & 0x00000001u) {
     total_size += 2 +
@@ -2544,7 +2591,7 @@ size_t Header::ByteSizeLong() const {
         *_impl_.transaction_hash_);
   }
 
-  if (cached_has_bits & 0x0000000eu) {
+  if (cached_has_bits & 0x0000001eu) {
     // optional .types.H256 base_fee_per_gas = 17;
     if (cached_has_bits & 0x00000002u) {
       total_size += 2 +
@@ -2564,6 +2611,13 @@ size_t Header::ByteSizeLong() const {
       total_size += 2 +
         ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
           *_impl_.parent_beacon_block_root_);
+    }
+
+    // optional .types.H256 requests_root = 22;
+    if (cached_has_bits & 0x00000010u) {
+      total_size += 2 +
+        ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+          *_impl_.requests_root_);
     }
 
   }
@@ -2592,23 +2646,23 @@ size_t Header::ByteSizeLong() const {
     total_size += ::_pbi::WireFormatLite::UInt64SizePlusOne(this->_internal_nonce());
   }
 
-  if (cached_has_bits & 0x00000070u) {
+  if (cached_has_bits & 0x000000e0u) {
     // optional uint64 blob_gas_used = 19;
-    if (cached_has_bits & 0x00000010u) {
+    if (cached_has_bits & 0x00000020u) {
       total_size += 2 +
         ::_pbi::WireFormatLite::UInt64Size(
           this->_internal_blob_gas_used());
     }
 
     // optional uint64 excess_blob_gas = 20;
-    if (cached_has_bits & 0x00000020u) {
+    if (cached_has_bits & 0x00000040u) {
       total_size += 2 +
         ::_pbi::WireFormatLite::UInt64Size(
           this->_internal_excess_blob_gas());
     }
 
-    // optional uint64 aura_step = 22;
-    if (cached_has_bits & 0x00000040u) {
+    // optional uint64 aura_step = 23;
+    if (cached_has_bits & 0x00000080u) {
       total_size += 2 +
         ::_pbi::WireFormatLite::UInt64Size(
           this->_internal_aura_step());
@@ -2680,7 +2734,7 @@ void Header::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBU
         from._internal_transaction_hash());
   }
   cached_has_bits = from._impl_._has_bits_[0];
-  if (cached_has_bits & 0x0000000eu) {
+  if (cached_has_bits & 0x0000001eu) {
     if (cached_has_bits & 0x00000002u) {
       _this->_internal_mutable_base_fee_per_gas()->::types::H256::MergeFrom(
           from._internal_base_fee_per_gas());
@@ -2692,6 +2746,10 @@ void Header::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBU
     if (cached_has_bits & 0x00000008u) {
       _this->_internal_mutable_parent_beacon_block_root()->::types::H256::MergeFrom(
           from._internal_parent_beacon_block_root());
+    }
+    if (cached_has_bits & 0x00000010u) {
+      _this->_internal_mutable_requests_root()->::types::H256::MergeFrom(
+          from._internal_requests_root());
     }
   }
   if (from._internal_block_number() != 0) {
@@ -2709,14 +2767,14 @@ void Header::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBU
   if (from._internal_nonce() != 0) {
     _this->_internal_set_nonce(from._internal_nonce());
   }
-  if (cached_has_bits & 0x00000070u) {
-    if (cached_has_bits & 0x00000010u) {
+  if (cached_has_bits & 0x000000e0u) {
+    if (cached_has_bits & 0x00000020u) {
       _this->_impl_.blob_gas_used_ = from._impl_.blob_gas_used_;
     }
-    if (cached_has_bits & 0x00000020u) {
+    if (cached_has_bits & 0x00000040u) {
       _this->_impl_.excess_blob_gas_ = from._impl_.excess_blob_gas_;
     }
-    if (cached_has_bits & 0x00000040u) {
+    if (cached_has_bits & 0x00000080u) {
       _this->_impl_.aura_step_ = from._impl_.aura_step_;
     }
     _this->_impl_._has_bits_[0] |= cached_has_bits;
@@ -2796,6 +2854,7 @@ BlockBody::BlockBody(const BlockBody& from)
       decltype(_impl_.transactions_){from._impl_.transactions_}
     , decltype(_impl_.uncles_){from._impl_.uncles_}
     , decltype(_impl_.withdrawals_){from._impl_.withdrawals_}
+    , decltype(_impl_.requests_){from._impl_.requests_}
     , decltype(_impl_.block_hash_){nullptr}
     , decltype(_impl_.block_number_){}
     , /*decltype(_impl_._cached_size_)*/{}};
@@ -2816,6 +2875,7 @@ inline void BlockBody::SharedCtor(
       decltype(_impl_.transactions_){arena}
     , decltype(_impl_.uncles_){arena}
     , decltype(_impl_.withdrawals_){arena}
+    , decltype(_impl_.requests_){arena}
     , decltype(_impl_.block_hash_){nullptr}
     , decltype(_impl_.block_number_){uint64_t{0u}}
     , /*decltype(_impl_._cached_size_)*/{}
@@ -2836,6 +2896,7 @@ inline void BlockBody::SharedDtor() {
   _impl_.transactions_.~RepeatedPtrField();
   _impl_.uncles_.~RepeatedPtrField();
   _impl_.withdrawals_.~RepeatedPtrField();
+  _impl_.requests_.~RepeatedPtrField();
   if (this != internal_default_instance()) delete _impl_.block_hash_;
 }
 
@@ -2852,6 +2913,7 @@ void BlockBody::Clear() {
   _impl_.transactions_.Clear();
   _impl_.uncles_.Clear();
   _impl_.withdrawals_.Clear();
+  _impl_.requests_.Clear();
   if (GetArenaForAllocation() == nullptr && _impl_.block_hash_ != nullptr) {
     delete _impl_.block_hash_;
   }
@@ -2922,6 +2984,20 @@ const char* BlockBody::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx
         } else
           goto handle_unusual;
         continue;
+      // repeated bytes requests = 6;
+      case 6:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 50)) {
+          ptr -= 1;
+          do {
+            ptr += 1;
+            auto str = _internal_add_requests();
+            ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+            CHK_(ptr);
+            if (!ctx->DataAvailable(ptr)) break;
+          } while (::PROTOBUF_NAMESPACE_ID::internal::ExpectTag<50>(ptr));
+        } else
+          goto handle_unusual;
+        continue;
       default:
         goto handle_unusual;
     }  // switch
@@ -2986,6 +3062,12 @@ uint8_t* BlockBody::_InternalSerialize(
         InternalWriteMessage(5, repfield, repfield.GetCachedSize(), target, stream);
   }
 
+  // repeated bytes requests = 6;
+  for (int i = 0, n = this->_internal_requests_size(); i < n; i++) {
+    const auto& s = this->_internal_requests(i);
+    target = stream->WriteBytes(6, s, target);
+  }
+
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
     target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
         _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
@@ -3024,6 +3106,14 @@ size_t BlockBody::ByteSizeLong() const {
       ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(msg);
   }
 
+  // repeated bytes requests = 6;
+  total_size += 1 *
+      ::PROTOBUF_NAMESPACE_ID::internal::FromIntSize(_impl_.requests_.size());
+  for (int i = 0, n = _impl_.requests_.size(); i < n; i++) {
+    total_size += ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::BytesSize(
+      _impl_.requests_.Get(i));
+  }
+
   // .types.H256 block_hash = 1;
   if (this->_internal_has_block_hash()) {
     total_size += 1 +
@@ -3057,6 +3147,7 @@ void BlockBody::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROT
   _this->_impl_.transactions_.MergeFrom(from._impl_.transactions_);
   _this->_impl_.uncles_.MergeFrom(from._impl_.uncles_);
   _this->_impl_.withdrawals_.MergeFrom(from._impl_.withdrawals_);
+  _this->_impl_.requests_.MergeFrom(from._impl_.requests_);
   if (from._internal_has_block_hash()) {
     _this->_internal_mutable_block_hash()->::types::H256::MergeFrom(
         from._internal_block_hash());
@@ -3084,6 +3175,7 @@ void BlockBody::InternalSwap(BlockBody* other) {
   _impl_.transactions_.InternalSwap(&other->_impl_.transactions_);
   _impl_.uncles_.InternalSwap(&other->_impl_.uncles_);
   _impl_.withdrawals_.InternalSwap(&other->_impl_.withdrawals_);
+  _impl_.requests_.InternalSwap(&other->_impl_.requests_);
   ::PROTOBUF_NAMESPACE_ID::internal::memswap<
       PROTOBUF_FIELD_OFFSET(BlockBody, _impl_.block_number_)
       + sizeof(BlockBody::_impl_.block_number_)
@@ -7454,10 +7546,13 @@ FrozenBlocksResponse::FrozenBlocksResponse(const FrozenBlocksResponse& from)
   FrozenBlocksResponse* const _this = this; (void)_this;
   new (&_impl_) Impl_{
       decltype(_impl_.frozen_blocks_){}
+    , decltype(_impl_.has_gap_){}
     , /*decltype(_impl_._cached_size_)*/{}};
 
   _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
-  _this->_impl_.frozen_blocks_ = from._impl_.frozen_blocks_;
+  ::memcpy(&_impl_.frozen_blocks_, &from._impl_.frozen_blocks_,
+    static_cast<size_t>(reinterpret_cast<char*>(&_impl_.has_gap_) -
+    reinterpret_cast<char*>(&_impl_.frozen_blocks_)) + sizeof(_impl_.has_gap_));
   // @@protoc_insertion_point(copy_constructor:execution.FrozenBlocksResponse)
 }
 
@@ -7467,6 +7562,7 @@ inline void FrozenBlocksResponse::SharedCtor(
   (void)is_message_owned;
   new (&_impl_) Impl_{
       decltype(_impl_.frozen_blocks_){uint64_t{0u}}
+    , decltype(_impl_.has_gap_){false}
     , /*decltype(_impl_._cached_size_)*/{}
   };
 }
@@ -7494,7 +7590,9 @@ void FrozenBlocksResponse::Clear() {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
-  _impl_.frozen_blocks_ = uint64_t{0u};
+  ::memset(&_impl_.frozen_blocks_, 0, static_cast<size_t>(
+      reinterpret_cast<char*>(&_impl_.has_gap_) -
+      reinterpret_cast<char*>(&_impl_.frozen_blocks_)) + sizeof(_impl_.has_gap_));
   _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
@@ -7508,6 +7606,14 @@ const char* FrozenBlocksResponse::_InternalParse(const char* ptr, ::_pbi::ParseC
       case 1:
         if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 8)) {
           _impl_.frozen_blocks_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      // bool has_gap = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 16)) {
+          _impl_.has_gap_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
           CHK_(ptr);
         } else
           goto handle_unusual;
@@ -7547,6 +7653,12 @@ uint8_t* FrozenBlocksResponse::_InternalSerialize(
     target = ::_pbi::WireFormatLite::WriteUInt64ToArray(1, this->_internal_frozen_blocks(), target);
   }
 
+  // bool has_gap = 2;
+  if (this->_internal_has_gap() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteBoolToArray(2, this->_internal_has_gap(), target);
+  }
+
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
     target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
         _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
@@ -7566,6 +7678,11 @@ size_t FrozenBlocksResponse::ByteSizeLong() const {
   // uint64 frozen_blocks = 1;
   if (this->_internal_frozen_blocks() != 0) {
     total_size += ::_pbi::WireFormatLite::UInt64SizePlusOne(this->_internal_frozen_blocks());
+  }
+
+  // bool has_gap = 2;
+  if (this->_internal_has_gap() != 0) {
+    total_size += 1 + 1;
   }
 
   return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
@@ -7589,6 +7706,9 @@ void FrozenBlocksResponse::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, c
   if (from._internal_frozen_blocks() != 0) {
     _this->_internal_set_frozen_blocks(from._internal_frozen_blocks());
   }
+  if (from._internal_has_gap() != 0) {
+    _this->_internal_set_has_gap(from._internal_has_gap());
+  }
   _this->_internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
 }
 
@@ -7606,7 +7726,12 @@ bool FrozenBlocksResponse::IsInitialized() const {
 void FrozenBlocksResponse::InternalSwap(FrozenBlocksResponse* other) {
   using std::swap;
   _internal_metadata_.InternalSwap(&other->_internal_metadata_);
-  swap(_impl_.frozen_blocks_, other->_impl_.frozen_blocks_);
+  ::PROTOBUF_NAMESPACE_ID::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(FrozenBlocksResponse, _impl_.has_gap_)
+      + sizeof(FrozenBlocksResponse::_impl_.has_gap_)
+      - PROTOBUF_FIELD_OFFSET(FrozenBlocksResponse, _impl_.frozen_blocks_)>(
+          reinterpret_cast<char*>(&_impl_.frozen_blocks_),
+          reinterpret_cast<char*>(&other->_impl_.frozen_blocks_));
 }
 
 ::PROTOBUF_NAMESPACE_ID::Metadata FrozenBlocksResponse::GetMetadata() const {

--- a/silkworm/interfaces/3.21.12/execution/execution.pb.h
+++ b/silkworm/interfaces/3.21.12/execution/execution.pb.h
@@ -826,7 +826,7 @@ class Header final :
 
   enum : int {
     kExtraDataFieldNumber = 12,
-    kAuraSealFieldNumber = 23,
+    kAuraSealFieldNumber = 24,
     kParentHashFieldNumber = 1,
     kCoinbaseFieldNumber = 2,
     kStateRootFieldNumber = 3,
@@ -840,6 +840,7 @@ class Header final :
     kBaseFeePerGasFieldNumber = 17,
     kWithdrawalHashFieldNumber = 18,
     kParentBeaconBlockRootFieldNumber = 21,
+    kRequestsRootFieldNumber = 22,
     kBlockNumberFieldNumber = 7,
     kGasLimitFieldNumber = 8,
     kGasUsedFieldNumber = 9,
@@ -847,7 +848,7 @@ class Header final :
     kNonceFieldNumber = 11,
     kBlobGasUsedFieldNumber = 19,
     kExcessBlobGasFieldNumber = 20,
-    kAuraStepFieldNumber = 22,
+    kAuraStepFieldNumber = 23,
   };
   // bytes extra_data = 12;
   void clear_extra_data();
@@ -863,7 +864,7 @@ class Header final :
   std::string* _internal_mutable_extra_data();
   public:
 
-  // optional bytes aura_seal = 23;
+  // optional bytes aura_seal = 24;
   bool has_aura_seal() const;
   private:
   bool _internal_has_aura_seal() const;
@@ -1115,6 +1116,24 @@ class Header final :
       ::types::H256* parent_beacon_block_root);
   ::types::H256* unsafe_arena_release_parent_beacon_block_root();
 
+  // optional .types.H256 requests_root = 22;
+  bool has_requests_root() const;
+  private:
+  bool _internal_has_requests_root() const;
+  public:
+  void clear_requests_root();
+  const ::types::H256& requests_root() const;
+  PROTOBUF_NODISCARD ::types::H256* release_requests_root();
+  ::types::H256* mutable_requests_root();
+  void set_allocated_requests_root(::types::H256* requests_root);
+  private:
+  const ::types::H256& _internal_requests_root() const;
+  ::types::H256* _internal_mutable_requests_root();
+  public:
+  void unsafe_arena_set_allocated_requests_root(
+      ::types::H256* requests_root);
+  ::types::H256* unsafe_arena_release_requests_root();
+
   // uint64 block_number = 7;
   void clear_block_number();
   uint64_t block_number() const;
@@ -1186,7 +1205,7 @@ class Header final :
   void _internal_set_excess_blob_gas(uint64_t value);
   public:
 
-  // optional uint64 aura_step = 22;
+  // optional uint64 aura_step = 23;
   bool has_aura_step() const;
   private:
   bool _internal_has_aura_step() const;
@@ -1224,6 +1243,7 @@ class Header final :
     ::types::H256* base_fee_per_gas_;
     ::types::H256* withdrawal_hash_;
     ::types::H256* parent_beacon_block_root_;
+    ::types::H256* requests_root_;
     uint64_t block_number_;
     uint64_t gas_limit_;
     uint64_t gas_used_;
@@ -1362,6 +1382,7 @@ class BlockBody final :
     kTransactionsFieldNumber = 3,
     kUnclesFieldNumber = 4,
     kWithdrawalsFieldNumber = 5,
+    kRequestsFieldNumber = 6,
     kBlockHashFieldNumber = 1,
     kBlockNumberFieldNumber = 2,
   };
@@ -1425,6 +1446,30 @@ class BlockBody final :
   const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::Withdrawal >&
       withdrawals() const;
 
+  // repeated bytes requests = 6;
+  int requests_size() const;
+  private:
+  int _internal_requests_size() const;
+  public:
+  void clear_requests();
+  const std::string& requests(int index) const;
+  std::string* mutable_requests(int index);
+  void set_requests(int index, const std::string& value);
+  void set_requests(int index, std::string&& value);
+  void set_requests(int index, const char* value);
+  void set_requests(int index, const void* value, size_t size);
+  std::string* add_requests();
+  void add_requests(const std::string& value);
+  void add_requests(std::string&& value);
+  void add_requests(const char* value);
+  void add_requests(const void* value, size_t size);
+  const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField<std::string>& requests() const;
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField<std::string>* mutable_requests();
+  private:
+  const std::string& _internal_requests(int index) const;
+  std::string* _internal_add_requests();
+  public:
+
   // .types.H256 block_hash = 1;
   bool has_block_hash() const;
   private:
@@ -1463,6 +1508,7 @@ class BlockBody final :
     ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField<std::string> transactions_;
     ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::execution::Header > uncles_;
     ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::Withdrawal > withdrawals_;
+    ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField<std::string> requests_;
     ::types::H256* block_hash_;
     uint64_t block_number_;
     mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
@@ -4796,6 +4842,7 @@ class FrozenBlocksResponse final :
 
   enum : int {
     kFrozenBlocksFieldNumber = 1,
+    kHasGapFieldNumber = 2,
   };
   // uint64 frozen_blocks = 1;
   void clear_frozen_blocks();
@@ -4804,6 +4851,15 @@ class FrozenBlocksResponse final :
   private:
   uint64_t _internal_frozen_blocks() const;
   void _internal_set_frozen_blocks(uint64_t value);
+  public:
+
+  // bool has_gap = 2;
+  void clear_has_gap();
+  bool has_gap() const;
+  void set_has_gap(bool value);
+  private:
+  bool _internal_has_gap() const;
+  void _internal_set_has_gap(bool value);
   public:
 
   // @@protoc_insertion_point(class_scope:execution.FrozenBlocksResponse)
@@ -4815,6 +4871,7 @@ class FrozenBlocksResponse final :
   typedef void DestructorSkippable_;
   struct Impl_ {
     uint64_t frozen_blocks_;
+    bool has_gap_;
     mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   };
   union { Impl_ _impl_; };
@@ -6497,7 +6554,7 @@ inline void Header::set_allocated_withdrawal_hash(::types::H256* withdrawal_hash
 
 // optional uint64 blob_gas_used = 19;
 inline bool Header::_internal_has_blob_gas_used() const {
-  bool value = (_impl_._has_bits_[0] & 0x00000010u) != 0;
+  bool value = (_impl_._has_bits_[0] & 0x00000020u) != 0;
   return value;
 }
 inline bool Header::has_blob_gas_used() const {
@@ -6505,7 +6562,7 @@ inline bool Header::has_blob_gas_used() const {
 }
 inline void Header::clear_blob_gas_used() {
   _impl_.blob_gas_used_ = uint64_t{0u};
-  _impl_._has_bits_[0] &= ~0x00000010u;
+  _impl_._has_bits_[0] &= ~0x00000020u;
 }
 inline uint64_t Header::_internal_blob_gas_used() const {
   return _impl_.blob_gas_used_;
@@ -6515,7 +6572,7 @@ inline uint64_t Header::blob_gas_used() const {
   return _internal_blob_gas_used();
 }
 inline void Header::_internal_set_blob_gas_used(uint64_t value) {
-  _impl_._has_bits_[0] |= 0x00000010u;
+  _impl_._has_bits_[0] |= 0x00000020u;
   _impl_.blob_gas_used_ = value;
 }
 inline void Header::set_blob_gas_used(uint64_t value) {
@@ -6525,7 +6582,7 @@ inline void Header::set_blob_gas_used(uint64_t value) {
 
 // optional uint64 excess_blob_gas = 20;
 inline bool Header::_internal_has_excess_blob_gas() const {
-  bool value = (_impl_._has_bits_[0] & 0x00000020u) != 0;
+  bool value = (_impl_._has_bits_[0] & 0x00000040u) != 0;
   return value;
 }
 inline bool Header::has_excess_blob_gas() const {
@@ -6533,7 +6590,7 @@ inline bool Header::has_excess_blob_gas() const {
 }
 inline void Header::clear_excess_blob_gas() {
   _impl_.excess_blob_gas_ = uint64_t{0u};
-  _impl_._has_bits_[0] &= ~0x00000020u;
+  _impl_._has_bits_[0] &= ~0x00000040u;
 }
 inline uint64_t Header::_internal_excess_blob_gas() const {
   return _impl_.excess_blob_gas_;
@@ -6543,7 +6600,7 @@ inline uint64_t Header::excess_blob_gas() const {
   return _internal_excess_blob_gas();
 }
 inline void Header::_internal_set_excess_blob_gas(uint64_t value) {
-  _impl_._has_bits_[0] |= 0x00000020u;
+  _impl_._has_bits_[0] |= 0x00000040u;
   _impl_.excess_blob_gas_ = value;
 }
 inline void Header::set_excess_blob_gas(uint64_t value) {
@@ -6638,9 +6695,96 @@ inline void Header::set_allocated_parent_beacon_block_root(::types::H256* parent
   // @@protoc_insertion_point(field_set_allocated:execution.Header.parent_beacon_block_root)
 }
 
-// optional uint64 aura_step = 22;
+// optional .types.H256 requests_root = 22;
+inline bool Header::_internal_has_requests_root() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000010u) != 0;
+  PROTOBUF_ASSUME(!value || _impl_.requests_root_ != nullptr);
+  return value;
+}
+inline bool Header::has_requests_root() const {
+  return _internal_has_requests_root();
+}
+inline const ::types::H256& Header::_internal_requests_root() const {
+  const ::types::H256* p = _impl_.requests_root_;
+  return p != nullptr ? *p : reinterpret_cast<const ::types::H256&>(
+      ::types::_H256_default_instance_);
+}
+inline const ::types::H256& Header::requests_root() const {
+  // @@protoc_insertion_point(field_get:execution.Header.requests_root)
+  return _internal_requests_root();
+}
+inline void Header::unsafe_arena_set_allocated_requests_root(
+    ::types::H256* requests_root) {
+  if (GetArenaForAllocation() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(_impl_.requests_root_);
+  }
+  _impl_.requests_root_ = requests_root;
+  if (requests_root) {
+    _impl_._has_bits_[0] |= 0x00000010u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000010u;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:execution.Header.requests_root)
+}
+inline ::types::H256* Header::release_requests_root() {
+  _impl_._has_bits_[0] &= ~0x00000010u;
+  ::types::H256* temp = _impl_.requests_root_;
+  _impl_.requests_root_ = nullptr;
+#ifdef PROTOBUF_FORCE_COPY_IN_RELEASE
+  auto* old =  reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(temp);
+  temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  if (GetArenaForAllocation() == nullptr) { delete old; }
+#else  // PROTOBUF_FORCE_COPY_IN_RELEASE
+  if (GetArenaForAllocation() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+#endif  // !PROTOBUF_FORCE_COPY_IN_RELEASE
+  return temp;
+}
+inline ::types::H256* Header::unsafe_arena_release_requests_root() {
+  // @@protoc_insertion_point(field_release:execution.Header.requests_root)
+  _impl_._has_bits_[0] &= ~0x00000010u;
+  ::types::H256* temp = _impl_.requests_root_;
+  _impl_.requests_root_ = nullptr;
+  return temp;
+}
+inline ::types::H256* Header::_internal_mutable_requests_root() {
+  _impl_._has_bits_[0] |= 0x00000010u;
+  if (_impl_.requests_root_ == nullptr) {
+    auto* p = CreateMaybeMessage<::types::H256>(GetArenaForAllocation());
+    _impl_.requests_root_ = p;
+  }
+  return _impl_.requests_root_;
+}
+inline ::types::H256* Header::mutable_requests_root() {
+  ::types::H256* _msg = _internal_mutable_requests_root();
+  // @@protoc_insertion_point(field_mutable:execution.Header.requests_root)
+  return _msg;
+}
+inline void Header::set_allocated_requests_root(::types::H256* requests_root) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
+  if (message_arena == nullptr) {
+    delete reinterpret_cast< ::PROTOBUF_NAMESPACE_ID::MessageLite*>(_impl_.requests_root_);
+  }
+  if (requests_root) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+        ::PROTOBUF_NAMESPACE_ID::Arena::InternalGetOwningArena(
+                reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(requests_root));
+    if (message_arena != submessage_arena) {
+      requests_root = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, requests_root, submessage_arena);
+    }
+    _impl_._has_bits_[0] |= 0x00000010u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000010u;
+  }
+  _impl_.requests_root_ = requests_root;
+  // @@protoc_insertion_point(field_set_allocated:execution.Header.requests_root)
+}
+
+// optional uint64 aura_step = 23;
 inline bool Header::_internal_has_aura_step() const {
-  bool value = (_impl_._has_bits_[0] & 0x00000040u) != 0;
+  bool value = (_impl_._has_bits_[0] & 0x00000080u) != 0;
   return value;
 }
 inline bool Header::has_aura_step() const {
@@ -6648,7 +6792,7 @@ inline bool Header::has_aura_step() const {
 }
 inline void Header::clear_aura_step() {
   _impl_.aura_step_ = uint64_t{0u};
-  _impl_._has_bits_[0] &= ~0x00000040u;
+  _impl_._has_bits_[0] &= ~0x00000080u;
 }
 inline uint64_t Header::_internal_aura_step() const {
   return _impl_.aura_step_;
@@ -6658,7 +6802,7 @@ inline uint64_t Header::aura_step() const {
   return _internal_aura_step();
 }
 inline void Header::_internal_set_aura_step(uint64_t value) {
-  _impl_._has_bits_[0] |= 0x00000040u;
+  _impl_._has_bits_[0] |= 0x00000080u;
   _impl_.aura_step_ = value;
 }
 inline void Header::set_aura_step(uint64_t value) {
@@ -6666,7 +6810,7 @@ inline void Header::set_aura_step(uint64_t value) {
   // @@protoc_insertion_point(field_set:execution.Header.aura_step)
 }
 
-// optional bytes aura_seal = 23;
+// optional bytes aura_seal = 24;
 inline bool Header::_internal_has_aura_seal() const {
   bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
   return value;
@@ -6993,6 +7137,81 @@ inline const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::Withdrawal >&
 BlockBody::withdrawals() const {
   // @@protoc_insertion_point(field_list:execution.BlockBody.withdrawals)
   return _impl_.withdrawals_;
+}
+
+// repeated bytes requests = 6;
+inline int BlockBody::_internal_requests_size() const {
+  return _impl_.requests_.size();
+}
+inline int BlockBody::requests_size() const {
+  return _internal_requests_size();
+}
+inline void BlockBody::clear_requests() {
+  _impl_.requests_.Clear();
+}
+inline std::string* BlockBody::add_requests() {
+  std::string* _s = _internal_add_requests();
+  // @@protoc_insertion_point(field_add_mutable:execution.BlockBody.requests)
+  return _s;
+}
+inline const std::string& BlockBody::_internal_requests(int index) const {
+  return _impl_.requests_.Get(index);
+}
+inline const std::string& BlockBody::requests(int index) const {
+  // @@protoc_insertion_point(field_get:execution.BlockBody.requests)
+  return _internal_requests(index);
+}
+inline std::string* BlockBody::mutable_requests(int index) {
+  // @@protoc_insertion_point(field_mutable:execution.BlockBody.requests)
+  return _impl_.requests_.Mutable(index);
+}
+inline void BlockBody::set_requests(int index, const std::string& value) {
+  _impl_.requests_.Mutable(index)->assign(value);
+  // @@protoc_insertion_point(field_set:execution.BlockBody.requests)
+}
+inline void BlockBody::set_requests(int index, std::string&& value) {
+  _impl_.requests_.Mutable(index)->assign(std::move(value));
+  // @@protoc_insertion_point(field_set:execution.BlockBody.requests)
+}
+inline void BlockBody::set_requests(int index, const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  _impl_.requests_.Mutable(index)->assign(value);
+  // @@protoc_insertion_point(field_set_char:execution.BlockBody.requests)
+}
+inline void BlockBody::set_requests(int index, const void* value, size_t size) {
+  _impl_.requests_.Mutable(index)->assign(
+    reinterpret_cast<const char*>(value), size);
+  // @@protoc_insertion_point(field_set_pointer:execution.BlockBody.requests)
+}
+inline std::string* BlockBody::_internal_add_requests() {
+  return _impl_.requests_.Add();
+}
+inline void BlockBody::add_requests(const std::string& value) {
+  _impl_.requests_.Add()->assign(value);
+  // @@protoc_insertion_point(field_add:execution.BlockBody.requests)
+}
+inline void BlockBody::add_requests(std::string&& value) {
+  _impl_.requests_.Add(std::move(value));
+  // @@protoc_insertion_point(field_add:execution.BlockBody.requests)
+}
+inline void BlockBody::add_requests(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  _impl_.requests_.Add()->assign(value);
+  // @@protoc_insertion_point(field_add_char:execution.BlockBody.requests)
+}
+inline void BlockBody::add_requests(const void* value, size_t size) {
+  _impl_.requests_.Add()->assign(reinterpret_cast<const char*>(value), size);
+  // @@protoc_insertion_point(field_add_pointer:execution.BlockBody.requests)
+}
+inline const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField<std::string>&
+BlockBody::requests() const {
+  // @@protoc_insertion_point(field_list:execution.BlockBody.requests)
+  return _impl_.requests_;
+}
+inline ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField<std::string>*
+BlockBody::mutable_requests() {
+  // @@protoc_insertion_point(field_mutable_list:execution.BlockBody.requests)
+  return &_impl_.requests_;
 }
 
 // -------------------------------------------------------------------
@@ -9088,6 +9307,26 @@ inline void FrozenBlocksResponse::_internal_set_frozen_blocks(uint64_t value) {
 inline void FrozenBlocksResponse::set_frozen_blocks(uint64_t value) {
   _internal_set_frozen_blocks(value);
   // @@protoc_insertion_point(field_set:execution.FrozenBlocksResponse.frozen_blocks)
+}
+
+// bool has_gap = 2;
+inline void FrozenBlocksResponse::clear_has_gap() {
+  _impl_.has_gap_ = false;
+}
+inline bool FrozenBlocksResponse::_internal_has_gap() const {
+  return _impl_.has_gap_;
+}
+inline bool FrozenBlocksResponse::has_gap() const {
+  // @@protoc_insertion_point(field_get:execution.FrozenBlocksResponse.has_gap)
+  return _internal_has_gap();
+}
+inline void FrozenBlocksResponse::_internal_set_has_gap(bool value) {
+  
+  _impl_.has_gap_ = value;
+}
+inline void FrozenBlocksResponse::set_has_gap(bool value) {
+  _internal_set_has_gap(value);
+  // @@protoc_insertion_point(field_set:execution.FrozenBlocksResponse.has_gap)
 }
 
 // -------------------------------------------------------------------

--- a/silkworm/interfaces/3.21.12/p2psentry/sentry.pb.cc
+++ b/silkworm/interfaces/3.21.12/p2psentry/sentry.pb.cc
@@ -663,8 +663,8 @@ const char descriptor_table_protodef_p2psentry_2fsentry_2eproto[] PROTOBUF_SECTI
   "try.PeerEventsRequest\032\021.sentry.PeerEvent"
   "0\001\0227\n\007AddPeer\022\026.sentry.AddPeerRequest\032\024."
   "sentry.AddPeerReply\0228\n\010NodeInfo\022\026.google"
-  ".protobuf.Empty\032\024.types.NodeInfoReplyB\021Z"
-  "\017./sentry;sentryb\006proto3"
+  ".protobuf.Empty\032\024.types.NodeInfoReplyB\026Z"
+  "\024./sentry;sentryprotob\006proto3"
   ;
 static const ::_pbi::DescriptorTable* const descriptor_table_p2psentry_2fsentry_2eproto_deps[2] = {
   &::descriptor_table_google_2fprotobuf_2fempty_2eproto,
@@ -672,7 +672,7 @@ static const ::_pbi::DescriptorTable* const descriptor_table_p2psentry_2fsentry_
 };
 static ::_pbi::once_flag descriptor_table_p2psentry_2fsentry_2eproto_once;
 const ::_pbi::DescriptorTable descriptor_table_p2psentry_2fsentry_2eproto = {
-    false, false, 3584, descriptor_table_protodef_p2psentry_2fsentry_2eproto,
+    false, false, 3589, descriptor_table_protodef_p2psentry_2fsentry_2eproto,
     "p2psentry/sentry.proto",
     &descriptor_table_p2psentry_2fsentry_2eproto_once, descriptor_table_p2psentry_2fsentry_2eproto_deps, 2, 23,
     schemas, file_default_instances, TableStruct_p2psentry_2fsentry_2eproto::offsets,

--- a/silkworm/interfaces/3.21.12/remote/ethbackend.pb.cc
+++ b/silkworm/interfaces/3.21.12/remote/ethbackend.pb.cc
@@ -736,8 +736,8 @@ const char descriptor_table_protodef_remote_2fethbackend_2eproto[] PROTOBUF_SECT
   "e.AddPeerReply\022A\n\014PendingBlock\022\026.google."
   "protobuf.Empty\032\031.remote.PendingBlockRepl"
   "y\022:\n\010BorEvent\022\027.remote.BorEventRequest\032\025"
-  ".remote.BorEventReplyB\021Z\017./remote;remote"
-  "b\006proto3"
+  ".remote.BorEventReplyB\026Z\024./remote;remote"
+  "protob\006proto3"
   ;
 static const ::_pbi::DescriptorTable* const descriptor_table_remote_2fethbackend_2eproto_deps[2] = {
   &::descriptor_table_google_2fprotobuf_2fempty_2eproto,
@@ -745,7 +745,7 @@ static const ::_pbi::DescriptorTable* const descriptor_table_remote_2fethbackend
 };
 static ::_pbi::once_flag descriptor_table_remote_2fethbackend_2eproto_once;
 const ::_pbi::DescriptorTable descriptor_table_remote_2fethbackend_2eproto = {
-    false, false, 2688, descriptor_table_protodef_remote_2fethbackend_2eproto,
+    false, false, 2693, descriptor_table_protodef_remote_2fethbackend_2eproto,
     "remote/ethbackend.proto",
     &descriptor_table_remote_2fethbackend_2eproto_once, descriptor_table_remote_2fethbackend_2eproto_deps, 2, 28,
     schemas, file_default_instances, TableStruct_remote_2fethbackend_2eproto::offsets,

--- a/silkworm/interfaces/3.21.12/remote/kv.grpc.pb.cc
+++ b/silkworm/interfaces/3.21.12/remote/kv.grpc.pb.cc
@@ -28,7 +28,7 @@ static const char* KV_method_names[] = {
   "/remote.KV/Snapshots",
   "/remote.KV/Range",
   "/remote.KV/DomainGet",
-  "/remote.KV/HistoryGet",
+  "/remote.KV/HistorySeek",
   "/remote.KV/IndexRange",
   "/remote.KV/HistoryRange",
   "/remote.KV/DomainRange",
@@ -47,7 +47,7 @@ KV::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const 
   , rpcmethod_Snapshots_(KV_method_names[3], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_Range_(KV_method_names[4], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_DomainGet_(KV_method_names[5], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_HistoryGet_(KV_method_names[6], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_HistorySeek_(KV_method_names[6], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_IndexRange_(KV_method_names[7], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_HistoryRange_(KV_method_names[8], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_DomainRange_(KV_method_names[9], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
@@ -177,25 +177,25 @@ void KV::Stub::async::DomainGet(::grpc::ClientContext* context, const ::remote::
   return result;
 }
 
-::grpc::Status KV::Stub::HistoryGet(::grpc::ClientContext* context, const ::remote::HistoryGetReq& request, ::remote::HistoryGetReply* response) {
-  return ::grpc::internal::BlockingUnaryCall< ::remote::HistoryGetReq, ::remote::HistoryGetReply, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_HistoryGet_, context, request, response);
+::grpc::Status KV::Stub::HistorySeek(::grpc::ClientContext* context, const ::remote::HistorySeekReq& request, ::remote::HistorySeekReply* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::remote::HistorySeekReq, ::remote::HistorySeekReply, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_HistorySeek_, context, request, response);
 }
 
-void KV::Stub::async::HistoryGet(::grpc::ClientContext* context, const ::remote::HistoryGetReq* request, ::remote::HistoryGetReply* response, std::function<void(::grpc::Status)> f) {
-  ::grpc::internal::CallbackUnaryCall< ::remote::HistoryGetReq, ::remote::HistoryGetReply, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_HistoryGet_, context, request, response, std::move(f));
+void KV::Stub::async::HistorySeek(::grpc::ClientContext* context, const ::remote::HistorySeekReq* request, ::remote::HistorySeekReply* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::remote::HistorySeekReq, ::remote::HistorySeekReply, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_HistorySeek_, context, request, response, std::move(f));
 }
 
-void KV::Stub::async::HistoryGet(::grpc::ClientContext* context, const ::remote::HistoryGetReq* request, ::remote::HistoryGetReply* response, ::grpc::ClientUnaryReactor* reactor) {
-  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_HistoryGet_, context, request, response, reactor);
+void KV::Stub::async::HistorySeek(::grpc::ClientContext* context, const ::remote::HistorySeekReq* request, ::remote::HistorySeekReply* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_HistorySeek_, context, request, response, reactor);
 }
 
-::grpc::ClientAsyncResponseReader< ::remote::HistoryGetReply>* KV::Stub::PrepareAsyncHistoryGetRaw(::grpc::ClientContext* context, const ::remote::HistoryGetReq& request, ::grpc::CompletionQueue* cq) {
-  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::remote::HistoryGetReply, ::remote::HistoryGetReq, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_HistoryGet_, context, request);
+::grpc::ClientAsyncResponseReader< ::remote::HistorySeekReply>* KV::Stub::PrepareAsyncHistorySeekRaw(::grpc::ClientContext* context, const ::remote::HistorySeekReq& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::remote::HistorySeekReply, ::remote::HistorySeekReq, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_HistorySeek_, context, request);
 }
 
-::grpc::ClientAsyncResponseReader< ::remote::HistoryGetReply>* KV::Stub::AsyncHistoryGetRaw(::grpc::ClientContext* context, const ::remote::HistoryGetReq& request, ::grpc::CompletionQueue* cq) {
+::grpc::ClientAsyncResponseReader< ::remote::HistorySeekReply>* KV::Stub::AsyncHistorySeekRaw(::grpc::ClientContext* context, const ::remote::HistorySeekReq& request, ::grpc::CompletionQueue* cq) {
   auto* result =
-    this->PrepareAsyncHistoryGetRaw(context, request, cq);
+    this->PrepareAsyncHistorySeekRaw(context, request, cq);
   result->StartCall();
   return result;
 }
@@ -333,12 +333,12 @@ KV::Service::Service() {
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       KV_method_names[6],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
-      new ::grpc::internal::RpcMethodHandler< KV::Service, ::remote::HistoryGetReq, ::remote::HistoryGetReply, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+      new ::grpc::internal::RpcMethodHandler< KV::Service, ::remote::HistorySeekReq, ::remote::HistorySeekReply, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](KV::Service* service,
              ::grpc::ServerContext* ctx,
-             const ::remote::HistoryGetReq* req,
-             ::remote::HistoryGetReply* resp) {
-               return service->HistoryGet(ctx, req, resp);
+             const ::remote::HistorySeekReq* req,
+             ::remote::HistorySeekReply* resp) {
+               return service->HistorySeek(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       KV_method_names[7],
@@ -416,7 +416,7 @@ KV::Service::~Service() {
   return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
 }
 
-::grpc::Status KV::Service::HistoryGet(::grpc::ServerContext* context, const ::remote::HistoryGetReq* request, ::remote::HistoryGetReply* response) {
+::grpc::Status KV::Service::HistorySeek(::grpc::ServerContext* context, const ::remote::HistorySeekReq* request, ::remote::HistorySeekReply* response) {
   (void) context;
   (void) request;
   (void) response;

--- a/silkworm/interfaces/3.21.12/remote/kv.grpc.pb.h
+++ b/silkworm/interfaces/3.21.12/remote/kv.grpc.pb.h
@@ -118,12 +118,12 @@ class KV final {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::remote::DomainGetReply>>(PrepareAsyncDomainGetRaw(context, request, cq));
     }
     // can return latest value or as of given timestamp
-    virtual ::grpc::Status HistoryGet(::grpc::ClientContext* context, const ::remote::HistoryGetReq& request, ::remote::HistoryGetReply* response) = 0;
-    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::remote::HistoryGetReply>> AsyncHistoryGet(::grpc::ClientContext* context, const ::remote::HistoryGetReq& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::remote::HistoryGetReply>>(AsyncHistoryGetRaw(context, request, cq));
+    virtual ::grpc::Status HistorySeek(::grpc::ClientContext* context, const ::remote::HistorySeekReq& request, ::remote::HistorySeekReply* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::remote::HistorySeekReply>> AsyncHistorySeek(::grpc::ClientContext* context, const ::remote::HistorySeekReq& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::remote::HistorySeekReply>>(AsyncHistorySeekRaw(context, request, cq));
     }
-    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::remote::HistoryGetReply>> PrepareAsyncHistoryGet(::grpc::ClientContext* context, const ::remote::HistoryGetReq& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::remote::HistoryGetReply>>(PrepareAsyncHistoryGetRaw(context, request, cq));
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::remote::HistorySeekReply>> PrepareAsyncHistorySeek(::grpc::ClientContext* context, const ::remote::HistorySeekReq& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::remote::HistorySeekReply>>(PrepareAsyncHistorySeekRaw(context, request, cq));
     }
     virtual ::grpc::Status IndexRange(::grpc::ClientContext* context, const ::remote::IndexRangeReq& request, ::remote::IndexRangeReply* response) = 0;
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::remote::IndexRangeReply>> AsyncIndexRange(::grpc::ClientContext* context, const ::remote::IndexRangeReq& request, ::grpc::CompletionQueue* cq) {
@@ -173,8 +173,8 @@ class KV final {
       virtual void DomainGet(::grpc::ClientContext* context, const ::remote::DomainGetReq* request, ::remote::DomainGetReply* response, std::function<void(::grpc::Status)>) = 0;
       virtual void DomainGet(::grpc::ClientContext* context, const ::remote::DomainGetReq* request, ::remote::DomainGetReply* response, ::grpc::ClientUnaryReactor* reactor) = 0;
       // can return latest value or as of given timestamp
-      virtual void HistoryGet(::grpc::ClientContext* context, const ::remote::HistoryGetReq* request, ::remote::HistoryGetReply* response, std::function<void(::grpc::Status)>) = 0;
-      virtual void HistoryGet(::grpc::ClientContext* context, const ::remote::HistoryGetReq* request, ::remote::HistoryGetReply* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      virtual void HistorySeek(::grpc::ClientContext* context, const ::remote::HistorySeekReq* request, ::remote::HistorySeekReply* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void HistorySeek(::grpc::ClientContext* context, const ::remote::HistorySeekReq* request, ::remote::HistorySeekReply* response, ::grpc::ClientUnaryReactor* reactor) = 0;
       virtual void IndexRange(::grpc::ClientContext* context, const ::remote::IndexRangeReq* request, ::remote::IndexRangeReply* response, std::function<void(::grpc::Status)>) = 0;
       virtual void IndexRange(::grpc::ClientContext* context, const ::remote::IndexRangeReq* request, ::remote::IndexRangeReply* response, ::grpc::ClientUnaryReactor* reactor) = 0;
       virtual void HistoryRange(::grpc::ClientContext* context, const ::remote::HistoryRangeReq* request, ::remote::Pairs* response, std::function<void(::grpc::Status)>) = 0;
@@ -200,8 +200,8 @@ class KV final {
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::remote::Pairs>* PrepareAsyncRangeRaw(::grpc::ClientContext* context, const ::remote::RangeReq& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::remote::DomainGetReply>* AsyncDomainGetRaw(::grpc::ClientContext* context, const ::remote::DomainGetReq& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::remote::DomainGetReply>* PrepareAsyncDomainGetRaw(::grpc::ClientContext* context, const ::remote::DomainGetReq& request, ::grpc::CompletionQueue* cq) = 0;
-    virtual ::grpc::ClientAsyncResponseReaderInterface< ::remote::HistoryGetReply>* AsyncHistoryGetRaw(::grpc::ClientContext* context, const ::remote::HistoryGetReq& request, ::grpc::CompletionQueue* cq) = 0;
-    virtual ::grpc::ClientAsyncResponseReaderInterface< ::remote::HistoryGetReply>* PrepareAsyncHistoryGetRaw(::grpc::ClientContext* context, const ::remote::HistoryGetReq& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::remote::HistorySeekReply>* AsyncHistorySeekRaw(::grpc::ClientContext* context, const ::remote::HistorySeekReq& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::remote::HistorySeekReply>* PrepareAsyncHistorySeekRaw(::grpc::ClientContext* context, const ::remote::HistorySeekReq& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::remote::IndexRangeReply>* AsyncIndexRangeRaw(::grpc::ClientContext* context, const ::remote::IndexRangeReq& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::remote::IndexRangeReply>* PrepareAsyncIndexRangeRaw(::grpc::ClientContext* context, const ::remote::IndexRangeReq& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::remote::Pairs>* AsyncHistoryRangeRaw(::grpc::ClientContext* context, const ::remote::HistoryRangeReq& request, ::grpc::CompletionQueue* cq) = 0;
@@ -258,12 +258,12 @@ class KV final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::remote::DomainGetReply>> PrepareAsyncDomainGet(::grpc::ClientContext* context, const ::remote::DomainGetReq& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::remote::DomainGetReply>>(PrepareAsyncDomainGetRaw(context, request, cq));
     }
-    ::grpc::Status HistoryGet(::grpc::ClientContext* context, const ::remote::HistoryGetReq& request, ::remote::HistoryGetReply* response) override;
-    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::remote::HistoryGetReply>> AsyncHistoryGet(::grpc::ClientContext* context, const ::remote::HistoryGetReq& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::remote::HistoryGetReply>>(AsyncHistoryGetRaw(context, request, cq));
+    ::grpc::Status HistorySeek(::grpc::ClientContext* context, const ::remote::HistorySeekReq& request, ::remote::HistorySeekReply* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::remote::HistorySeekReply>> AsyncHistorySeek(::grpc::ClientContext* context, const ::remote::HistorySeekReq& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::remote::HistorySeekReply>>(AsyncHistorySeekRaw(context, request, cq));
     }
-    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::remote::HistoryGetReply>> PrepareAsyncHistoryGet(::grpc::ClientContext* context, const ::remote::HistoryGetReq& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::remote::HistoryGetReply>>(PrepareAsyncHistoryGetRaw(context, request, cq));
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::remote::HistorySeekReply>> PrepareAsyncHistorySeek(::grpc::ClientContext* context, const ::remote::HistorySeekReq& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::remote::HistorySeekReply>>(PrepareAsyncHistorySeekRaw(context, request, cq));
     }
     ::grpc::Status IndexRange(::grpc::ClientContext* context, const ::remote::IndexRangeReq& request, ::remote::IndexRangeReply* response) override;
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::remote::IndexRangeReply>> AsyncIndexRange(::grpc::ClientContext* context, const ::remote::IndexRangeReq& request, ::grpc::CompletionQueue* cq) {
@@ -299,8 +299,8 @@ class KV final {
       void Range(::grpc::ClientContext* context, const ::remote::RangeReq* request, ::remote::Pairs* response, ::grpc::ClientUnaryReactor* reactor) override;
       void DomainGet(::grpc::ClientContext* context, const ::remote::DomainGetReq* request, ::remote::DomainGetReply* response, std::function<void(::grpc::Status)>) override;
       void DomainGet(::grpc::ClientContext* context, const ::remote::DomainGetReq* request, ::remote::DomainGetReply* response, ::grpc::ClientUnaryReactor* reactor) override;
-      void HistoryGet(::grpc::ClientContext* context, const ::remote::HistoryGetReq* request, ::remote::HistoryGetReply* response, std::function<void(::grpc::Status)>) override;
-      void HistoryGet(::grpc::ClientContext* context, const ::remote::HistoryGetReq* request, ::remote::HistoryGetReply* response, ::grpc::ClientUnaryReactor* reactor) override;
+      void HistorySeek(::grpc::ClientContext* context, const ::remote::HistorySeekReq* request, ::remote::HistorySeekReply* response, std::function<void(::grpc::Status)>) override;
+      void HistorySeek(::grpc::ClientContext* context, const ::remote::HistorySeekReq* request, ::remote::HistorySeekReply* response, ::grpc::ClientUnaryReactor* reactor) override;
       void IndexRange(::grpc::ClientContext* context, const ::remote::IndexRangeReq* request, ::remote::IndexRangeReply* response, std::function<void(::grpc::Status)>) override;
       void IndexRange(::grpc::ClientContext* context, const ::remote::IndexRangeReq* request, ::remote::IndexRangeReply* response, ::grpc::ClientUnaryReactor* reactor) override;
       void HistoryRange(::grpc::ClientContext* context, const ::remote::HistoryRangeReq* request, ::remote::Pairs* response, std::function<void(::grpc::Status)>) override;
@@ -332,8 +332,8 @@ class KV final {
     ::grpc::ClientAsyncResponseReader< ::remote::Pairs>* PrepareAsyncRangeRaw(::grpc::ClientContext* context, const ::remote::RangeReq& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::remote::DomainGetReply>* AsyncDomainGetRaw(::grpc::ClientContext* context, const ::remote::DomainGetReq& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::remote::DomainGetReply>* PrepareAsyncDomainGetRaw(::grpc::ClientContext* context, const ::remote::DomainGetReq& request, ::grpc::CompletionQueue* cq) override;
-    ::grpc::ClientAsyncResponseReader< ::remote::HistoryGetReply>* AsyncHistoryGetRaw(::grpc::ClientContext* context, const ::remote::HistoryGetReq& request, ::grpc::CompletionQueue* cq) override;
-    ::grpc::ClientAsyncResponseReader< ::remote::HistoryGetReply>* PrepareAsyncHistoryGetRaw(::grpc::ClientContext* context, const ::remote::HistoryGetReq& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::remote::HistorySeekReply>* AsyncHistorySeekRaw(::grpc::ClientContext* context, const ::remote::HistorySeekReq& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::remote::HistorySeekReply>* PrepareAsyncHistorySeekRaw(::grpc::ClientContext* context, const ::remote::HistorySeekReq& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::remote::IndexRangeReply>* AsyncIndexRangeRaw(::grpc::ClientContext* context, const ::remote::IndexRangeReq& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::remote::IndexRangeReply>* PrepareAsyncIndexRangeRaw(::grpc::ClientContext* context, const ::remote::IndexRangeReq& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::remote::Pairs>* AsyncHistoryRangeRaw(::grpc::ClientContext* context, const ::remote::HistoryRangeReq& request, ::grpc::CompletionQueue* cq) override;
@@ -346,7 +346,7 @@ class KV final {
     const ::grpc::internal::RpcMethod rpcmethod_Snapshots_;
     const ::grpc::internal::RpcMethod rpcmethod_Range_;
     const ::grpc::internal::RpcMethod rpcmethod_DomainGet_;
-    const ::grpc::internal::RpcMethod rpcmethod_HistoryGet_;
+    const ::grpc::internal::RpcMethod rpcmethod_HistorySeek_;
     const ::grpc::internal::RpcMethod rpcmethod_IndexRange_;
     const ::grpc::internal::RpcMethod rpcmethod_HistoryRange_;
     const ::grpc::internal::RpcMethod rpcmethod_DomainRange_;
@@ -377,7 +377,7 @@ class KV final {
     // Temporal methods
     virtual ::grpc::Status DomainGet(::grpc::ServerContext* context, const ::remote::DomainGetReq* request, ::remote::DomainGetReply* response);
     // can return latest value or as of given timestamp
-    virtual ::grpc::Status HistoryGet(::grpc::ServerContext* context, const ::remote::HistoryGetReq* request, ::remote::HistoryGetReply* response);
+    virtual ::grpc::Status HistorySeek(::grpc::ServerContext* context, const ::remote::HistorySeekReq* request, ::remote::HistorySeekReply* response);
     virtual ::grpc::Status IndexRange(::grpc::ServerContext* context, const ::remote::IndexRangeReq* request, ::remote::IndexRangeReply* response);
     virtual ::grpc::Status HistoryRange(::grpc::ServerContext* context, const ::remote::HistoryRangeReq* request, ::remote::Pairs* response);
     virtual ::grpc::Status DomainRange(::grpc::ServerContext* context, const ::remote::DomainRangeReq* request, ::remote::Pairs* response);
@@ -503,22 +503,22 @@ class KV final {
     }
   };
   template <class BaseClass>
-  class WithAsyncMethod_HistoryGet : public BaseClass {
+  class WithAsyncMethod_HistorySeek : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
-    WithAsyncMethod_HistoryGet() {
+    WithAsyncMethod_HistorySeek() {
       ::grpc::Service::MarkMethodAsync(6);
     }
-    ~WithAsyncMethod_HistoryGet() override {
+    ~WithAsyncMethod_HistorySeek() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status HistoryGet(::grpc::ServerContext* /*context*/, const ::remote::HistoryGetReq* /*request*/, ::remote::HistoryGetReply* /*response*/) override {
+    ::grpc::Status HistorySeek(::grpc::ServerContext* /*context*/, const ::remote::HistorySeekReq* /*request*/, ::remote::HistorySeekReply* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    void RequestHistoryGet(::grpc::ServerContext* context, ::remote::HistoryGetReq* request, ::grpc::ServerAsyncResponseWriter< ::remote::HistoryGetReply>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+    void RequestHistorySeek(::grpc::ServerContext* context, ::remote::HistorySeekReq* request, ::grpc::ServerAsyncResponseWriter< ::remote::HistorySeekReply>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
       ::grpc::Service::RequestAsyncUnary(6, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
@@ -582,7 +582,7 @@ class KV final {
       ::grpc::Service::RequestAsyncUnary(9, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
-  typedef WithAsyncMethod_Version<WithAsyncMethod_Tx<WithAsyncMethod_StateChanges<WithAsyncMethod_Snapshots<WithAsyncMethod_Range<WithAsyncMethod_DomainGet<WithAsyncMethod_HistoryGet<WithAsyncMethod_IndexRange<WithAsyncMethod_HistoryRange<WithAsyncMethod_DomainRange<Service > > > > > > > > > > AsyncService;
+  typedef WithAsyncMethod_Version<WithAsyncMethod_Tx<WithAsyncMethod_StateChanges<WithAsyncMethod_Snapshots<WithAsyncMethod_Range<WithAsyncMethod_DomainGet<WithAsyncMethod_HistorySeek<WithAsyncMethod_IndexRange<WithAsyncMethod_HistoryRange<WithAsyncMethod_DomainRange<Service > > > > > > > > > > AsyncService;
   template <class BaseClass>
   class WithCallbackMethod_Version : public BaseClass {
    private:
@@ -737,31 +737,31 @@ class KV final {
       ::grpc::CallbackServerContext* /*context*/, const ::remote::DomainGetReq* /*request*/, ::remote::DomainGetReply* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
-  class WithCallbackMethod_HistoryGet : public BaseClass {
+  class WithCallbackMethod_HistorySeek : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
-    WithCallbackMethod_HistoryGet() {
+    WithCallbackMethod_HistorySeek() {
       ::grpc::Service::MarkMethodCallback(6,
-          new ::grpc::internal::CallbackUnaryHandler< ::remote::HistoryGetReq, ::remote::HistoryGetReply>(
+          new ::grpc::internal::CallbackUnaryHandler< ::remote::HistorySeekReq, ::remote::HistorySeekReply>(
             [this](
-                   ::grpc::CallbackServerContext* context, const ::remote::HistoryGetReq* request, ::remote::HistoryGetReply* response) { return this->HistoryGet(context, request, response); }));}
-    void SetMessageAllocatorFor_HistoryGet(
-        ::grpc::MessageAllocator< ::remote::HistoryGetReq, ::remote::HistoryGetReply>* allocator) {
+                   ::grpc::CallbackServerContext* context, const ::remote::HistorySeekReq* request, ::remote::HistorySeekReply* response) { return this->HistorySeek(context, request, response); }));}
+    void SetMessageAllocatorFor_HistorySeek(
+        ::grpc::MessageAllocator< ::remote::HistorySeekReq, ::remote::HistorySeekReply>* allocator) {
       ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(6);
-      static_cast<::grpc::internal::CallbackUnaryHandler< ::remote::HistoryGetReq, ::remote::HistoryGetReply>*>(handler)
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::remote::HistorySeekReq, ::remote::HistorySeekReply>*>(handler)
               ->SetMessageAllocator(allocator);
     }
-    ~WithCallbackMethod_HistoryGet() override {
+    ~WithCallbackMethod_HistorySeek() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status HistoryGet(::grpc::ServerContext* /*context*/, const ::remote::HistoryGetReq* /*request*/, ::remote::HistoryGetReply* /*response*/) override {
+    ::grpc::Status HistorySeek(::grpc::ServerContext* /*context*/, const ::remote::HistorySeekReq* /*request*/, ::remote::HistorySeekReply* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    virtual ::grpc::ServerUnaryReactor* HistoryGet(
-      ::grpc::CallbackServerContext* /*context*/, const ::remote::HistoryGetReq* /*request*/, ::remote::HistoryGetReply* /*response*/)  { return nullptr; }
+    virtual ::grpc::ServerUnaryReactor* HistorySeek(
+      ::grpc::CallbackServerContext* /*context*/, const ::remote::HistorySeekReq* /*request*/, ::remote::HistorySeekReply* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
   class WithCallbackMethod_IndexRange : public BaseClass {
@@ -844,7 +844,7 @@ class KV final {
     virtual ::grpc::ServerUnaryReactor* DomainRange(
       ::grpc::CallbackServerContext* /*context*/, const ::remote::DomainRangeReq* /*request*/, ::remote::Pairs* /*response*/)  { return nullptr; }
   };
-  typedef WithCallbackMethod_Version<WithCallbackMethod_Tx<WithCallbackMethod_StateChanges<WithCallbackMethod_Snapshots<WithCallbackMethod_Range<WithCallbackMethod_DomainGet<WithCallbackMethod_HistoryGet<WithCallbackMethod_IndexRange<WithCallbackMethod_HistoryRange<WithCallbackMethod_DomainRange<Service > > > > > > > > > > CallbackService;
+  typedef WithCallbackMethod_Version<WithCallbackMethod_Tx<WithCallbackMethod_StateChanges<WithCallbackMethod_Snapshots<WithCallbackMethod_Range<WithCallbackMethod_DomainGet<WithCallbackMethod_HistorySeek<WithCallbackMethod_IndexRange<WithCallbackMethod_HistoryRange<WithCallbackMethod_DomainRange<Service > > > > > > > > > > CallbackService;
   typedef CallbackService ExperimentalCallbackService;
   template <class BaseClass>
   class WithGenericMethod_Version : public BaseClass {
@@ -949,18 +949,18 @@ class KV final {
     }
   };
   template <class BaseClass>
-  class WithGenericMethod_HistoryGet : public BaseClass {
+  class WithGenericMethod_HistorySeek : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
-    WithGenericMethod_HistoryGet() {
+    WithGenericMethod_HistorySeek() {
       ::grpc::Service::MarkMethodGeneric(6);
     }
-    ~WithGenericMethod_HistoryGet() override {
+    ~WithGenericMethod_HistorySeek() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status HistoryGet(::grpc::ServerContext* /*context*/, const ::remote::HistoryGetReq* /*request*/, ::remote::HistoryGetReply* /*response*/) override {
+    ::grpc::Status HistorySeek(::grpc::ServerContext* /*context*/, const ::remote::HistorySeekReq* /*request*/, ::remote::HistorySeekReply* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
@@ -1137,22 +1137,22 @@ class KV final {
     }
   };
   template <class BaseClass>
-  class WithRawMethod_HistoryGet : public BaseClass {
+  class WithRawMethod_HistorySeek : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
-    WithRawMethod_HistoryGet() {
+    WithRawMethod_HistorySeek() {
       ::grpc::Service::MarkMethodRaw(6);
     }
-    ~WithRawMethod_HistoryGet() override {
+    ~WithRawMethod_HistorySeek() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status HistoryGet(::grpc::ServerContext* /*context*/, const ::remote::HistoryGetReq* /*request*/, ::remote::HistoryGetReply* /*response*/) override {
+    ::grpc::Status HistorySeek(::grpc::ServerContext* /*context*/, const ::remote::HistorySeekReq* /*request*/, ::remote::HistorySeekReply* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    void RequestHistoryGet(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+    void RequestHistorySeek(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
       ::grpc::Service::RequestAsyncUnary(6, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
@@ -1350,25 +1350,25 @@ class KV final {
       ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
-  class WithRawCallbackMethod_HistoryGet : public BaseClass {
+  class WithRawCallbackMethod_HistorySeek : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
-    WithRawCallbackMethod_HistoryGet() {
+    WithRawCallbackMethod_HistorySeek() {
       ::grpc::Service::MarkMethodRawCallback(6,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
-                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->HistoryGet(context, request, response); }));
+                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->HistorySeek(context, request, response); }));
     }
-    ~WithRawCallbackMethod_HistoryGet() override {
+    ~WithRawCallbackMethod_HistorySeek() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status HistoryGet(::grpc::ServerContext* /*context*/, const ::remote::HistoryGetReq* /*request*/, ::remote::HistoryGetReply* /*response*/) override {
+    ::grpc::Status HistorySeek(::grpc::ServerContext* /*context*/, const ::remote::HistorySeekReq* /*request*/, ::remote::HistorySeekReply* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    virtual ::grpc::ServerUnaryReactor* HistoryGet(
+    virtual ::grpc::ServerUnaryReactor* HistorySeek(
       ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
@@ -1546,31 +1546,31 @@ class KV final {
     virtual ::grpc::Status StreamedDomainGet(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::remote::DomainGetReq,::remote::DomainGetReply>* server_unary_streamer) = 0;
   };
   template <class BaseClass>
-  class WithStreamedUnaryMethod_HistoryGet : public BaseClass {
+  class WithStreamedUnaryMethod_HistorySeek : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
-    WithStreamedUnaryMethod_HistoryGet() {
+    WithStreamedUnaryMethod_HistorySeek() {
       ::grpc::Service::MarkMethodStreamed(6,
         new ::grpc::internal::StreamedUnaryHandler<
-          ::remote::HistoryGetReq, ::remote::HistoryGetReply>(
+          ::remote::HistorySeekReq, ::remote::HistorySeekReply>(
             [this](::grpc::ServerContext* context,
                    ::grpc::ServerUnaryStreamer<
-                     ::remote::HistoryGetReq, ::remote::HistoryGetReply>* streamer) {
-                       return this->StreamedHistoryGet(context,
+                     ::remote::HistorySeekReq, ::remote::HistorySeekReply>* streamer) {
+                       return this->StreamedHistorySeek(context,
                          streamer);
                   }));
     }
-    ~WithStreamedUnaryMethod_HistoryGet() override {
+    ~WithStreamedUnaryMethod_HistorySeek() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable regular version of this method
-    ::grpc::Status HistoryGet(::grpc::ServerContext* /*context*/, const ::remote::HistoryGetReq* /*request*/, ::remote::HistoryGetReply* /*response*/) override {
+    ::grpc::Status HistorySeek(::grpc::ServerContext* /*context*/, const ::remote::HistorySeekReq* /*request*/, ::remote::HistorySeekReply* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     // replace default version of method with streamed unary
-    virtual ::grpc::Status StreamedHistoryGet(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::remote::HistoryGetReq,::remote::HistoryGetReply>* server_unary_streamer) = 0;
+    virtual ::grpc::Status StreamedHistorySeek(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::remote::HistorySeekReq,::remote::HistorySeekReply>* server_unary_streamer) = 0;
   };
   template <class BaseClass>
   class WithStreamedUnaryMethod_IndexRange : public BaseClass {
@@ -1653,7 +1653,7 @@ class KV final {
     // replace default version of method with streamed unary
     virtual ::grpc::Status StreamedDomainRange(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::remote::DomainRangeReq,::remote::Pairs>* server_unary_streamer) = 0;
   };
-  typedef WithStreamedUnaryMethod_Version<WithStreamedUnaryMethod_Snapshots<WithStreamedUnaryMethod_Range<WithStreamedUnaryMethod_DomainGet<WithStreamedUnaryMethod_HistoryGet<WithStreamedUnaryMethod_IndexRange<WithStreamedUnaryMethod_HistoryRange<WithStreamedUnaryMethod_DomainRange<Service > > > > > > > > StreamedUnaryService;
+  typedef WithStreamedUnaryMethod_Version<WithStreamedUnaryMethod_Snapshots<WithStreamedUnaryMethod_Range<WithStreamedUnaryMethod_DomainGet<WithStreamedUnaryMethod_HistorySeek<WithStreamedUnaryMethod_IndexRange<WithStreamedUnaryMethod_HistoryRange<WithStreamedUnaryMethod_DomainRange<Service > > > > > > > > StreamedUnaryService;
   template <class BaseClass>
   class WithSplitStreamingMethod_StateChanges : public BaseClass {
    private:
@@ -1682,7 +1682,7 @@ class KV final {
     virtual ::grpc::Status StreamedStateChanges(::grpc::ServerContext* context, ::grpc::ServerSplitStreamer< ::remote::StateChangeRequest,::remote::StateChangeBatch>* server_split_streamer) = 0;
   };
   typedef WithSplitStreamingMethod_StateChanges<Service > SplitStreamedService;
-  typedef WithStreamedUnaryMethod_Version<WithSplitStreamingMethod_StateChanges<WithStreamedUnaryMethod_Snapshots<WithStreamedUnaryMethod_Range<WithStreamedUnaryMethod_DomainGet<WithStreamedUnaryMethod_HistoryGet<WithStreamedUnaryMethod_IndexRange<WithStreamedUnaryMethod_HistoryRange<WithStreamedUnaryMethod_DomainRange<Service > > > > > > > > > StreamedService;
+  typedef WithStreamedUnaryMethod_Version<WithSplitStreamingMethod_StateChanges<WithStreamedUnaryMethod_Snapshots<WithStreamedUnaryMethod_Range<WithStreamedUnaryMethod_DomainGet<WithStreamedUnaryMethod_HistorySeek<WithStreamedUnaryMethod_IndexRange<WithStreamedUnaryMethod_HistoryRange<WithStreamedUnaryMethod_DomainRange<Service > > > > > > > > > StreamedService;
 };
 
 }  // namespace remote

--- a/silkworm/interfaces/3.21.12/remote/kv.pb.cc
+++ b/silkworm/interfaces/3.21.12/remote/kv.pb.cc
@@ -213,36 +213,36 @@ struct DomainGetReplyDefaultTypeInternal {
   };
 };
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 DomainGetReplyDefaultTypeInternal _DomainGetReply_default_instance_;
-PROTOBUF_CONSTEXPR HistoryGetReq::HistoryGetReq(
+PROTOBUF_CONSTEXPR HistorySeekReq::HistorySeekReq(
     ::_pbi::ConstantInitialized): _impl_{
     /*decltype(_impl_.table_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
   , /*decltype(_impl_.k_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
   , /*decltype(_impl_.tx_id_)*/uint64_t{0u}
   , /*decltype(_impl_.ts_)*/uint64_t{0u}
   , /*decltype(_impl_._cached_size_)*/{}} {}
-struct HistoryGetReqDefaultTypeInternal {
-  PROTOBUF_CONSTEXPR HistoryGetReqDefaultTypeInternal()
+struct HistorySeekReqDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR HistorySeekReqDefaultTypeInternal()
       : _instance(::_pbi::ConstantInitialized{}) {}
-  ~HistoryGetReqDefaultTypeInternal() {}
+  ~HistorySeekReqDefaultTypeInternal() {}
   union {
-    HistoryGetReq _instance;
+    HistorySeekReq _instance;
   };
 };
-PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 HistoryGetReqDefaultTypeInternal _HistoryGetReq_default_instance_;
-PROTOBUF_CONSTEXPR HistoryGetReply::HistoryGetReply(
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 HistorySeekReqDefaultTypeInternal _HistorySeekReq_default_instance_;
+PROTOBUF_CONSTEXPR HistorySeekReply::HistorySeekReply(
     ::_pbi::ConstantInitialized): _impl_{
     /*decltype(_impl_.v_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
   , /*decltype(_impl_.ok_)*/false
   , /*decltype(_impl_._cached_size_)*/{}} {}
-struct HistoryGetReplyDefaultTypeInternal {
-  PROTOBUF_CONSTEXPR HistoryGetReplyDefaultTypeInternal()
+struct HistorySeekReplyDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR HistorySeekReplyDefaultTypeInternal()
       : _instance(::_pbi::ConstantInitialized{}) {}
-  ~HistoryGetReplyDefaultTypeInternal() {}
+  ~HistorySeekReplyDefaultTypeInternal() {}
   union {
-    HistoryGetReply _instance;
+    HistorySeekReply _instance;
   };
 };
-PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 HistoryGetReplyDefaultTypeInternal _HistoryGetReply_default_instance_;
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 HistorySeekReplyDefaultTypeInternal _HistorySeekReply_default_instance_;
 PROTOBUF_CONSTEXPR IndexRangeReq::IndexRangeReq(
     ::_pbi::ConstantInitialized): _impl_{
     /*decltype(_impl_.table_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
@@ -492,23 +492,23 @@ const uint32_t TableStruct_remote_2fkv_2eproto::offsets[] PROTOBUF_SECTION_VARIA
   PROTOBUF_FIELD_OFFSET(::remote::DomainGetReply, _impl_.v_),
   PROTOBUF_FIELD_OFFSET(::remote::DomainGetReply, _impl_.ok_),
   ~0u,  // no _has_bits_
-  PROTOBUF_FIELD_OFFSET(::remote::HistoryGetReq, _internal_metadata_),
+  PROTOBUF_FIELD_OFFSET(::remote::HistorySeekReq, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
   ~0u,  // no _inlined_string_donated_
-  PROTOBUF_FIELD_OFFSET(::remote::HistoryGetReq, _impl_.tx_id_),
-  PROTOBUF_FIELD_OFFSET(::remote::HistoryGetReq, _impl_.table_),
-  PROTOBUF_FIELD_OFFSET(::remote::HistoryGetReq, _impl_.k_),
-  PROTOBUF_FIELD_OFFSET(::remote::HistoryGetReq, _impl_.ts_),
+  PROTOBUF_FIELD_OFFSET(::remote::HistorySeekReq, _impl_.tx_id_),
+  PROTOBUF_FIELD_OFFSET(::remote::HistorySeekReq, _impl_.table_),
+  PROTOBUF_FIELD_OFFSET(::remote::HistorySeekReq, _impl_.k_),
+  PROTOBUF_FIELD_OFFSET(::remote::HistorySeekReq, _impl_.ts_),
   ~0u,  // no _has_bits_
-  PROTOBUF_FIELD_OFFSET(::remote::HistoryGetReply, _internal_metadata_),
+  PROTOBUF_FIELD_OFFSET(::remote::HistorySeekReply, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
   ~0u,  // no _inlined_string_donated_
-  PROTOBUF_FIELD_OFFSET(::remote::HistoryGetReply, _impl_.v_),
-  PROTOBUF_FIELD_OFFSET(::remote::HistoryGetReply, _impl_.ok_),
+  PROTOBUF_FIELD_OFFSET(::remote::HistorySeekReply, _impl_.v_),
+  PROTOBUF_FIELD_OFFSET(::remote::HistorySeekReply, _impl_.ok_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::remote::IndexRangeReq, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -601,8 +601,8 @@ static const ::_pbi::MigrationSchema schemas[] PROTOBUF_SECTION_VARIABLE(protode
   { 87, -1, -1, sizeof(::remote::RangeReq)},
   { 101, -1, -1, sizeof(::remote::DomainGetReq)},
   { 113, -1, -1, sizeof(::remote::DomainGetReply)},
-  { 121, -1, -1, sizeof(::remote::HistoryGetReq)},
-  { 131, -1, -1, sizeof(::remote::HistoryGetReply)},
+  { 121, -1, -1, sizeof(::remote::HistorySeekReq)},
+  { 131, -1, -1, sizeof(::remote::HistorySeekReply)},
   { 139, -1, -1, sizeof(::remote::IndexRangeReq)},
   { 154, -1, -1, sizeof(::remote::IndexRangeReply)},
   { 162, -1, -1, sizeof(::remote::HistoryRangeReq)},
@@ -625,8 +625,8 @@ static const ::_pb::Message* const file_default_instances[] = {
   &::remote::_RangeReq_default_instance_._instance,
   &::remote::_DomainGetReq_default_instance_._instance,
   &::remote::_DomainGetReply_default_instance_._instance,
-  &::remote::_HistoryGetReq_default_instance_._instance,
-  &::remote::_HistoryGetReply_default_instance_._instance,
+  &::remote::_HistorySeekReq_default_instance_._instance,
+  &::remote::_HistorySeekReply_default_instance_._instance,
   &::remote::_IndexRangeReq_default_instance_._instance,
   &::remote::_IndexRangeReply_default_instance_._instance,
   &::remote::_HistoryRangeReq_default_instance_._instance,
@@ -669,53 +669,53 @@ const char descriptor_table_protodef_remote_2fkv_2eproto[] PROTOBUF_SECTION_VARI
   "n\030\010 \001(\t\"_\n\014DomainGetReq\022\r\n\005tx_id\030\001 \001(\004\022\r"
   "\n\005table\030\002 \001(\t\022\t\n\001k\030\003 \001(\014\022\n\n\002ts\030\004 \001(\004\022\n\n\002"
   "k2\030\005 \001(\014\022\016\n\006latest\030\006 \001(\010\"\'\n\016DomainGetRep"
-  "ly\022\t\n\001v\030\001 \001(\014\022\n\n\002ok\030\002 \001(\010\"D\n\rHistoryGetR"
-  "eq\022\r\n\005tx_id\030\001 \001(\004\022\r\n\005table\030\002 \001(\t\022\t\n\001k\030\003 "
-  "\001(\014\022\n\n\002ts\030\004 \001(\004\"(\n\017HistoryGetReply\022\t\n\001v\030"
-  "\001 \001(\014\022\n\n\002ok\030\002 \001(\010\"\244\001\n\rIndexRangeReq\022\r\n\005t"
-  "x_id\030\001 \001(\004\022\r\n\005table\030\002 \001(\t\022\t\n\001k\030\003 \001(\014\022\017\n\007"
-  "from_ts\030\004 \001(\022\022\r\n\005to_ts\030\005 \001(\022\022\024\n\014order_as"
-  "cend\030\006 \001(\010\022\r\n\005limit\030\007 \001(\022\022\021\n\tpage_size\030\010"
-  " \001(\005\022\022\n\npage_token\030\t \001(\t\">\n\017IndexRangeRe"
-  "ply\022\022\n\ntimestamps\030\001 \003(\004\022\027\n\017next_page_tok"
-  "en\030\002 \001(\t\"\233\001\n\017HistoryRangeReq\022\r\n\005tx_id\030\001 "
-  "\001(\004\022\r\n\005table\030\002 \001(\t\022\017\n\007from_ts\030\004 \001(\022\022\r\n\005t"
-  "o_ts\030\005 \001(\022\022\024\n\014order_ascend\030\006 \001(\010\022\r\n\005limi"
-  "t\030\007 \001(\022\022\021\n\tpage_size\030\010 \001(\005\022\022\n\npage_token"
-  "\030\t \001(\t\"\270\001\n\016DomainRangeReq\022\r\n\005tx_id\030\001 \001(\004"
-  "\022\r\n\005table\030\002 \001(\t\022\020\n\010from_key\030\003 \001(\014\022\016\n\006to_"
-  "key\030\004 \001(\014\022\n\n\002ts\030\005 \001(\004\022\016\n\006latest\030\006 \001(\010\022\024\n"
-  "\014order_ascend\030\007 \001(\010\022\r\n\005limit\030\010 \001(\022\022\021\n\tpa"
-  "ge_size\030\t \001(\005\022\022\n\npage_token\030\n \001(\t\">\n\005Pai"
-  "rs\022\014\n\004keys\030\001 \003(\014\022\016\n\006values\030\002 \003(\014\022\027\n\017next"
-  "_page_token\030\003 \001(\t\"2\n\017ParisPagination\022\020\n\010"
-  "next_key\030\001 \001(\014\022\r\n\005limit\030\002 \001(\022\"9\n\017IndexPa"
-  "gination\022\027\n\017next_time_stamp\030\001 \001(\022\022\r\n\005lim"
-  "it\030\002 \001(\022*\206\002\n\002Op\022\t\n\005FIRST\020\000\022\r\n\tFIRST_DUP\020"
-  "\001\022\010\n\004SEEK\020\002\022\r\n\tSEEK_BOTH\020\003\022\013\n\007CURRENT\020\004\022"
-  "\010\n\004LAST\020\006\022\014\n\010LAST_DUP\020\007\022\010\n\004NEXT\020\010\022\014\n\010NEX"
-  "T_DUP\020\t\022\017\n\013NEXT_NO_DUP\020\013\022\010\n\004PREV\020\014\022\014\n\010PR"
-  "EV_DUP\020\r\022\017\n\013PREV_NO_DUP\020\016\022\016\n\nSEEK_EXACT\020"
-  "\017\022\023\n\017SEEK_BOTH_EXACT\020\020\022\010\n\004OPEN\020\036\022\t\n\005CLOS"
-  "E\020\037\022\021\n\rOPEN_DUP_SORT\020 \022\t\n\005COUNT\020!*H\n\006Act"
-  "ion\022\013\n\007STORAGE\020\000\022\n\n\006UPSERT\020\001\022\010\n\004CODE\020\002\022\017"
-  "\n\013UPSERT_CODE\020\003\022\n\n\006REMOVE\020\004*$\n\tDirection"
-  "\022\013\n\007FORWARD\020\000\022\n\n\006UNWIND\020\0012\272\004\n\002KV\0226\n\007Vers"
-  "ion\022\026.google.protobuf.Empty\032\023.types.Vers"
-  "ionReply\022&\n\002Tx\022\016.remote.Cursor\032\014.remote."
-  "Pair(\0010\001\022F\n\014StateChanges\022\032.remote.StateC"
-  "hangeRequest\032\030.remote.StateChangeBatch0\001"
-  "\022=\n\tSnapshots\022\030.remote.SnapshotsRequest\032"
-  "\026.remote.SnapshotsReply\022(\n\005Range\022\020.remot"
-  "e.RangeReq\032\r.remote.Pairs\0229\n\tDomainGet\022\024"
-  ".remote.DomainGetReq\032\026.remote.DomainGetR"
-  "eply\022<\n\nHistoryGet\022\025.remote.HistoryGetRe"
-  "q\032\027.remote.HistoryGetReply\022<\n\nIndexRange"
-  "\022\025.remote.IndexRangeReq\032\027.remote.IndexRa"
-  "ngeReply\0226\n\014HistoryRange\022\027.remote.Histor"
-  "yRangeReq\032\r.remote.Pairs\0224\n\013DomainRange\022"
-  "\026.remote.DomainRangeReq\032\r.remote.PairsB\021"
-  "Z\017./remote;remoteb\006proto3"
+  "ly\022\t\n\001v\030\001 \001(\014\022\n\n\002ok\030\002 \001(\010\"E\n\016HistorySeek"
+  "Req\022\r\n\005tx_id\030\001 \001(\004\022\r\n\005table\030\002 \001(\t\022\t\n\001k\030\003"
+  " \001(\014\022\n\n\002ts\030\004 \001(\004\")\n\020HistorySeekReply\022\t\n\001"
+  "v\030\001 \001(\014\022\n\n\002ok\030\002 \001(\010\"\244\001\n\rIndexRangeReq\022\r\n"
+  "\005tx_id\030\001 \001(\004\022\r\n\005table\030\002 \001(\t\022\t\n\001k\030\003 \001(\014\022\017"
+  "\n\007from_ts\030\004 \001(\022\022\r\n\005to_ts\030\005 \001(\022\022\024\n\014order_"
+  "ascend\030\006 \001(\010\022\r\n\005limit\030\007 \001(\022\022\021\n\tpage_size"
+  "\030\010 \001(\005\022\022\n\npage_token\030\t \001(\t\">\n\017IndexRange"
+  "Reply\022\022\n\ntimestamps\030\001 \003(\004\022\027\n\017next_page_t"
+  "oken\030\002 \001(\t\"\233\001\n\017HistoryRangeReq\022\r\n\005tx_id\030"
+  "\001 \001(\004\022\r\n\005table\030\002 \001(\t\022\017\n\007from_ts\030\004 \001(\022\022\r\n"
+  "\005to_ts\030\005 \001(\022\022\024\n\014order_ascend\030\006 \001(\010\022\r\n\005li"
+  "mit\030\007 \001(\022\022\021\n\tpage_size\030\010 \001(\005\022\022\n\npage_tok"
+  "en\030\t \001(\t\"\270\001\n\016DomainRangeReq\022\r\n\005tx_id\030\001 \001"
+  "(\004\022\r\n\005table\030\002 \001(\t\022\020\n\010from_key\030\003 \001(\014\022\016\n\006t"
+  "o_key\030\004 \001(\014\022\n\n\002ts\030\005 \001(\004\022\016\n\006latest\030\006 \001(\010\022"
+  "\024\n\014order_ascend\030\007 \001(\010\022\r\n\005limit\030\010 \001(\022\022\021\n\t"
+  "page_size\030\t \001(\005\022\022\n\npage_token\030\n \001(\t\">\n\005P"
+  "airs\022\014\n\004keys\030\001 \003(\014\022\016\n\006values\030\002 \003(\014\022\027\n\017ne"
+  "xt_page_token\030\003 \001(\t\"2\n\017ParisPagination\022\020"
+  "\n\010next_key\030\001 \001(\014\022\r\n\005limit\030\002 \001(\022\"9\n\017Index"
+  "Pagination\022\027\n\017next_time_stamp\030\001 \001(\022\022\r\n\005l"
+  "imit\030\002 \001(\022*\373\001\n\002Op\022\t\n\005FIRST\020\000\022\r\n\tFIRST_DU"
+  "P\020\001\022\010\n\004SEEK\020\002\022\r\n\tSEEK_BOTH\020\003\022\013\n\007CURRENT\020"
+  "\004\022\010\n\004LAST\020\006\022\014\n\010LAST_DUP\020\007\022\010\n\004NEXT\020\010\022\014\n\010N"
+  "EXT_DUP\020\t\022\017\n\013NEXT_NO_DUP\020\013\022\010\n\004PREV\020\014\022\014\n\010"
+  "PREV_DUP\020\r\022\017\n\013PREV_NO_DUP\020\016\022\016\n\nSEEK_EXAC"
+  "T\020\017\022\023\n\017SEEK_BOTH_EXACT\020\020\022\010\n\004OPEN\020\036\022\t\n\005CL"
+  "OSE\020\037\022\021\n\rOPEN_DUP_SORT\020 *H\n\006Action\022\013\n\007ST"
+  "ORAGE\020\000\022\n\n\006UPSERT\020\001\022\010\n\004CODE\020\002\022\017\n\013UPSERT_"
+  "CODE\020\003\022\n\n\006REMOVE\020\004*$\n\tDirection\022\013\n\007FORWA"
+  "RD\020\000\022\n\n\006UNWIND\020\0012\275\004\n\002KV\0226\n\007Version\022\026.goo"
+  "gle.protobuf.Empty\032\023.types.VersionReply\022"
+  "&\n\002Tx\022\016.remote.Cursor\032\014.remote.Pair(\0010\001\022"
+  "F\n\014StateChanges\022\032.remote.StateChangeRequ"
+  "est\032\030.remote.StateChangeBatch0\001\022=\n\tSnaps"
+  "hots\022\030.remote.SnapshotsRequest\032\026.remote."
+  "SnapshotsReply\022(\n\005Range\022\020.remote.RangeRe"
+  "q\032\r.remote.Pairs\0229\n\tDomainGet\022\024.remote.D"
+  "omainGetReq\032\026.remote.DomainGetReply\022\?\n\013H"
+  "istorySeek\022\026.remote.HistorySeekReq\032\030.rem"
+  "ote.HistorySeekReply\022<\n\nIndexRange\022\025.rem"
+  "ote.IndexRangeReq\032\027.remote.IndexRangeRep"
+  "ly\0226\n\014HistoryRange\022\027.remote.HistoryRange"
+  "Req\032\r.remote.Pairs\0224\n\013DomainRange\022\026.remo"
+  "te.DomainRangeReq\032\r.remote.PairsB\026Z\024./re"
+  "mote;remoteprotob\006proto3"
   ;
 static const ::_pbi::DescriptorTable* const descriptor_table_remote_2fkv_2eproto_deps[2] = {
   &::descriptor_table_google_2fprotobuf_2fempty_2eproto,
@@ -723,7 +723,7 @@ static const ::_pbi::DescriptorTable* const descriptor_table_remote_2fkv_2eproto
 };
 static ::_pbi::once_flag descriptor_table_remote_2fkv_2eproto_once;
 const ::_pbi::DescriptorTable descriptor_table_remote_2fkv_2eproto = {
-    false, false, 3145, descriptor_table_protodef_remote_2fkv_2eproto,
+    false, false, 3144, descriptor_table_protodef_remote_2fkv_2eproto,
     "remote/kv.proto",
     &descriptor_table_remote_2fkv_2eproto_once, descriptor_table_remote_2fkv_2eproto_deps, 2, 21,
     schemas, file_default_instances, TableStruct_remote_2fkv_2eproto::offsets,
@@ -761,7 +761,6 @@ bool Op_IsValid(int value) {
     case 30:
     case 31:
     case 32:
-    case 33:
       return true;
     default:
       return false;
@@ -4297,19 +4296,19 @@ void DomainGetReply::InternalSwap(DomainGetReply* other) {
 
 // ===================================================================
 
-class HistoryGetReq::_Internal {
+class HistorySeekReq::_Internal {
  public:
 };
 
-HistoryGetReq::HistoryGetReq(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+HistorySeekReq::HistorySeekReq(::PROTOBUF_NAMESPACE_ID::Arena* arena,
                          bool is_message_owned)
   : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
   SharedCtor(arena, is_message_owned);
-  // @@protoc_insertion_point(arena_constructor:remote.HistoryGetReq)
+  // @@protoc_insertion_point(arena_constructor:remote.HistorySeekReq)
 }
-HistoryGetReq::HistoryGetReq(const HistoryGetReq& from)
+HistorySeekReq::HistorySeekReq(const HistorySeekReq& from)
   : ::PROTOBUF_NAMESPACE_ID::Message() {
-  HistoryGetReq* const _this = this; (void)_this;
+  HistorySeekReq* const _this = this; (void)_this;
   new (&_impl_) Impl_{
       decltype(_impl_.table_){}
     , decltype(_impl_.k_){}
@@ -4337,10 +4336,10 @@ HistoryGetReq::HistoryGetReq(const HistoryGetReq& from)
   ::memcpy(&_impl_.tx_id_, &from._impl_.tx_id_,
     static_cast<size_t>(reinterpret_cast<char*>(&_impl_.ts_) -
     reinterpret_cast<char*>(&_impl_.tx_id_)) + sizeof(_impl_.ts_));
-  // @@protoc_insertion_point(copy_constructor:remote.HistoryGetReq)
+  // @@protoc_insertion_point(copy_constructor:remote.HistorySeekReq)
 }
 
-inline void HistoryGetReq::SharedCtor(
+inline void HistorySeekReq::SharedCtor(
     ::_pb::Arena* arena, bool is_message_owned) {
   (void)arena;
   (void)is_message_owned;
@@ -4361,8 +4360,8 @@ inline void HistoryGetReq::SharedCtor(
   #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
 }
 
-HistoryGetReq::~HistoryGetReq() {
-  // @@protoc_insertion_point(destructor:remote.HistoryGetReq)
+HistorySeekReq::~HistorySeekReq() {
+  // @@protoc_insertion_point(destructor:remote.HistorySeekReq)
   if (auto *arena = _internal_metadata_.DeleteReturnArena<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>()) {
   (void)arena;
     return;
@@ -4370,18 +4369,18 @@ HistoryGetReq::~HistoryGetReq() {
   SharedDtor();
 }
 
-inline void HistoryGetReq::SharedDtor() {
+inline void HistorySeekReq::SharedDtor() {
   GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
   _impl_.table_.Destroy();
   _impl_.k_.Destroy();
 }
 
-void HistoryGetReq::SetCachedSize(int size) const {
+void HistorySeekReq::SetCachedSize(int size) const {
   _impl_._cached_size_.Set(size);
 }
 
-void HistoryGetReq::Clear() {
-// @@protoc_insertion_point(message_clear_start:remote.HistoryGetReq)
+void HistorySeekReq::Clear() {
+// @@protoc_insertion_point(message_clear_start:remote.HistorySeekReq)
   uint32_t cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
@@ -4394,7 +4393,7 @@ void HistoryGetReq::Clear() {
   _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
-const char* HistoryGetReq::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
+const char* HistorySeekReq::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
 #define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
   while (!ctx->Done(&ptr)) {
     uint32_t tag;
@@ -4414,7 +4413,7 @@ const char* HistoryGetReq::_InternalParse(const char* ptr, ::_pbi::ParseContext*
           auto str = _internal_mutable_table();
           ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
           CHK_(ptr);
-          CHK_(::_pbi::VerifyUTF8(str, "remote.HistoryGetReq.table"));
+          CHK_(::_pbi::VerifyUTF8(str, "remote.HistorySeekReq.table"));
         } else
           goto handle_unusual;
         continue;
@@ -4458,9 +4457,9 @@ failure:
 #undef CHK_
 }
 
-uint8_t* HistoryGetReq::_InternalSerialize(
+uint8_t* HistorySeekReq::_InternalSerialize(
     uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
-  // @@protoc_insertion_point(serialize_to_array_start:remote.HistoryGetReq)
+  // @@protoc_insertion_point(serialize_to_array_start:remote.HistorySeekReq)
   uint32_t cached_has_bits = 0;
   (void) cached_has_bits;
 
@@ -4475,7 +4474,7 @@ uint8_t* HistoryGetReq::_InternalSerialize(
     ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
       this->_internal_table().data(), static_cast<int>(this->_internal_table().length()),
       ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
-      "remote.HistoryGetReq.table");
+      "remote.HistorySeekReq.table");
     target = stream->WriteStringMaybeAliased(
         2, this->_internal_table(), target);
   }
@@ -4496,12 +4495,12 @@ uint8_t* HistoryGetReq::_InternalSerialize(
     target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
         _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
   }
-  // @@protoc_insertion_point(serialize_to_array_end:remote.HistoryGetReq)
+  // @@protoc_insertion_point(serialize_to_array_end:remote.HistorySeekReq)
   return target;
 }
 
-size_t HistoryGetReq::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:remote.HistoryGetReq)
+size_t HistorySeekReq::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:remote.HistorySeekReq)
   size_t total_size = 0;
 
   uint32_t cached_has_bits = 0;
@@ -4535,17 +4534,17 @@ size_t HistoryGetReq::ByteSizeLong() const {
   return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
 }
 
-const ::PROTOBUF_NAMESPACE_ID::Message::ClassData HistoryGetReq::_class_data_ = {
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData HistorySeekReq::_class_data_ = {
     ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSourceCheck,
-    HistoryGetReq::MergeImpl
+    HistorySeekReq::MergeImpl
 };
-const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*HistoryGetReq::GetClassData() const { return &_class_data_; }
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*HistorySeekReq::GetClassData() const { return &_class_data_; }
 
 
-void HistoryGetReq::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg) {
-  auto* const _this = static_cast<HistoryGetReq*>(&to_msg);
-  auto& from = static_cast<const HistoryGetReq&>(from_msg);
-  // @@protoc_insertion_point(class_specific_merge_from_start:remote.HistoryGetReq)
+void HistorySeekReq::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg) {
+  auto* const _this = static_cast<HistorySeekReq*>(&to_msg);
+  auto& from = static_cast<const HistorySeekReq&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:remote.HistorySeekReq)
   GOOGLE_DCHECK_NE(&from, _this);
   uint32_t cached_has_bits = 0;
   (void) cached_has_bits;
@@ -4565,18 +4564,18 @@ void HistoryGetReq::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::
   _this->_internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
 }
 
-void HistoryGetReq::CopyFrom(const HistoryGetReq& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:remote.HistoryGetReq)
+void HistorySeekReq::CopyFrom(const HistorySeekReq& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:remote.HistorySeekReq)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
-bool HistoryGetReq::IsInitialized() const {
+bool HistorySeekReq::IsInitialized() const {
   return true;
 }
 
-void HistoryGetReq::InternalSwap(HistoryGetReq* other) {
+void HistorySeekReq::InternalSwap(HistorySeekReq* other) {
   using std::swap;
   auto* lhs_arena = GetArenaForAllocation();
   auto* rhs_arena = other->GetArenaForAllocation();
@@ -4590,14 +4589,14 @@ void HistoryGetReq::InternalSwap(HistoryGetReq* other) {
       &other->_impl_.k_, rhs_arena
   );
   ::PROTOBUF_NAMESPACE_ID::internal::memswap<
-      PROTOBUF_FIELD_OFFSET(HistoryGetReq, _impl_.ts_)
-      + sizeof(HistoryGetReq::_impl_.ts_)
-      - PROTOBUF_FIELD_OFFSET(HistoryGetReq, _impl_.tx_id_)>(
+      PROTOBUF_FIELD_OFFSET(HistorySeekReq, _impl_.ts_)
+      + sizeof(HistorySeekReq::_impl_.ts_)
+      - PROTOBUF_FIELD_OFFSET(HistorySeekReq, _impl_.tx_id_)>(
           reinterpret_cast<char*>(&_impl_.tx_id_),
           reinterpret_cast<char*>(&other->_impl_.tx_id_));
 }
 
-::PROTOBUF_NAMESPACE_ID::Metadata HistoryGetReq::GetMetadata() const {
+::PROTOBUF_NAMESPACE_ID::Metadata HistorySeekReq::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_remote_2fkv_2eproto_getter, &descriptor_table_remote_2fkv_2eproto_once,
       file_level_metadata_remote_2fkv_2eproto[12]);
@@ -4605,19 +4604,19 @@ void HistoryGetReq::InternalSwap(HistoryGetReq* other) {
 
 // ===================================================================
 
-class HistoryGetReply::_Internal {
+class HistorySeekReply::_Internal {
  public:
 };
 
-HistoryGetReply::HistoryGetReply(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+HistorySeekReply::HistorySeekReply(::PROTOBUF_NAMESPACE_ID::Arena* arena,
                          bool is_message_owned)
   : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
   SharedCtor(arena, is_message_owned);
-  // @@protoc_insertion_point(arena_constructor:remote.HistoryGetReply)
+  // @@protoc_insertion_point(arena_constructor:remote.HistorySeekReply)
 }
-HistoryGetReply::HistoryGetReply(const HistoryGetReply& from)
+HistorySeekReply::HistorySeekReply(const HistorySeekReply& from)
   : ::PROTOBUF_NAMESPACE_ID::Message() {
-  HistoryGetReply* const _this = this; (void)_this;
+  HistorySeekReply* const _this = this; (void)_this;
   new (&_impl_) Impl_{
       decltype(_impl_.v_){}
     , decltype(_impl_.ok_){}
@@ -4633,10 +4632,10 @@ HistoryGetReply::HistoryGetReply(const HistoryGetReply& from)
       _this->GetArenaForAllocation());
   }
   _this->_impl_.ok_ = from._impl_.ok_;
-  // @@protoc_insertion_point(copy_constructor:remote.HistoryGetReply)
+  // @@protoc_insertion_point(copy_constructor:remote.HistorySeekReply)
 }
 
-inline void HistoryGetReply::SharedCtor(
+inline void HistorySeekReply::SharedCtor(
     ::_pb::Arena* arena, bool is_message_owned) {
   (void)arena;
   (void)is_message_owned;
@@ -4651,8 +4650,8 @@ inline void HistoryGetReply::SharedCtor(
   #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
 }
 
-HistoryGetReply::~HistoryGetReply() {
-  // @@protoc_insertion_point(destructor:remote.HistoryGetReply)
+HistorySeekReply::~HistorySeekReply() {
+  // @@protoc_insertion_point(destructor:remote.HistorySeekReply)
   if (auto *arena = _internal_metadata_.DeleteReturnArena<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>()) {
   (void)arena;
     return;
@@ -4660,17 +4659,17 @@ HistoryGetReply::~HistoryGetReply() {
   SharedDtor();
 }
 
-inline void HistoryGetReply::SharedDtor() {
+inline void HistorySeekReply::SharedDtor() {
   GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
   _impl_.v_.Destroy();
 }
 
-void HistoryGetReply::SetCachedSize(int size) const {
+void HistorySeekReply::SetCachedSize(int size) const {
   _impl_._cached_size_.Set(size);
 }
 
-void HistoryGetReply::Clear() {
-// @@protoc_insertion_point(message_clear_start:remote.HistoryGetReply)
+void HistorySeekReply::Clear() {
+// @@protoc_insertion_point(message_clear_start:remote.HistorySeekReply)
   uint32_t cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
@@ -4680,7 +4679,7 @@ void HistoryGetReply::Clear() {
   _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
-const char* HistoryGetReply::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
+const char* HistorySeekReply::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
 #define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
   while (!ctx->Done(&ptr)) {
     uint32_t tag;
@@ -4726,9 +4725,9 @@ failure:
 #undef CHK_
 }
 
-uint8_t* HistoryGetReply::_InternalSerialize(
+uint8_t* HistorySeekReply::_InternalSerialize(
     uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
-  // @@protoc_insertion_point(serialize_to_array_start:remote.HistoryGetReply)
+  // @@protoc_insertion_point(serialize_to_array_start:remote.HistorySeekReply)
   uint32_t cached_has_bits = 0;
   (void) cached_has_bits;
 
@@ -4748,12 +4747,12 @@ uint8_t* HistoryGetReply::_InternalSerialize(
     target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
         _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
   }
-  // @@protoc_insertion_point(serialize_to_array_end:remote.HistoryGetReply)
+  // @@protoc_insertion_point(serialize_to_array_end:remote.HistorySeekReply)
   return target;
 }
 
-size_t HistoryGetReply::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:remote.HistoryGetReply)
+size_t HistorySeekReply::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:remote.HistorySeekReply)
   size_t total_size = 0;
 
   uint32_t cached_has_bits = 0;
@@ -4775,17 +4774,17 @@ size_t HistoryGetReply::ByteSizeLong() const {
   return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
 }
 
-const ::PROTOBUF_NAMESPACE_ID::Message::ClassData HistoryGetReply::_class_data_ = {
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData HistorySeekReply::_class_data_ = {
     ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSourceCheck,
-    HistoryGetReply::MergeImpl
+    HistorySeekReply::MergeImpl
 };
-const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*HistoryGetReply::GetClassData() const { return &_class_data_; }
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*HistorySeekReply::GetClassData() const { return &_class_data_; }
 
 
-void HistoryGetReply::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg) {
-  auto* const _this = static_cast<HistoryGetReply*>(&to_msg);
-  auto& from = static_cast<const HistoryGetReply&>(from_msg);
-  // @@protoc_insertion_point(class_specific_merge_from_start:remote.HistoryGetReply)
+void HistorySeekReply::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg) {
+  auto* const _this = static_cast<HistorySeekReply*>(&to_msg);
+  auto& from = static_cast<const HistorySeekReply&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:remote.HistorySeekReply)
   GOOGLE_DCHECK_NE(&from, _this);
   uint32_t cached_has_bits = 0;
   (void) cached_has_bits;
@@ -4799,18 +4798,18 @@ void HistoryGetReply::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const 
   _this->_internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
 }
 
-void HistoryGetReply::CopyFrom(const HistoryGetReply& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:remote.HistoryGetReply)
+void HistorySeekReply::CopyFrom(const HistorySeekReply& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:remote.HistorySeekReply)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
-bool HistoryGetReply::IsInitialized() const {
+bool HistorySeekReply::IsInitialized() const {
   return true;
 }
 
-void HistoryGetReply::InternalSwap(HistoryGetReply* other) {
+void HistorySeekReply::InternalSwap(HistorySeekReply* other) {
   using std::swap;
   auto* lhs_arena = GetArenaForAllocation();
   auto* rhs_arena = other->GetArenaForAllocation();
@@ -4822,7 +4821,7 @@ void HistoryGetReply::InternalSwap(HistoryGetReply* other) {
   swap(_impl_.ok_, other->_impl_.ok_);
 }
 
-::PROTOBUF_NAMESPACE_ID::Metadata HistoryGetReply::GetMetadata() const {
+::PROTOBUF_NAMESPACE_ID::Metadata HistorySeekReply::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_remote_2fkv_2eproto_getter, &descriptor_table_remote_2fkv_2eproto_once,
       file_level_metadata_remote_2fkv_2eproto[13]);
@@ -7193,13 +7192,13 @@ template<> PROTOBUF_NOINLINE ::remote::DomainGetReply*
 Arena::CreateMaybeMessage< ::remote::DomainGetReply >(Arena* arena) {
   return Arena::CreateMessageInternal< ::remote::DomainGetReply >(arena);
 }
-template<> PROTOBUF_NOINLINE ::remote::HistoryGetReq*
-Arena::CreateMaybeMessage< ::remote::HistoryGetReq >(Arena* arena) {
-  return Arena::CreateMessageInternal< ::remote::HistoryGetReq >(arena);
+template<> PROTOBUF_NOINLINE ::remote::HistorySeekReq*
+Arena::CreateMaybeMessage< ::remote::HistorySeekReq >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::remote::HistorySeekReq >(arena);
 }
-template<> PROTOBUF_NOINLINE ::remote::HistoryGetReply*
-Arena::CreateMaybeMessage< ::remote::HistoryGetReply >(Arena* arena) {
-  return Arena::CreateMessageInternal< ::remote::HistoryGetReply >(arena);
+template<> PROTOBUF_NOINLINE ::remote::HistorySeekReply*
+Arena::CreateMaybeMessage< ::remote::HistorySeekReply >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::remote::HistorySeekReply >(arena);
 }
 template<> PROTOBUF_NOINLINE ::remote::IndexRangeReq*
 Arena::CreateMaybeMessage< ::remote::IndexRangeReq >(Arena* arena) {

--- a/silkworm/interfaces/3.21.12/remote/kv.pb.h
+++ b/silkworm/interfaces/3.21.12/remote/kv.pb.h
@@ -64,15 +64,15 @@ extern DomainGetReqDefaultTypeInternal _DomainGetReq_default_instance_;
 class DomainRangeReq;
 struct DomainRangeReqDefaultTypeInternal;
 extern DomainRangeReqDefaultTypeInternal _DomainRangeReq_default_instance_;
-class HistoryGetReply;
-struct HistoryGetReplyDefaultTypeInternal;
-extern HistoryGetReplyDefaultTypeInternal _HistoryGetReply_default_instance_;
-class HistoryGetReq;
-struct HistoryGetReqDefaultTypeInternal;
-extern HistoryGetReqDefaultTypeInternal _HistoryGetReq_default_instance_;
 class HistoryRangeReq;
 struct HistoryRangeReqDefaultTypeInternal;
 extern HistoryRangeReqDefaultTypeInternal _HistoryRangeReq_default_instance_;
+class HistorySeekReply;
+struct HistorySeekReplyDefaultTypeInternal;
+extern HistorySeekReplyDefaultTypeInternal _HistorySeekReply_default_instance_;
+class HistorySeekReq;
+struct HistorySeekReqDefaultTypeInternal;
+extern HistorySeekReqDefaultTypeInternal _HistorySeekReq_default_instance_;
 class IndexPagination;
 struct IndexPaginationDefaultTypeInternal;
 extern IndexPaginationDefaultTypeInternal _IndexPagination_default_instance_;
@@ -119,9 +119,9 @@ template<> ::remote::Cursor* Arena::CreateMaybeMessage<::remote::Cursor>(Arena*)
 template<> ::remote::DomainGetReply* Arena::CreateMaybeMessage<::remote::DomainGetReply>(Arena*);
 template<> ::remote::DomainGetReq* Arena::CreateMaybeMessage<::remote::DomainGetReq>(Arena*);
 template<> ::remote::DomainRangeReq* Arena::CreateMaybeMessage<::remote::DomainRangeReq>(Arena*);
-template<> ::remote::HistoryGetReply* Arena::CreateMaybeMessage<::remote::HistoryGetReply>(Arena*);
-template<> ::remote::HistoryGetReq* Arena::CreateMaybeMessage<::remote::HistoryGetReq>(Arena*);
 template<> ::remote::HistoryRangeReq* Arena::CreateMaybeMessage<::remote::HistoryRangeReq>(Arena*);
+template<> ::remote::HistorySeekReply* Arena::CreateMaybeMessage<::remote::HistorySeekReply>(Arena*);
+template<> ::remote::HistorySeekReq* Arena::CreateMaybeMessage<::remote::HistorySeekReq>(Arena*);
 template<> ::remote::IndexPagination* Arena::CreateMaybeMessage<::remote::IndexPagination>(Arena*);
 template<> ::remote::IndexRangeReply* Arena::CreateMaybeMessage<::remote::IndexRangeReply>(Arena*);
 template<> ::remote::IndexRangeReq* Arena::CreateMaybeMessage<::remote::IndexRangeReq>(Arena*);
@@ -157,13 +157,12 @@ enum Op : int {
   OPEN = 30,
   CLOSE = 31,
   OPEN_DUP_SORT = 32,
-  COUNT = 33,
   Op_INT_MIN_SENTINEL_DO_NOT_USE_ = std::numeric_limits<int32_t>::min(),
   Op_INT_MAX_SENTINEL_DO_NOT_USE_ = std::numeric_limits<int32_t>::max()
 };
 bool Op_IsValid(int value);
 constexpr Op Op_MIN = FIRST;
-constexpr Op Op_MAX = COUNT;
+constexpr Op Op_MAX = OPEN_DUP_SORT;
 constexpr int Op_ARRAYSIZE = Op_MAX + 1;
 
 const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* Op_descriptor();
@@ -2578,24 +2577,24 @@ class DomainGetReply final :
 };
 // -------------------------------------------------------------------
 
-class HistoryGetReq final :
-    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:remote.HistoryGetReq) */ {
+class HistorySeekReq final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:remote.HistorySeekReq) */ {
  public:
-  inline HistoryGetReq() : HistoryGetReq(nullptr) {}
-  ~HistoryGetReq() override;
-  explicit PROTOBUF_CONSTEXPR HistoryGetReq(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+  inline HistorySeekReq() : HistorySeekReq(nullptr) {}
+  ~HistorySeekReq() override;
+  explicit PROTOBUF_CONSTEXPR HistorySeekReq(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
 
-  HistoryGetReq(const HistoryGetReq& from);
-  HistoryGetReq(HistoryGetReq&& from) noexcept
-    : HistoryGetReq() {
+  HistorySeekReq(const HistorySeekReq& from);
+  HistorySeekReq(HistorySeekReq&& from) noexcept
+    : HistorySeekReq() {
     *this = ::std::move(from);
   }
 
-  inline HistoryGetReq& operator=(const HistoryGetReq& from) {
+  inline HistorySeekReq& operator=(const HistorySeekReq& from) {
     CopyFrom(from);
     return *this;
   }
-  inline HistoryGetReq& operator=(HistoryGetReq&& from) noexcept {
+  inline HistorySeekReq& operator=(HistorySeekReq&& from) noexcept {
     if (this == &from) return *this;
     if (GetOwningArena() == from.GetOwningArena()
   #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
@@ -2618,20 +2617,20 @@ class HistoryGetReq final :
   static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
     return default_instance().GetMetadata().reflection;
   }
-  static const HistoryGetReq& default_instance() {
+  static const HistorySeekReq& default_instance() {
     return *internal_default_instance();
   }
-  static inline const HistoryGetReq* internal_default_instance() {
-    return reinterpret_cast<const HistoryGetReq*>(
-               &_HistoryGetReq_default_instance_);
+  static inline const HistorySeekReq* internal_default_instance() {
+    return reinterpret_cast<const HistorySeekReq*>(
+               &_HistorySeekReq_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
     12;
 
-  friend void swap(HistoryGetReq& a, HistoryGetReq& b) {
+  friend void swap(HistorySeekReq& a, HistorySeekReq& b) {
     a.Swap(&b);
   }
-  inline void Swap(HistoryGetReq* other) {
+  inline void Swap(HistorySeekReq* other) {
     if (other == this) return;
   #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
     if (GetOwningArena() != nullptr &&
@@ -2644,7 +2643,7 @@ class HistoryGetReq final :
       ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
     }
   }
-  void UnsafeArenaSwap(HistoryGetReq* other) {
+  void UnsafeArenaSwap(HistorySeekReq* other) {
     if (other == this) return;
     GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
     InternalSwap(other);
@@ -2652,14 +2651,14 @@ class HistoryGetReq final :
 
   // implements Message ----------------------------------------------
 
-  HistoryGetReq* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
-    return CreateMaybeMessage<HistoryGetReq>(arena);
+  HistorySeekReq* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
+    return CreateMaybeMessage<HistorySeekReq>(arena);
   }
   using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
-  void CopyFrom(const HistoryGetReq& from);
+  void CopyFrom(const HistorySeekReq& from);
   using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
-  void MergeFrom( const HistoryGetReq& from) {
-    HistoryGetReq::MergeImpl(*this, from);
+  void MergeFrom( const HistorySeekReq& from) {
+    HistorySeekReq::MergeImpl(*this, from);
   }
   private:
   static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg);
@@ -2677,15 +2676,15 @@ class HistoryGetReq final :
   void SharedCtor(::PROTOBUF_NAMESPACE_ID::Arena* arena, bool is_message_owned);
   void SharedDtor();
   void SetCachedSize(int size) const final;
-  void InternalSwap(HistoryGetReq* other);
+  void InternalSwap(HistorySeekReq* other);
 
   private:
   friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
   static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
-    return "remote.HistoryGetReq";
+    return "remote.HistorySeekReq";
   }
   protected:
-  explicit HistoryGetReq(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+  explicit HistorySeekReq(::PROTOBUF_NAMESPACE_ID::Arena* arena,
                        bool is_message_owned = false);
   public:
 
@@ -2750,7 +2749,7 @@ class HistoryGetReq final :
   void _internal_set_ts(uint64_t value);
   public:
 
-  // @@protoc_insertion_point(class_scope:remote.HistoryGetReq)
+  // @@protoc_insertion_point(class_scope:remote.HistorySeekReq)
  private:
   class _Internal;
 
@@ -2769,24 +2768,24 @@ class HistoryGetReq final :
 };
 // -------------------------------------------------------------------
 
-class HistoryGetReply final :
-    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:remote.HistoryGetReply) */ {
+class HistorySeekReply final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:remote.HistorySeekReply) */ {
  public:
-  inline HistoryGetReply() : HistoryGetReply(nullptr) {}
-  ~HistoryGetReply() override;
-  explicit PROTOBUF_CONSTEXPR HistoryGetReply(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+  inline HistorySeekReply() : HistorySeekReply(nullptr) {}
+  ~HistorySeekReply() override;
+  explicit PROTOBUF_CONSTEXPR HistorySeekReply(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
 
-  HistoryGetReply(const HistoryGetReply& from);
-  HistoryGetReply(HistoryGetReply&& from) noexcept
-    : HistoryGetReply() {
+  HistorySeekReply(const HistorySeekReply& from);
+  HistorySeekReply(HistorySeekReply&& from) noexcept
+    : HistorySeekReply() {
     *this = ::std::move(from);
   }
 
-  inline HistoryGetReply& operator=(const HistoryGetReply& from) {
+  inline HistorySeekReply& operator=(const HistorySeekReply& from) {
     CopyFrom(from);
     return *this;
   }
-  inline HistoryGetReply& operator=(HistoryGetReply&& from) noexcept {
+  inline HistorySeekReply& operator=(HistorySeekReply&& from) noexcept {
     if (this == &from) return *this;
     if (GetOwningArena() == from.GetOwningArena()
   #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
@@ -2809,20 +2808,20 @@ class HistoryGetReply final :
   static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
     return default_instance().GetMetadata().reflection;
   }
-  static const HistoryGetReply& default_instance() {
+  static const HistorySeekReply& default_instance() {
     return *internal_default_instance();
   }
-  static inline const HistoryGetReply* internal_default_instance() {
-    return reinterpret_cast<const HistoryGetReply*>(
-               &_HistoryGetReply_default_instance_);
+  static inline const HistorySeekReply* internal_default_instance() {
+    return reinterpret_cast<const HistorySeekReply*>(
+               &_HistorySeekReply_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
     13;
 
-  friend void swap(HistoryGetReply& a, HistoryGetReply& b) {
+  friend void swap(HistorySeekReply& a, HistorySeekReply& b) {
     a.Swap(&b);
   }
-  inline void Swap(HistoryGetReply* other) {
+  inline void Swap(HistorySeekReply* other) {
     if (other == this) return;
   #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
     if (GetOwningArena() != nullptr &&
@@ -2835,7 +2834,7 @@ class HistoryGetReply final :
       ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
     }
   }
-  void UnsafeArenaSwap(HistoryGetReply* other) {
+  void UnsafeArenaSwap(HistorySeekReply* other) {
     if (other == this) return;
     GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
     InternalSwap(other);
@@ -2843,14 +2842,14 @@ class HistoryGetReply final :
 
   // implements Message ----------------------------------------------
 
-  HistoryGetReply* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
-    return CreateMaybeMessage<HistoryGetReply>(arena);
+  HistorySeekReply* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
+    return CreateMaybeMessage<HistorySeekReply>(arena);
   }
   using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
-  void CopyFrom(const HistoryGetReply& from);
+  void CopyFrom(const HistorySeekReply& from);
   using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
-  void MergeFrom( const HistoryGetReply& from) {
-    HistoryGetReply::MergeImpl(*this, from);
+  void MergeFrom( const HistorySeekReply& from) {
+    HistorySeekReply::MergeImpl(*this, from);
   }
   private:
   static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg);
@@ -2868,15 +2867,15 @@ class HistoryGetReply final :
   void SharedCtor(::PROTOBUF_NAMESPACE_ID::Arena* arena, bool is_message_owned);
   void SharedDtor();
   void SetCachedSize(int size) const final;
-  void InternalSwap(HistoryGetReply* other);
+  void InternalSwap(HistorySeekReply* other);
 
   private:
   friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
   static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
-    return "remote.HistoryGetReply";
+    return "remote.HistorySeekReply";
   }
   protected:
-  explicit HistoryGetReply(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+  explicit HistorySeekReply(::PROTOBUF_NAMESPACE_ID::Arena* arena,
                        bool is_message_owned = false);
   public:
 
@@ -2916,7 +2915,7 @@ class HistoryGetReply final :
   void _internal_set_ok(bool value);
   public:
 
-  // @@protoc_insertion_point(class_scope:remote.HistoryGetReply)
+  // @@protoc_insertion_point(class_scope:remote.HistorySeekReply)
  private:
   class _Internal;
 
@@ -6327,64 +6326,64 @@ inline void DomainGetReply::set_ok(bool value) {
 
 // -------------------------------------------------------------------
 
-// HistoryGetReq
+// HistorySeekReq
 
 // uint64 tx_id = 1;
-inline void HistoryGetReq::clear_tx_id() {
+inline void HistorySeekReq::clear_tx_id() {
   _impl_.tx_id_ = uint64_t{0u};
 }
-inline uint64_t HistoryGetReq::_internal_tx_id() const {
+inline uint64_t HistorySeekReq::_internal_tx_id() const {
   return _impl_.tx_id_;
 }
-inline uint64_t HistoryGetReq::tx_id() const {
-  // @@protoc_insertion_point(field_get:remote.HistoryGetReq.tx_id)
+inline uint64_t HistorySeekReq::tx_id() const {
+  // @@protoc_insertion_point(field_get:remote.HistorySeekReq.tx_id)
   return _internal_tx_id();
 }
-inline void HistoryGetReq::_internal_set_tx_id(uint64_t value) {
+inline void HistorySeekReq::_internal_set_tx_id(uint64_t value) {
   
   _impl_.tx_id_ = value;
 }
-inline void HistoryGetReq::set_tx_id(uint64_t value) {
+inline void HistorySeekReq::set_tx_id(uint64_t value) {
   _internal_set_tx_id(value);
-  // @@protoc_insertion_point(field_set:remote.HistoryGetReq.tx_id)
+  // @@protoc_insertion_point(field_set:remote.HistorySeekReq.tx_id)
 }
 
 // string table = 2;
-inline void HistoryGetReq::clear_table() {
+inline void HistorySeekReq::clear_table() {
   _impl_.table_.ClearToEmpty();
 }
-inline const std::string& HistoryGetReq::table() const {
-  // @@protoc_insertion_point(field_get:remote.HistoryGetReq.table)
+inline const std::string& HistorySeekReq::table() const {
+  // @@protoc_insertion_point(field_get:remote.HistorySeekReq.table)
   return _internal_table();
 }
 template <typename ArgT0, typename... ArgT>
 inline PROTOBUF_ALWAYS_INLINE
-void HistoryGetReq::set_table(ArgT0&& arg0, ArgT... args) {
+void HistorySeekReq::set_table(ArgT0&& arg0, ArgT... args) {
  
  _impl_.table_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
-  // @@protoc_insertion_point(field_set:remote.HistoryGetReq.table)
+  // @@protoc_insertion_point(field_set:remote.HistorySeekReq.table)
 }
-inline std::string* HistoryGetReq::mutable_table() {
+inline std::string* HistorySeekReq::mutable_table() {
   std::string* _s = _internal_mutable_table();
-  // @@protoc_insertion_point(field_mutable:remote.HistoryGetReq.table)
+  // @@protoc_insertion_point(field_mutable:remote.HistorySeekReq.table)
   return _s;
 }
-inline const std::string& HistoryGetReq::_internal_table() const {
+inline const std::string& HistorySeekReq::_internal_table() const {
   return _impl_.table_.Get();
 }
-inline void HistoryGetReq::_internal_set_table(const std::string& value) {
+inline void HistorySeekReq::_internal_set_table(const std::string& value) {
   
   _impl_.table_.Set(value, GetArenaForAllocation());
 }
-inline std::string* HistoryGetReq::_internal_mutable_table() {
+inline std::string* HistorySeekReq::_internal_mutable_table() {
   
   return _impl_.table_.Mutable(GetArenaForAllocation());
 }
-inline std::string* HistoryGetReq::release_table() {
-  // @@protoc_insertion_point(field_release:remote.HistoryGetReq.table)
+inline std::string* HistorySeekReq::release_table() {
+  // @@protoc_insertion_point(field_release:remote.HistorySeekReq.table)
   return _impl_.table_.Release();
 }
-inline void HistoryGetReq::set_allocated_table(std::string* table) {
+inline void HistorySeekReq::set_allocated_table(std::string* table) {
   if (table != nullptr) {
     
   } else {
@@ -6396,45 +6395,45 @@ inline void HistoryGetReq::set_allocated_table(std::string* table) {
     _impl_.table_.Set("", GetArenaForAllocation());
   }
 #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  // @@protoc_insertion_point(field_set_allocated:remote.HistoryGetReq.table)
+  // @@protoc_insertion_point(field_set_allocated:remote.HistorySeekReq.table)
 }
 
 // bytes k = 3;
-inline void HistoryGetReq::clear_k() {
+inline void HistorySeekReq::clear_k() {
   _impl_.k_.ClearToEmpty();
 }
-inline const std::string& HistoryGetReq::k() const {
-  // @@protoc_insertion_point(field_get:remote.HistoryGetReq.k)
+inline const std::string& HistorySeekReq::k() const {
+  // @@protoc_insertion_point(field_get:remote.HistorySeekReq.k)
   return _internal_k();
 }
 template <typename ArgT0, typename... ArgT>
 inline PROTOBUF_ALWAYS_INLINE
-void HistoryGetReq::set_k(ArgT0&& arg0, ArgT... args) {
+void HistorySeekReq::set_k(ArgT0&& arg0, ArgT... args) {
  
  _impl_.k_.SetBytes(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
-  // @@protoc_insertion_point(field_set:remote.HistoryGetReq.k)
+  // @@protoc_insertion_point(field_set:remote.HistorySeekReq.k)
 }
-inline std::string* HistoryGetReq::mutable_k() {
+inline std::string* HistorySeekReq::mutable_k() {
   std::string* _s = _internal_mutable_k();
-  // @@protoc_insertion_point(field_mutable:remote.HistoryGetReq.k)
+  // @@protoc_insertion_point(field_mutable:remote.HistorySeekReq.k)
   return _s;
 }
-inline const std::string& HistoryGetReq::_internal_k() const {
+inline const std::string& HistorySeekReq::_internal_k() const {
   return _impl_.k_.Get();
 }
-inline void HistoryGetReq::_internal_set_k(const std::string& value) {
+inline void HistorySeekReq::_internal_set_k(const std::string& value) {
   
   _impl_.k_.Set(value, GetArenaForAllocation());
 }
-inline std::string* HistoryGetReq::_internal_mutable_k() {
+inline std::string* HistorySeekReq::_internal_mutable_k() {
   
   return _impl_.k_.Mutable(GetArenaForAllocation());
 }
-inline std::string* HistoryGetReq::release_k() {
-  // @@protoc_insertion_point(field_release:remote.HistoryGetReq.k)
+inline std::string* HistorySeekReq::release_k() {
+  // @@protoc_insertion_point(field_release:remote.HistorySeekReq.k)
   return _impl_.k_.Release();
 }
-inline void HistoryGetReq::set_allocated_k(std::string* k) {
+inline void HistorySeekReq::set_allocated_k(std::string* k) {
   if (k != nullptr) {
     
   } else {
@@ -6446,69 +6445,69 @@ inline void HistoryGetReq::set_allocated_k(std::string* k) {
     _impl_.k_.Set("", GetArenaForAllocation());
   }
 #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  // @@protoc_insertion_point(field_set_allocated:remote.HistoryGetReq.k)
+  // @@protoc_insertion_point(field_set_allocated:remote.HistorySeekReq.k)
 }
 
 // uint64 ts = 4;
-inline void HistoryGetReq::clear_ts() {
+inline void HistorySeekReq::clear_ts() {
   _impl_.ts_ = uint64_t{0u};
 }
-inline uint64_t HistoryGetReq::_internal_ts() const {
+inline uint64_t HistorySeekReq::_internal_ts() const {
   return _impl_.ts_;
 }
-inline uint64_t HistoryGetReq::ts() const {
-  // @@protoc_insertion_point(field_get:remote.HistoryGetReq.ts)
+inline uint64_t HistorySeekReq::ts() const {
+  // @@protoc_insertion_point(field_get:remote.HistorySeekReq.ts)
   return _internal_ts();
 }
-inline void HistoryGetReq::_internal_set_ts(uint64_t value) {
+inline void HistorySeekReq::_internal_set_ts(uint64_t value) {
   
   _impl_.ts_ = value;
 }
-inline void HistoryGetReq::set_ts(uint64_t value) {
+inline void HistorySeekReq::set_ts(uint64_t value) {
   _internal_set_ts(value);
-  // @@protoc_insertion_point(field_set:remote.HistoryGetReq.ts)
+  // @@protoc_insertion_point(field_set:remote.HistorySeekReq.ts)
 }
 
 // -------------------------------------------------------------------
 
-// HistoryGetReply
+// HistorySeekReply
 
 // bytes v = 1;
-inline void HistoryGetReply::clear_v() {
+inline void HistorySeekReply::clear_v() {
   _impl_.v_.ClearToEmpty();
 }
-inline const std::string& HistoryGetReply::v() const {
-  // @@protoc_insertion_point(field_get:remote.HistoryGetReply.v)
+inline const std::string& HistorySeekReply::v() const {
+  // @@protoc_insertion_point(field_get:remote.HistorySeekReply.v)
   return _internal_v();
 }
 template <typename ArgT0, typename... ArgT>
 inline PROTOBUF_ALWAYS_INLINE
-void HistoryGetReply::set_v(ArgT0&& arg0, ArgT... args) {
+void HistorySeekReply::set_v(ArgT0&& arg0, ArgT... args) {
  
  _impl_.v_.SetBytes(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
-  // @@protoc_insertion_point(field_set:remote.HistoryGetReply.v)
+  // @@protoc_insertion_point(field_set:remote.HistorySeekReply.v)
 }
-inline std::string* HistoryGetReply::mutable_v() {
+inline std::string* HistorySeekReply::mutable_v() {
   std::string* _s = _internal_mutable_v();
-  // @@protoc_insertion_point(field_mutable:remote.HistoryGetReply.v)
+  // @@protoc_insertion_point(field_mutable:remote.HistorySeekReply.v)
   return _s;
 }
-inline const std::string& HistoryGetReply::_internal_v() const {
+inline const std::string& HistorySeekReply::_internal_v() const {
   return _impl_.v_.Get();
 }
-inline void HistoryGetReply::_internal_set_v(const std::string& value) {
+inline void HistorySeekReply::_internal_set_v(const std::string& value) {
   
   _impl_.v_.Set(value, GetArenaForAllocation());
 }
-inline std::string* HistoryGetReply::_internal_mutable_v() {
+inline std::string* HistorySeekReply::_internal_mutable_v() {
   
   return _impl_.v_.Mutable(GetArenaForAllocation());
 }
-inline std::string* HistoryGetReply::release_v() {
-  // @@protoc_insertion_point(field_release:remote.HistoryGetReply.v)
+inline std::string* HistorySeekReply::release_v() {
+  // @@protoc_insertion_point(field_release:remote.HistorySeekReply.v)
   return _impl_.v_.Release();
 }
-inline void HistoryGetReply::set_allocated_v(std::string* v) {
+inline void HistorySeekReply::set_allocated_v(std::string* v) {
   if (v != nullptr) {
     
   } else {
@@ -6520,27 +6519,27 @@ inline void HistoryGetReply::set_allocated_v(std::string* v) {
     _impl_.v_.Set("", GetArenaForAllocation());
   }
 #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  // @@protoc_insertion_point(field_set_allocated:remote.HistoryGetReply.v)
+  // @@protoc_insertion_point(field_set_allocated:remote.HistorySeekReply.v)
 }
 
 // bool ok = 2;
-inline void HistoryGetReply::clear_ok() {
+inline void HistorySeekReply::clear_ok() {
   _impl_.ok_ = false;
 }
-inline bool HistoryGetReply::_internal_ok() const {
+inline bool HistorySeekReply::_internal_ok() const {
   return _impl_.ok_;
 }
-inline bool HistoryGetReply::ok() const {
-  // @@protoc_insertion_point(field_get:remote.HistoryGetReply.ok)
+inline bool HistorySeekReply::ok() const {
+  // @@protoc_insertion_point(field_get:remote.HistorySeekReply.ok)
   return _internal_ok();
 }
-inline void HistoryGetReply::_internal_set_ok(bool value) {
+inline void HistorySeekReply::_internal_set_ok(bool value) {
   
   _impl_.ok_ = value;
 }
-inline void HistoryGetReply::set_ok(bool value) {
+inline void HistorySeekReply::set_ok(bool value) {
   _internal_set_ok(value);
-  // @@protoc_insertion_point(field_set:remote.HistoryGetReply.ok)
+  // @@protoc_insertion_point(field_set:remote.HistorySeekReply.ok)
 }
 
 // -------------------------------------------------------------------

--- a/silkworm/interfaces/3.21.12/remote/kv_mock.grpc.pb.h
+++ b/silkworm/interfaces/3.21.12/remote/kv_mock.grpc.pb.h
@@ -33,9 +33,9 @@ class MockKVStub : public KV::StubInterface {
   MOCK_METHOD3(DomainGet, ::grpc::Status(::grpc::ClientContext* context, const ::remote::DomainGetReq& request, ::remote::DomainGetReply* response));
   MOCK_METHOD3(AsyncDomainGetRaw, ::grpc::ClientAsyncResponseReaderInterface< ::remote::DomainGetReply>*(::grpc::ClientContext* context, const ::remote::DomainGetReq& request, ::grpc::CompletionQueue* cq));
   MOCK_METHOD3(PrepareAsyncDomainGetRaw, ::grpc::ClientAsyncResponseReaderInterface< ::remote::DomainGetReply>*(::grpc::ClientContext* context, const ::remote::DomainGetReq& request, ::grpc::CompletionQueue* cq));
-  MOCK_METHOD3(HistoryGet, ::grpc::Status(::grpc::ClientContext* context, const ::remote::HistoryGetReq& request, ::remote::HistoryGetReply* response));
-  MOCK_METHOD3(AsyncHistoryGetRaw, ::grpc::ClientAsyncResponseReaderInterface< ::remote::HistoryGetReply>*(::grpc::ClientContext* context, const ::remote::HistoryGetReq& request, ::grpc::CompletionQueue* cq));
-  MOCK_METHOD3(PrepareAsyncHistoryGetRaw, ::grpc::ClientAsyncResponseReaderInterface< ::remote::HistoryGetReply>*(::grpc::ClientContext* context, const ::remote::HistoryGetReq& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD3(HistorySeek, ::grpc::Status(::grpc::ClientContext* context, const ::remote::HistorySeekReq& request, ::remote::HistorySeekReply* response));
+  MOCK_METHOD3(AsyncHistorySeekRaw, ::grpc::ClientAsyncResponseReaderInterface< ::remote::HistorySeekReply>*(::grpc::ClientContext* context, const ::remote::HistorySeekReq& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD3(PrepareAsyncHistorySeekRaw, ::grpc::ClientAsyncResponseReaderInterface< ::remote::HistorySeekReply>*(::grpc::ClientContext* context, const ::remote::HistorySeekReq& request, ::grpc::CompletionQueue* cq));
   MOCK_METHOD3(IndexRange, ::grpc::Status(::grpc::ClientContext* context, const ::remote::IndexRangeReq& request, ::remote::IndexRangeReply* response));
   MOCK_METHOD3(AsyncIndexRangeRaw, ::grpc::ClientAsyncResponseReaderInterface< ::remote::IndexRangeReply>*(::grpc::ClientContext* context, const ::remote::IndexRangeReq& request, ::grpc::CompletionQueue* cq));
   MOCK_METHOD3(PrepareAsyncIndexRangeRaw, ::grpc::ClientAsyncResponseReaderInterface< ::remote::IndexRangeReply>*(::grpc::ClientContext* context, const ::remote::IndexRangeReq& request, ::grpc::CompletionQueue* cq));

--- a/silkworm/interfaces/3.21.12/txpool/mining.pb.cc
+++ b/silkworm/interfaces/3.21.12/txpool/mining.pb.cc
@@ -415,8 +415,8 @@ const char descriptor_table_protodef_txpool_2fmining_2eproto[] PROTOBUF_SECTION_
   "Request\032\033.txpool.SubmitHashRateReply\022:\n\010"
   "HashRate\022\027.txpool.HashRateRequest\032\025.txpo"
   "ol.HashRateReply\0224\n\006Mining\022\025.txpool.Mini"
-  "ngRequest\032\023.txpool.MiningReplyB\021Z\017./txpo"
-  "ol;txpoolb\006proto3"
+  "ngRequest\032\023.txpool.MiningReplyB\026Z\024./txpo"
+  "ol;txpoolprotob\006proto3"
   ;
 static const ::_pbi::DescriptorTable* const descriptor_table_txpool_2fmining_2eproto_deps[2] = {
   &::descriptor_table_google_2fprotobuf_2fempty_2eproto,
@@ -424,7 +424,7 @@ static const ::_pbi::DescriptorTable* const descriptor_table_txpool_2fmining_2ep
 };
 static ::_pbi::once_flag descriptor_table_txpool_2fmining_2eproto_once;
 const ::_pbi::DescriptorTable descriptor_table_txpool_2fmining_2eproto = {
-    false, false, 1337, descriptor_table_protodef_txpool_2fmining_2eproto,
+    false, false, 1342, descriptor_table_protodef_txpool_2fmining_2eproto,
     "txpool/mining.proto",
     &descriptor_table_txpool_2fmining_2eproto_once, descriptor_table_txpool_2fmining_2eproto_deps, 2, 16,
     schemas, file_default_instances, TableStruct_txpool_2fmining_2eproto::offsets,

--- a/silkworm/interfaces/3.21.12/txpool/txpool.pb.cc
+++ b/silkworm/interfaces/3.21.12/txpool/txpool.pb.cc
@@ -432,7 +432,7 @@ const char descriptor_table_protodef_txpool_2ftxpool_2eproto[] PROTOBUF_SECTION_
   "l.OnAddReply0\001\0224\n\006Status\022\025.txpool.Status"
   "Request\032\023.txpool.StatusReply\0221\n\005Nonce\022\024."
   "txpool.NonceRequest\032\022.txpool.NonceReplyB"
-  "\021Z\017./txpool;txpoolb\006proto3"
+  "\026Z\024./txpool;txpoolprotob\006proto3"
   ;
 static const ::_pbi::DescriptorTable* const descriptor_table_txpool_2ftxpool_2eproto_deps[2] = {
   &::descriptor_table_google_2fprotobuf_2fempty_2eproto,
@@ -440,7 +440,7 @@ static const ::_pbi::DescriptorTable* const descriptor_table_txpool_2ftxpool_2ep
 };
 static ::_pbi::once_flag descriptor_table_txpool_2ftxpool_2eproto_once;
 const ::_pbi::DescriptorTable descriptor_table_txpool_2ftxpool_2eproto = {
-    false, false, 1506, descriptor_table_protodef_txpool_2ftxpool_2eproto,
+    false, false, 1511, descriptor_table_protodef_txpool_2ftxpool_2eproto,
     "txpool/txpool.proto",
     &descriptor_table_txpool_2ftxpool_2eproto_once, descriptor_table_txpool_2ftxpool_2eproto_deps, 2, 16,
     schemas, file_default_instances, TableStruct_txpool_2ftxpool_2eproto::offsets,

--- a/silkworm/interfaces/3.21.12/types/types.pb.cc
+++ b/silkworm/interfaces/3.21.12/types/types.pb.cc
@@ -126,6 +126,9 @@ PROTOBUF_CONSTEXPR ExecutionPayload::ExecutionPayload(
   , /*decltype(_impl_._cached_size_)*/{}
   , /*decltype(_impl_.transactions_)*/{}
   , /*decltype(_impl_.withdrawals_)*/{}
+  , /*decltype(_impl_.deposit_requests_)*/{}
+  , /*decltype(_impl_.withdrawal_requests_)*/{}
+  , /*decltype(_impl_.consolidation_requests_)*/{}
   , /*decltype(_impl_.extra_data_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
   , /*decltype(_impl_.parent_hash_)*/nullptr
   , /*decltype(_impl_.coinbase_)*/nullptr
@@ -151,6 +154,53 @@ struct ExecutionPayloadDefaultTypeInternal {
   };
 };
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 ExecutionPayloadDefaultTypeInternal _ExecutionPayload_default_instance_;
+PROTOBUF_CONSTEXPR DepositRequest::DepositRequest(
+    ::_pbi::ConstantInitialized): _impl_{
+    /*decltype(_impl_.pubkey_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+  , /*decltype(_impl_.signature_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+  , /*decltype(_impl_.withdrawal_credentials_)*/nullptr
+  , /*decltype(_impl_.amount_)*/uint64_t{0u}
+  , /*decltype(_impl_.index_)*/uint64_t{0u}
+  , /*decltype(_impl_._cached_size_)*/{}} {}
+struct DepositRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR DepositRequestDefaultTypeInternal()
+      : _instance(::_pbi::ConstantInitialized{}) {}
+  ~DepositRequestDefaultTypeInternal() {}
+  union {
+    DepositRequest _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 DepositRequestDefaultTypeInternal _DepositRequest_default_instance_;
+PROTOBUF_CONSTEXPR WithdrawalRequest::WithdrawalRequest(
+    ::_pbi::ConstantInitialized): _impl_{
+    /*decltype(_impl_.validator_pubkey_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+  , /*decltype(_impl_.source_address_)*/nullptr
+  , /*decltype(_impl_.amount_)*/uint64_t{0u}
+  , /*decltype(_impl_._cached_size_)*/{}} {}
+struct WithdrawalRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR WithdrawalRequestDefaultTypeInternal()
+      : _instance(::_pbi::ConstantInitialized{}) {}
+  ~WithdrawalRequestDefaultTypeInternal() {}
+  union {
+    WithdrawalRequest _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 WithdrawalRequestDefaultTypeInternal _WithdrawalRequest_default_instance_;
+PROTOBUF_CONSTEXPR ConsolidationRequest::ConsolidationRequest(
+    ::_pbi::ConstantInitialized): _impl_{
+    /*decltype(_impl_.source_pubkey_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+  , /*decltype(_impl_.target_pubkey_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+  , /*decltype(_impl_.source_address_)*/nullptr
+  , /*decltype(_impl_._cached_size_)*/{}} {}
+struct ConsolidationRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR ConsolidationRequestDefaultTypeInternal()
+      : _instance(::_pbi::ConstantInitialized{}) {}
+  ~ConsolidationRequestDefaultTypeInternal() {}
+  union {
+    ConsolidationRequest _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 ConsolidationRequestDefaultTypeInternal _ConsolidationRequest_default_instance_;
 PROTOBUF_CONSTEXPR Withdrawal::Withdrawal(
     ::_pbi::ConstantInitialized): _impl_{
     /*decltype(_impl_.address_)*/nullptr
@@ -252,7 +302,7 @@ struct ExecutionPayloadBodyV1DefaultTypeInternal {
 };
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 ExecutionPayloadBodyV1DefaultTypeInternal _ExecutionPayloadBodyV1_default_instance_;
 }  // namespace types
-static ::_pb::Metadata file_level_metadata_types_2ftypes_2eproto[14];
+static ::_pb::Metadata file_level_metadata_types_2ftypes_2eproto[17];
 static constexpr ::_pb::EnumDescriptor const** file_level_enum_descriptors_types_2ftypes_2eproto = nullptr;
 static constexpr ::_pb::ServiceDescriptor const** file_level_service_descriptors_types_2ftypes_2eproto = nullptr;
 
@@ -338,6 +388,9 @@ const uint32_t TableStruct_types_2ftypes_2eproto::offsets[] PROTOBUF_SECTION_VAR
   PROTOBUF_FIELD_OFFSET(::types::ExecutionPayload, _impl_.withdrawals_),
   PROTOBUF_FIELD_OFFSET(::types::ExecutionPayload, _impl_.blob_gas_used_),
   PROTOBUF_FIELD_OFFSET(::types::ExecutionPayload, _impl_.excess_blob_gas_),
+  PROTOBUF_FIELD_OFFSET(::types::ExecutionPayload, _impl_.deposit_requests_),
+  PROTOBUF_FIELD_OFFSET(::types::ExecutionPayload, _impl_.withdrawal_requests_),
+  PROTOBUF_FIELD_OFFSET(::types::ExecutionPayload, _impl_.consolidation_requests_),
   ~0u,
   ~0u,
   ~0u,
@@ -356,6 +409,38 @@ const uint32_t TableStruct_types_2ftypes_2eproto::offsets[] PROTOBUF_SECTION_VAR
   ~0u,
   0,
   1,
+  ~0u,
+  ~0u,
+  ~0u,
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::types::DepositRequest, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  ~0u,  // no _inlined_string_donated_
+  PROTOBUF_FIELD_OFFSET(::types::DepositRequest, _impl_.pubkey_),
+  PROTOBUF_FIELD_OFFSET(::types::DepositRequest, _impl_.withdrawal_credentials_),
+  PROTOBUF_FIELD_OFFSET(::types::DepositRequest, _impl_.amount_),
+  PROTOBUF_FIELD_OFFSET(::types::DepositRequest, _impl_.signature_),
+  PROTOBUF_FIELD_OFFSET(::types::DepositRequest, _impl_.index_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::types::WithdrawalRequest, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  ~0u,  // no _inlined_string_donated_
+  PROTOBUF_FIELD_OFFSET(::types::WithdrawalRequest, _impl_.source_address_),
+  PROTOBUF_FIELD_OFFSET(::types::WithdrawalRequest, _impl_.validator_pubkey_),
+  PROTOBUF_FIELD_OFFSET(::types::WithdrawalRequest, _impl_.amount_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::types::ConsolidationRequest, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  ~0u,  // no _inlined_string_donated_
+  PROTOBUF_FIELD_OFFSET(::types::ConsolidationRequest, _impl_.source_address_),
+  PROTOBUF_FIELD_OFFSET(::types::ConsolidationRequest, _impl_.source_pubkey_),
+  PROTOBUF_FIELD_OFFSET(::types::ConsolidationRequest, _impl_.target_pubkey_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::types::Withdrawal, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -429,13 +514,16 @@ static const ::_pbi::MigrationSchema schemas[] PROTOBUF_SECTION_VARIABLE(protode
   { 32, -1, -1, sizeof(::types::H1024)},
   { 40, -1, -1, sizeof(::types::H2048)},
   { 48, -1, -1, sizeof(::types::VersionReply)},
-  { 57, 81, -1, sizeof(::types::ExecutionPayload)},
-  { 99, -1, -1, sizeof(::types::Withdrawal)},
-  { 109, -1, -1, sizeof(::types::BlobsBundleV1)},
-  { 118, -1, -1, sizeof(::types::NodeInfoPorts)},
-  { 126, -1, -1, sizeof(::types::NodeInfoReply)},
-  { 139, -1, -1, sizeof(::types::PeerInfo)},
-  { 155, -1, -1, sizeof(::types::ExecutionPayloadBodyV1)},
+  { 57, 84, -1, sizeof(::types::ExecutionPayload)},
+  { 105, -1, -1, sizeof(::types::DepositRequest)},
+  { 116, -1, -1, sizeof(::types::WithdrawalRequest)},
+  { 125, -1, -1, sizeof(::types::ConsolidationRequest)},
+  { 134, -1, -1, sizeof(::types::Withdrawal)},
+  { 144, -1, -1, sizeof(::types::BlobsBundleV1)},
+  { 153, -1, -1, sizeof(::types::NodeInfoPorts)},
+  { 161, -1, -1, sizeof(::types::NodeInfoReply)},
+  { 174, -1, -1, sizeof(::types::PeerInfo)},
+  { 190, -1, -1, sizeof(::types::ExecutionPayloadBodyV1)},
 };
 
 static const ::_pb::Message* const file_default_instances[] = {
@@ -447,6 +535,9 @@ static const ::_pb::Message* const file_default_instances[] = {
   &::types::_H2048_default_instance_._instance,
   &::types::_VersionReply_default_instance_._instance,
   &::types::_ExecutionPayload_default_instance_._instance,
+  &::types::_DepositRequest_default_instance_._instance,
+  &::types::_WithdrawalRequest_default_instance_._instance,
+  &::types::_ConsolidationRequest_default_instance_._instance,
   &::types::_Withdrawal_default_instance_._instance,
   &::types::_BlobsBundleV1_default_instance_._instance,
   &::types::_NodeInfoPorts_default_instance_._instance,
@@ -466,7 +557,7 @@ const char descriptor_table_protodef_types_2ftypes_2eproto[] PROTOBUF_SECTION_VA
   "es.H512\022\027\n\002lo\030\002 \001(\0132\013.types.H512\";\n\005H204"
   "8\022\030\n\002hi\030\001 \001(\0132\014.types.H1024\022\030\n\002lo\030\002 \001(\0132"
   "\014.types.H1024\";\n\014VersionReply\022\r\n\005major\030\001"
-  " \001(\r\022\r\n\005minor\030\002 \001(\r\022\r\n\005patch\030\003 \001(\r\"\264\004\n\020E"
+  " \001(\r\022\r\n\005minor\030\002 \001(\r\022\r\n\005patch\030\003 \001(\r\"\331\005\n\020E"
   "xecutionPayload\022\017\n\007version\030\001 \001(\r\022 \n\013pare"
   "nt_hash\030\002 \001(\0132\013.types.H256\022\035\n\010coinbase\030\003"
   " \001(\0132\013.types.H160\022\037\n\nstate_root\030\004 \001(\0132\013."
@@ -480,39 +571,51 @@ const char descriptor_table_protodef_types_2ftypes_2eproto[] PROTOBUF_SECTION_VA
   "256\022\024\n\014transactions\030\017 \003(\014\022&\n\013withdrawals"
   "\030\020 \003(\0132\021.types.Withdrawal\022\032\n\rblob_gas_us"
   "ed\030\021 \001(\004H\000\210\001\001\022\034\n\017excess_blob_gas\030\022 \001(\004H\001"
-  "\210\001\001B\020\n\016_blob_gas_usedB\022\n\020_excess_blob_ga"
-  "s\"b\n\nWithdrawal\022\r\n\005index\030\001 \001(\004\022\027\n\017valida"
-  "tor_index\030\002 \001(\004\022\034\n\007address\030\003 \001(\0132\013.types"
-  ".H160\022\016\n\006amount\030\004 \001(\004\"C\n\rBlobsBundleV1\022\023"
-  "\n\013commitments\030\001 \003(\014\022\r\n\005blobs\030\002 \003(\014\022\016\n\006pr"
-  "oofs\030\003 \003(\014\"4\n\rNodeInfoPorts\022\021\n\tdiscovery"
-  "\030\001 \001(\r\022\020\n\010listener\030\002 \001(\r\"\224\001\n\rNodeInfoRep"
-  "ly\022\n\n\002id\030\001 \001(\t\022\014\n\004name\030\002 \001(\t\022\r\n\005enode\030\003 "
-  "\001(\t\022\013\n\003enr\030\004 \001(\t\022#\n\005ports\030\005 \001(\0132\024.types."
-  "NodeInfoPorts\022\025\n\rlistener_addr\030\006 \001(\t\022\021\n\t"
-  "protocols\030\007 \001(\014\"\313\001\n\010PeerInfo\022\n\n\002id\030\001 \001(\t"
-  "\022\014\n\004name\030\002 \001(\t\022\r\n\005enode\030\003 \001(\t\022\013\n\003enr\030\004 \001"
-  "(\t\022\014\n\004caps\030\005 \003(\t\022\027\n\017conn_local_addr\030\006 \001("
-  "\t\022\030\n\020conn_remote_addr\030\007 \001(\t\022\027\n\017conn_is_i"
-  "nbound\030\010 \001(\010\022\027\n\017conn_is_trusted\030\t \001(\010\022\026\n"
-  "\016conn_is_static\030\n \001(\010\"V\n\026ExecutionPayloa"
-  "dBodyV1\022\024\n\014transactions\030\001 \003(\014\022&\n\013withdra"
-  "wals\030\002 \003(\0132\021.types.Withdrawal:=\n\025service"
-  "_major_version\022\034.google.protobuf.FileOpt"
-  "ions\030\321\206\003 \001(\r:=\n\025service_minor_version\022\034."
-  "google.protobuf.FileOptions\030\322\206\003 \001(\r:=\n\025s"
-  "ervice_patch_version\022\034.google.protobuf.F"
-  "ileOptions\030\323\206\003 \001(\rB\017Z\r./types;typesb\006pro"
-  "to3"
+  "\210\001\001\022/\n\020deposit_requests\030\023 \003(\0132\025.types.De"
+  "positRequest\0225\n\023withdrawal_requests\030\024 \003("
+  "\0132\030.types.WithdrawalRequest\022;\n\026consolida"
+  "tion_requests\030\025 \003(\0132\033.types.Consolidatio"
+  "nRequestB\020\n\016_blob_gas_usedB\022\n\020_excess_bl"
+  "ob_gas\"\177\n\016DepositRequest\022\016\n\006pubkey\030\001 \001(\014"
+  "\022+\n\026withdrawal_credentials\030\002 \001(\0132\013.types"
+  ".H256\022\016\n\006amount\030\003 \001(\004\022\021\n\tsignature\030\004 \001(\014"
+  "\022\r\n\005index\030\005 \001(\004\"b\n\021WithdrawalRequest\022#\n\016"
+  "source_address\030\001 \001(\0132\013.types.H160\022\030\n\020val"
+  "idator_pubkey\030\002 \001(\014\022\016\n\006amount\030\003 \001(\004\"i\n\024C"
+  "onsolidationRequest\022#\n\016source_address\030\001 "
+  "\001(\0132\013.types.H160\022\025\n\rsource_pubkey\030\002 \001(\014\022"
+  "\025\n\rtarget_pubkey\030\003 \001(\014\"b\n\nWithdrawal\022\r\n\005"
+  "index\030\001 \001(\004\022\027\n\017validator_index\030\002 \001(\004\022\034\n\007"
+  "address\030\003 \001(\0132\013.types.H160\022\016\n\006amount\030\004 \001"
+  "(\004\"C\n\rBlobsBundleV1\022\023\n\013commitments\030\001 \003(\014"
+  "\022\r\n\005blobs\030\002 \003(\014\022\016\n\006proofs\030\003 \003(\014\"4\n\rNodeI"
+  "nfoPorts\022\021\n\tdiscovery\030\001 \001(\r\022\020\n\010listener\030"
+  "\002 \001(\r\"\224\001\n\rNodeInfoReply\022\n\n\002id\030\001 \001(\t\022\014\n\004n"
+  "ame\030\002 \001(\t\022\r\n\005enode\030\003 \001(\t\022\013\n\003enr\030\004 \001(\t\022#\n"
+  "\005ports\030\005 \001(\0132\024.types.NodeInfoPorts\022\025\n\rli"
+  "stener_addr\030\006 \001(\t\022\021\n\tprotocols\030\007 \001(\014\"\313\001\n"
+  "\010PeerInfo\022\n\n\002id\030\001 \001(\t\022\014\n\004name\030\002 \001(\t\022\r\n\005e"
+  "node\030\003 \001(\t\022\013\n\003enr\030\004 \001(\t\022\014\n\004caps\030\005 \003(\t\022\027\n"
+  "\017conn_local_addr\030\006 \001(\t\022\030\n\020conn_remote_ad"
+  "dr\030\007 \001(\t\022\027\n\017conn_is_inbound\030\010 \001(\010\022\027\n\017con"
+  "n_is_trusted\030\t \001(\010\022\026\n\016conn_is_static\030\n \001"
+  "(\010\"V\n\026ExecutionPayloadBodyV1\022\024\n\014transact"
+  "ions\030\001 \003(\014\022&\n\013withdrawals\030\002 \003(\0132\021.types."
+  "Withdrawal:=\n\025service_major_version\022\034.go"
+  "ogle.protobuf.FileOptions\030\321\206\003 \001(\r:=\n\025ser"
+  "vice_minor_version\022\034.google.protobuf.Fil"
+  "eOptions\030\322\206\003 \001(\r:=\n\025service_patch_versio"
+  "n\022\034.google.protobuf.FileOptions\030\323\206\003 \001(\rB"
+  "\024Z\022./types;typesprotob\006proto3"
   ;
 static const ::_pbi::DescriptorTable* const descriptor_table_types_2ftypes_2eproto_deps[1] = {
   &::descriptor_table_google_2fprotobuf_2fdescriptor_2eproto,
 };
 static ::_pbi::once_flag descriptor_table_types_2ftypes_2eproto_once;
 const ::_pbi::DescriptorTable descriptor_table_types_2ftypes_2eproto = {
-    false, false, 1883, descriptor_table_protodef_types_2ftypes_2eproto,
+    false, false, 2389, descriptor_table_protodef_types_2ftypes_2eproto,
     "types/types.proto",
-    &descriptor_table_types_2ftypes_2eproto_once, descriptor_table_types_2ftypes_2eproto_deps, 1, 14,
+    &descriptor_table_types_2ftypes_2eproto_once, descriptor_table_types_2ftypes_2eproto_deps, 1, 17,
     schemas, file_default_instances, TableStruct_types_2ftypes_2eproto::offsets,
     file_level_metadata_types_2ftypes_2eproto, file_level_enum_descriptors_types_2ftypes_2eproto,
     file_level_service_descriptors_types_2ftypes_2eproto,
@@ -2218,6 +2321,9 @@ ExecutionPayload::ExecutionPayload(const ExecutionPayload& from)
     , /*decltype(_impl_._cached_size_)*/{}
     , decltype(_impl_.transactions_){from._impl_.transactions_}
     , decltype(_impl_.withdrawals_){from._impl_.withdrawals_}
+    , decltype(_impl_.deposit_requests_){from._impl_.deposit_requests_}
+    , decltype(_impl_.withdrawal_requests_){from._impl_.withdrawal_requests_}
+    , decltype(_impl_.consolidation_requests_){from._impl_.consolidation_requests_}
     , decltype(_impl_.extra_data_){}
     , decltype(_impl_.parent_hash_){nullptr}
     , decltype(_impl_.coinbase_){nullptr}
@@ -2283,6 +2389,9 @@ inline void ExecutionPayload::SharedCtor(
     , /*decltype(_impl_._cached_size_)*/{}
     , decltype(_impl_.transactions_){arena}
     , decltype(_impl_.withdrawals_){arena}
+    , decltype(_impl_.deposit_requests_){arena}
+    , decltype(_impl_.withdrawal_requests_){arena}
+    , decltype(_impl_.consolidation_requests_){arena}
     , decltype(_impl_.extra_data_){}
     , decltype(_impl_.parent_hash_){nullptr}
     , decltype(_impl_.coinbase_){nullptr}
@@ -2319,6 +2428,9 @@ inline void ExecutionPayload::SharedDtor() {
   GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
   _impl_.transactions_.~RepeatedPtrField();
   _impl_.withdrawals_.~RepeatedPtrField();
+  _impl_.deposit_requests_.~RepeatedPtrField();
+  _impl_.withdrawal_requests_.~RepeatedPtrField();
+  _impl_.consolidation_requests_.~RepeatedPtrField();
   _impl_.extra_data_.Destroy();
   if (this != internal_default_instance()) delete _impl_.parent_hash_;
   if (this != internal_default_instance()) delete _impl_.coinbase_;
@@ -2342,6 +2454,9 @@ void ExecutionPayload::Clear() {
 
   _impl_.transactions_.Clear();
   _impl_.withdrawals_.Clear();
+  _impl_.deposit_requests_.Clear();
+  _impl_.withdrawal_requests_.Clear();
+  _impl_.consolidation_requests_.Clear();
   _impl_.extra_data_.ClearToEmpty();
   if (GetArenaForAllocation() == nullptr && _impl_.parent_hash_ != nullptr) {
     delete _impl_.parent_hash_;
@@ -2554,6 +2669,45 @@ const char* ExecutionPayload::_InternalParse(const char* ptr, ::_pbi::ParseConte
         } else
           goto handle_unusual;
         continue;
+      // repeated .types.DepositRequest deposit_requests = 19;
+      case 19:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 154)) {
+          ptr -= 2;
+          do {
+            ptr += 2;
+            ptr = ctx->ParseMessage(_internal_add_deposit_requests(), ptr);
+            CHK_(ptr);
+            if (!ctx->DataAvailable(ptr)) break;
+          } while (::PROTOBUF_NAMESPACE_ID::internal::ExpectTag<154>(ptr));
+        } else
+          goto handle_unusual;
+        continue;
+      // repeated .types.WithdrawalRequest withdrawal_requests = 20;
+      case 20:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 162)) {
+          ptr -= 2;
+          do {
+            ptr += 2;
+            ptr = ctx->ParseMessage(_internal_add_withdrawal_requests(), ptr);
+            CHK_(ptr);
+            if (!ctx->DataAvailable(ptr)) break;
+          } while (::PROTOBUF_NAMESPACE_ID::internal::ExpectTag<162>(ptr));
+        } else
+          goto handle_unusual;
+        continue;
+      // repeated .types.ConsolidationRequest consolidation_requests = 21;
+      case 21:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 170)) {
+          ptr -= 2;
+          do {
+            ptr += 2;
+            ptr = ctx->ParseMessage(_internal_add_consolidation_requests(), ptr);
+            CHK_(ptr);
+            if (!ctx->DataAvailable(ptr)) break;
+          } while (::PROTOBUF_NAMESPACE_ID::internal::ExpectTag<170>(ptr));
+        } else
+          goto handle_unusual;
+        continue;
       default:
         goto handle_unusual;
     }  // switch
@@ -2702,6 +2856,30 @@ uint8_t* ExecutionPayload::_InternalSerialize(
     target = ::_pbi::WireFormatLite::WriteUInt64ToArray(18, this->_internal_excess_blob_gas(), target);
   }
 
+  // repeated .types.DepositRequest deposit_requests = 19;
+  for (unsigned i = 0,
+      n = static_cast<unsigned>(this->_internal_deposit_requests_size()); i < n; i++) {
+    const auto& repfield = this->_internal_deposit_requests(i);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+        InternalWriteMessage(19, repfield, repfield.GetCachedSize(), target, stream);
+  }
+
+  // repeated .types.WithdrawalRequest withdrawal_requests = 20;
+  for (unsigned i = 0,
+      n = static_cast<unsigned>(this->_internal_withdrawal_requests_size()); i < n; i++) {
+    const auto& repfield = this->_internal_withdrawal_requests(i);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+        InternalWriteMessage(20, repfield, repfield.GetCachedSize(), target, stream);
+  }
+
+  // repeated .types.ConsolidationRequest consolidation_requests = 21;
+  for (unsigned i = 0,
+      n = static_cast<unsigned>(this->_internal_consolidation_requests_size()); i < n; i++) {
+    const auto& repfield = this->_internal_consolidation_requests(i);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+        InternalWriteMessage(21, repfield, repfield.GetCachedSize(), target, stream);
+  }
+
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
     target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
         _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
@@ -2729,6 +2907,27 @@ size_t ExecutionPayload::ByteSizeLong() const {
   // repeated .types.Withdrawal withdrawals = 16;
   total_size += 2UL * this->_internal_withdrawals_size();
   for (const auto& msg : this->_impl_.withdrawals_) {
+    total_size +=
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(msg);
+  }
+
+  // repeated .types.DepositRequest deposit_requests = 19;
+  total_size += 2UL * this->_internal_deposit_requests_size();
+  for (const auto& msg : this->_impl_.deposit_requests_) {
+    total_size +=
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(msg);
+  }
+
+  // repeated .types.WithdrawalRequest withdrawal_requests = 20;
+  total_size += 2UL * this->_internal_withdrawal_requests_size();
+  for (const auto& msg : this->_impl_.withdrawal_requests_) {
+    total_size +=
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(msg);
+  }
+
+  // repeated .types.ConsolidationRequest consolidation_requests = 21;
+  total_size += 2UL * this->_internal_consolidation_requests_size();
+  for (const auto& msg : this->_impl_.consolidation_requests_) {
     total_size +=
       ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(msg);
   }
@@ -2858,6 +3057,9 @@ void ExecutionPayload::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const
 
   _this->_impl_.transactions_.MergeFrom(from._impl_.transactions_);
   _this->_impl_.withdrawals_.MergeFrom(from._impl_.withdrawals_);
+  _this->_impl_.deposit_requests_.MergeFrom(from._impl_.deposit_requests_);
+  _this->_impl_.withdrawal_requests_.MergeFrom(from._impl_.withdrawal_requests_);
+  _this->_impl_.consolidation_requests_.MergeFrom(from._impl_.consolidation_requests_);
   if (!from._internal_extra_data().empty()) {
     _this->_internal_set_extra_data(from._internal_extra_data());
   }
@@ -2940,6 +3142,9 @@ void ExecutionPayload::InternalSwap(ExecutionPayload* other) {
   swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
   _impl_.transactions_.InternalSwap(&other->_impl_.transactions_);
   _impl_.withdrawals_.InternalSwap(&other->_impl_.withdrawals_);
+  _impl_.deposit_requests_.InternalSwap(&other->_impl_.deposit_requests_);
+  _impl_.withdrawal_requests_.InternalSwap(&other->_impl_.withdrawal_requests_);
+  _impl_.consolidation_requests_.InternalSwap(&other->_impl_.consolidation_requests_);
   ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
       &_impl_.extra_data_, lhs_arena,
       &other->_impl_.extra_data_, rhs_arena
@@ -2956,6 +3161,906 @@ void ExecutionPayload::InternalSwap(ExecutionPayload* other) {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_types_2ftypes_2eproto_getter, &descriptor_table_types_2ftypes_2eproto_once,
       file_level_metadata_types_2ftypes_2eproto[7]);
+}
+
+// ===================================================================
+
+class DepositRequest::_Internal {
+ public:
+  static const ::types::H256& withdrawal_credentials(const DepositRequest* msg);
+};
+
+const ::types::H256&
+DepositRequest::_Internal::withdrawal_credentials(const DepositRequest* msg) {
+  return *msg->_impl_.withdrawal_credentials_;
+}
+DepositRequest::DepositRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                         bool is_message_owned)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
+  SharedCtor(arena, is_message_owned);
+  // @@protoc_insertion_point(arena_constructor:types.DepositRequest)
+}
+DepositRequest::DepositRequest(const DepositRequest& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  DepositRequest* const _this = this; (void)_this;
+  new (&_impl_) Impl_{
+      decltype(_impl_.pubkey_){}
+    , decltype(_impl_.signature_){}
+    , decltype(_impl_.withdrawal_credentials_){nullptr}
+    , decltype(_impl_.amount_){}
+    , decltype(_impl_.index_){}
+    , /*decltype(_impl_._cached_size_)*/{}};
+
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  _impl_.pubkey_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.pubkey_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (!from._internal_pubkey().empty()) {
+    _this->_impl_.pubkey_.Set(from._internal_pubkey(), 
+      _this->GetArenaForAllocation());
+  }
+  _impl_.signature_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.signature_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (!from._internal_signature().empty()) {
+    _this->_impl_.signature_.Set(from._internal_signature(), 
+      _this->GetArenaForAllocation());
+  }
+  if (from._internal_has_withdrawal_credentials()) {
+    _this->_impl_.withdrawal_credentials_ = new ::types::H256(*from._impl_.withdrawal_credentials_);
+  }
+  ::memcpy(&_impl_.amount_, &from._impl_.amount_,
+    static_cast<size_t>(reinterpret_cast<char*>(&_impl_.index_) -
+    reinterpret_cast<char*>(&_impl_.amount_)) + sizeof(_impl_.index_));
+  // @@protoc_insertion_point(copy_constructor:types.DepositRequest)
+}
+
+inline void DepositRequest::SharedCtor(
+    ::_pb::Arena* arena, bool is_message_owned) {
+  (void)arena;
+  (void)is_message_owned;
+  new (&_impl_) Impl_{
+      decltype(_impl_.pubkey_){}
+    , decltype(_impl_.signature_){}
+    , decltype(_impl_.withdrawal_credentials_){nullptr}
+    , decltype(_impl_.amount_){uint64_t{0u}}
+    , decltype(_impl_.index_){uint64_t{0u}}
+    , /*decltype(_impl_._cached_size_)*/{}
+  };
+  _impl_.pubkey_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.pubkey_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  _impl_.signature_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.signature_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+}
+
+DepositRequest::~DepositRequest() {
+  // @@protoc_insertion_point(destructor:types.DepositRequest)
+  if (auto *arena = _internal_metadata_.DeleteReturnArena<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>()) {
+  (void)arena;
+    return;
+  }
+  SharedDtor();
+}
+
+inline void DepositRequest::SharedDtor() {
+  GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+  _impl_.pubkey_.Destroy();
+  _impl_.signature_.Destroy();
+  if (this != internal_default_instance()) delete _impl_.withdrawal_credentials_;
+}
+
+void DepositRequest::SetCachedSize(int size) const {
+  _impl_._cached_size_.Set(size);
+}
+
+void DepositRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:types.DepositRequest)
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.pubkey_.ClearToEmpty();
+  _impl_.signature_.ClearToEmpty();
+  if (GetArenaForAllocation() == nullptr && _impl_.withdrawal_credentials_ != nullptr) {
+    delete _impl_.withdrawal_credentials_;
+  }
+  _impl_.withdrawal_credentials_ = nullptr;
+  ::memset(&_impl_.amount_, 0, static_cast<size_t>(
+      reinterpret_cast<char*>(&_impl_.index_) -
+      reinterpret_cast<char*>(&_impl_.amount_)) + sizeof(_impl_.index_));
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* DepositRequest::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    uint32_t tag;
+    ptr = ::_pbi::ReadTag(ptr, &tag);
+    switch (tag >> 3) {
+      // bytes pubkey = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 10)) {
+          auto str = _internal_mutable_pubkey();
+          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      // .types.H256 withdrawal_credentials = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 18)) {
+          ptr = ctx->ParseMessage(_internal_mutable_withdrawal_credentials(), ptr);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      // uint64 amount = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 24)) {
+          _impl_.amount_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      // bytes signature = 4;
+      case 4:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 34)) {
+          auto str = _internal_mutable_signature();
+          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      // uint64 index = 5;
+      case 5:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 40)) {
+          _impl_.index_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      default:
+        goto handle_unusual;
+    }  // switch
+  handle_unusual:
+    if ((tag == 0) || ((tag & 7) == 4)) {
+      CHK_(ptr);
+      ctx->SetLastTag(tag);
+      goto message_done;
+    }
+    ptr = UnknownFieldParse(
+        tag,
+        _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+        ptr, ctx);
+    CHK_(ptr != nullptr);
+  }  // while
+message_done:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto message_done;
+#undef CHK_
+}
+
+uint8_t* DepositRequest::_InternalSerialize(
+    uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:types.DepositRequest)
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // bytes pubkey = 1;
+  if (!this->_internal_pubkey().empty()) {
+    target = stream->WriteBytesMaybeAliased(
+        1, this->_internal_pubkey(), target);
+  }
+
+  // .types.H256 withdrawal_credentials = 2;
+  if (this->_internal_has_withdrawal_credentials()) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(2, _Internal::withdrawal_credentials(this),
+        _Internal::withdrawal_credentials(this).GetCachedSize(), target, stream);
+  }
+
+  // uint64 amount = 3;
+  if (this->_internal_amount() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteUInt64ToArray(3, this->_internal_amount(), target);
+  }
+
+  // bytes signature = 4;
+  if (!this->_internal_signature().empty()) {
+    target = stream->WriteBytesMaybeAliased(
+        4, this->_internal_signature(), target);
+  }
+
+  // uint64 index = 5;
+  if (this->_internal_index() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteUInt64ToArray(5, this->_internal_index(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:types.DepositRequest)
+  return target;
+}
+
+size_t DepositRequest::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:types.DepositRequest)
+  size_t total_size = 0;
+
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // bytes pubkey = 1;
+  if (!this->_internal_pubkey().empty()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::BytesSize(
+        this->_internal_pubkey());
+  }
+
+  // bytes signature = 4;
+  if (!this->_internal_signature().empty()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::BytesSize(
+        this->_internal_signature());
+  }
+
+  // .types.H256 withdrawal_credentials = 2;
+  if (this->_internal_has_withdrawal_credentials()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *_impl_.withdrawal_credentials_);
+  }
+
+  // uint64 amount = 3;
+  if (this->_internal_amount() != 0) {
+    total_size += ::_pbi::WireFormatLite::UInt64SizePlusOne(this->_internal_amount());
+  }
+
+  // uint64 index = 5;
+  if (this->_internal_index() != 0) {
+    total_size += ::_pbi::WireFormatLite::UInt64SizePlusOne(this->_internal_index());
+  }
+
+  return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
+}
+
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData DepositRequest::_class_data_ = {
+    ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSourceCheck,
+    DepositRequest::MergeImpl
+};
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*DepositRequest::GetClassData() const { return &_class_data_; }
+
+
+void DepositRequest::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg) {
+  auto* const _this = static_cast<DepositRequest*>(&to_msg);
+  auto& from = static_cast<const DepositRequest&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:types.DepositRequest)
+  GOOGLE_DCHECK_NE(&from, _this);
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (!from._internal_pubkey().empty()) {
+    _this->_internal_set_pubkey(from._internal_pubkey());
+  }
+  if (!from._internal_signature().empty()) {
+    _this->_internal_set_signature(from._internal_signature());
+  }
+  if (from._internal_has_withdrawal_credentials()) {
+    _this->_internal_mutable_withdrawal_credentials()->::types::H256::MergeFrom(
+        from._internal_withdrawal_credentials());
+  }
+  if (from._internal_amount() != 0) {
+    _this->_internal_set_amount(from._internal_amount());
+  }
+  if (from._internal_index() != 0) {
+    _this->_internal_set_index(from._internal_index());
+  }
+  _this->_internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void DepositRequest::CopyFrom(const DepositRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:types.DepositRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool DepositRequest::IsInitialized() const {
+  return true;
+}
+
+void DepositRequest::InternalSwap(DepositRequest* other) {
+  using std::swap;
+  auto* lhs_arena = GetArenaForAllocation();
+  auto* rhs_arena = other->GetArenaForAllocation();
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
+      &_impl_.pubkey_, lhs_arena,
+      &other->_impl_.pubkey_, rhs_arena
+  );
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
+      &_impl_.signature_, lhs_arena,
+      &other->_impl_.signature_, rhs_arena
+  );
+  ::PROTOBUF_NAMESPACE_ID::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(DepositRequest, _impl_.index_)
+      + sizeof(DepositRequest::_impl_.index_)
+      - PROTOBUF_FIELD_OFFSET(DepositRequest, _impl_.withdrawal_credentials_)>(
+          reinterpret_cast<char*>(&_impl_.withdrawal_credentials_),
+          reinterpret_cast<char*>(&other->_impl_.withdrawal_credentials_));
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata DepositRequest::GetMetadata() const {
+  return ::_pbi::AssignDescriptors(
+      &descriptor_table_types_2ftypes_2eproto_getter, &descriptor_table_types_2ftypes_2eproto_once,
+      file_level_metadata_types_2ftypes_2eproto[8]);
+}
+
+// ===================================================================
+
+class WithdrawalRequest::_Internal {
+ public:
+  static const ::types::H160& source_address(const WithdrawalRequest* msg);
+};
+
+const ::types::H160&
+WithdrawalRequest::_Internal::source_address(const WithdrawalRequest* msg) {
+  return *msg->_impl_.source_address_;
+}
+WithdrawalRequest::WithdrawalRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                         bool is_message_owned)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
+  SharedCtor(arena, is_message_owned);
+  // @@protoc_insertion_point(arena_constructor:types.WithdrawalRequest)
+}
+WithdrawalRequest::WithdrawalRequest(const WithdrawalRequest& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  WithdrawalRequest* const _this = this; (void)_this;
+  new (&_impl_) Impl_{
+      decltype(_impl_.validator_pubkey_){}
+    , decltype(_impl_.source_address_){nullptr}
+    , decltype(_impl_.amount_){}
+    , /*decltype(_impl_._cached_size_)*/{}};
+
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  _impl_.validator_pubkey_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.validator_pubkey_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (!from._internal_validator_pubkey().empty()) {
+    _this->_impl_.validator_pubkey_.Set(from._internal_validator_pubkey(), 
+      _this->GetArenaForAllocation());
+  }
+  if (from._internal_has_source_address()) {
+    _this->_impl_.source_address_ = new ::types::H160(*from._impl_.source_address_);
+  }
+  _this->_impl_.amount_ = from._impl_.amount_;
+  // @@protoc_insertion_point(copy_constructor:types.WithdrawalRequest)
+}
+
+inline void WithdrawalRequest::SharedCtor(
+    ::_pb::Arena* arena, bool is_message_owned) {
+  (void)arena;
+  (void)is_message_owned;
+  new (&_impl_) Impl_{
+      decltype(_impl_.validator_pubkey_){}
+    , decltype(_impl_.source_address_){nullptr}
+    , decltype(_impl_.amount_){uint64_t{0u}}
+    , /*decltype(_impl_._cached_size_)*/{}
+  };
+  _impl_.validator_pubkey_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.validator_pubkey_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+}
+
+WithdrawalRequest::~WithdrawalRequest() {
+  // @@protoc_insertion_point(destructor:types.WithdrawalRequest)
+  if (auto *arena = _internal_metadata_.DeleteReturnArena<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>()) {
+  (void)arena;
+    return;
+  }
+  SharedDtor();
+}
+
+inline void WithdrawalRequest::SharedDtor() {
+  GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+  _impl_.validator_pubkey_.Destroy();
+  if (this != internal_default_instance()) delete _impl_.source_address_;
+}
+
+void WithdrawalRequest::SetCachedSize(int size) const {
+  _impl_._cached_size_.Set(size);
+}
+
+void WithdrawalRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:types.WithdrawalRequest)
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.validator_pubkey_.ClearToEmpty();
+  if (GetArenaForAllocation() == nullptr && _impl_.source_address_ != nullptr) {
+    delete _impl_.source_address_;
+  }
+  _impl_.source_address_ = nullptr;
+  _impl_.amount_ = uint64_t{0u};
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* WithdrawalRequest::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    uint32_t tag;
+    ptr = ::_pbi::ReadTag(ptr, &tag);
+    switch (tag >> 3) {
+      // .types.H160 source_address = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 10)) {
+          ptr = ctx->ParseMessage(_internal_mutable_source_address(), ptr);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      // bytes validator_pubkey = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 18)) {
+          auto str = _internal_mutable_validator_pubkey();
+          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      // uint64 amount = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 24)) {
+          _impl_.amount_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      default:
+        goto handle_unusual;
+    }  // switch
+  handle_unusual:
+    if ((tag == 0) || ((tag & 7) == 4)) {
+      CHK_(ptr);
+      ctx->SetLastTag(tag);
+      goto message_done;
+    }
+    ptr = UnknownFieldParse(
+        tag,
+        _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+        ptr, ctx);
+    CHK_(ptr != nullptr);
+  }  // while
+message_done:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto message_done;
+#undef CHK_
+}
+
+uint8_t* WithdrawalRequest::_InternalSerialize(
+    uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:types.WithdrawalRequest)
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // .types.H160 source_address = 1;
+  if (this->_internal_has_source_address()) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(1, _Internal::source_address(this),
+        _Internal::source_address(this).GetCachedSize(), target, stream);
+  }
+
+  // bytes validator_pubkey = 2;
+  if (!this->_internal_validator_pubkey().empty()) {
+    target = stream->WriteBytesMaybeAliased(
+        2, this->_internal_validator_pubkey(), target);
+  }
+
+  // uint64 amount = 3;
+  if (this->_internal_amount() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteUInt64ToArray(3, this->_internal_amount(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:types.WithdrawalRequest)
+  return target;
+}
+
+size_t WithdrawalRequest::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:types.WithdrawalRequest)
+  size_t total_size = 0;
+
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // bytes validator_pubkey = 2;
+  if (!this->_internal_validator_pubkey().empty()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::BytesSize(
+        this->_internal_validator_pubkey());
+  }
+
+  // .types.H160 source_address = 1;
+  if (this->_internal_has_source_address()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *_impl_.source_address_);
+  }
+
+  // uint64 amount = 3;
+  if (this->_internal_amount() != 0) {
+    total_size += ::_pbi::WireFormatLite::UInt64SizePlusOne(this->_internal_amount());
+  }
+
+  return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
+}
+
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData WithdrawalRequest::_class_data_ = {
+    ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSourceCheck,
+    WithdrawalRequest::MergeImpl
+};
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*WithdrawalRequest::GetClassData() const { return &_class_data_; }
+
+
+void WithdrawalRequest::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg) {
+  auto* const _this = static_cast<WithdrawalRequest*>(&to_msg);
+  auto& from = static_cast<const WithdrawalRequest&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:types.WithdrawalRequest)
+  GOOGLE_DCHECK_NE(&from, _this);
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (!from._internal_validator_pubkey().empty()) {
+    _this->_internal_set_validator_pubkey(from._internal_validator_pubkey());
+  }
+  if (from._internal_has_source_address()) {
+    _this->_internal_mutable_source_address()->::types::H160::MergeFrom(
+        from._internal_source_address());
+  }
+  if (from._internal_amount() != 0) {
+    _this->_internal_set_amount(from._internal_amount());
+  }
+  _this->_internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void WithdrawalRequest::CopyFrom(const WithdrawalRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:types.WithdrawalRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool WithdrawalRequest::IsInitialized() const {
+  return true;
+}
+
+void WithdrawalRequest::InternalSwap(WithdrawalRequest* other) {
+  using std::swap;
+  auto* lhs_arena = GetArenaForAllocation();
+  auto* rhs_arena = other->GetArenaForAllocation();
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
+      &_impl_.validator_pubkey_, lhs_arena,
+      &other->_impl_.validator_pubkey_, rhs_arena
+  );
+  ::PROTOBUF_NAMESPACE_ID::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(WithdrawalRequest, _impl_.amount_)
+      + sizeof(WithdrawalRequest::_impl_.amount_)
+      - PROTOBUF_FIELD_OFFSET(WithdrawalRequest, _impl_.source_address_)>(
+          reinterpret_cast<char*>(&_impl_.source_address_),
+          reinterpret_cast<char*>(&other->_impl_.source_address_));
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata WithdrawalRequest::GetMetadata() const {
+  return ::_pbi::AssignDescriptors(
+      &descriptor_table_types_2ftypes_2eproto_getter, &descriptor_table_types_2ftypes_2eproto_once,
+      file_level_metadata_types_2ftypes_2eproto[9]);
+}
+
+// ===================================================================
+
+class ConsolidationRequest::_Internal {
+ public:
+  static const ::types::H160& source_address(const ConsolidationRequest* msg);
+};
+
+const ::types::H160&
+ConsolidationRequest::_Internal::source_address(const ConsolidationRequest* msg) {
+  return *msg->_impl_.source_address_;
+}
+ConsolidationRequest::ConsolidationRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                         bool is_message_owned)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
+  SharedCtor(arena, is_message_owned);
+  // @@protoc_insertion_point(arena_constructor:types.ConsolidationRequest)
+}
+ConsolidationRequest::ConsolidationRequest(const ConsolidationRequest& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  ConsolidationRequest* const _this = this; (void)_this;
+  new (&_impl_) Impl_{
+      decltype(_impl_.source_pubkey_){}
+    , decltype(_impl_.target_pubkey_){}
+    , decltype(_impl_.source_address_){nullptr}
+    , /*decltype(_impl_._cached_size_)*/{}};
+
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  _impl_.source_pubkey_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.source_pubkey_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (!from._internal_source_pubkey().empty()) {
+    _this->_impl_.source_pubkey_.Set(from._internal_source_pubkey(), 
+      _this->GetArenaForAllocation());
+  }
+  _impl_.target_pubkey_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.target_pubkey_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (!from._internal_target_pubkey().empty()) {
+    _this->_impl_.target_pubkey_.Set(from._internal_target_pubkey(), 
+      _this->GetArenaForAllocation());
+  }
+  if (from._internal_has_source_address()) {
+    _this->_impl_.source_address_ = new ::types::H160(*from._impl_.source_address_);
+  }
+  // @@protoc_insertion_point(copy_constructor:types.ConsolidationRequest)
+}
+
+inline void ConsolidationRequest::SharedCtor(
+    ::_pb::Arena* arena, bool is_message_owned) {
+  (void)arena;
+  (void)is_message_owned;
+  new (&_impl_) Impl_{
+      decltype(_impl_.source_pubkey_){}
+    , decltype(_impl_.target_pubkey_){}
+    , decltype(_impl_.source_address_){nullptr}
+    , /*decltype(_impl_._cached_size_)*/{}
+  };
+  _impl_.source_pubkey_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.source_pubkey_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  _impl_.target_pubkey_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.target_pubkey_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+}
+
+ConsolidationRequest::~ConsolidationRequest() {
+  // @@protoc_insertion_point(destructor:types.ConsolidationRequest)
+  if (auto *arena = _internal_metadata_.DeleteReturnArena<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>()) {
+  (void)arena;
+    return;
+  }
+  SharedDtor();
+}
+
+inline void ConsolidationRequest::SharedDtor() {
+  GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+  _impl_.source_pubkey_.Destroy();
+  _impl_.target_pubkey_.Destroy();
+  if (this != internal_default_instance()) delete _impl_.source_address_;
+}
+
+void ConsolidationRequest::SetCachedSize(int size) const {
+  _impl_._cached_size_.Set(size);
+}
+
+void ConsolidationRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:types.ConsolidationRequest)
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.source_pubkey_.ClearToEmpty();
+  _impl_.target_pubkey_.ClearToEmpty();
+  if (GetArenaForAllocation() == nullptr && _impl_.source_address_ != nullptr) {
+    delete _impl_.source_address_;
+  }
+  _impl_.source_address_ = nullptr;
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* ConsolidationRequest::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    uint32_t tag;
+    ptr = ::_pbi::ReadTag(ptr, &tag);
+    switch (tag >> 3) {
+      // .types.H160 source_address = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 10)) {
+          ptr = ctx->ParseMessage(_internal_mutable_source_address(), ptr);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      // bytes source_pubkey = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 18)) {
+          auto str = _internal_mutable_source_pubkey();
+          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      // bytes target_pubkey = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 26)) {
+          auto str = _internal_mutable_target_pubkey();
+          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      default:
+        goto handle_unusual;
+    }  // switch
+  handle_unusual:
+    if ((tag == 0) || ((tag & 7) == 4)) {
+      CHK_(ptr);
+      ctx->SetLastTag(tag);
+      goto message_done;
+    }
+    ptr = UnknownFieldParse(
+        tag,
+        _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+        ptr, ctx);
+    CHK_(ptr != nullptr);
+  }  // while
+message_done:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto message_done;
+#undef CHK_
+}
+
+uint8_t* ConsolidationRequest::_InternalSerialize(
+    uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:types.ConsolidationRequest)
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // .types.H160 source_address = 1;
+  if (this->_internal_has_source_address()) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(1, _Internal::source_address(this),
+        _Internal::source_address(this).GetCachedSize(), target, stream);
+  }
+
+  // bytes source_pubkey = 2;
+  if (!this->_internal_source_pubkey().empty()) {
+    target = stream->WriteBytesMaybeAliased(
+        2, this->_internal_source_pubkey(), target);
+  }
+
+  // bytes target_pubkey = 3;
+  if (!this->_internal_target_pubkey().empty()) {
+    target = stream->WriteBytesMaybeAliased(
+        3, this->_internal_target_pubkey(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:types.ConsolidationRequest)
+  return target;
+}
+
+size_t ConsolidationRequest::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:types.ConsolidationRequest)
+  size_t total_size = 0;
+
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // bytes source_pubkey = 2;
+  if (!this->_internal_source_pubkey().empty()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::BytesSize(
+        this->_internal_source_pubkey());
+  }
+
+  // bytes target_pubkey = 3;
+  if (!this->_internal_target_pubkey().empty()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::BytesSize(
+        this->_internal_target_pubkey());
+  }
+
+  // .types.H160 source_address = 1;
+  if (this->_internal_has_source_address()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *_impl_.source_address_);
+  }
+
+  return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
+}
+
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData ConsolidationRequest::_class_data_ = {
+    ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSourceCheck,
+    ConsolidationRequest::MergeImpl
+};
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*ConsolidationRequest::GetClassData() const { return &_class_data_; }
+
+
+void ConsolidationRequest::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg) {
+  auto* const _this = static_cast<ConsolidationRequest*>(&to_msg);
+  auto& from = static_cast<const ConsolidationRequest&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:types.ConsolidationRequest)
+  GOOGLE_DCHECK_NE(&from, _this);
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (!from._internal_source_pubkey().empty()) {
+    _this->_internal_set_source_pubkey(from._internal_source_pubkey());
+  }
+  if (!from._internal_target_pubkey().empty()) {
+    _this->_internal_set_target_pubkey(from._internal_target_pubkey());
+  }
+  if (from._internal_has_source_address()) {
+    _this->_internal_mutable_source_address()->::types::H160::MergeFrom(
+        from._internal_source_address());
+  }
+  _this->_internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void ConsolidationRequest::CopyFrom(const ConsolidationRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:types.ConsolidationRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool ConsolidationRequest::IsInitialized() const {
+  return true;
+}
+
+void ConsolidationRequest::InternalSwap(ConsolidationRequest* other) {
+  using std::swap;
+  auto* lhs_arena = GetArenaForAllocation();
+  auto* rhs_arena = other->GetArenaForAllocation();
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
+      &_impl_.source_pubkey_, lhs_arena,
+      &other->_impl_.source_pubkey_, rhs_arena
+  );
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
+      &_impl_.target_pubkey_, lhs_arena,
+      &other->_impl_.target_pubkey_, rhs_arena
+  );
+  swap(_impl_.source_address_, other->_impl_.source_address_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata ConsolidationRequest::GetMetadata() const {
+  return ::_pbi::AssignDescriptors(
+      &descriptor_table_types_2ftypes_2eproto_getter, &descriptor_table_types_2ftypes_2eproto_once,
+      file_level_metadata_types_2ftypes_2eproto[10]);
 }
 
 // ===================================================================
@@ -3231,7 +4336,7 @@ void Withdrawal::InternalSwap(Withdrawal* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata Withdrawal::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_types_2ftypes_2eproto_getter, &descriptor_table_types_2ftypes_2eproto_once,
-      file_level_metadata_types_2ftypes_2eproto[8]);
+      file_level_metadata_types_2ftypes_2eproto[11]);
 }
 
 // ===================================================================
@@ -3484,7 +4589,7 @@ void BlobsBundleV1::InternalSwap(BlobsBundleV1* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata BlobsBundleV1::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_types_2ftypes_2eproto_getter, &descriptor_table_types_2ftypes_2eproto_once,
-      file_level_metadata_types_2ftypes_2eproto[9]);
+      file_level_metadata_types_2ftypes_2eproto[12]);
 }
 
 // ===================================================================
@@ -3695,7 +4800,7 @@ void NodeInfoPorts::InternalSwap(NodeInfoPorts* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata NodeInfoPorts::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_types_2ftypes_2eproto_getter, &descriptor_table_types_2ftypes_2eproto_once,
-      file_level_metadata_types_2ftypes_2eproto[10]);
+      file_level_metadata_types_2ftypes_2eproto[13]);
 }
 
 // ===================================================================
@@ -4185,7 +5290,7 @@ void NodeInfoReply::InternalSwap(NodeInfoReply* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata NodeInfoReply::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_types_2ftypes_2eproto_getter, &descriptor_table_types_2ftypes_2eproto_once,
-      file_level_metadata_types_2ftypes_2eproto[11]);
+      file_level_metadata_types_2ftypes_2eproto[14]);
 }
 
 // ===================================================================
@@ -4761,7 +5866,7 @@ void PeerInfo::InternalSwap(PeerInfo* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata PeerInfo::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_types_2ftypes_2eproto_getter, &descriptor_table_types_2ftypes_2eproto_once,
-      file_level_metadata_types_2ftypes_2eproto[12]);
+      file_level_metadata_types_2ftypes_2eproto[15]);
 }
 
 // ===================================================================
@@ -4980,7 +6085,7 @@ void ExecutionPayloadBodyV1::InternalSwap(ExecutionPayloadBodyV1* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata ExecutionPayloadBodyV1::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_types_2ftypes_2eproto_getter, &descriptor_table_types_2ftypes_2eproto_once,
-      file_level_metadata_types_2ftypes_2eproto[13]);
+      file_level_metadata_types_2ftypes_2eproto[16]);
 }
 PROTOBUF_ATTRIBUTE_INIT_PRIORITY2 ::PROTOBUF_NAMESPACE_ID::internal::ExtensionIdentifier< ::PROTOBUF_NAMESPACE_ID::FileOptions,
     ::PROTOBUF_NAMESPACE_ID::internal::PrimitiveTypeTraits< uint32_t >, 13, false>
@@ -5026,6 +6131,18 @@ Arena::CreateMaybeMessage< ::types::VersionReply >(Arena* arena) {
 template<> PROTOBUF_NOINLINE ::types::ExecutionPayload*
 Arena::CreateMaybeMessage< ::types::ExecutionPayload >(Arena* arena) {
   return Arena::CreateMessageInternal< ::types::ExecutionPayload >(arena);
+}
+template<> PROTOBUF_NOINLINE ::types::DepositRequest*
+Arena::CreateMaybeMessage< ::types::DepositRequest >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::types::DepositRequest >(arena);
+}
+template<> PROTOBUF_NOINLINE ::types::WithdrawalRequest*
+Arena::CreateMaybeMessage< ::types::WithdrawalRequest >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::types::WithdrawalRequest >(arena);
+}
+template<> PROTOBUF_NOINLINE ::types::ConsolidationRequest*
+Arena::CreateMaybeMessage< ::types::ConsolidationRequest >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::types::ConsolidationRequest >(arena);
 }
 template<> PROTOBUF_NOINLINE ::types::Withdrawal*
 Arena::CreateMaybeMessage< ::types::Withdrawal >(Arena* arena) {

--- a/silkworm/interfaces/3.21.12/types/types.pb.h
+++ b/silkworm/interfaces/3.21.12/types/types.pb.h
@@ -49,6 +49,12 @@ namespace types {
 class BlobsBundleV1;
 struct BlobsBundleV1DefaultTypeInternal;
 extern BlobsBundleV1DefaultTypeInternal _BlobsBundleV1_default_instance_;
+class ConsolidationRequest;
+struct ConsolidationRequestDefaultTypeInternal;
+extern ConsolidationRequestDefaultTypeInternal _ConsolidationRequest_default_instance_;
+class DepositRequest;
+struct DepositRequestDefaultTypeInternal;
+extern DepositRequestDefaultTypeInternal _DepositRequest_default_instance_;
 class ExecutionPayload;
 struct ExecutionPayloadDefaultTypeInternal;
 extern ExecutionPayloadDefaultTypeInternal _ExecutionPayload_default_instance_;
@@ -88,9 +94,14 @@ extern VersionReplyDefaultTypeInternal _VersionReply_default_instance_;
 class Withdrawal;
 struct WithdrawalDefaultTypeInternal;
 extern WithdrawalDefaultTypeInternal _Withdrawal_default_instance_;
+class WithdrawalRequest;
+struct WithdrawalRequestDefaultTypeInternal;
+extern WithdrawalRequestDefaultTypeInternal _WithdrawalRequest_default_instance_;
 }  // namespace types
 PROTOBUF_NAMESPACE_OPEN
 template<> ::types::BlobsBundleV1* Arena::CreateMaybeMessage<::types::BlobsBundleV1>(Arena*);
+template<> ::types::ConsolidationRequest* Arena::CreateMaybeMessage<::types::ConsolidationRequest>(Arena*);
+template<> ::types::DepositRequest* Arena::CreateMaybeMessage<::types::DepositRequest>(Arena*);
 template<> ::types::ExecutionPayload* Arena::CreateMaybeMessage<::types::ExecutionPayload>(Arena*);
 template<> ::types::ExecutionPayloadBodyV1* Arena::CreateMaybeMessage<::types::ExecutionPayloadBodyV1>(Arena*);
 template<> ::types::H1024* Arena::CreateMaybeMessage<::types::H1024>(Arena*);
@@ -104,6 +115,7 @@ template<> ::types::NodeInfoReply* Arena::CreateMaybeMessage<::types::NodeInfoRe
 template<> ::types::PeerInfo* Arena::CreateMaybeMessage<::types::PeerInfo>(Arena*);
 template<> ::types::VersionReply* Arena::CreateMaybeMessage<::types::VersionReply>(Arena*);
 template<> ::types::Withdrawal* Arena::CreateMaybeMessage<::types::Withdrawal>(Arena*);
+template<> ::types::WithdrawalRequest* Arena::CreateMaybeMessage<::types::WithdrawalRequest>(Arena*);
 PROTOBUF_NAMESPACE_CLOSE
 namespace types {
 
@@ -1437,6 +1449,9 @@ class ExecutionPayload final :
   enum : int {
     kTransactionsFieldNumber = 15,
     kWithdrawalsFieldNumber = 16,
+    kDepositRequestsFieldNumber = 19,
+    kWithdrawalRequestsFieldNumber = 20,
+    kConsolidationRequestsFieldNumber = 21,
     kExtraDataFieldNumber = 12,
     kParentHashFieldNumber = 2,
     kCoinbaseFieldNumber = 3,
@@ -1495,6 +1510,60 @@ class ExecutionPayload final :
   ::types::Withdrawal* add_withdrawals();
   const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::Withdrawal >&
       withdrawals() const;
+
+  // repeated .types.DepositRequest deposit_requests = 19;
+  int deposit_requests_size() const;
+  private:
+  int _internal_deposit_requests_size() const;
+  public:
+  void clear_deposit_requests();
+  ::types::DepositRequest* mutable_deposit_requests(int index);
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::DepositRequest >*
+      mutable_deposit_requests();
+  private:
+  const ::types::DepositRequest& _internal_deposit_requests(int index) const;
+  ::types::DepositRequest* _internal_add_deposit_requests();
+  public:
+  const ::types::DepositRequest& deposit_requests(int index) const;
+  ::types::DepositRequest* add_deposit_requests();
+  const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::DepositRequest >&
+      deposit_requests() const;
+
+  // repeated .types.WithdrawalRequest withdrawal_requests = 20;
+  int withdrawal_requests_size() const;
+  private:
+  int _internal_withdrawal_requests_size() const;
+  public:
+  void clear_withdrawal_requests();
+  ::types::WithdrawalRequest* mutable_withdrawal_requests(int index);
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::WithdrawalRequest >*
+      mutable_withdrawal_requests();
+  private:
+  const ::types::WithdrawalRequest& _internal_withdrawal_requests(int index) const;
+  ::types::WithdrawalRequest* _internal_add_withdrawal_requests();
+  public:
+  const ::types::WithdrawalRequest& withdrawal_requests(int index) const;
+  ::types::WithdrawalRequest* add_withdrawal_requests();
+  const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::WithdrawalRequest >&
+      withdrawal_requests() const;
+
+  // repeated .types.ConsolidationRequest consolidation_requests = 21;
+  int consolidation_requests_size() const;
+  private:
+  int _internal_consolidation_requests_size() const;
+  public:
+  void clear_consolidation_requests();
+  ::types::ConsolidationRequest* mutable_consolidation_requests(int index);
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::ConsolidationRequest >*
+      mutable_consolidation_requests();
+  private:
+  const ::types::ConsolidationRequest& _internal_consolidation_requests(int index) const;
+  ::types::ConsolidationRequest* _internal_add_consolidation_requests();
+  public:
+  const ::types::ConsolidationRequest& consolidation_requests(int index) const;
+  ::types::ConsolidationRequest* add_consolidation_requests();
+  const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::ConsolidationRequest >&
+      consolidation_requests() const;
 
   // bytes extra_data = 12;
   void clear_extra_data();
@@ -1737,6 +1806,9 @@ class ExecutionPayload final :
     mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
     ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField<std::string> transactions_;
     ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::Withdrawal > withdrawals_;
+    ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::DepositRequest > deposit_requests_;
+    ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::WithdrawalRequest > withdrawal_requests_;
+    ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::ConsolidationRequest > consolidation_requests_;
     ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr extra_data_;
     ::types::H256* parent_hash_;
     ::types::H160* coinbase_;
@@ -1753,6 +1825,590 @@ class ExecutionPayload final :
     uint64_t blob_gas_used_;
     uint64_t excess_blob_gas_;
     uint32_t version_;
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_types_2ftypes_2eproto;
+};
+// -------------------------------------------------------------------
+
+class DepositRequest final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:types.DepositRequest) */ {
+ public:
+  inline DepositRequest() : DepositRequest(nullptr) {}
+  ~DepositRequest() override;
+  explicit PROTOBUF_CONSTEXPR DepositRequest(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  DepositRequest(const DepositRequest& from);
+  DepositRequest(DepositRequest&& from) noexcept
+    : DepositRequest() {
+    *this = ::std::move(from);
+  }
+
+  inline DepositRequest& operator=(const DepositRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline DepositRequest& operator=(DepositRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetOwningArena() == from.GetOwningArena()
+  #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
+        && GetOwningArena() != nullptr
+  #endif  // !PROTOBUF_FORCE_COPY_IN_MOVE
+    ) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const DepositRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const DepositRequest* internal_default_instance() {
+    return reinterpret_cast<const DepositRequest*>(
+               &_DepositRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    8;
+
+  friend void swap(DepositRequest& a, DepositRequest& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(DepositRequest* other) {
+    if (other == this) return;
+  #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() != nullptr &&
+        GetOwningArena() == other->GetOwningArena()) {
+   #else  // PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() == other->GetOwningArena()) {
+  #endif  // !PROTOBUF_FORCE_COPY_IN_SWAP
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(DepositRequest* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  DepositRequest* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
+    return CreateMaybeMessage<DepositRequest>(arena);
+  }
+  using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
+  void CopyFrom(const DepositRequest& from);
+  using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
+  void MergeFrom( const DepositRequest& from) {
+    DepositRequest::MergeImpl(*this, from);
+  }
+  private:
+  static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg);
+  public:
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  uint8_t* _InternalSerialize(
+      uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::PROTOBUF_NAMESPACE_ID::Arena* arena, bool is_message_owned);
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(DepositRequest* other);
+
+  private:
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "types.DepositRequest";
+  }
+  protected:
+  explicit DepositRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                       bool is_message_owned = false);
+  public:
+
+  static const ClassData _class_data_;
+  const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetClassData() const final;
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kPubkeyFieldNumber = 1,
+    kSignatureFieldNumber = 4,
+    kWithdrawalCredentialsFieldNumber = 2,
+    kAmountFieldNumber = 3,
+    kIndexFieldNumber = 5,
+  };
+  // bytes pubkey = 1;
+  void clear_pubkey();
+  const std::string& pubkey() const;
+  template <typename ArgT0 = const std::string&, typename... ArgT>
+  void set_pubkey(ArgT0&& arg0, ArgT... args);
+  std::string* mutable_pubkey();
+  PROTOBUF_NODISCARD std::string* release_pubkey();
+  void set_allocated_pubkey(std::string* pubkey);
+  private:
+  const std::string& _internal_pubkey() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_pubkey(const std::string& value);
+  std::string* _internal_mutable_pubkey();
+  public:
+
+  // bytes signature = 4;
+  void clear_signature();
+  const std::string& signature() const;
+  template <typename ArgT0 = const std::string&, typename... ArgT>
+  void set_signature(ArgT0&& arg0, ArgT... args);
+  std::string* mutable_signature();
+  PROTOBUF_NODISCARD std::string* release_signature();
+  void set_allocated_signature(std::string* signature);
+  private:
+  const std::string& _internal_signature() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_signature(const std::string& value);
+  std::string* _internal_mutable_signature();
+  public:
+
+  // .types.H256 withdrawal_credentials = 2;
+  bool has_withdrawal_credentials() const;
+  private:
+  bool _internal_has_withdrawal_credentials() const;
+  public:
+  void clear_withdrawal_credentials();
+  const ::types::H256& withdrawal_credentials() const;
+  PROTOBUF_NODISCARD ::types::H256* release_withdrawal_credentials();
+  ::types::H256* mutable_withdrawal_credentials();
+  void set_allocated_withdrawal_credentials(::types::H256* withdrawal_credentials);
+  private:
+  const ::types::H256& _internal_withdrawal_credentials() const;
+  ::types::H256* _internal_mutable_withdrawal_credentials();
+  public:
+  void unsafe_arena_set_allocated_withdrawal_credentials(
+      ::types::H256* withdrawal_credentials);
+  ::types::H256* unsafe_arena_release_withdrawal_credentials();
+
+  // uint64 amount = 3;
+  void clear_amount();
+  uint64_t amount() const;
+  void set_amount(uint64_t value);
+  private:
+  uint64_t _internal_amount() const;
+  void _internal_set_amount(uint64_t value);
+  public:
+
+  // uint64 index = 5;
+  void clear_index();
+  uint64_t index() const;
+  void set_index(uint64_t value);
+  private:
+  uint64_t _internal_index() const;
+  void _internal_set_index(uint64_t value);
+  public:
+
+  // @@protoc_insertion_point(class_scope:types.DepositRequest)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  struct Impl_ {
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr pubkey_;
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr signature_;
+    ::types::H256* withdrawal_credentials_;
+    uint64_t amount_;
+    uint64_t index_;
+    mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_types_2ftypes_2eproto;
+};
+// -------------------------------------------------------------------
+
+class WithdrawalRequest final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:types.WithdrawalRequest) */ {
+ public:
+  inline WithdrawalRequest() : WithdrawalRequest(nullptr) {}
+  ~WithdrawalRequest() override;
+  explicit PROTOBUF_CONSTEXPR WithdrawalRequest(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  WithdrawalRequest(const WithdrawalRequest& from);
+  WithdrawalRequest(WithdrawalRequest&& from) noexcept
+    : WithdrawalRequest() {
+    *this = ::std::move(from);
+  }
+
+  inline WithdrawalRequest& operator=(const WithdrawalRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline WithdrawalRequest& operator=(WithdrawalRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetOwningArena() == from.GetOwningArena()
+  #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
+        && GetOwningArena() != nullptr
+  #endif  // !PROTOBUF_FORCE_COPY_IN_MOVE
+    ) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const WithdrawalRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const WithdrawalRequest* internal_default_instance() {
+    return reinterpret_cast<const WithdrawalRequest*>(
+               &_WithdrawalRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    9;
+
+  friend void swap(WithdrawalRequest& a, WithdrawalRequest& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(WithdrawalRequest* other) {
+    if (other == this) return;
+  #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() != nullptr &&
+        GetOwningArena() == other->GetOwningArena()) {
+   #else  // PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() == other->GetOwningArena()) {
+  #endif  // !PROTOBUF_FORCE_COPY_IN_SWAP
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(WithdrawalRequest* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  WithdrawalRequest* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
+    return CreateMaybeMessage<WithdrawalRequest>(arena);
+  }
+  using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
+  void CopyFrom(const WithdrawalRequest& from);
+  using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
+  void MergeFrom( const WithdrawalRequest& from) {
+    WithdrawalRequest::MergeImpl(*this, from);
+  }
+  private:
+  static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg);
+  public:
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  uint8_t* _InternalSerialize(
+      uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::PROTOBUF_NAMESPACE_ID::Arena* arena, bool is_message_owned);
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(WithdrawalRequest* other);
+
+  private:
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "types.WithdrawalRequest";
+  }
+  protected:
+  explicit WithdrawalRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                       bool is_message_owned = false);
+  public:
+
+  static const ClassData _class_data_;
+  const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetClassData() const final;
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kValidatorPubkeyFieldNumber = 2,
+    kSourceAddressFieldNumber = 1,
+    kAmountFieldNumber = 3,
+  };
+  // bytes validator_pubkey = 2;
+  void clear_validator_pubkey();
+  const std::string& validator_pubkey() const;
+  template <typename ArgT0 = const std::string&, typename... ArgT>
+  void set_validator_pubkey(ArgT0&& arg0, ArgT... args);
+  std::string* mutable_validator_pubkey();
+  PROTOBUF_NODISCARD std::string* release_validator_pubkey();
+  void set_allocated_validator_pubkey(std::string* validator_pubkey);
+  private:
+  const std::string& _internal_validator_pubkey() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_validator_pubkey(const std::string& value);
+  std::string* _internal_mutable_validator_pubkey();
+  public:
+
+  // .types.H160 source_address = 1;
+  bool has_source_address() const;
+  private:
+  bool _internal_has_source_address() const;
+  public:
+  void clear_source_address();
+  const ::types::H160& source_address() const;
+  PROTOBUF_NODISCARD ::types::H160* release_source_address();
+  ::types::H160* mutable_source_address();
+  void set_allocated_source_address(::types::H160* source_address);
+  private:
+  const ::types::H160& _internal_source_address() const;
+  ::types::H160* _internal_mutable_source_address();
+  public:
+  void unsafe_arena_set_allocated_source_address(
+      ::types::H160* source_address);
+  ::types::H160* unsafe_arena_release_source_address();
+
+  // uint64 amount = 3;
+  void clear_amount();
+  uint64_t amount() const;
+  void set_amount(uint64_t value);
+  private:
+  uint64_t _internal_amount() const;
+  void _internal_set_amount(uint64_t value);
+  public:
+
+  // @@protoc_insertion_point(class_scope:types.WithdrawalRequest)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  struct Impl_ {
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr validator_pubkey_;
+    ::types::H160* source_address_;
+    uint64_t amount_;
+    mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_types_2ftypes_2eproto;
+};
+// -------------------------------------------------------------------
+
+class ConsolidationRequest final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:types.ConsolidationRequest) */ {
+ public:
+  inline ConsolidationRequest() : ConsolidationRequest(nullptr) {}
+  ~ConsolidationRequest() override;
+  explicit PROTOBUF_CONSTEXPR ConsolidationRequest(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  ConsolidationRequest(const ConsolidationRequest& from);
+  ConsolidationRequest(ConsolidationRequest&& from) noexcept
+    : ConsolidationRequest() {
+    *this = ::std::move(from);
+  }
+
+  inline ConsolidationRequest& operator=(const ConsolidationRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline ConsolidationRequest& operator=(ConsolidationRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetOwningArena() == from.GetOwningArena()
+  #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
+        && GetOwningArena() != nullptr
+  #endif  // !PROTOBUF_FORCE_COPY_IN_MOVE
+    ) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const ConsolidationRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const ConsolidationRequest* internal_default_instance() {
+    return reinterpret_cast<const ConsolidationRequest*>(
+               &_ConsolidationRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    10;
+
+  friend void swap(ConsolidationRequest& a, ConsolidationRequest& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(ConsolidationRequest* other) {
+    if (other == this) return;
+  #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() != nullptr &&
+        GetOwningArena() == other->GetOwningArena()) {
+   #else  // PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() == other->GetOwningArena()) {
+  #endif  // !PROTOBUF_FORCE_COPY_IN_SWAP
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(ConsolidationRequest* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  ConsolidationRequest* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
+    return CreateMaybeMessage<ConsolidationRequest>(arena);
+  }
+  using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
+  void CopyFrom(const ConsolidationRequest& from);
+  using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
+  void MergeFrom( const ConsolidationRequest& from) {
+    ConsolidationRequest::MergeImpl(*this, from);
+  }
+  private:
+  static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg);
+  public:
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  uint8_t* _InternalSerialize(
+      uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::PROTOBUF_NAMESPACE_ID::Arena* arena, bool is_message_owned);
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(ConsolidationRequest* other);
+
+  private:
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "types.ConsolidationRequest";
+  }
+  protected:
+  explicit ConsolidationRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                       bool is_message_owned = false);
+  public:
+
+  static const ClassData _class_data_;
+  const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetClassData() const final;
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kSourcePubkeyFieldNumber = 2,
+    kTargetPubkeyFieldNumber = 3,
+    kSourceAddressFieldNumber = 1,
+  };
+  // bytes source_pubkey = 2;
+  void clear_source_pubkey();
+  const std::string& source_pubkey() const;
+  template <typename ArgT0 = const std::string&, typename... ArgT>
+  void set_source_pubkey(ArgT0&& arg0, ArgT... args);
+  std::string* mutable_source_pubkey();
+  PROTOBUF_NODISCARD std::string* release_source_pubkey();
+  void set_allocated_source_pubkey(std::string* source_pubkey);
+  private:
+  const std::string& _internal_source_pubkey() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_source_pubkey(const std::string& value);
+  std::string* _internal_mutable_source_pubkey();
+  public:
+
+  // bytes target_pubkey = 3;
+  void clear_target_pubkey();
+  const std::string& target_pubkey() const;
+  template <typename ArgT0 = const std::string&, typename... ArgT>
+  void set_target_pubkey(ArgT0&& arg0, ArgT... args);
+  std::string* mutable_target_pubkey();
+  PROTOBUF_NODISCARD std::string* release_target_pubkey();
+  void set_allocated_target_pubkey(std::string* target_pubkey);
+  private:
+  const std::string& _internal_target_pubkey() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_target_pubkey(const std::string& value);
+  std::string* _internal_mutable_target_pubkey();
+  public:
+
+  // .types.H160 source_address = 1;
+  bool has_source_address() const;
+  private:
+  bool _internal_has_source_address() const;
+  public:
+  void clear_source_address();
+  const ::types::H160& source_address() const;
+  PROTOBUF_NODISCARD ::types::H160* release_source_address();
+  ::types::H160* mutable_source_address();
+  void set_allocated_source_address(::types::H160* source_address);
+  private:
+  const ::types::H160& _internal_source_address() const;
+  ::types::H160* _internal_mutable_source_address();
+  public:
+  void unsafe_arena_set_allocated_source_address(
+      ::types::H160* source_address);
+  ::types::H160* unsafe_arena_release_source_address();
+
+  // @@protoc_insertion_point(class_scope:types.ConsolidationRequest)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  struct Impl_ {
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr source_pubkey_;
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr target_pubkey_;
+    ::types::H160* source_address_;
+    mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   };
   union { Impl_ _impl_; };
   friend struct ::TableStruct_types_2ftypes_2eproto;
@@ -1807,7 +2463,7 @@ class Withdrawal final :
                &_Withdrawal_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    8;
+    11;
 
   friend void swap(Withdrawal& a, Withdrawal& b) {
     a.Swap(&b);
@@ -1997,7 +2653,7 @@ class BlobsBundleV1 final :
                &_BlobsBundleV1_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    9;
+    12;
 
   friend void swap(BlobsBundleV1& a, BlobsBundleV1& b) {
     a.Swap(&b);
@@ -2212,7 +2868,7 @@ class NodeInfoPorts final :
                &_NodeInfoPorts_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    10;
+    13;
 
   friend void swap(NodeInfoPorts& a, NodeInfoPorts& b) {
     a.Swap(&b);
@@ -2371,7 +3027,7 @@ class NodeInfoReply final :
                &_NodeInfoReply_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    11;
+    14;
 
   friend void swap(NodeInfoReply& a, NodeInfoReply& b) {
     a.Swap(&b);
@@ -2624,7 +3280,7 @@ class PeerInfo final :
                &_PeerInfo_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    12;
+    15;
 
   friend void swap(PeerInfo& a, PeerInfo& b) {
     a.Swap(&b);
@@ -2916,7 +3572,7 @@ class ExecutionPayloadBodyV1 final :
                &_ExecutionPayloadBodyV1_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    13;
+    16;
 
   friend void swap(ExecutionPayloadBodyV1& a, ExecutionPayloadBodyV1& b) {
     a.Swap(&b);
@@ -5071,6 +5727,718 @@ inline void ExecutionPayload::set_excess_blob_gas(uint64_t value) {
   // @@protoc_insertion_point(field_set:types.ExecutionPayload.excess_blob_gas)
 }
 
+// repeated .types.DepositRequest deposit_requests = 19;
+inline int ExecutionPayload::_internal_deposit_requests_size() const {
+  return _impl_.deposit_requests_.size();
+}
+inline int ExecutionPayload::deposit_requests_size() const {
+  return _internal_deposit_requests_size();
+}
+inline void ExecutionPayload::clear_deposit_requests() {
+  _impl_.deposit_requests_.Clear();
+}
+inline ::types::DepositRequest* ExecutionPayload::mutable_deposit_requests(int index) {
+  // @@protoc_insertion_point(field_mutable:types.ExecutionPayload.deposit_requests)
+  return _impl_.deposit_requests_.Mutable(index);
+}
+inline ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::DepositRequest >*
+ExecutionPayload::mutable_deposit_requests() {
+  // @@protoc_insertion_point(field_mutable_list:types.ExecutionPayload.deposit_requests)
+  return &_impl_.deposit_requests_;
+}
+inline const ::types::DepositRequest& ExecutionPayload::_internal_deposit_requests(int index) const {
+  return _impl_.deposit_requests_.Get(index);
+}
+inline const ::types::DepositRequest& ExecutionPayload::deposit_requests(int index) const {
+  // @@protoc_insertion_point(field_get:types.ExecutionPayload.deposit_requests)
+  return _internal_deposit_requests(index);
+}
+inline ::types::DepositRequest* ExecutionPayload::_internal_add_deposit_requests() {
+  return _impl_.deposit_requests_.Add();
+}
+inline ::types::DepositRequest* ExecutionPayload::add_deposit_requests() {
+  ::types::DepositRequest* _add = _internal_add_deposit_requests();
+  // @@protoc_insertion_point(field_add:types.ExecutionPayload.deposit_requests)
+  return _add;
+}
+inline const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::DepositRequest >&
+ExecutionPayload::deposit_requests() const {
+  // @@protoc_insertion_point(field_list:types.ExecutionPayload.deposit_requests)
+  return _impl_.deposit_requests_;
+}
+
+// repeated .types.WithdrawalRequest withdrawal_requests = 20;
+inline int ExecutionPayload::_internal_withdrawal_requests_size() const {
+  return _impl_.withdrawal_requests_.size();
+}
+inline int ExecutionPayload::withdrawal_requests_size() const {
+  return _internal_withdrawal_requests_size();
+}
+inline void ExecutionPayload::clear_withdrawal_requests() {
+  _impl_.withdrawal_requests_.Clear();
+}
+inline ::types::WithdrawalRequest* ExecutionPayload::mutable_withdrawal_requests(int index) {
+  // @@protoc_insertion_point(field_mutable:types.ExecutionPayload.withdrawal_requests)
+  return _impl_.withdrawal_requests_.Mutable(index);
+}
+inline ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::WithdrawalRequest >*
+ExecutionPayload::mutable_withdrawal_requests() {
+  // @@protoc_insertion_point(field_mutable_list:types.ExecutionPayload.withdrawal_requests)
+  return &_impl_.withdrawal_requests_;
+}
+inline const ::types::WithdrawalRequest& ExecutionPayload::_internal_withdrawal_requests(int index) const {
+  return _impl_.withdrawal_requests_.Get(index);
+}
+inline const ::types::WithdrawalRequest& ExecutionPayload::withdrawal_requests(int index) const {
+  // @@protoc_insertion_point(field_get:types.ExecutionPayload.withdrawal_requests)
+  return _internal_withdrawal_requests(index);
+}
+inline ::types::WithdrawalRequest* ExecutionPayload::_internal_add_withdrawal_requests() {
+  return _impl_.withdrawal_requests_.Add();
+}
+inline ::types::WithdrawalRequest* ExecutionPayload::add_withdrawal_requests() {
+  ::types::WithdrawalRequest* _add = _internal_add_withdrawal_requests();
+  // @@protoc_insertion_point(field_add:types.ExecutionPayload.withdrawal_requests)
+  return _add;
+}
+inline const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::WithdrawalRequest >&
+ExecutionPayload::withdrawal_requests() const {
+  // @@protoc_insertion_point(field_list:types.ExecutionPayload.withdrawal_requests)
+  return _impl_.withdrawal_requests_;
+}
+
+// repeated .types.ConsolidationRequest consolidation_requests = 21;
+inline int ExecutionPayload::_internal_consolidation_requests_size() const {
+  return _impl_.consolidation_requests_.size();
+}
+inline int ExecutionPayload::consolidation_requests_size() const {
+  return _internal_consolidation_requests_size();
+}
+inline void ExecutionPayload::clear_consolidation_requests() {
+  _impl_.consolidation_requests_.Clear();
+}
+inline ::types::ConsolidationRequest* ExecutionPayload::mutable_consolidation_requests(int index) {
+  // @@protoc_insertion_point(field_mutable:types.ExecutionPayload.consolidation_requests)
+  return _impl_.consolidation_requests_.Mutable(index);
+}
+inline ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::ConsolidationRequest >*
+ExecutionPayload::mutable_consolidation_requests() {
+  // @@protoc_insertion_point(field_mutable_list:types.ExecutionPayload.consolidation_requests)
+  return &_impl_.consolidation_requests_;
+}
+inline const ::types::ConsolidationRequest& ExecutionPayload::_internal_consolidation_requests(int index) const {
+  return _impl_.consolidation_requests_.Get(index);
+}
+inline const ::types::ConsolidationRequest& ExecutionPayload::consolidation_requests(int index) const {
+  // @@protoc_insertion_point(field_get:types.ExecutionPayload.consolidation_requests)
+  return _internal_consolidation_requests(index);
+}
+inline ::types::ConsolidationRequest* ExecutionPayload::_internal_add_consolidation_requests() {
+  return _impl_.consolidation_requests_.Add();
+}
+inline ::types::ConsolidationRequest* ExecutionPayload::add_consolidation_requests() {
+  ::types::ConsolidationRequest* _add = _internal_add_consolidation_requests();
+  // @@protoc_insertion_point(field_add:types.ExecutionPayload.consolidation_requests)
+  return _add;
+}
+inline const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::types::ConsolidationRequest >&
+ExecutionPayload::consolidation_requests() const {
+  // @@protoc_insertion_point(field_list:types.ExecutionPayload.consolidation_requests)
+  return _impl_.consolidation_requests_;
+}
+
+// -------------------------------------------------------------------
+
+// DepositRequest
+
+// bytes pubkey = 1;
+inline void DepositRequest::clear_pubkey() {
+  _impl_.pubkey_.ClearToEmpty();
+}
+inline const std::string& DepositRequest::pubkey() const {
+  // @@protoc_insertion_point(field_get:types.DepositRequest.pubkey)
+  return _internal_pubkey();
+}
+template <typename ArgT0, typename... ArgT>
+inline PROTOBUF_ALWAYS_INLINE
+void DepositRequest::set_pubkey(ArgT0&& arg0, ArgT... args) {
+ 
+ _impl_.pubkey_.SetBytes(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+  // @@protoc_insertion_point(field_set:types.DepositRequest.pubkey)
+}
+inline std::string* DepositRequest::mutable_pubkey() {
+  std::string* _s = _internal_mutable_pubkey();
+  // @@protoc_insertion_point(field_mutable:types.DepositRequest.pubkey)
+  return _s;
+}
+inline const std::string& DepositRequest::_internal_pubkey() const {
+  return _impl_.pubkey_.Get();
+}
+inline void DepositRequest::_internal_set_pubkey(const std::string& value) {
+  
+  _impl_.pubkey_.Set(value, GetArenaForAllocation());
+}
+inline std::string* DepositRequest::_internal_mutable_pubkey() {
+  
+  return _impl_.pubkey_.Mutable(GetArenaForAllocation());
+}
+inline std::string* DepositRequest::release_pubkey() {
+  // @@protoc_insertion_point(field_release:types.DepositRequest.pubkey)
+  return _impl_.pubkey_.Release();
+}
+inline void DepositRequest::set_allocated_pubkey(std::string* pubkey) {
+  if (pubkey != nullptr) {
+    
+  } else {
+    
+  }
+  _impl_.pubkey_.SetAllocated(pubkey, GetArenaForAllocation());
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.pubkey_.IsDefault()) {
+    _impl_.pubkey_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  // @@protoc_insertion_point(field_set_allocated:types.DepositRequest.pubkey)
+}
+
+// .types.H256 withdrawal_credentials = 2;
+inline bool DepositRequest::_internal_has_withdrawal_credentials() const {
+  return this != internal_default_instance() && _impl_.withdrawal_credentials_ != nullptr;
+}
+inline bool DepositRequest::has_withdrawal_credentials() const {
+  return _internal_has_withdrawal_credentials();
+}
+inline void DepositRequest::clear_withdrawal_credentials() {
+  if (GetArenaForAllocation() == nullptr && _impl_.withdrawal_credentials_ != nullptr) {
+    delete _impl_.withdrawal_credentials_;
+  }
+  _impl_.withdrawal_credentials_ = nullptr;
+}
+inline const ::types::H256& DepositRequest::_internal_withdrawal_credentials() const {
+  const ::types::H256* p = _impl_.withdrawal_credentials_;
+  return p != nullptr ? *p : reinterpret_cast<const ::types::H256&>(
+      ::types::_H256_default_instance_);
+}
+inline const ::types::H256& DepositRequest::withdrawal_credentials() const {
+  // @@protoc_insertion_point(field_get:types.DepositRequest.withdrawal_credentials)
+  return _internal_withdrawal_credentials();
+}
+inline void DepositRequest::unsafe_arena_set_allocated_withdrawal_credentials(
+    ::types::H256* withdrawal_credentials) {
+  if (GetArenaForAllocation() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(_impl_.withdrawal_credentials_);
+  }
+  _impl_.withdrawal_credentials_ = withdrawal_credentials;
+  if (withdrawal_credentials) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:types.DepositRequest.withdrawal_credentials)
+}
+inline ::types::H256* DepositRequest::release_withdrawal_credentials() {
+  
+  ::types::H256* temp = _impl_.withdrawal_credentials_;
+  _impl_.withdrawal_credentials_ = nullptr;
+#ifdef PROTOBUF_FORCE_COPY_IN_RELEASE
+  auto* old =  reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(temp);
+  temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  if (GetArenaForAllocation() == nullptr) { delete old; }
+#else  // PROTOBUF_FORCE_COPY_IN_RELEASE
+  if (GetArenaForAllocation() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+#endif  // !PROTOBUF_FORCE_COPY_IN_RELEASE
+  return temp;
+}
+inline ::types::H256* DepositRequest::unsafe_arena_release_withdrawal_credentials() {
+  // @@protoc_insertion_point(field_release:types.DepositRequest.withdrawal_credentials)
+  
+  ::types::H256* temp = _impl_.withdrawal_credentials_;
+  _impl_.withdrawal_credentials_ = nullptr;
+  return temp;
+}
+inline ::types::H256* DepositRequest::_internal_mutable_withdrawal_credentials() {
+  
+  if (_impl_.withdrawal_credentials_ == nullptr) {
+    auto* p = CreateMaybeMessage<::types::H256>(GetArenaForAllocation());
+    _impl_.withdrawal_credentials_ = p;
+  }
+  return _impl_.withdrawal_credentials_;
+}
+inline ::types::H256* DepositRequest::mutable_withdrawal_credentials() {
+  ::types::H256* _msg = _internal_mutable_withdrawal_credentials();
+  // @@protoc_insertion_point(field_mutable:types.DepositRequest.withdrawal_credentials)
+  return _msg;
+}
+inline void DepositRequest::set_allocated_withdrawal_credentials(::types::H256* withdrawal_credentials) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
+  if (message_arena == nullptr) {
+    delete _impl_.withdrawal_credentials_;
+  }
+  if (withdrawal_credentials) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+        ::PROTOBUF_NAMESPACE_ID::Arena::InternalGetOwningArena(withdrawal_credentials);
+    if (message_arena != submessage_arena) {
+      withdrawal_credentials = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, withdrawal_credentials, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  _impl_.withdrawal_credentials_ = withdrawal_credentials;
+  // @@protoc_insertion_point(field_set_allocated:types.DepositRequest.withdrawal_credentials)
+}
+
+// uint64 amount = 3;
+inline void DepositRequest::clear_amount() {
+  _impl_.amount_ = uint64_t{0u};
+}
+inline uint64_t DepositRequest::_internal_amount() const {
+  return _impl_.amount_;
+}
+inline uint64_t DepositRequest::amount() const {
+  // @@protoc_insertion_point(field_get:types.DepositRequest.amount)
+  return _internal_amount();
+}
+inline void DepositRequest::_internal_set_amount(uint64_t value) {
+  
+  _impl_.amount_ = value;
+}
+inline void DepositRequest::set_amount(uint64_t value) {
+  _internal_set_amount(value);
+  // @@protoc_insertion_point(field_set:types.DepositRequest.amount)
+}
+
+// bytes signature = 4;
+inline void DepositRequest::clear_signature() {
+  _impl_.signature_.ClearToEmpty();
+}
+inline const std::string& DepositRequest::signature() const {
+  // @@protoc_insertion_point(field_get:types.DepositRequest.signature)
+  return _internal_signature();
+}
+template <typename ArgT0, typename... ArgT>
+inline PROTOBUF_ALWAYS_INLINE
+void DepositRequest::set_signature(ArgT0&& arg0, ArgT... args) {
+ 
+ _impl_.signature_.SetBytes(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+  // @@protoc_insertion_point(field_set:types.DepositRequest.signature)
+}
+inline std::string* DepositRequest::mutable_signature() {
+  std::string* _s = _internal_mutable_signature();
+  // @@protoc_insertion_point(field_mutable:types.DepositRequest.signature)
+  return _s;
+}
+inline const std::string& DepositRequest::_internal_signature() const {
+  return _impl_.signature_.Get();
+}
+inline void DepositRequest::_internal_set_signature(const std::string& value) {
+  
+  _impl_.signature_.Set(value, GetArenaForAllocation());
+}
+inline std::string* DepositRequest::_internal_mutable_signature() {
+  
+  return _impl_.signature_.Mutable(GetArenaForAllocation());
+}
+inline std::string* DepositRequest::release_signature() {
+  // @@protoc_insertion_point(field_release:types.DepositRequest.signature)
+  return _impl_.signature_.Release();
+}
+inline void DepositRequest::set_allocated_signature(std::string* signature) {
+  if (signature != nullptr) {
+    
+  } else {
+    
+  }
+  _impl_.signature_.SetAllocated(signature, GetArenaForAllocation());
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.signature_.IsDefault()) {
+    _impl_.signature_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  // @@protoc_insertion_point(field_set_allocated:types.DepositRequest.signature)
+}
+
+// uint64 index = 5;
+inline void DepositRequest::clear_index() {
+  _impl_.index_ = uint64_t{0u};
+}
+inline uint64_t DepositRequest::_internal_index() const {
+  return _impl_.index_;
+}
+inline uint64_t DepositRequest::index() const {
+  // @@protoc_insertion_point(field_get:types.DepositRequest.index)
+  return _internal_index();
+}
+inline void DepositRequest::_internal_set_index(uint64_t value) {
+  
+  _impl_.index_ = value;
+}
+inline void DepositRequest::set_index(uint64_t value) {
+  _internal_set_index(value);
+  // @@protoc_insertion_point(field_set:types.DepositRequest.index)
+}
+
+// -------------------------------------------------------------------
+
+// WithdrawalRequest
+
+// .types.H160 source_address = 1;
+inline bool WithdrawalRequest::_internal_has_source_address() const {
+  return this != internal_default_instance() && _impl_.source_address_ != nullptr;
+}
+inline bool WithdrawalRequest::has_source_address() const {
+  return _internal_has_source_address();
+}
+inline void WithdrawalRequest::clear_source_address() {
+  if (GetArenaForAllocation() == nullptr && _impl_.source_address_ != nullptr) {
+    delete _impl_.source_address_;
+  }
+  _impl_.source_address_ = nullptr;
+}
+inline const ::types::H160& WithdrawalRequest::_internal_source_address() const {
+  const ::types::H160* p = _impl_.source_address_;
+  return p != nullptr ? *p : reinterpret_cast<const ::types::H160&>(
+      ::types::_H160_default_instance_);
+}
+inline const ::types::H160& WithdrawalRequest::source_address() const {
+  // @@protoc_insertion_point(field_get:types.WithdrawalRequest.source_address)
+  return _internal_source_address();
+}
+inline void WithdrawalRequest::unsafe_arena_set_allocated_source_address(
+    ::types::H160* source_address) {
+  if (GetArenaForAllocation() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(_impl_.source_address_);
+  }
+  _impl_.source_address_ = source_address;
+  if (source_address) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:types.WithdrawalRequest.source_address)
+}
+inline ::types::H160* WithdrawalRequest::release_source_address() {
+  
+  ::types::H160* temp = _impl_.source_address_;
+  _impl_.source_address_ = nullptr;
+#ifdef PROTOBUF_FORCE_COPY_IN_RELEASE
+  auto* old =  reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(temp);
+  temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  if (GetArenaForAllocation() == nullptr) { delete old; }
+#else  // PROTOBUF_FORCE_COPY_IN_RELEASE
+  if (GetArenaForAllocation() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+#endif  // !PROTOBUF_FORCE_COPY_IN_RELEASE
+  return temp;
+}
+inline ::types::H160* WithdrawalRequest::unsafe_arena_release_source_address() {
+  // @@protoc_insertion_point(field_release:types.WithdrawalRequest.source_address)
+  
+  ::types::H160* temp = _impl_.source_address_;
+  _impl_.source_address_ = nullptr;
+  return temp;
+}
+inline ::types::H160* WithdrawalRequest::_internal_mutable_source_address() {
+  
+  if (_impl_.source_address_ == nullptr) {
+    auto* p = CreateMaybeMessage<::types::H160>(GetArenaForAllocation());
+    _impl_.source_address_ = p;
+  }
+  return _impl_.source_address_;
+}
+inline ::types::H160* WithdrawalRequest::mutable_source_address() {
+  ::types::H160* _msg = _internal_mutable_source_address();
+  // @@protoc_insertion_point(field_mutable:types.WithdrawalRequest.source_address)
+  return _msg;
+}
+inline void WithdrawalRequest::set_allocated_source_address(::types::H160* source_address) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
+  if (message_arena == nullptr) {
+    delete _impl_.source_address_;
+  }
+  if (source_address) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+        ::PROTOBUF_NAMESPACE_ID::Arena::InternalGetOwningArena(source_address);
+    if (message_arena != submessage_arena) {
+      source_address = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, source_address, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  _impl_.source_address_ = source_address;
+  // @@protoc_insertion_point(field_set_allocated:types.WithdrawalRequest.source_address)
+}
+
+// bytes validator_pubkey = 2;
+inline void WithdrawalRequest::clear_validator_pubkey() {
+  _impl_.validator_pubkey_.ClearToEmpty();
+}
+inline const std::string& WithdrawalRequest::validator_pubkey() const {
+  // @@protoc_insertion_point(field_get:types.WithdrawalRequest.validator_pubkey)
+  return _internal_validator_pubkey();
+}
+template <typename ArgT0, typename... ArgT>
+inline PROTOBUF_ALWAYS_INLINE
+void WithdrawalRequest::set_validator_pubkey(ArgT0&& arg0, ArgT... args) {
+ 
+ _impl_.validator_pubkey_.SetBytes(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+  // @@protoc_insertion_point(field_set:types.WithdrawalRequest.validator_pubkey)
+}
+inline std::string* WithdrawalRequest::mutable_validator_pubkey() {
+  std::string* _s = _internal_mutable_validator_pubkey();
+  // @@protoc_insertion_point(field_mutable:types.WithdrawalRequest.validator_pubkey)
+  return _s;
+}
+inline const std::string& WithdrawalRequest::_internal_validator_pubkey() const {
+  return _impl_.validator_pubkey_.Get();
+}
+inline void WithdrawalRequest::_internal_set_validator_pubkey(const std::string& value) {
+  
+  _impl_.validator_pubkey_.Set(value, GetArenaForAllocation());
+}
+inline std::string* WithdrawalRequest::_internal_mutable_validator_pubkey() {
+  
+  return _impl_.validator_pubkey_.Mutable(GetArenaForAllocation());
+}
+inline std::string* WithdrawalRequest::release_validator_pubkey() {
+  // @@protoc_insertion_point(field_release:types.WithdrawalRequest.validator_pubkey)
+  return _impl_.validator_pubkey_.Release();
+}
+inline void WithdrawalRequest::set_allocated_validator_pubkey(std::string* validator_pubkey) {
+  if (validator_pubkey != nullptr) {
+    
+  } else {
+    
+  }
+  _impl_.validator_pubkey_.SetAllocated(validator_pubkey, GetArenaForAllocation());
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.validator_pubkey_.IsDefault()) {
+    _impl_.validator_pubkey_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  // @@protoc_insertion_point(field_set_allocated:types.WithdrawalRequest.validator_pubkey)
+}
+
+// uint64 amount = 3;
+inline void WithdrawalRequest::clear_amount() {
+  _impl_.amount_ = uint64_t{0u};
+}
+inline uint64_t WithdrawalRequest::_internal_amount() const {
+  return _impl_.amount_;
+}
+inline uint64_t WithdrawalRequest::amount() const {
+  // @@protoc_insertion_point(field_get:types.WithdrawalRequest.amount)
+  return _internal_amount();
+}
+inline void WithdrawalRequest::_internal_set_amount(uint64_t value) {
+  
+  _impl_.amount_ = value;
+}
+inline void WithdrawalRequest::set_amount(uint64_t value) {
+  _internal_set_amount(value);
+  // @@protoc_insertion_point(field_set:types.WithdrawalRequest.amount)
+}
+
+// -------------------------------------------------------------------
+
+// ConsolidationRequest
+
+// .types.H160 source_address = 1;
+inline bool ConsolidationRequest::_internal_has_source_address() const {
+  return this != internal_default_instance() && _impl_.source_address_ != nullptr;
+}
+inline bool ConsolidationRequest::has_source_address() const {
+  return _internal_has_source_address();
+}
+inline void ConsolidationRequest::clear_source_address() {
+  if (GetArenaForAllocation() == nullptr && _impl_.source_address_ != nullptr) {
+    delete _impl_.source_address_;
+  }
+  _impl_.source_address_ = nullptr;
+}
+inline const ::types::H160& ConsolidationRequest::_internal_source_address() const {
+  const ::types::H160* p = _impl_.source_address_;
+  return p != nullptr ? *p : reinterpret_cast<const ::types::H160&>(
+      ::types::_H160_default_instance_);
+}
+inline const ::types::H160& ConsolidationRequest::source_address() const {
+  // @@protoc_insertion_point(field_get:types.ConsolidationRequest.source_address)
+  return _internal_source_address();
+}
+inline void ConsolidationRequest::unsafe_arena_set_allocated_source_address(
+    ::types::H160* source_address) {
+  if (GetArenaForAllocation() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(_impl_.source_address_);
+  }
+  _impl_.source_address_ = source_address;
+  if (source_address) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:types.ConsolidationRequest.source_address)
+}
+inline ::types::H160* ConsolidationRequest::release_source_address() {
+  
+  ::types::H160* temp = _impl_.source_address_;
+  _impl_.source_address_ = nullptr;
+#ifdef PROTOBUF_FORCE_COPY_IN_RELEASE
+  auto* old =  reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(temp);
+  temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  if (GetArenaForAllocation() == nullptr) { delete old; }
+#else  // PROTOBUF_FORCE_COPY_IN_RELEASE
+  if (GetArenaForAllocation() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+#endif  // !PROTOBUF_FORCE_COPY_IN_RELEASE
+  return temp;
+}
+inline ::types::H160* ConsolidationRequest::unsafe_arena_release_source_address() {
+  // @@protoc_insertion_point(field_release:types.ConsolidationRequest.source_address)
+  
+  ::types::H160* temp = _impl_.source_address_;
+  _impl_.source_address_ = nullptr;
+  return temp;
+}
+inline ::types::H160* ConsolidationRequest::_internal_mutable_source_address() {
+  
+  if (_impl_.source_address_ == nullptr) {
+    auto* p = CreateMaybeMessage<::types::H160>(GetArenaForAllocation());
+    _impl_.source_address_ = p;
+  }
+  return _impl_.source_address_;
+}
+inline ::types::H160* ConsolidationRequest::mutable_source_address() {
+  ::types::H160* _msg = _internal_mutable_source_address();
+  // @@protoc_insertion_point(field_mutable:types.ConsolidationRequest.source_address)
+  return _msg;
+}
+inline void ConsolidationRequest::set_allocated_source_address(::types::H160* source_address) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
+  if (message_arena == nullptr) {
+    delete _impl_.source_address_;
+  }
+  if (source_address) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+        ::PROTOBUF_NAMESPACE_ID::Arena::InternalGetOwningArena(source_address);
+    if (message_arena != submessage_arena) {
+      source_address = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, source_address, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  _impl_.source_address_ = source_address;
+  // @@protoc_insertion_point(field_set_allocated:types.ConsolidationRequest.source_address)
+}
+
+// bytes source_pubkey = 2;
+inline void ConsolidationRequest::clear_source_pubkey() {
+  _impl_.source_pubkey_.ClearToEmpty();
+}
+inline const std::string& ConsolidationRequest::source_pubkey() const {
+  // @@protoc_insertion_point(field_get:types.ConsolidationRequest.source_pubkey)
+  return _internal_source_pubkey();
+}
+template <typename ArgT0, typename... ArgT>
+inline PROTOBUF_ALWAYS_INLINE
+void ConsolidationRequest::set_source_pubkey(ArgT0&& arg0, ArgT... args) {
+ 
+ _impl_.source_pubkey_.SetBytes(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+  // @@protoc_insertion_point(field_set:types.ConsolidationRequest.source_pubkey)
+}
+inline std::string* ConsolidationRequest::mutable_source_pubkey() {
+  std::string* _s = _internal_mutable_source_pubkey();
+  // @@protoc_insertion_point(field_mutable:types.ConsolidationRequest.source_pubkey)
+  return _s;
+}
+inline const std::string& ConsolidationRequest::_internal_source_pubkey() const {
+  return _impl_.source_pubkey_.Get();
+}
+inline void ConsolidationRequest::_internal_set_source_pubkey(const std::string& value) {
+  
+  _impl_.source_pubkey_.Set(value, GetArenaForAllocation());
+}
+inline std::string* ConsolidationRequest::_internal_mutable_source_pubkey() {
+  
+  return _impl_.source_pubkey_.Mutable(GetArenaForAllocation());
+}
+inline std::string* ConsolidationRequest::release_source_pubkey() {
+  // @@protoc_insertion_point(field_release:types.ConsolidationRequest.source_pubkey)
+  return _impl_.source_pubkey_.Release();
+}
+inline void ConsolidationRequest::set_allocated_source_pubkey(std::string* source_pubkey) {
+  if (source_pubkey != nullptr) {
+    
+  } else {
+    
+  }
+  _impl_.source_pubkey_.SetAllocated(source_pubkey, GetArenaForAllocation());
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.source_pubkey_.IsDefault()) {
+    _impl_.source_pubkey_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  // @@protoc_insertion_point(field_set_allocated:types.ConsolidationRequest.source_pubkey)
+}
+
+// bytes target_pubkey = 3;
+inline void ConsolidationRequest::clear_target_pubkey() {
+  _impl_.target_pubkey_.ClearToEmpty();
+}
+inline const std::string& ConsolidationRequest::target_pubkey() const {
+  // @@protoc_insertion_point(field_get:types.ConsolidationRequest.target_pubkey)
+  return _internal_target_pubkey();
+}
+template <typename ArgT0, typename... ArgT>
+inline PROTOBUF_ALWAYS_INLINE
+void ConsolidationRequest::set_target_pubkey(ArgT0&& arg0, ArgT... args) {
+ 
+ _impl_.target_pubkey_.SetBytes(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+  // @@protoc_insertion_point(field_set:types.ConsolidationRequest.target_pubkey)
+}
+inline std::string* ConsolidationRequest::mutable_target_pubkey() {
+  std::string* _s = _internal_mutable_target_pubkey();
+  // @@protoc_insertion_point(field_mutable:types.ConsolidationRequest.target_pubkey)
+  return _s;
+}
+inline const std::string& ConsolidationRequest::_internal_target_pubkey() const {
+  return _impl_.target_pubkey_.Get();
+}
+inline void ConsolidationRequest::_internal_set_target_pubkey(const std::string& value) {
+  
+  _impl_.target_pubkey_.Set(value, GetArenaForAllocation());
+}
+inline std::string* ConsolidationRequest::_internal_mutable_target_pubkey() {
+  
+  return _impl_.target_pubkey_.Mutable(GetArenaForAllocation());
+}
+inline std::string* ConsolidationRequest::release_target_pubkey() {
+  // @@protoc_insertion_point(field_release:types.ConsolidationRequest.target_pubkey)
+  return _impl_.target_pubkey_.Release();
+}
+inline void ConsolidationRequest::set_allocated_target_pubkey(std::string* target_pubkey) {
+  if (target_pubkey != nullptr) {
+    
+  } else {
+    
+  }
+  _impl_.target_pubkey_.SetAllocated(target_pubkey, GetArenaForAllocation());
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.target_pubkey_.IsDefault()) {
+    _impl_.target_pubkey_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  // @@protoc_insertion_point(field_set_allocated:types.ConsolidationRequest.target_pubkey)
+}
+
 // -------------------------------------------------------------------
 
 // Withdrawal
@@ -6453,6 +7821,12 @@ ExecutionPayloadBodyV1::withdrawals() const {
 #ifdef __GNUC__
   #pragma GCC diagnostic pop
 #endif  // __GNUC__
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------


### PR DESCRIPTION
This PR updates the internal gRPC interfaces to https://github.com/erigontech/interfaces/commit/0d10589c853376fc093fafc4c45d4d2c48f8e9e4, which is compatible with the one used in Erigon2 https://github.com/ledgerwatch/interfaces/commit/b57f05746087760985ae755dd1431a35377a2363 but also contains the change in https://github.com/erigontech/interfaces/commit/51e2d4cc3e3980924696cceb0e79f5560b5c50ea necessary to work with Erigon3 Temporal KV.

*Extras*

- fix encoding/decoding for keys and values in gRPC _HistorySeek_
- fix the procedure to update gRPC interfaces into our Contribution Guide