### PR TITLE
db: first and last queries in KV local cursor

### DIFF
--- a/silkworm/db/access_layer.cpp
+++ b/silkworm/db/access_layer.cpp
@@ -197,14 +197,6 @@ void delete_header(RWTxn& txn, BlockNum number, const evmc::bytes32& hash) {
     cursor->erase(to_slice(key));
 }
 
-std::optional<ByteView> read_rlp_encoded_header(ROTxn& txn, BlockNum bn, const evmc::bytes32& hash) {
-    auto header_cursor = txn.ro_cursor(db::table::kHeaders);
-    auto key = db::block_key(bn, hash.bytes);
-    auto data = header_cursor->find(db::to_slice(key), /*throw_notfound*/ false);
-    if (!data) return std::nullopt;
-    return db::from_slice(data.value);
-}
-
 std::optional<BlockNum> read_stored_header_number_after(ROTxn& txn, BlockNum min_number) {
     auto cursor = txn.ro_cursor(db::table::kHeaders);
     auto key = db::block_key(min_number);

--- a/silkworm/db/access_layer.hpp
+++ b/silkworm/db/access_layer.hpp
@@ -74,9 +74,6 @@ std::vector<BlockHeader> read_headers(ROTxn& txn, BlockNum height);
 //! \brief Apply a user defined func to the headers at specific height
 size_t process_headers_at_height(ROTxn& txn, BlockNum height, std::function<void(BlockHeader&&)> process_func);
 
-//! \brief Reads a header without rlp-decoding it
-std::optional<ByteView> read_rlp_encoded_header(ROTxn& txn, BlockNum bn, const evmc::bytes32& hash);
-
 //! \brief Reads the canonical head
 std::tuple<BlockNum, evmc::bytes32> read_canonical_head(ROTxn& txn);
 

--- a/silkworm/db/kv/api/cursor.hpp
+++ b/silkworm/db/kv/api/cursor.hpp
@@ -43,6 +43,10 @@ class Cursor {
 
     virtual Task<KeyValue> seek_exact(ByteView key) = 0;
 
+    virtual Task<KeyValue> first() = 0;
+
+    virtual Task<KeyValue> last() = 0;
+
     virtual Task<KeyValue> next() = 0;
 
     virtual Task<KeyValue> previous() = 0;

--- a/silkworm/db/kv/api/local_cursor.hpp
+++ b/silkworm/db/kv/api/local_cursor.hpp
@@ -34,10 +34,7 @@ namespace silkworm::db::kv::api {
 
 class LocalCursor : public CursorDupSort {
   public:
-    explicit LocalCursor(mdbx::txn& txn, uint32_t cursor_id, const std::string& table_name)
-        : cursor_id_{cursor_id},
-          db_cursor_{txn, MapConfig{table_name.c_str()}},
-          txn_{txn} {}
+    LocalCursor(mdbx::txn& txn, uint32_t cursor_id) : cursor_id_{cursor_id}, txn_{txn} {}
 
     [[nodiscard]] uint32_t cursor_id() const override { return cursor_id_; };
 
@@ -46,6 +43,10 @@ class LocalCursor : public CursorDupSort {
     Task<KeyValue> seek(ByteView key) override;
 
     Task<KeyValue> seek_exact(ByteView key) override;
+
+    Task<KeyValue> first() override;
+
+    Task<KeyValue> last() override;
 
     Task<KeyValue> next() override;
 

--- a/silkworm/db/kv/api/local_cursor_test.cpp
+++ b/silkworm/db/kv/api/local_cursor_test.cpp
@@ -1,0 +1,136 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "local_cursor.hpp"
+
+#include <silkworm/infra/concurrency/task.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <silkworm/db/test_util/test_database_context.hpp>
+#include <silkworm/infra/test_util/context_test_base.hpp>
+#include <silkworm/infra/test_util/fixture.hpp>
+
+#include "../../tables.hpp"
+
+namespace silkworm::db::kv::api {
+
+using namespace silkworm::test_util;
+using silkworm::test_util::ContextTestBase;
+using test_util::TestDatabaseContext;
+
+struct LocalCursorTest : public ContextTestBase, TestDatabaseContext {
+    inline static uint32_t last_cursor_id{0};
+};
+
+// In all following tests we need to create the MDBX transaction using the io_context scheduler thread, so we simply
+// wrap the test body into a coroutine lamda run onto the scheduler facility provided by ContextTestBase.
+
+TEST_CASE_METHOD(LocalCursorTest, "LocalCursor::open_cursor", "[db][kv][api][local_cursor]") {
+    spawn_and_wait([&]() -> Task<void> {
+        db::ROTxnManaged txn{mdbx_env()};
+        LocalCursor cursor{txn, ++last_cursor_id};
+
+        CHECK_NOTHROW(co_await cursor.open_cursor(table::kHeadersName, /*is_dup_sorted=*/false));
+        CHECK(cursor.cursor_id() > 0);
+    });
+}
+
+TEST_CASE_METHOD(LocalCursorTest, "LocalCursor::close_cursor", "[db][kv][api][local_cursor]") {
+    spawn_and_wait([&]() -> Task<void> {
+        db::ROTxnManaged txn{mdbx_env()};
+        LocalCursor cursor{txn, ++last_cursor_id};
+        REQUIRE_NOTHROW(co_await cursor.open_cursor(table::kHeadersName, /*is_dup_sorted=*/false));
+        REQUIRE(cursor.cursor_id() > 0);
+
+        CHECK_NOTHROW(co_await cursor.close_cursor());
+        CHECK(cursor.cursor_id() == 0);
+    });
+}
+
+static auto decode_header(ByteView data_view) {
+    BlockHeader header;
+    return rlp::decode(data_view, header);
+}
+
+TEST_CASE_METHOD(LocalCursorTest, "LocalCursor::first", "[db][kv][api][local_cursor]") {
+    spawn_and_wait([&]() -> Task<void> {
+        db::ROTxnManaged txn{mdbx_env()};
+        LocalCursor cursor{txn, ++last_cursor_id};
+        REQUIRE_NOTHROW(co_await cursor.open_cursor(table::kHeadersName, /*is_dup_sorted=*/false));
+
+        KeyValue k_and_v{};
+        CHECK_NOTHROW((k_and_v = co_await cursor.first()));
+        CHECK(k_and_v.key == db::block_key(0, Hash{0x51181a9927eef038d77a7be22d9555af451cfba4bf4fd02e43ea592c1687eb98_bytes32}.bytes));
+        CHECK(decode_header(k_and_v.value));
+
+        REQUIRE_NOTHROW(co_await cursor.close_cursor());
+    });
+}
+
+TEST_CASE_METHOD(LocalCursorTest, "LocalCursor::last", "[db][kv][api][local_cursor]") {
+    spawn_and_wait([&]() -> Task<void> {
+        db::ROTxnManaged txn{mdbx_env()};
+        LocalCursor cursor{txn, ++last_cursor_id};
+        REQUIRE_NOTHROW(co_await cursor.open_cursor(table::kHeadersName, /*is_dup_sorted=*/false));
+
+        KeyValue k_and_v{};
+        CHECK_NOTHROW((k_and_v = co_await cursor.last()));
+        CHECK(k_and_v.key == db::block_key(9, Hash{0x9032fd0afc97b3c5b28fe887051ecb2cc3a3475c102b0aeeaadaebd87d8e1cd3_bytes32}.bytes));
+        CHECK(decode_header(k_and_v.value));
+
+        REQUIRE_NOTHROW(co_await cursor.close_cursor());
+    });
+}
+
+TEST_CASE_METHOD(LocalCursorTest, "LocalCursor::next", "[db][kv][api][local_cursor]") {
+    spawn_and_wait([&]() -> Task<void> {
+        db::ROTxnManaged txn{mdbx_env()};
+        LocalCursor cursor{txn, ++last_cursor_id};
+        REQUIRE_NOTHROW(co_await cursor.open_cursor(table::kHeadersName, /*is_dup_sorted=*/false));
+
+        KeyValue k_and_v{};
+        CHECK_NOTHROW((k_and_v = co_await cursor.next()));
+        CHECK(k_and_v.key == db::block_key(0, Hash{0x51181a9927eef038d77a7be22d9555af451cfba4bf4fd02e43ea592c1687eb98_bytes32}.bytes));
+        CHECK(decode_header(k_and_v.value));
+        CHECK_NOTHROW((k_and_v = co_await cursor.next()));
+        CHECK(k_and_v.key == db::block_key(1, Hash{0x7cb4dd3daba1f739d0c1ec7d998b4a2f6fd83019116455afa54ca4f49dfa0ad4_bytes32}.bytes));
+        CHECK(decode_header(k_and_v.value));
+
+        REQUIRE_NOTHROW(co_await cursor.close_cursor());
+    });
+}
+
+TEST_CASE_METHOD(LocalCursorTest, "LocalCursor::previous", "[db][kv][api][local_cursor]") {
+    spawn_and_wait([&]() -> Task<void> {
+        db::ROTxnManaged txn{mdbx_env()};
+        LocalCursor cursor{txn, ++last_cursor_id};
+        REQUIRE_NOTHROW(co_await cursor.open_cursor(table::kHeadersName, /*is_dup_sorted=*/false));
+
+        KeyValue k_and_v{};
+        CHECK_NOTHROW((k_and_v = co_await cursor.last()));
+        CHECK_NOTHROW((k_and_v = co_await cursor.previous()));
+        CHECK(k_and_v.key == db::block_key(8, Hash{0x3d50efbbad1818ab34b8d2fd272aa0d149225e7c489b9f955b7758ad7c5918df_bytes32}.bytes));
+        CHECK(decode_header(k_and_v.value));
+        CHECK_NOTHROW((k_and_v = co_await cursor.previous()));
+        CHECK(k_and_v.key == db::block_key(7, Hash{0xa5c7bcf72090b64c6f00fae9897096b7f1593358d4915dc30b4e60f13ce6e301_bytes32}.bytes));
+        CHECK(decode_header(k_and_v.value));
+
+        REQUIRE_NOTHROW(co_await cursor.close_cursor());
+    });
+}
+
+}  // namespace silkworm::db::kv::api

--- a/silkworm/db/kv/api/local_transaction.cpp
+++ b/silkworm/db/kv/api/local_transaction.cpp
@@ -50,7 +50,7 @@ Task<std::shared_ptr<CursorDupSort>> LocalTransaction::get_cursor(const std::str
             co_return cursor_it->second;
         }
     }
-    auto cursor = std::make_shared<LocalCursor>(txn_, ++last_cursor_id_, table);
+    auto cursor = std::make_shared<LocalCursor>(txn_, ++last_cursor_id_);
     co_await cursor->open_cursor(table, is_cursor_dup_sort);
     if (is_cursor_dup_sort) {
         dup_cursors_[table] = cursor;

--- a/silkworm/db/kv/grpc/client/remote_cursor.cpp
+++ b/silkworm/db/kv/grpc/client/remote_cursor.cpp
@@ -69,6 +69,30 @@ Task<api::KeyValue> RemoteCursor::seek_exact(ByteView key) {
     co_return api::KeyValue{std::move(k), std::move(v)};
 }
 
+Task<api::KeyValue> RemoteCursor::first() {
+    const auto start_time = clock_time::now();
+    auto next_message = remote::Cursor{};
+    next_message.set_op(remote::Op::FIRST);
+    next_message.set_cursor(cursor_id_);
+    auto first_pair = co_await tx_rpc_.write_and_read(next_message);
+    auto k = string_to_bytes(first_pair.k());
+    auto v = string_to_bytes(first_pair.v());
+    SILK_DEBUG << "RemoteCursor::first k: " << k << " v: " << v << " c=" << cursor_id_ << " t=" << clock_time::since(start_time);
+    co_return api::KeyValue{std::move(k), std::move(v)};
+}
+
+Task<api::KeyValue> RemoteCursor::last() {
+    const auto start_time = clock_time::now();
+    auto next_message = remote::Cursor{};
+    next_message.set_op(remote::Op::LAST);
+    next_message.set_cursor(cursor_id_);
+    auto last_pair = co_await tx_rpc_.write_and_read(next_message);
+    auto k = string_to_bytes(last_pair.k());
+    auto v = string_to_bytes(last_pair.v());
+    SILK_DEBUG << "RemoteCursor::last k: " << k << " v: " << v << " c=" << cursor_id_ << " t=" << clock_time::since(start_time);
+    co_return api::KeyValue{std::move(k), std::move(v)};
+}
+
 Task<api::KeyValue> RemoteCursor::next() {
     const auto start_time = clock_time::now();
     auto next_message = remote::Cursor{};

--- a/silkworm/db/kv/grpc/client/remote_cursor.hpp
+++ b/silkworm/db/kv/grpc/client/remote_cursor.hpp
@@ -44,6 +44,10 @@ class RemoteCursor : public api::CursorDupSort {
 
     Task<api::KeyValue> seek_exact(ByteView key) override;
 
+    Task<api::KeyValue> first() override;
+
+    Task<api::KeyValue> last() override;
+
     Task<api::KeyValue> next() override;
 
     Task<api::KeyValue> previous() override;

--- a/silkworm/db/mdbx/mdbx.cpp
+++ b/silkworm/db/mdbx/mdbx.cpp
@@ -33,6 +33,10 @@ namespace detail {
         return dump;
     }
 
+    std::string slice_as_hex(const db::Slice& data) {
+        return ::mdbx::to_hex(data).as_string();
+    }
+
     log::Args log_args_for_commit_latency(const MDBX_commit_latency& commit_latency) {
         return {
             "preparation",

--- a/silkworm/db/mdbx/mdbx.hpp
+++ b/silkworm/db/mdbx/mdbx.hpp
@@ -72,6 +72,7 @@ namespace detail {
     };
 
     std::string dump_mdbx_result(const db::CursorResult& result);
+    std::string slice_as_hex(const db::Slice& data);
 }  // namespace detail
 
 class ROTxn;

--- a/silkworm/db/test_util/mock_cursor.hpp
+++ b/silkworm/db/test_util/mock_cursor.hpp
@@ -28,6 +28,8 @@ class MockCursor : public kv::api::Cursor {
     MOCK_METHOD((Task<void>), open_cursor, (const std::string& table_name, bool is_dup_sorted));
     MOCK_METHOD((Task<kv::api::KeyValue>), seek, (ByteView key));
     MOCK_METHOD((Task<kv::api::KeyValue>), seek_exact, (ByteView key));
+    MOCK_METHOD((Task<kv::api::KeyValue>), first, ());
+    MOCK_METHOD((Task<kv::api::KeyValue>), last, ());
     MOCK_METHOD((Task<kv::api::KeyValue>), next, ());
     MOCK_METHOD((Task<kv::api::KeyValue>), previous, ());
     MOCK_METHOD((Task<void>), close_cursor, ());
@@ -39,6 +41,8 @@ class MockCursorDupSort : public kv::api::CursorDupSort {
     MOCK_METHOD((Task<void>), open_cursor, (const std::string& table_name, bool is_dup_sorted));
     MOCK_METHOD((Task<kv::api::KeyValue>), seek, (ByteView key));
     MOCK_METHOD((Task<kv::api::KeyValue>), seek_exact, (ByteView key));
+    MOCK_METHOD((Task<kv::api::KeyValue>), first, ());
+    MOCK_METHOD((Task<kv::api::KeyValue>), last, ());
     MOCK_METHOD((Task<kv::api::KeyValue>), next, ());
     MOCK_METHOD((Task<kv::api::KeyValue>), previous, ());
     MOCK_METHOD((Task<kv::api::KeyValue>), next_dup, ());

--- a/silkworm/infra/grpc/test_util/grpc_matcher.hpp
+++ b/silkworm/infra/grpc/test_util/grpc_matcher.hpp
@@ -28,6 +28,10 @@ inline auto exception_has_grpc_status_code(::grpc::StatusCode status_code) {
         [status_code](auto& e) { return std::error_code(e.code()).value() == status_code; });
 }
 
+inline auto exception_has_aborted_grpc_status_code() {
+    return test::exception_has_grpc_status_code(::grpc::StatusCode::ABORTED);
+}
+
 inline auto exception_has_cancelled_grpc_status_code() {
     return test::exception_has_grpc_status_code(::grpc::StatusCode::CANCELLED);
 }

--- a/silkworm/rpc/commands/debug_api_test.cpp
+++ b/silkworm/rpc/commands/debug_api_test.cpp
@@ -102,6 +102,14 @@ class DummyCursor : public CursorDupSort {
         co_return kv;
     }
 
+    Task<KeyValue> first() override {
+        throw std::logic_error{"not implemented"};
+    }
+
+    Task<KeyValue> last() override {
+        throw std::logic_error{"not implemented"};
+    }
+
     Task<KeyValue> next() override {
         KeyValue out;
 

--- a/silkworm/rpc/core/account_dumper_test.cpp
+++ b/silkworm/rpc/core/account_dumper_test.cpp
@@ -97,6 +97,14 @@ class DummyCursor : public CursorDupSort {
         co_return kv;
     }
 
+    Task<KeyValue> first() override {
+        throw std::logic_error{"not implemented"};
+    }
+
+    Task<KeyValue> last() override {
+        throw std::logic_error{"not implemented"};
+    }
+
     Task<KeyValue> next() override {
         KeyValue out;
 

--- a/silkworm/rpc/core/account_walker_test.cpp
+++ b/silkworm/rpc/core/account_walker_test.cpp
@@ -96,6 +96,14 @@ class DummyCursor : public CursorDupSort {
         co_return kv;
     }
 
+    Task<KeyValue> first() override {
+        throw std::logic_error{"not implemented"};
+    }
+
+    Task<KeyValue> last() override {
+        throw std::logic_error{"not implemented"};
+    }
+
     Task<KeyValue> next() override {
         KeyValue out;
 

--- a/silkworm/rpc/core/storage_walker_test.cpp
+++ b/silkworm/rpc/core/storage_walker_test.cpp
@@ -96,6 +96,14 @@ class DummyCursor : public CursorDupSort {
         co_return kv;
     }
 
+    Task<KeyValue> first() override {
+        throw std::logic_error{"not implemented"};
+    }
+
+    Task<KeyValue> last() override {
+        throw std::logic_error{"not implemented"};
+    }
+
     Task<KeyValue> next() override {
         KeyValue out;
 


### PR DESCRIPTION
This PR adds missing `first` and `last` queries in local (i.e. in-process) implementation of `KV` API cursor.

*Extras*
- remove unused `read_rlp_encoded_header` function from DB access layer
- add unit tests for both remote and local cursor implementations
- add `exception_has_aborted_grpc_status_code` test utility