### PR TITLE
db: snapshots repository thread safety

### DIFF
--- a/cmd/capi/execute.cpp
+++ b/cmd/capi/execute.cpp
@@ -151,7 +151,8 @@ std::vector<SilkwormChainSnapshot> collect_all_snapshots(SnapshotRepository& sna
     std::vector<SilkwormBodiesSnapshot> bodies_snapshot_sequence;
     std::vector<SilkwormTransactionsSnapshot> transactions_snapshot_sequence;
 
-    for (const SnapshotBundle& bundle : snapshot_repository.view_bundles()) {
+    for (const auto& bundle_ptr : snapshot_repository.view_bundles()) {
+        const auto& bundle = *bundle_ptr;
         {
             {
                 SilkwormHeadersSnapshot raw_headers_snapshot{

--- a/silkworm/db/access_layer.cpp
+++ b/silkworm/db/access_layer.cpp
@@ -1298,7 +1298,7 @@ std::optional<BlockHeader> DataModel::read_header_from_snapshot(BlockNum height)
 
     std::optional<BlockHeader> block_header;
     // We know the header snapshot in advance: find it based on target block number
-    const auto snapshot_and_index = repository_->find_segment(SnapshotType::headers, height);
+    const auto [snapshot_and_index, _] = repository_->find_segment(SnapshotType::headers, height);
     if (snapshot_and_index) {
         block_header = HeaderFindByBlockNumQuery{*snapshot_and_index}.exec(height);
     }
@@ -1312,7 +1312,8 @@ std::optional<BlockHeader> DataModel::read_header_from_snapshot(const Hash& hash
 
     std::optional<BlockHeader> block_header;
     // We don't know the header snapshot in advance: search for block hash in each header snapshot in reverse order
-    for (const SnapshotBundle& bundle : repository_->view_bundles_reverse()) {
+    for (const auto& bundle_ptr : repository_->view_bundles_reverse()) {
+        const auto& bundle = *bundle_ptr;
         auto snapshot_and_index = bundle.snapshot_and_index(SnapshotType::headers);
         block_header = HeaderFindByHashQuery{snapshot_and_index}.exec(hash);
         if (block_header) break;
@@ -1326,7 +1327,7 @@ std::optional<BlockBodyForStorage> DataModel::read_body_for_storage_from_snapsho
     }
 
     // We know the body snapshot in advance: find it based on target block number
-    const auto snapshot_and_index = repository_->find_segment(SnapshotType::bodies, height);
+    const auto [snapshot_and_index, _] = repository_->find_segment(SnapshotType::bodies, height);
     if (!snapshot_and_index) return std::nullopt;
 
     auto stored_body = BodyFindByBlockNumQuery{*snapshot_and_index}.exec(height);
@@ -1357,7 +1358,7 @@ bool DataModel::is_body_in_snapshot(BlockNum height) {
     }
 
     // We know the body snapshot in advance: find it based on target block number
-    const auto snapshot_and_index = repository_->find_segment(SnapshotType::bodies, height);
+    const auto [snapshot_and_index, _] = repository_->find_segment(SnapshotType::bodies, height);
     if (snapshot_and_index) {
         const auto stored_body = BodyFindByBlockNumQuery{*snapshot_and_index}.exec(height);
         return stored_body.has_value();
@@ -1371,7 +1372,7 @@ bool DataModel::read_transactions_from_snapshot(BlockNum height, uint64_t base_t
         return true;
     }
 
-    const auto snapshot_and_index = repository_->find_segment(SnapshotType::transactions, height);
+    const auto [snapshot_and_index, _] = repository_->find_segment(SnapshotType::transactions, height);
     if (!snapshot_and_index) return false;
 
     txs = TransactionRangeFromIdQuery{*snapshot_and_index}.exec_into_vector(base_txn_id, txn_count);
@@ -1380,7 +1381,7 @@ bool DataModel::read_transactions_from_snapshot(BlockNum height, uint64_t base_t
 }
 
 bool DataModel::read_rlp_transactions_from_snapshot(BlockNum height, std::vector<Bytes>& rlp_txs) {
-    const auto body_snapshot_and_index = repository_->find_segment(SnapshotType::bodies, height);
+    const auto [body_snapshot_and_index, _] = repository_->find_segment(SnapshotType::bodies, height);
     if (body_snapshot_and_index) {
         auto stored_body = BodyFindByBlockNumQuery{*body_snapshot_and_index}.exec(height);
         if (!stored_body) return false;
@@ -1391,7 +1392,7 @@ bool DataModel::read_rlp_transactions_from_snapshot(BlockNum height, std::vector
 
         if (txn_count == 0) return true;
 
-        const auto tx_snapshot_and_index = repository_->find_segment(SnapshotType::transactions, height);
+        const auto [tx_snapshot_and_index, _2] = repository_->find_segment(SnapshotType::transactions, height);
         if (!tx_snapshot_and_index) return false;
 
         rlp_txs = TransactionPayloadRlpRangeFromIdQuery{*tx_snapshot_and_index}.exec_into_vector(base_txn_id, txn_count);

--- a/silkworm/db/snapshot_repository_test.cpp
+++ b/silkworm/db/snapshot_repository_test.cpp
@@ -41,6 +41,9 @@ static std::unique_ptr<SnapshotBundleFactory> bundle_factory() {
     return std::make_unique<db::SnapshotBundleFactoryImpl>();
 }
 
+#define CHECK_FIRST(x) CHECK((x).first)
+#define CHECK_FALSE_FIRST(x) CHECK_FALSE((x).first)
+
 TEST_CASE("SnapshotRepository::SnapshotRepository", "[silkworm][node][snapshot]") {
     SetLogVerbosityGuard guard{log::Level::kNone};
     CHECK_NOTHROW(SnapshotRepository{SnapshotSettings{}, bundle_factory()});
@@ -70,9 +73,9 @@ TEST_CASE("SnapshotRepository::view", "[silkworm][node][snapshot]") {
     SECTION("no snapshots") {
         repository.reopen_folder();
 
-        CHECK_FALSE(repository.find_segment(SnapshotType::headers, 14'500'000));
-        CHECK_FALSE(repository.find_segment(SnapshotType::bodies, 11'500'000));
-        CHECK_FALSE(repository.find_segment(SnapshotType::transactions, 15'000'000));
+        CHECK_FALSE_FIRST(repository.find_segment(SnapshotType::headers, 14'500'000));
+        CHECK_FALSE_FIRST(repository.find_segment(SnapshotType::bodies, 11'500'000));
+        CHECK_FALSE_FIRST(repository.find_segment(SnapshotType::transactions, 15'000'000));
 
         size_t bundles_count = 0;
         for ([[maybe_unused]] const auto& bundle : repository.view_bundles()) {
@@ -80,9 +83,9 @@ TEST_CASE("SnapshotRepository::view", "[silkworm][node][snapshot]") {
         }
         CHECK(bundles_count == 0);
 
-        CHECK_FALSE(repository.find_segment(SnapshotType::headers, 14'500'000));
-        CHECK_FALSE(repository.find_segment(SnapshotType::bodies, 11'500'000));
-        CHECK_FALSE(repository.find_segment(SnapshotType::transactions, 15'000'000));
+        CHECK_FALSE_FIRST(repository.find_segment(SnapshotType::headers, 14'500'000));
+        CHECK_FALSE_FIRST(repository.find_segment(SnapshotType::bodies, 11'500'000));
+        CHECK_FALSE_FIRST(repository.find_segment(SnapshotType::transactions, 15'000'000));
     }
 
     SECTION("partial bundle") {
@@ -91,9 +94,9 @@ TEST_CASE("SnapshotRepository::view", "[silkworm][node][snapshot]") {
         test::TemporarySnapshotFile tmp_snapshot_3{tmp_dir.path(), "v1-015000-015500-transactions.seg"};
         repository.reopen_folder();
 
-        CHECK_FALSE(repository.find_segment(SnapshotType::headers, 14'500'000));
-        CHECK_FALSE(repository.find_segment(SnapshotType::bodies, 11'500'000));
-        CHECK_FALSE(repository.find_segment(SnapshotType::transactions, 15'000'000));
+        CHECK_FALSE_FIRST(repository.find_segment(SnapshotType::headers, 14'500'000));
+        CHECK_FALSE_FIRST(repository.find_segment(SnapshotType::bodies, 11'500'000));
+        CHECK_FALSE_FIRST(repository.find_segment(SnapshotType::transactions, 15'000'000));
 
         size_t bundles_count = 0;
         for ([[maybe_unused]] const auto& bundle : repository.view_bundles()) {
@@ -102,9 +105,9 @@ TEST_CASE("SnapshotRepository::view", "[silkworm][node][snapshot]") {
         // empty snapshots are ignored by repository
         CHECK(bundles_count == 0);
 
-        CHECK_FALSE(repository.find_segment(SnapshotType::headers, 14'500'000));
-        CHECK_FALSE(repository.find_segment(SnapshotType::bodies, 11'500'000));
-        CHECK_FALSE(repository.find_segment(SnapshotType::transactions, 15'000'000));
+        CHECK_FALSE_FIRST(repository.find_segment(SnapshotType::headers, 14'500'000));
+        CHECK_FALSE_FIRST(repository.find_segment(SnapshotType::bodies, 11'500'000));
+        CHECK_FALSE_FIRST(repository.find_segment(SnapshotType::transactions, 15'000'000));
     }
 
     SECTION("non-empty snapshots") {
@@ -124,9 +127,9 @@ TEST_CASE("SnapshotRepository::view", "[silkworm][node][snapshot]") {
         }
         CHECK(bundles_count == 1);
 
-        CHECK(repository.find_segment(SnapshotType::headers, 1'500'000).has_value());
-        CHECK(repository.find_segment(SnapshotType::bodies, 1'500'000).has_value());
-        CHECK(repository.find_segment(SnapshotType::transactions, 1'500'000).has_value());
+        CHECK_FIRST(repository.find_segment(SnapshotType::headers, 1'500'000));
+        CHECK_FIRST(repository.find_segment(SnapshotType::bodies, 1'500'000));
+        CHECK_FIRST(repository.find_segment(SnapshotType::transactions, 1'500'000));
 
         bundles_count = 0;
         for ([[maybe_unused]] const auto& bundle : repository.view_bundles()) {
@@ -164,22 +167,22 @@ TEST_CASE("SnapshotRepository::find_segment", "[silkworm][node][snapshot]") {
     test::SampleTransactionSnapshotFile txn_snapshot{tmp_dir.path()};
 
     SECTION("header w/o index") {
-        CHECK_FALSE(repository.find_segment(SnapshotType::headers, 1'500'011));
-        CHECK_FALSE(repository.find_segment(SnapshotType::headers, 1'500'012));
-        CHECK_FALSE(repository.find_segment(SnapshotType::headers, 1'500'013));
-        CHECK_FALSE(repository.find_segment(SnapshotType::headers, 1'500'014));
+        CHECK_FALSE_FIRST(repository.find_segment(SnapshotType::headers, 1'500'011));
+        CHECK_FALSE_FIRST(repository.find_segment(SnapshotType::headers, 1'500'012));
+        CHECK_FALSE_FIRST(repository.find_segment(SnapshotType::headers, 1'500'013));
+        CHECK_FALSE_FIRST(repository.find_segment(SnapshotType::headers, 1'500'014));
     }
     SECTION("body w/o index") {
-        CHECK_FALSE(repository.find_segment(SnapshotType::bodies, 1'500'011));
-        CHECK_FALSE(repository.find_segment(SnapshotType::bodies, 1'500'012));
-        CHECK_FALSE(repository.find_segment(SnapshotType::bodies, 1'500'013));
-        CHECK_FALSE(repository.find_segment(SnapshotType::bodies, 1'500'014));
+        CHECK_FALSE_FIRST(repository.find_segment(SnapshotType::bodies, 1'500'011));
+        CHECK_FALSE_FIRST(repository.find_segment(SnapshotType::bodies, 1'500'012));
+        CHECK_FALSE_FIRST(repository.find_segment(SnapshotType::bodies, 1'500'013));
+        CHECK_FALSE_FIRST(repository.find_segment(SnapshotType::bodies, 1'500'014));
     }
     SECTION("tx w/o index") {
-        CHECK_FALSE(repository.find_segment(SnapshotType::transactions, 1'500'011));
-        CHECK_FALSE(repository.find_segment(SnapshotType::transactions, 1'500'012));
-        CHECK_FALSE(repository.find_segment(SnapshotType::transactions, 1'500'013));
-        CHECK_FALSE(repository.find_segment(SnapshotType::transactions, 1'500'014));
+        CHECK_FALSE_FIRST(repository.find_segment(SnapshotType::transactions, 1'500'011));
+        CHECK_FALSE_FIRST(repository.find_segment(SnapshotType::transactions, 1'500'012));
+        CHECK_FALSE_FIRST(repository.find_segment(SnapshotType::transactions, 1'500'013));
+        CHECK_FALSE_FIRST(repository.find_segment(SnapshotType::transactions, 1'500'014));
     }
 
     test::SampleHeaderSnapshotPath header_snapshot_path{header_snapshot.path()};  // necessary to tweak the block numbers
@@ -195,25 +198,25 @@ TEST_CASE("SnapshotRepository::find_segment", "[silkworm][node][snapshot]") {
     REQUIRE_NOTHROW(repository.reopen_folder());
 
     SECTION("header w/ index") {
-        CHECK_FALSE(repository.find_segment(SnapshotType::headers, 1'500'011));
-        // CHECK(repository.find_segment(SnapshotType::headers, 1'500'012) != nullptr);  // needs full block number in snapshot file names
-        // CHECK(repository.find_segment(SnapshotType::headers, 1'500'013) != nullptr);  // needs full block number in snapshot file names
-        CHECK_FALSE(repository.find_segment(SnapshotType::headers, 1'500'014));
+        CHECK_FALSE_FIRST(repository.find_segment(SnapshotType::headers, 1'500'011));
+        // CHECK_FIRST(repository.find_segment(SnapshotType::headers, 1'500'012) != nullptr);  // needs full block number in snapshot file names
+        // CHECK_FIRST(repository.find_segment(SnapshotType::headers, 1'500'013) != nullptr);  // needs full block number in snapshot file names
+        CHECK_FALSE_FIRST(repository.find_segment(SnapshotType::headers, 1'500'014));
     }
     SECTION("body w/ index") {
-        CHECK_FALSE(repository.find_segment(SnapshotType::bodies, 1'500'011));
-        // CHECK(repository.find_segment(SnapshotType::bodies, 1'500'012) != nullptr);  // needs full block number in snapshot file names
-        // CHECK(repository.find_segment(SnapshotType::bodies, 1'500'013) != nullptr);  // needs full block number in snapshot file names
-        CHECK_FALSE(repository.find_segment(SnapshotType::bodies, 1'500'014));
+        CHECK_FALSE_FIRST(repository.find_segment(SnapshotType::bodies, 1'500'011));
+        // CHECK_FIRST(repository.find_segment(SnapshotType::bodies, 1'500'012) != nullptr);  // needs full block number in snapshot file names
+        // CHECK_FIRST(repository.find_segment(SnapshotType::bodies, 1'500'013) != nullptr);  // needs full block number in snapshot file names
+        CHECK_FALSE_FIRST(repository.find_segment(SnapshotType::bodies, 1'500'014));
     }
     SECTION("tx w/ index") {
-        CHECK_FALSE(repository.find_segment(SnapshotType::transactions, 1'500'011));
-        // CHECK(repository.find_segment(SnapshotType::transactions, 1'500'012) != nullptr);  // needs full block number in snapshot file names
-        // CHECK(repository.find_segment(SnapshotType::transactions, 1'500'013) != nullptr);  // needs full block number in snapshot file names
-        CHECK_FALSE(repository.find_segment(SnapshotType::transactions, 1'500'014));
+        CHECK_FALSE_FIRST(repository.find_segment(SnapshotType::transactions, 1'500'011));
+        // CHECK_FIRST(repository.find_segment(SnapshotType::transactions, 1'500'012) != nullptr);  // needs full block number in snapshot file names
+        // CHECK_FIRST(repository.find_segment(SnapshotType::transactions, 1'500'013) != nullptr);  // needs full block number in snapshot file names
+        CHECK_FALSE_FIRST(repository.find_segment(SnapshotType::transactions, 1'500'014));
     }
     SECTION("greater than max_block_available") {
-        CHECK_FALSE(repository.find_segment(SnapshotType::bodies, repository.max_block_available() + 1));
+        CHECK_FALSE_FIRST(repository.find_segment(SnapshotType::bodies, repository.max_block_available() + 1));
     }
 }
 

--- a/silkworm/db/transactions/txn_queries.hpp
+++ b/silkworm/db/transactions/txn_queries.hpp
@@ -58,7 +58,8 @@ class TransactionBlockNumByTxnHashRepoQuery {
         : bundles_(std::move(bundles)) {}
 
     std::optional<BlockNum> exec(const Hash& hash) {
-        for (const TBundle& bundle : bundles_) {
+        for (const TBundle& bundle_ptr : bundles_) {
+            const auto& bundle = *bundle_ptr;
             const Snapshot& snapshot = bundle.txn_snapshot;
             const Index& idx_txn_hash = bundle.idx_txn_hash;
             const Index& idx_txn_hash_2_block = bundle.idx_txn_hash_2_block;


### PR DESCRIPTION
depends on https://github.com/erigontech/silkworm/pull/2215

Protect view_bundles and find_segment from threading issues without blocking too much.
The method is similar to the one used for e3 snapshots.

Bundles list is now a shared pointer and follows "copy on write" logic. If multiple readers want to read snapshots, they copy the source shared pointer (increasing a reference count). Modifying the bundles list (e.g. by add_snapshot_bundle) makes a copy. The old list and its iterators will be still usable by the readers from their shared pointers. When all the readers finish, the old list will be destroyed.

view_bundles() returns a BundlesView that holds the bundles list shared pointer for the iteration duration. This ensures that on bundles list modification the iterated list is not destroyed prematurely.

find_segment() additionally returns a bundle shared pointer. A reader must hold it while it operates on a snapshot/index. This ensures that on bundles list modification that snapshot is not closed prematurely.
