### PR TITLE
capi: fix Windows build after PR 2201

### DIFF
--- a/silkworm/capi/fork_validator.cpp
+++ b/silkworm/capi/fork_validator.cpp
@@ -41,22 +41,18 @@ static void set_node_settings(SilkwormHandle handle, const struct SilkwormForkVa
     handle->node_settings.data_directory = std::move(data_dir);
 
     auto db_env_flags = unmanaged_env.get_flags();
-    handle->node_settings.chaindata_env_config = {
-        .path = handle->data_dir_path,
-        .create = false,
-        .readonly = (db_env_flags & MDBX_RDONLY) != 0,
-        .exclusive = (db_env_flags & MDBX_EXCLUSIVE) != 0,
-        .in_memory = (db_env_flags & MDBX_NOMETASYNC) != 0,
-        .shared = (db_env_flags & MDBX_ACCEDE) != 0,
-        .read_ahead = (db_env_flags & MDBX_NORDAHEAD) == 0,
-        .write_map = (db_env_flags & MDBX_WRITEMAP) != 0,
-        .page_size = unmanaged_env.get_pagesize(),
-        .max_size = unmanaged_env.dbsize_max(),
-        //.growth_size = ?
-        .max_tables = unmanaged_env.max_maps(),
-        .max_readers = unmanaged_env.max_readers(),
-    };
-
+    handle->node_settings.chaindata_env_config.path = handle->data_dir_path;
+    handle->node_settings.chaindata_env_config.create = false;
+    handle->node_settings.chaindata_env_config.readonly = (db_env_flags & MDBX_RDONLY) != 0;
+    handle->node_settings.chaindata_env_config.exclusive = (db_env_flags & MDBX_EXCLUSIVE) != 0;
+    handle->node_settings.chaindata_env_config.in_memory = (db_env_flags & MDBX_NOMETASYNC) != 0;
+    handle->node_settings.chaindata_env_config.shared = (db_env_flags & MDBX_ACCEDE) != 0;
+    handle->node_settings.chaindata_env_config.read_ahead = (db_env_flags & MDBX_NORDAHEAD) == 0;
+    handle->node_settings.chaindata_env_config.write_map = (db_env_flags & MDBX_WRITEMAP) != 0;
+    handle->node_settings.chaindata_env_config.page_size = unmanaged_env.get_pagesize();
+    handle->node_settings.chaindata_env_config.max_size = unmanaged_env.dbsize_max();
+    handle->node_settings.chaindata_env_config.max_tables = unmanaged_env.max_maps();
+    handle->node_settings.chaindata_env_config.max_readers = unmanaged_env.max_readers();
     handle->node_settings.build_info = silkworm::make_application_info(silkworm_get_buildinfo());
     handle->node_settings.network_id = chain_config->chain_id;
     handle->node_settings.chain_config = chain_config;

--- a/silkworm/capi/fork_validator.cpp
+++ b/silkworm/capi/fork_validator.cpp
@@ -41,18 +41,22 @@ static void set_node_settings(SilkwormHandle handle, const struct SilkwormForkVa
     handle->node_settings.data_directory = std::move(data_dir);
 
     auto db_env_flags = unmanaged_env.get_flags();
-    handle->node_settings.chaindata_env_config.path = handle->data_dir_path;
-    handle->node_settings.chaindata_env_config.create = false;
-    handle->node_settings.chaindata_env_config.readonly = (db_env_flags & MDBX_RDONLY) != 0;
-    handle->node_settings.chaindata_env_config.exclusive = (db_env_flags & MDBX_EXCLUSIVE) != 0;
-    handle->node_settings.chaindata_env_config.in_memory = (db_env_flags & MDBX_NOMETASYNC) != 0;
-    handle->node_settings.chaindata_env_config.shared = (db_env_flags & MDBX_ACCEDE) != 0;
-    handle->node_settings.chaindata_env_config.read_ahead = (db_env_flags & MDBX_NORDAHEAD) == 0;
-    handle->node_settings.chaindata_env_config.write_map = (db_env_flags & MDBX_WRITEMAP) != 0;
-    handle->node_settings.chaindata_env_config.page_size = unmanaged_env.get_pagesize();
-    handle->node_settings.chaindata_env_config.max_size = unmanaged_env.dbsize_max();
-    handle->node_settings.chaindata_env_config.max_tables = unmanaged_env.max_maps();
-    handle->node_settings.chaindata_env_config.max_readers = unmanaged_env.max_readers();
+    handle->node_settings.chaindata_env_config = silkworm::db::EnvConfig{
+        .path = handle->data_dir_path.string(),
+        .create = false,
+        .readonly = (db_env_flags & MDBX_RDONLY) != 0,
+        .exclusive = (db_env_flags & MDBX_EXCLUSIVE) != 0,
+        .in_memory = (db_env_flags & MDBX_NOMETASYNC) != 0,
+        .shared = (db_env_flags & MDBX_ACCEDE) != 0,
+        .read_ahead = (db_env_flags & MDBX_NORDAHEAD) == 0,
+        .write_map = (db_env_flags & MDBX_WRITEMAP) != 0,
+        .page_size = unmanaged_env.get_pagesize(),
+        .max_size = unmanaged_env.dbsize_max(),
+        //.growth_size = ?
+        .max_tables = unmanaged_env.max_maps(),
+        .max_readers = unmanaged_env.max_readers(),
+    };
+
     handle->node_settings.build_info = silkworm::make_application_info(silkworm_get_buildinfo());
     handle->node_settings.network_id = chain_config->chain_id;
     handle->node_settings.chain_config = chain_config;

--- a/silkworm/capi/fork_validator.cpp
+++ b/silkworm/capi/fork_validator.cpp
@@ -15,7 +15,6 @@
 */
 
 #include <silkworm/buildinfo.h>
-#include <silkworm/core/chain/config.hpp>
 #include <silkworm/core/common/base.hpp>
 #include <silkworm/infra/common/environment.hpp>
 
@@ -42,15 +41,15 @@ static void set_node_settings(SilkwormHandle handle, const struct SilkwormForkVa
     handle->node_settings.data_directory = std::move(data_dir);
 
     auto db_env_flags = unmanaged_env.get_flags();
-    handle->node_settings.chaindata_env_config = silkworm::db::EnvConfig{
+    handle->node_settings.chaindata_env_config = {
         .path = handle->data_dir_path,
         .create = false,
-        .readonly = db_env_flags & MDBX_RDONLY ? true : false,
-        .exclusive = db_env_flags & MDBX_EXCLUSIVE ? true : false,
-        .in_memory = db_env_flags & MDBX_NOMETASYNC ? true : false,
-        .shared = db_env_flags & MDBX_ACCEDE ? true : false,
-        .read_ahead = db_env_flags & MDBX_NORDAHEAD ? false : true,
-        .write_map = db_env_flags & MDBX_WRITEMAP ? true : false,
+        .readonly = (db_env_flags & MDBX_RDONLY) != 0,
+        .exclusive = (db_env_flags & MDBX_EXCLUSIVE) != 0,
+        .in_memory = (db_env_flags & MDBX_NOMETASYNC) != 0,
+        .shared = (db_env_flags & MDBX_ACCEDE) != 0,
+        .read_ahead = (db_env_flags & MDBX_NORDAHEAD) == 0,
+        .write_map = (db_env_flags & MDBX_WRITEMAP) != 0,
         .page_size = unmanaged_env.get_pagesize(),
         .max_size = unmanaged_env.dbsize_max(),
         //.growth_size = ?


### PR DESCRIPTION
This PR fix Windows build after #2201.

The error was misleading because MSVC 19.40 complains about [Compiler Error C2440](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/compiler-error-c2440?view=msvc-170), which seems strange at first, but in the end it's due to the missing conversion operator from `std::filesystem::path` to `std::string`.

*Extras*
- remove unused include
- simplify some expressions as suggested by CLion