### PR TITLE
db: temporal KV client domain_get API via gRPC

### DIFF
--- a/silkworm/db/kv/api/direct_service.cpp
+++ b/silkworm/db/kv/api/direct_service.cpp
@@ -58,12 +58,4 @@ Task<void> DirectService::state_changes(const api::StateChangeOptions& options, 
     }
 }
 
-/** Temporal Point Queries **/
-
-// rpc DomainGet(DomainGetReq) returns (DomainGetReply);
-Task<DomainPointResult> DirectService::get_domain(const DomainPointQuery&) {
-    // TODO(canepat) implement
-    co_return DomainPointResult{};
-}
-
 }  // namespace silkworm::db::kv::api

--- a/silkworm/db/kv/api/direct_service.hpp
+++ b/silkworm/db/kv/api/direct_service.hpp
@@ -46,11 +46,6 @@ class DirectService : public Service {
     // rpc StateChanges(StateChangeRequest) returns (stream StateChangeBatch);
     Task<void> state_changes(const StateChangeOptions&, StateChangeConsumer) override;
 
-    /** Temporal Point Queries **/
-
-    // rpc DomainGet(DomainGetReq) returns (DomainGetReply);
-    Task<DomainPointResult> get_domain(const DomainPointQuery&) override;
-
   private:
     //! The router to service endpoint implementation
     ServiceRouter router_;

--- a/silkworm/db/kv/api/local_transaction.cpp
+++ b/silkworm/db/kv/api/local_transaction.cpp
@@ -69,13 +69,19 @@ std::shared_ptr<chain::ChainStorage> LocalTransaction::create_storage() {
 }
 
 // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
-Task<HistoryPointResult> LocalTransaction::history_seek(api::HistoryPointQuery&& /*query*/) {
+Task<DomainPointResult> LocalTransaction::domain_get(DomainPointQuery&& /*query*/) {
+    // TODO(canepat) implement using E3-like aggregator abstraction [tx_id_ must be changed]
+    co_return DomainPointResult{};
+}
+
+// NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
+Task<HistoryPointResult> LocalTransaction::history_seek(HistoryPointQuery&& /*query*/) {
     // TODO(canepat) implement using E3-like aggregator abstraction [tx_id_ must be changed]
     co_return HistoryPointResult{};
 }
 
 // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
-Task<PaginatedTimestamps> LocalTransaction::index_range(api::IndexRangeQuery&& /*query*/) {
+Task<PaginatedTimestamps> LocalTransaction::index_range(IndexRangeQuery&& /*query*/) {
     // TODO(canepat) implement using E3-like aggregator abstraction [tx_id_ must be changed]
     auto paginator = []() mutable -> Task<api::PaginatedTimestamps::PageResult> {
         co_return api::PaginatedTimestamps::PageResult{};

--- a/silkworm/db/kv/api/local_transaction.hpp
+++ b/silkworm/db/kv/api/local_transaction.hpp
@@ -55,8 +55,11 @@ class LocalTransaction : public BaseTransaction {
 
     Task<void> close() override;
 
-    // rpc HistoryGet(HistoryGetReq) returns (HistoryGetReply);
-    Task<HistoryPointResult> history_seek(api::HistoryPointQuery&& query) override;
+    // rpc DomainGet(DomainGetReq) returns (DomainGetReply);
+    Task<DomainPointResult> domain_get(DomainPointQuery&&) override;
+
+    // rpc HistorySeek(HistorySeekReq) returns (HistorySeekReply);
+    Task<HistoryPointResult> history_seek(HistoryPointQuery&& query) override;
 
     // rpc IndexRange(IndexRangeReq) returns (IndexRangeReply);
     Task<PaginatedTimestamps> index_range(IndexRangeQuery&& query) override;

--- a/silkworm/db/kv/api/service.hpp
+++ b/silkworm/db/kv/api/service.hpp
@@ -37,11 +37,6 @@ struct Service {
 
     // rpc StateChanges(StateChangeRequest) returns (stream StateChangeBatch);
     virtual Task<void> state_changes(const StateChangeOptions& options, StateChangeConsumer consumer) = 0;
-
-    /** Temporal Point Queries **/
-
-    // rpc DomainGet(DomainGetReq) returns (DomainGetReply);
-    virtual Task<DomainPointResult> get_domain(const DomainPointQuery&) = 0;
 };
 
 }  // namespace silkworm::db::kv::api

--- a/silkworm/db/kv/api/transaction.hpp
+++ b/silkworm/db/kv/api/transaction.hpp
@@ -68,8 +68,11 @@ class Transaction {
 
     /** Temporal Point Queries **/
 
-    // rpc HistoryGet(HistoryGetReq) returns (HistoryGetReply);
-    virtual Task<HistoryPointResult> history_seek(api::HistoryPointQuery&& query) = 0;
+    // rpc DomainGet(DomainGetReq) returns (DomainGetReply);
+    virtual Task<DomainPointResult> domain_get(DomainPointQuery&& query) = 0;
+
+    // rpc HistorySeek(HistorySeekReq) returns (HistorySeekReply);
+    virtual Task<HistoryPointResult> history_seek(HistoryPointQuery&& query) = 0;
 
     /** Temporal Range Queries **/
 

--- a/silkworm/db/kv/grpc/client/endpoint/temporal_point.cpp
+++ b/silkworm/db/kv/grpc/client/endpoint/temporal_point.cpp
@@ -43,23 +43,20 @@ proto::DomainGetReq domain_get_request_from_query(const api::DomainPointQuery& q
     proto::DomainGetReq request;
     request.set_tx_id(query.tx_id);
     request.set_table(query.table);
-    request.set_k(to_hex(query.key));
+    request.set_k(query.key.data(), query.key.size());
     if (query.timestamp) {
         request.set_ts(static_cast<uint64_t>(*query.timestamp));
     } else {
         request.set_latest(true);
     }
-    request.set_k2(to_hex(query.sub_key));
+    request.set_k2(query.sub_key.data(), query.sub_key.size());
     return request;
 }
 
 api::DomainPointResult domain_get_result_from_response(const proto::DomainGetReply& response) {
     api::DomainPointResult result;
     result.success = response.ok();
-    auto hex{from_hex(response.v())};
-    if (hex) {
-        result.value = std::move(*hex);
-    }
+    result.value = string_to_bytes(response.v());
     return result;
 }
 

--- a/silkworm/db/kv/grpc/client/remote_client.cpp
+++ b/silkworm/db/kv/grpc/client/remote_client.cpp
@@ -137,15 +137,6 @@ class RemoteClientImpl final : public api::Service {
         }
     }
 
-    /** Temporal Point Queries **/
-
-    // rpc DomainGet(DomainGetReq) returns (DomainGetReply);
-    Task<api::DomainPointResult> get_domain(const api::DomainPointQuery& query) override {
-        auto request = domain_get_request_from_query(query);
-        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncDomainGet, *stub_, std::move(request), grpc_context_);
-        co_return domain_get_result_from_response(reply);
-    }
-
     void set_min_backoff_timeout(const std::chrono::milliseconds& min_backoff_timeout) {
         min_backoff_timeout_ = min_backoff_timeout;
     }

--- a/silkworm/db/kv/grpc/client/remote_transaction.hpp
+++ b/silkworm/db/kv/grpc/client/remote_transaction.hpp
@@ -59,7 +59,10 @@ class RemoteTransaction : public api::BaseTransaction {
 
     Task<void> close() override;
 
-    // rpc HistoryGet(HistoryGetReq) returns (HistoryGetReply);
+    // rpc DomainGet(DomainGetReq) returns (DomainGetReply);
+    Task<api::DomainPointResult> domain_get(api::DomainPointQuery&&) override;
+
+    // rpc HistorySeek(HistorySeekReq) returns (HistorySeekReply);
     Task<api::HistoryPointResult> history_seek(api::HistoryPointQuery&& query) override;
 
     // rpc IndexRange(IndexRangeReq) returns (IndexRangeReply);

--- a/silkworm/db/kv/grpc/test_util/sample_protos.hpp
+++ b/silkworm/db/kv/grpc/test_util/sample_protos.hpp
@@ -85,16 +85,16 @@ inline proto::DomainGetReq sample_proto_domain_point_request() {
     proto::DomainGetReq request;
     request.set_tx_id(1);
     request.set_table("AAA");
-    request.set_k("0011ff");
+    request.set_k(ascii_from_hex("0011ff"));
     request.set_ts(1234567);
-    request.set_k2("001122");
+    request.set_k2(ascii_from_hex("001122"));
     return request;
 }
 
 inline proto::DomainGetReply sample_proto_domain_get_response() {
     proto::DomainGetReply response;
     response.set_ok(true);
-    response.set_v("ff00ff00");
+    response.set_v(ascii_from_hex("ff00ff00"));
     return response;
 }
 

--- a/silkworm/db/test_util/mock_transaction.hpp
+++ b/silkworm/db/test_util/mock_transaction.hpp
@@ -46,6 +46,7 @@ class MockTransaction : public kv::api::Transaction {
     MOCK_METHOD((Task<Bytes>), get_one, (const std::string&, ByteView), (override));
     MOCK_METHOD((Task<std::optional<Bytes>>), get_both_range,
                 (const std::string&, ByteView, ByteView), (override));
+    MOCK_METHOD((Task<kv::api::DomainPointResult>), domain_get, (kv::api::DomainPointQuery&&), (override));
     MOCK_METHOD((Task<kv::api::HistoryPointResult>), history_seek, (kv::api::HistoryPointQuery&&), (override));
     MOCK_METHOD((Task<kv::api::PaginatedTimestamps>), index_range, (kv::api::IndexRangeQuery&&), (override));
     MOCK_METHOD((Task<kv::api::PaginatedKeysValues>), history_range, (kv::api::HistoryRangeQuery&&), (override));

--- a/silkworm/rpc/commands/debug_api_test.cpp
+++ b/silkworm/rpc/commands/debug_api_test.cpp
@@ -212,6 +212,11 @@ class DummyTransaction : public db::kv::api::BaseTransaction {
     }
 
     // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
+    Task<db::kv::api::DomainPointResult> domain_get(db::kv::api::DomainPointQuery&& /*query*/) override {
+        co_return db::kv::api::DomainPointResult{};
+    }
+
+    // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
     Task<db::kv::api::HistoryPointResult> history_seek(db::kv::api::HistoryPointQuery&& /*query*/) override {
         co_return db::kv::api::HistoryPointResult{};
     }

--- a/silkworm/rpc/core/account_dumper_test.cpp
+++ b/silkworm/rpc/core/account_dumper_test.cpp
@@ -201,6 +201,11 @@ class DummyTransaction : public BaseTransaction {
     }
 
     // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
+    Task<db::kv::api::DomainPointResult> domain_get(db::kv::api::DomainPointQuery&& /*query*/) override {
+        co_return db::kv::api::DomainPointResult{};
+    }
+
+    // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
     Task<db::kv::api::HistoryPointResult> history_seek(db::kv::api::HistoryPointQuery&& /*query*/) override {
         co_return db::kv::api::HistoryPointResult{};
     }

--- a/silkworm/rpc/core/account_walker_test.cpp
+++ b/silkworm/rpc/core/account_walker_test.cpp
@@ -200,6 +200,11 @@ class DummyTransaction : public BaseTransaction {
     }
 
     // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
+    Task<db::kv::api::DomainPointResult> domain_get(db::kv::api::DomainPointQuery&& /*query*/) override {
+        co_return db::kv::api::DomainPointResult{};
+    }
+
+    // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
     Task<db::kv::api::HistoryPointResult> history_seek(db::kv::api::HistoryPointQuery&& /*query*/) override {
         co_return db::kv::api::HistoryPointResult{};
     }

--- a/silkworm/rpc/core/storage_walker_test.cpp
+++ b/silkworm/rpc/core/storage_walker_test.cpp
@@ -200,6 +200,11 @@ class DummyTransaction : public BaseTransaction {
     }
 
     // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
+    Task<db::kv::api::DomainPointResult> domain_get(db::kv::api::DomainPointQuery&& /*query*/) override {
+        co_return db::kv::api::DomainPointResult{};
+    }
+
+    // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
     Task<db::kv::api::HistoryPointResult> history_seek(db::kv::api::HistoryPointQuery&& /*query*/) override {
         co_return db::kv::api::HistoryPointResult{};
     }

--- a/silkworm/rpc/test_util/dummy_transaction.hpp
+++ b/silkworm/rpc/test_util/dummy_transaction.hpp
@@ -81,6 +81,11 @@ class DummyTransaction : public db::kv::api::BaseTransaction {
     Task<void> close() override { co_return; }
 
     // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
+    Task<db::kv::api::DomainPointResult> domain_get(db::kv::api::DomainPointQuery&& /*query*/) override {
+        co_return db::kv::api::DomainPointResult{};
+    }
+
+    // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
     Task<db::kv::api::HistoryPointResult> history_seek(db::kv::api::HistoryPointQuery&& /*query*/) override {
         co_return db::kv::api::HistoryPointResult{};
     }


### PR DESCRIPTION
This PR implements temporal KV `domain_get` API in gRPC client. The following interface changes become necessary:

- the declaration of such API must be moved from `api::Service` to `api::Transaction`, as the input `api::DomainPointQuery` always needs to specify the `tx_id`, i.e. the unique identifier of the enclosing db transaction

*Extras*
- `cmd`: add `kv_domain_get` command in `grpc_toolbox` to allow testing _DomainGet_ KV RPC wrt Erigon3
- fix wire format for keys and values in gRPC