### PR TITLE
db: snapshot freezers cleanup

### DIFF
--- a/silkworm/db/access_layer.hpp
+++ b/silkworm/db/access_layer.hpp
@@ -89,11 +89,20 @@ void write_header(RWTxn& txn, const BlockHeader& header, bool with_header_number
 //! \brief Writes given header to table::kHeaders and returns its hash
 evmc::bytes32 write_header_ex(RWTxn& txn, const BlockHeader& header, bool with_header_numbers);
 
+//! \brief Deletes a header from table::kHeaders
+void delete_header(RWTxn& txn, BlockNum number, const evmc::bytes32& hash);
+
+//! \brief Finds the first header with a number >= min_number in table::kHeaders
+std::optional<BlockNum> read_stored_header_number_after(ROTxn& txn, BlockNum min_number);
+
 //! \brief Read block number from hash
 std::optional<BlockNum> read_block_number(ROTxn& txn, const evmc::bytes32& hash);
 
 //! \brief Writes header hash in table::kHeaderNumbers
 void write_header_number(RWTxn& txn, const uint8_t (&hash)[kHashLength], BlockNum number);
+
+//! \brief Deletes a header hash to number entry in table::kHeaderNumbers
+void delete_header_number(RWTxn& txn, const evmc::bytes32& hash);
 
 //! \brief Writes the header hash in table::kCanonicalHashes
 void write_canonical_header(RWTxn& txn, const BlockHeader& header);
@@ -131,6 +140,9 @@ void write_body(RWTxn& txn, const BlockBody& body, const evmc::bytes32& hash, Bl
 void write_body(RWTxn& txn, const BlockBody& body, const uint8_t (&hash)[kHashLength], BlockNum number);
 void write_raw_body(RWTxn& txn, const BlockBody& body, const evmc::bytes32& hash, BlockNum bn);
 
+//! \brief Deletes a block body from table::kBlockBodies
+void delete_body(RWTxn& txn, const evmc::bytes32& hash, BlockNum number);
+
 // See Erigon ReadTd
 std::optional<intx::uint256> read_total_difficulty(ROTxn& txn, BlockNum, const evmc::bytes32& hash);
 std::optional<intx::uint256> read_total_difficulty(ROTxn& txn, BlockNum, const uint8_t (&hash)[kHashLength]);
@@ -158,6 +170,7 @@ std::vector<evmc::address> read_senders(ROTxn& txn, BlockNum block_number, const
 //! \brief Fills transactions' senders addresses directly in place
 void parse_senders(ROTxn& txn, const Bytes& key, std::vector<Transaction>& out);
 void write_senders(RWTxn& txn, const evmc::bytes32& hash, const BlockNum& number, const Block& block);
+void delete_senders(RWTxn& txn, const evmc::bytes32& hash, const BlockNum& number);
 
 void write_tx_lookup(RWTxn& txn, const Block& block);
 void write_receipts(RWTxn& txn, const std::vector<silkworm::Receipt>& receipts, const BlockNum& block_number);
@@ -172,6 +185,9 @@ bool read_rlp_transactions(ROTxn& txn, BlockNum height, const evmc::bytes32& has
 //! The key starts from base_id and is incremented by 1 for each transaction.
 //! \remarks Before calling this ensure you got a proper base_id by incrementing sequence for table::kBlockTransactions.
 void write_transactions(RWTxn& txn, const std::vector<Transaction>& transactions, uint64_t base_id);
+
+//! \brief Delete transactions from table::kBlockTransactions.
+void delete_transactions(RWTxn& txn, uint64_t base_id, uint64_t count);
 
 std::optional<ByteView> read_code(ROTxn& txn, const evmc::bytes32& code_hash);
 

--- a/silkworm/db/bodies/body_snapshot_freezer.cpp
+++ b/silkworm/db/bodies/body_snapshot_freezer.cpp
@@ -34,4 +34,14 @@ void BodySnapshotFreezer::copy(ROTxn& txn, BlockNumRange range, snapshots::Snaps
     }
 }
 
+void BodySnapshotFreezer::cleanup(RWTxn& txn, BlockNumRange range) const {
+    for (BlockNum i = range.first; i < range.second; i++) {
+        auto hash_opt = read_canonical_hash(txn, i);
+        if (!hash_opt) continue;
+        auto hash = *hash_opt;
+
+        delete_body(txn, hash, i);
+    }
+}
+
 }  // namespace silkworm::db

--- a/silkworm/db/bodies/body_snapshot_freezer.hpp
+++ b/silkworm/db/bodies/body_snapshot_freezer.hpp
@@ -24,6 +24,7 @@ class BodySnapshotFreezer : public SnapshotFreezer {
   public:
     ~BodySnapshotFreezer() override = default;
     void copy(ROTxn& txn, BlockNumRange range, snapshots::SnapshotFileWriter& file_writer) const override;
+    void cleanup(RWTxn& txn, BlockNumRange range) const override;
 };
 
 }  // namespace silkworm::db

--- a/silkworm/db/freezer.hpp
+++ b/silkworm/db/freezer.hpp
@@ -40,6 +40,7 @@ class Freezer : public DataMigration {
     void index(std::shared_ptr<DataMigrationResult> result) override;
     void commit(std::shared_ptr<DataMigrationResult> result) override;
     void cleanup() override;
+    BlockNumRange cleanup_range();
 
     db::ROAccess db_access_;
     snapshots::SnapshotRepository& snapshots_;

--- a/silkworm/db/headers/header_snapshot_freezer.cpp
+++ b/silkworm/db/headers/header_snapshot_freezer.cpp
@@ -34,4 +34,14 @@ void HeaderSnapshotFreezer::copy(ROTxn& txn, BlockNumRange range, snapshots::Sna
     }
 }
 
+void HeaderSnapshotFreezer::cleanup(RWTxn& txn, BlockNumRange range) const {
+    for (BlockNum i = range.first; i < range.second; i++) {
+        auto hash_opt = read_canonical_hash(txn, i);
+        if (!hash_opt) continue;
+        auto& hash = *hash_opt;
+
+        delete_header(txn, i, hash);
+    }
+}
+
 }  // namespace silkworm::db

