### PR TITLE
db: BodySnapshotFreezer use sequential txn_id without gaps

### DIFF
--- a/silkworm/db/access_layer.hpp
+++ b/silkworm/db/access_layer.hpp
@@ -317,6 +317,9 @@ class DataModel {
     [[nodiscard]] bool read_body(const Hash& hash, BlockNum height, BlockBody& body) const;
     [[nodiscard]] bool read_body(const Hash& hash, BlockBody& body) const;
 
+    //! Read block body for storage from the snapshot repository
+    [[nodiscard]] static std::optional<BlockBodyForStorage> read_body_for_storage_from_snapshot(BlockNum height);
+
     //! Read the canonical block header at specified height
     [[nodiscard]] std::optional<Hash> read_canonical_hash(BlockNum height) const;
 

--- a/silkworm/db/bodies/body_snapshot_freezer.hpp
+++ b/silkworm/db/bodies/body_snapshot_freezer.hpp
@@ -23,7 +23,7 @@ namespace silkworm::db {
 class BodySnapshotFreezer : public SnapshotFreezer {
   public:
     ~BodySnapshotFreezer() override = default;
-    void copy(ROTxn& txn, BlockNumRange range, snapshots::SnapshotFileWriter& file_writer) const override;
+    void copy(ROTxn& txn, const FreezerCommand& command, snapshots::SnapshotFileWriter& file_writer) const override;
     void cleanup(RWTxn& txn, BlockNumRange range) const override;
 };
 

--- a/silkworm/db/data_migration_command.hpp
+++ b/silkworm/db/data_migration_command.hpp
@@ -16,27 +16,10 @@
 
 #pragma once
 
-#include <memory>
-
-#include "data_migration_command.hpp"
-
 namespace silkworm::db {
 
-struct DataMigrationResult {
-    virtual ~DataMigrationResult() = default;
-};
-
-struct DataMigration {
-    virtual ~DataMigration() = default;
-
-    void run();
-
-  protected:
-    virtual std::unique_ptr<DataMigrationCommand> next_command() = 0;
-    virtual std::shared_ptr<DataMigrationResult> migrate(std::unique_ptr<DataMigrationCommand> command) = 0;
-    virtual void index(std::shared_ptr<DataMigrationResult> result) = 0;
-    virtual void commit(std::shared_ptr<DataMigrationResult> result) = 0;
-    virtual void cleanup() = 0;
+struct DataMigrationCommand {
+    virtual ~DataMigrationCommand() = default;
 };
 
 }  // namespace silkworm::db

--- a/silkworm/db/headers/header_snapshot_freezer.cpp
+++ b/silkworm/db/headers/header_snapshot_freezer.cpp
@@ -24,7 +24,8 @@
 
 namespace silkworm::db {
 
-void HeaderSnapshotFreezer::copy(ROTxn& txn, BlockNumRange range, snapshots::SnapshotFileWriter& file_writer) const {
+void HeaderSnapshotFreezer::copy(ROTxn& txn, const FreezerCommand& command, snapshots::SnapshotFileWriter& file_writer) const {
+    BlockNumRange range = command.range;
     snapshots::HeaderSnapshotWriter writer{file_writer};
     auto out = writer.out();
     for (BlockNum i = range.first; i < range.second; i++) {

--- a/silkworm/db/headers/header_snapshot_freezer.hpp
+++ b/silkworm/db/headers/header_snapshot_freezer.hpp
@@ -23,7 +23,7 @@ namespace silkworm::db {
 class HeaderSnapshotFreezer : public SnapshotFreezer {
   public:
     ~HeaderSnapshotFreezer() override = default;
-    void copy(ROTxn& txn, BlockNumRange range, snapshots::SnapshotFileWriter& file_writer) const override;
+    void copy(ROTxn& txn, const FreezerCommand& command, snapshots::SnapshotFileWriter& file_writer) const override;
     void cleanup(RWTxn& txn, BlockNumRange range) const override;
 };
 

--- a/silkworm/db/snapshot_freezer.hpp
+++ b/silkworm/db/snapshot_freezer.hpp
@@ -18,16 +18,27 @@
 
 #include <silkworm/core/common/base.hpp>
 
+#include "data_migration_command.hpp"
 #include "mdbx/mdbx.hpp"
 #include "snapshots/snapshot_writer.hpp"
 
 namespace silkworm::db {
 
+struct FreezerCommand : public DataMigrationCommand {
+    BlockNumRange range;
+    uint64_t base_txn_id;
+
+    FreezerCommand(BlockNumRange range1, uint64_t base_txn_id1)
+        : range(std::move(range1)),
+          base_txn_id(base_txn_id1) {}
+    ~FreezerCommand() override = default;
+};
+
 struct SnapshotFreezer {
     virtual ~SnapshotFreezer() = default;
 
     //! Copies data for a block range from db to the snapshot file.
-    virtual void copy(ROTxn& txn, BlockNumRange range, snapshots::SnapshotFileWriter& file_writer) const = 0;
+    virtual void copy(ROTxn& txn, const FreezerCommand& command, snapshots::SnapshotFileWriter& file_writer) const = 0;
 
     //! Cleans up data for a block range from db after it was copied to the snapshot file.
     virtual void cleanup(RWTxn& txn, BlockNumRange range) const = 0;

--- a/silkworm/db/transactions/txn_snapshot_freezer.cpp
+++ b/silkworm/db/transactions/txn_snapshot_freezer.cpp
@@ -24,7 +24,8 @@
 
 namespace silkworm::db {
 
-void TransactionSnapshotFreezer::copy(ROTxn& txn, BlockNumRange range, snapshots::SnapshotFileWriter& file_writer) const {
+void TransactionSnapshotFreezer::copy(ROTxn& txn, const FreezerCommand& command, snapshots::SnapshotFileWriter& file_writer) const {
+    BlockNumRange range = command.range;
     snapshots::TransactionSnapshotWriter writer{file_writer};
     auto out = writer.out();
     auto system_tx = snapshots::empty_system_tx();

--- a/silkworm/db/transactions/txn_snapshot_freezer.hpp
+++ b/silkworm/db/transactions/txn_snapshot_freezer.hpp
@@ -23,7 +23,7 @@ namespace silkworm::db {
 class TransactionSnapshotFreezer : public SnapshotFreezer {
   public:
     ~TransactionSnapshotFreezer() override = default;
-    void copy(ROTxn& txn, BlockNumRange range, snapshots::SnapshotFileWriter& file_writer) const override;
+    void copy(ROTxn& txn, const FreezerCommand& command, snapshots::SnapshotFileWriter& file_writer) const override;
     void cleanup(RWTxn& txn, BlockNumRange range) const override;
 };
 


### PR DESCRIPTION
Original mdbx txn_id might have gaps due to chain reorgs. When moving the data to snapshots we remove potential gaps in BlockBodyForStorage txn_id. This makes snapshot files identical across nodes because different nodes might encounter different chain reorgs.

Note: the sequential numbering is called "TxNum" in erigon.