### PR TITLE
rpcdaemon: fixing fuzzer tests

### DIFF
--- a/silkworm/rpc/core/call_many.cpp
+++ b/silkworm/rpc/core/call_many.cpp
@@ -61,8 +61,8 @@ CallManyResult CallExecutor::executes_all_bundles(const silkworm::ChainConfig& c
         }
     }
     executor.reset();
-
-    result.results.reserve(bundles.size());
+    // Don't call reserve here to preallocate result.results - since json value is dynamic it doesn't know yet how much it should allocate!
+    // -> Don't uncomment this line result.results.reserve(bundles.size());
     for (const auto& bundle : bundles) {
         const auto& block_override = bundle.block_override;
 
@@ -91,7 +91,8 @@ CallManyResult CallExecutor::executes_all_bundles(const silkworm::ChainConfig& c
         }
 
         std::vector<nlohmann::json> results;
-        result.results.reserve(bundle.transactions.size());
+        // Don't call reserve here to preallocate result.results - since json value is dynamic it doesn't know yet how much it should allocate!
+        // -> Don't uncomment this line result.results.reserve(bundle.transactions.size());
         for (const auto& call : bundle.transactions) {
             silkworm::Transaction txn{call.to_transaction(block.header.base_fee_per_gas)};
 

--- a/silkworm/rpc/core/fee_history_oracle.cpp
+++ b/silkworm/rpc/core/fee_history_oracle.cpp
@@ -52,8 +52,9 @@ void to_json(nlohmann::json& json, const FeeHistory& fh) {
     }
 
     if (!fh.rewards.empty()) {
+        // Don't call reserve here to preallocate vector - since json value is dynamic it doesn't know yet how much it should allocate!
+        // -> Don't uncomment this line json_list.reserve(fh.rewards.size());
         std::vector<nlohmann::json> json_list;
-        json_list.reserve(fh.rewards.size());
         for (const auto& rewards : fh.rewards) {
             nlohmann::json item;
             to_json(item, rewards);


### PR DESCRIPTION
Calling preallocate on a collection keeping nlohmann::json caused the push_back to place elements beyond the allocated space. 