### PR TITLE
db: temporal KV client history_seek API via gRPC

### DIFF
--- a/silkworm/db/kv/api/direct_service.cpp
+++ b/silkworm/db/kv/api/direct_service.cpp
@@ -60,12 +60,6 @@ Task<void> DirectService::state_changes(const api::StateChangeOptions& options, 
 
 /** Temporal Point Queries **/
 
-// rpc HistoryGet(HistoryGetReq) returns (HistoryGetReply);
-Task<HistoryPointResult> DirectService::get_history(const HistoryPointQuery&) {
-    // TODO(canepat) implement
-    co_return HistoryPointResult{};
-}
-
 // rpc DomainGet(DomainGetReq) returns (DomainGetReply);
 Task<DomainPointResult> DirectService::get_domain(const DomainPointQuery&) {
     // TODO(canepat) implement

--- a/silkworm/db/kv/api/direct_service.hpp
+++ b/silkworm/db/kv/api/direct_service.hpp
@@ -48,9 +48,6 @@ class DirectService : public Service {
 
     /** Temporal Point Queries **/
 
-    // rpc HistoryGet(HistoryGetReq) returns (HistoryGetReply);
-    Task<HistoryPointResult> get_history(const HistoryPointQuery&) override;
-
     // rpc DomainGet(DomainGetReq) returns (DomainGetReply);
     Task<DomainPointResult> get_domain(const DomainPointQuery&) override;
 

--- a/silkworm/db/kv/api/local_transaction.cpp
+++ b/silkworm/db/kv/api/local_transaction.cpp
@@ -69,6 +69,12 @@ std::shared_ptr<chain::ChainStorage> LocalTransaction::create_storage() {
 }
 
 // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
+Task<HistoryPointResult> LocalTransaction::history_seek(api::HistoryPointQuery&& /*query*/) {
+    // TODO(canepat) implement using E3-like aggregator abstraction [tx_id_ must be changed]
+    co_return HistoryPointResult{};
+}
+
+// NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
 Task<PaginatedTimestamps> LocalTransaction::index_range(api::IndexRangeQuery&& /*query*/) {
     // TODO(canepat) implement using E3-like aggregator abstraction [tx_id_ must be changed]
     auto paginator = []() mutable -> Task<api::PaginatedTimestamps::PageResult> {

--- a/silkworm/db/kv/api/local_transaction.hpp
+++ b/silkworm/db/kv/api/local_transaction.hpp
@@ -55,6 +55,9 @@ class LocalTransaction : public BaseTransaction {
 
     Task<void> close() override;
 
+    // rpc HistoryGet(HistoryGetReq) returns (HistoryGetReply);
+    Task<HistoryPointResult> history_seek(api::HistoryPointQuery&& query) override;
+
     // rpc IndexRange(IndexRangeReq) returns (IndexRangeReply);
     Task<PaginatedTimestamps> index_range(IndexRangeQuery&& query) override;
 

--- a/silkworm/db/kv/api/service.hpp
+++ b/silkworm/db/kv/api/service.hpp
@@ -40,9 +40,6 @@ struct Service {
 
     /** Temporal Point Queries **/
 
-    // rpc HistoryGet(HistoryGetReq) returns (HistoryGetReply);
-    virtual Task<HistoryPointResult> get_history(const HistoryPointQuery&) = 0;
-
     // rpc DomainGet(DomainGetReq) returns (DomainGetReply);
     virtual Task<DomainPointResult> get_domain(const DomainPointQuery&) = 0;
 };

--- a/silkworm/db/kv/api/transaction.hpp
+++ b/silkworm/db/kv/api/transaction.hpp
@@ -27,6 +27,7 @@
 
 #include "cursor.hpp"
 #include "endpoint/key_value.hpp"
+#include "endpoint/temporal_point.hpp"
 #include "endpoint/temporal_range.hpp"
 
 namespace silkworm::db::kv::api {
@@ -64,6 +65,11 @@ class Transaction {
     virtual Task<Bytes> get_one(const std::string& table, ByteView key) = 0;
 
     virtual Task<std::optional<Bytes>> get_both_range(const std::string& table, ByteView key, ByteView subkey) = 0;
+
+    /** Temporal Point Queries **/
+
+    // rpc HistoryGet(HistoryGetReq) returns (HistoryGetReply);
+    virtual Task<HistoryPointResult> history_seek(api::HistoryPointQuery&& query) = 0;
 
     /** Temporal Range Queries **/
 

--- a/silkworm/db/kv/grpc/client/remote_client.cpp
+++ b/silkworm/db/kv/grpc/client/remote_client.cpp
@@ -139,13 +139,6 @@ class RemoteClientImpl final : public api::Service {
 
     /** Temporal Point Queries **/
 
-    // rpc HistoryGet(HistorySeekReq) returns (HistorySeekReply);
-    Task<api::HistoryPointResult> get_history(const api::HistoryPointQuery& query) override {
-        auto request = history_seek_request_from_query(query);
-        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncHistorySeek, *stub_, std::move(request), grpc_context_);
-        co_return history_seek_result_from_response(reply);
-    }
-
     // rpc DomainGet(DomainGetReq) returns (DomainGetReply);
     Task<api::DomainPointResult> get_domain(const api::DomainPointQuery& query) override {
         auto request = domain_get_request_from_query(query);

--- a/silkworm/db/kv/grpc/client/remote_transaction.hpp
+++ b/silkworm/db/kv/grpc/client/remote_transaction.hpp
@@ -59,6 +59,9 @@ class RemoteTransaction : public api::BaseTransaction {
 
     Task<void> close() override;
 
+    // rpc HistoryGet(HistoryGetReq) returns (HistoryGetReply);
+    Task<api::HistoryPointResult> history_seek(api::HistoryPointQuery&& query) override;
+
     // rpc IndexRange(IndexRangeReq) returns (IndexRangeReply);
     Task<api::PaginatedTimestamps> index_range(api::IndexRangeQuery&& query) override;
 

--- a/silkworm/db/test_util/mock_transaction.hpp
+++ b/silkworm/db/test_util/mock_transaction.hpp
@@ -46,6 +46,7 @@ class MockTransaction : public kv::api::Transaction {
     MOCK_METHOD((Task<Bytes>), get_one, (const std::string&, ByteView), (override));
     MOCK_METHOD((Task<std::optional<Bytes>>), get_both_range,
                 (const std::string&, ByteView, ByteView), (override));
+    MOCK_METHOD((Task<kv::api::HistoryPointResult>), history_seek, (kv::api::HistoryPointQuery&&), (override));
     MOCK_METHOD((Task<kv::api::PaginatedTimestamps>), index_range, (kv::api::IndexRangeQuery&&), (override));
     MOCK_METHOD((Task<kv::api::PaginatedKeysValues>), history_range, (kv::api::HistoryRangeQuery&&), (override));
     MOCK_METHOD((Task<kv::api::PaginatedKeysValues>), domain_range, (kv::api::DomainRangeQuery&&), (override));

--- a/silkworm/rpc/commands/debug_api_test.cpp
+++ b/silkworm/rpc/commands/debug_api_test.cpp
@@ -212,6 +212,11 @@ class DummyTransaction : public db::kv::api::BaseTransaction {
     }
 
     // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
+    Task<db::kv::api::HistoryPointResult> history_seek(db::kv::api::HistoryPointQuery&& /*query*/) override {
+        co_return db::kv::api::HistoryPointResult{};
+    }
+
+    // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
     Task<db::kv::api::PaginatedTimestamps> index_range(db::kv::api::IndexRangeQuery&& /*query*/) override {
         co_return test::empty_paginated_timestamps();
     }

--- a/silkworm/rpc/core/account_dumper_test.cpp
+++ b/silkworm/rpc/core/account_dumper_test.cpp
@@ -201,6 +201,11 @@ class DummyTransaction : public BaseTransaction {
     }
 
     // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
+    Task<db::kv::api::HistoryPointResult> history_seek(db::kv::api::HistoryPointQuery&& /*query*/) override {
+        co_return db::kv::api::HistoryPointResult{};
+    }
+
+    // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
     Task<db::kv::api::PaginatedTimestamps> index_range(db::kv::api::IndexRangeQuery&& /*query*/) override {
         co_return test::empty_paginated_timestamps();
     }

--- a/silkworm/rpc/core/account_walker_test.cpp
+++ b/silkworm/rpc/core/account_walker_test.cpp
@@ -200,6 +200,11 @@ class DummyTransaction : public BaseTransaction {
     }
 
     // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
+    Task<db::kv::api::HistoryPointResult> history_seek(db::kv::api::HistoryPointQuery&& /*query*/) override {
+        co_return db::kv::api::HistoryPointResult{};
+    }
+
+    // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
     Task<db::kv::api::PaginatedTimestamps> index_range(db::kv::api::IndexRangeQuery&& /*query*/) override {
         co_return test::empty_paginated_timestamps();
     }

--- a/silkworm/rpc/core/storage_walker_test.cpp
+++ b/silkworm/rpc/core/storage_walker_test.cpp
@@ -200,6 +200,11 @@ class DummyTransaction : public BaseTransaction {
     }
 
     // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
+    Task<db::kv::api::HistoryPointResult> history_seek(db::kv::api::HistoryPointQuery&& /*query*/) override {
+        co_return db::kv::api::HistoryPointResult{};
+    }
+
+    // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
     Task<db::kv::api::PaginatedTimestamps> index_range(db::kv::api::IndexRangeQuery&& /*query*/) override {
         co_return test::empty_paginated_timestamps();
     }

--- a/silkworm/rpc/test_util/dummy_transaction.hpp
+++ b/silkworm/rpc/test_util/dummy_transaction.hpp
@@ -81,6 +81,11 @@ class DummyTransaction : public db::kv::api::BaseTransaction {
     Task<void> close() override { co_return; }
 
     // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
+    Task<db::kv::api::HistoryPointResult> history_seek(db::kv::api::HistoryPointQuery&& /*query*/) override {
+        co_return db::kv::api::HistoryPointResult{};
+    }
+
+    // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
     Task<db::kv::api::PaginatedTimestamps> index_range(db::kv::api::IndexRangeQuery&& /*query*/) override {
         co_return empty_paginated_timestamps();
     }


### PR DESCRIPTION
This PR implements temporal KV `history_seek` API in gRPC client. The following interface changes become necessary:

- the declaration of such API must be moved from `api::Service` to `api::Transaction`, as the input `api::HistoryPointQuery` always needs to specify the `tx_id`, i.e. the unique identifier of the enclosing db transaction

*Extras*
- `cmd`: add `kv_ history_seek` command in `grpc_toolbox` to allow testing _ HistorySeek_ KV RPC wrt Erigon3