### PR TITLE
db: integrate snapshot freezer

### DIFF
--- a/silkworm/db/data_migration.hpp
+++ b/silkworm/db/data_migration.hpp
@@ -18,6 +18,8 @@
 
 #include <memory>
 
+#include <silkworm/infra/concurrency/task.hpp>
+
 #include "data_migration_command.hpp"
 
 namespace silkworm::db {
@@ -29,14 +31,15 @@ struct DataMigrationResult {
 struct DataMigration {
     virtual ~DataMigration() = default;
 
-    void run();
+    Task<bool> exec();
+    Task<void> run_loop();
 
   protected:
     virtual std::unique_ptr<DataMigrationCommand> next_command() = 0;
     virtual std::shared_ptr<DataMigrationResult> migrate(std::unique_ptr<DataMigrationCommand> command) = 0;
     virtual void index(std::shared_ptr<DataMigrationResult> result) = 0;
     virtual void commit(std::shared_ptr<DataMigrationResult> result) = 0;
-    virtual void cleanup() = 0;
+    virtual Task<void> cleanup() = 0;
 };
 
 }  // namespace silkworm::db

--- a/silkworm/db/freezer.hpp
+++ b/silkworm/db/freezer.hpp
@@ -19,6 +19,7 @@
 #include "data_migration.hpp"
 #include "mdbx/mdbx.hpp"
 #include "snapshots/repository.hpp"
+#include "stage_scheduler.hpp"
 
 namespace silkworm::db {
 
@@ -27,9 +28,11 @@ class Freezer : public DataMigration {
     Freezer(
         db::ROAccess db_access,
         snapshots::SnapshotRepository& snapshots,
+        stagedsync::StageScheduler& stage_scheduler,
         std::filesystem::path tmp_dir_path)
         : db_access_(std::move(db_access)),
           snapshots_(snapshots),
+          stage_scheduler_(stage_scheduler),
           tmp_dir_path_(std::move(tmp_dir_path)) {}
 
   private:
@@ -39,11 +42,13 @@ class Freezer : public DataMigration {
     std::shared_ptr<DataMigrationResult> migrate(std::unique_ptr<DataMigrationCommand> command) override;
     void index(std::shared_ptr<DataMigrationResult> result) override;
     void commit(std::shared_ptr<DataMigrationResult> result) override;
-    void cleanup() override;
+    Task<void> cleanup() override;
     BlockNumRange cleanup_range();
+    void cleanup(RWTxn& db_tx, BlockNumRange range);
 
     db::ROAccess db_access_;
     snapshots::SnapshotRepository& snapshots_;
+    stagedsync::StageScheduler& stage_scheduler_;
     std::filesystem::path tmp_dir_path_;
 };
 

--- a/silkworm/db/snapshots/repository.cpp
+++ b/silkworm/db/snapshots/repository.cpp
@@ -170,7 +170,7 @@ void SnapshotRepository::reopen_folder() {
               << " indexes: " << total_indexes_count();
 }
 
-const std::shared_ptr<SnapshotBundle> SnapshotRepository::find_bundle(BlockNum number) const {
+std::shared_ptr<SnapshotBundle> SnapshotRepository::find_bundle(BlockNum number) const {
     // Search for target segment in reverse order (from the newest segment to the oldest one)
     for (const auto& bundle_ptr : this->view_bundles_reverse()) {
         auto& bundle = *bundle_ptr;

--- a/silkworm/db/snapshots/repository.hpp
+++ b/silkworm/db/snapshots/repository.hpp
@@ -106,7 +106,7 @@ class SnapshotRepository {
     [[nodiscard]] std::pair<std::optional<SnapshotAndIndex>, std::shared_ptr<SnapshotBundle>> find_segment(SnapshotType type, BlockNum number) const;
 
   private:
-    const std::shared_ptr<SnapshotBundle> find_bundle(BlockNum number) const;
+    std::shared_ptr<SnapshotBundle> find_bundle(BlockNum number) const;
 
     [[nodiscard]] SnapshotPathList get_segment_files() const {
         return get_files(kSegmentExtension);

--- a/silkworm/db/stage_scheduler.hpp
+++ b/silkworm/db/stage_scheduler.hpp
@@ -1,0 +1,34 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <functional>
+
+#include <silkworm/infra/concurrency/task.hpp>
+
+#include <silkworm/db/mdbx/mdbx.hpp>
+
+namespace silkworm::stagedsync {
+
+struct StageScheduler {
+    virtual ~StageScheduler() = default;
+
+    //! Schedule a task to run inside the stage loop.
+    virtual Task<void> schedule(std::function<Task<void>(db::RWTxn&)> task) = 0;
+};
+
+}  // namespace silkworm::stagedsync

--- a/silkworm/db/stages.hpp
+++ b/silkworm/db/stages.hpp
@@ -67,6 +67,9 @@ inline constexpr const char* kTxLookupKey{"TxLookup"};
 //! \brief Starts Backend
 inline constexpr const char* kTxPoolKey{"TxPool"};
 
+//! \brief Triggers stage
+inline constexpr const char* kTriggersStageKey{"Triggers"};
+
 //! \brief Nominal stage after all other stages
 inline constexpr const char* kFinishKey{"Finish"};
 
@@ -89,6 +92,7 @@ inline constexpr const char* kAllStages[]{
     kCallTracesKey,
     kTxLookupKey,
     kTxPoolKey,
+    kTriggersStageKey,
     kFinishKey,
     kUnwindKey,
 };

--- a/silkworm/node/stagedsync/execution_engine.cpp
+++ b/silkworm/node/stagedsync/execution_engine.cpp
@@ -318,4 +318,8 @@ bool ExecutionEngine::is_canonical(Hash header_hash) const {
     return main_chain_.is_finalized_canonical(header_hash);
 }
 
+StageScheduler& ExecutionEngine::stage_scheduler() const {
+    return main_chain_.stage_scheduler();
+}
+
 }  // namespace silkworm::stagedsync

--- a/silkworm/node/stagedsync/execution_engine.hpp
+++ b/silkworm/node/stagedsync/execution_engine.hpp
@@ -29,6 +29,7 @@
 #include <silkworm/core/common/lru_cache.hpp>
 #include <silkworm/core/types/block.hpp>
 #include <silkworm/db/stage.hpp>
+#include <silkworm/db/stage_scheduler.hpp>
 #include <silkworm/node/stagedsync/execution_pipeline.hpp>
 
 #include "forks/extending_fork.hpp"
@@ -86,6 +87,8 @@ class ExecutionEngine : public Stoppable {
     virtual std::optional<BlockNum> get_block_number(Hash) const;
     virtual std::vector<BlockHeader> get_last_headers(uint64_t limit) const;
     std::optional<TotalDifficulty> get_header_td(Hash, std::optional<BlockNum> = std::nullopt) const;
+
+    StageScheduler& stage_scheduler() const;
 
   protected:
     struct ForkingPath {

--- a/silkworm/node/stagedsync/execution_pipeline.hpp
+++ b/silkworm/node/stagedsync/execution_pipeline.hpp
@@ -22,6 +22,7 @@
 
 #include <silkworm/core/types/hash.hpp>
 #include <silkworm/db/stage.hpp>
+#include <silkworm/db/stage_scheduler.hpp>
 #include <silkworm/node/common/node_settings.hpp>
 
 namespace silkworm::stagedsync {
@@ -41,6 +42,8 @@ class ExecutionPipeline : public Stoppable {
     std::optional<Hash> bad_block();
 
     bool stop() override;
+
+    StageScheduler& stage_scheduler() const;
 
   private:
     silkworm::NodeSettings* node_settings_;

--- a/silkworm/node/stagedsync/forks/main_chain.cpp
+++ b/silkworm/node/stagedsync/forks/main_chain.cpp
@@ -137,6 +137,10 @@ db::RWTxn& MainChain::tx() {
     return tx_;
 }
 
+StageScheduler& MainChain::stage_scheduler() const {
+    return pipeline_.stage_scheduler();
+}
+
 BlockId MainChain::current_head() const {
     return interim_canonical_chain_.current_head();
 }

--- a/silkworm/node/stagedsync/forks/main_chain.hpp
+++ b/silkworm/node/stagedsync/forks/main_chain.hpp
@@ -28,6 +28,7 @@
 #include <silkworm/core/types/block.hpp>
 #include <silkworm/db/mdbx/memory_mutation.hpp>
 #include <silkworm/db/stage.hpp>
+#include <silkworm/db/stage_scheduler.hpp>
 #include <silkworm/node/stagedsync/execution_pipeline.hpp>
 
 #include "canonical_chain.hpp"
@@ -85,6 +86,8 @@ class MainChain {
 
     NodeSettings& node_settings();
     db::RWTxn& tx();  // only for testing purposes due to MDBX limitations
+
+    StageScheduler& stage_scheduler() const;
 
   protected:
     Hash insert_header(const BlockHeader&);

--- a/silkworm/node/stagedsync/stages/stage_triggers.cpp
+++ b/silkworm/node/stagedsync/stages/stage_triggers.cpp
@@ -1,0 +1,59 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "stage_triggers.hpp"
+
+#include <cassert>
+
+#include <boost/asio/this_coro.hpp>
+#include <boost/asio/use_awaitable.hpp>
+#include <gsl/util>
+
+#include <silkworm/infra/concurrency/co_spawn_sw.hpp>
+
+namespace silkworm::stagedsync {
+
+TriggersStage::TriggersStage(SyncContext* sync_context)
+    : Stage(sync_context, db::stages::kTriggersStageKey) {
+}
+
+Stage::Result TriggersStage::forward(db::RWTxn& tx) {
+    current_tx_ = &tx;
+    [[maybe_unused]] auto _ = gsl::finally([this] {
+        current_tx_ = nullptr;
+    });
+
+    io_context_.restart();
+    io_context_.run();
+
+    return Stage::Result::kSuccess;
+}
+
+Task<void> TriggersStage::schedule(std::function<Task<void>(db::RWTxn&)> task) {
+    auto task_caller = [this, t = std::move(task)]() -> Task<void> {
+        db::RWTxn* tx = this->current_tx_;
+        assert(tx);
+        co_await t(*tx);
+    };
+    return concurrency::co_spawn_sw(io_context_, task_caller(), boost::asio::use_awaitable);
+}
+
+bool TriggersStage::stop() {
+    io_context_.stop();
+    return Stage::stop();
+}
+
+}  // namespace silkworm::stagedsync

--- a/silkworm/node/stagedsync/stages/stage_triggers.hpp
+++ b/silkworm/node/stagedsync/stages/stage_triggers.hpp
@@ -1,0 +1,45 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <boost/asio/io_context.hpp>
+
+#include <silkworm/db/stage.hpp>
+#include <silkworm/db/stage_scheduler.hpp>
+
+namespace silkworm::stagedsync {
+
+class TriggersStage : public Stage, public StageScheduler {
+  public:
+    explicit TriggersStage(SyncContext* sync_context);
+    ~TriggersStage() override = default;
+
+    Stage::Result forward(db::RWTxn& tx) override;
+
+    Stage::Result unwind(db::RWTxn&) override { return Stage::Result::kSuccess; }
+    Stage::Result prune(db::RWTxn&) override { return Stage::Result::kSuccess; }
+
+    Task<void> schedule(std::function<Task<void>(db::RWTxn&)> task) override;
+
+    bool stop() override;
+
+  private:
+    boost::asio::io_context io_context_;
+    db::RWTxn* current_tx_{};
+};
+
+}  // namespace silkworm::stagedsync


### PR DESCRIPTION
Run freezer data migration as a part of node tasks.
Freezer cleanup requires an RWTxn.
For that reason, schedule it in the stage loop via a helper TriggersStage.