--- a/silkworm/db/headers/header_snapshot_freezer.hpp
+++ b/silkworm/db/headers/header_snapshot_freezer.hpp
@@ -24,6 +24,7 @@ class HeaderSnapshotFreezer : public SnapshotFreezer {
   public:
     ~HeaderSnapshotFreezer() override = default;
     void copy(ROTxn& txn, BlockNumRange range, snapshots::SnapshotFileWriter& file_writer) const override;
+    void cleanup(RWTxn& txn, BlockNumRange range) const override;
 };
 
 }  // namespace silkworm::db

--- a/silkworm/db/snapshot_freezer.hpp
+++ b/silkworm/db/snapshot_freezer.hpp
@@ -28,6 +28,9 @@ struct SnapshotFreezer {
 
     //! Copies data for a block range from db to the snapshot file.
     virtual void copy(ROTxn& txn, BlockNumRange range, snapshots::SnapshotFileWriter& file_writer) const = 0;
+
+    //! Cleans up data for a block range from db after it was copied to the snapshot file.
+    virtual void cleanup(RWTxn& txn, BlockNumRange range) const = 0;
 };
 
 }  // namespace silkworm::db

--- a/silkworm/db/transactions/txn_snapshot_freezer.hpp
+++ b/silkworm/db/transactions/txn_snapshot_freezer.hpp
@@ -24,6 +24,7 @@ class TransactionSnapshotFreezer : public SnapshotFreezer {
   public:
     ~TransactionSnapshotFreezer() override = default;
     void copy(ROTxn& txn, BlockNumRange range, snapshots::SnapshotFileWriter& file_writer) const override;
+    void cleanup(RWTxn& txn, BlockNumRange range) const override;
 };
 
 }  // namespace silkworm::db


### PR DESCRIPTION
Prune block data that was copied to snapshots from mdbx.