### PR TITLE
db: txn unique numbering over KV API

### DIFF
--- a/silkworm/db/kv/txn_num.cpp
+++ b/silkworm/db/kv/txn_num.cpp
@@ -1,0 +1,82 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "txn_num.hpp"
+
+#include <stdexcept>
+
+#include <silkworm/core/common/endian.hpp>
+
+#include "../tables.hpp"
+
+namespace silkworm::db::txn {
+
+using kv::api::KeyValue;
+using kv::api::Transaction;
+
+static Task<TxNum> last_tx_num_for_block(Transaction& tx, BlockNum block_number) {
+    auto max_tx_num_cursor = co_await tx.cursor(table::kMaxTxNumName);
+    const auto block_number_key = block_key(block_number);
+    auto key_value = co_await max_tx_num_cursor->seek_exact(block_number_key);
+    if (key_value.value.empty()) {
+        key_value = co_await max_tx_num_cursor->last();
+        if (key_value.value.empty()) {
+            co_return 0;
+        }
+    }
+    if (key_value.value.size() != sizeof(TxNum)) {
+        throw std::length_error("Bad TxNum value size " + std::to_string(key_value.value.size()) + " in db");
+    }
+    co_return endian::load_big_u64(key_value.value.data());
+}
+
+static std::pair<BlockNum, TxNum> kv_to_block_num_and_tx_num(const KeyValue& key_value) {
+    if (key_value.key.empty() || key_value.value.empty()) {
+        return std::make_pair(0, 0);
+    }
+    if (key_value.key.size() != sizeof(BlockNum)) {
+        throw std::length_error("Bad BlockNum key size " + std::to_string(key_value.key.size()) + " in db");
+    }
+    if (key_value.value.size() != sizeof(TxNum)) {
+        throw std::length_error("Bad TxNum value size " + std::to_string(key_value.value.size()) + " in db");
+    }
+    return std::make_pair(endian::load_big_u64(key_value.key.data()), endian::load_big_u64(key_value.value.data()));
+}
+
+Task<TxNum> max_tx_num(Transaction& tx, BlockNum block_number) {
+    co_return co_await last_tx_num_for_block(tx, block_number);
+}
+
+Task<TxNum> min_tx_num(Transaction& tx, BlockNum block_number) {
+    if (block_number == 0) {
+        co_return 0;
+    }
+    co_return (co_await last_tx_num_for_block(tx, block_number - 1) + 1);
+}
+
+Task<BlockNumAndTxnNumber> first_tx_num(Transaction& tx) {
+    auto max_tx_num_cursor = co_await tx.cursor(table::kMaxTxNumName);
+    const auto key_value = co_await max_tx_num_cursor->first();
+    co_return kv_to_block_num_and_tx_num(key_value);
+}
+
+Task<BlockNumAndTxnNumber> last_tx_num(Transaction& tx) {
+    auto max_tx_num_cursor = co_await tx.cursor(table::kMaxTxNumName);
+    const auto key_value = co_await max_tx_num_cursor->last();
+    co_return kv_to_block_num_and_tx_num(key_value);
+}
+
+}  // namespace silkworm::db::txn

--- a/silkworm/db/kv/txn_num.hpp
+++ b/silkworm/db/kv/txn_num.hpp
@@ -1,0 +1,47 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <tuple>
+
+#include <silkworm/infra/concurrency/task.hpp>
+
+#include "../kv/api/transaction.hpp"
+
+namespace silkworm::db::txn {
+
+//! TxNum represents the monotonically increasing unique numbering of blockchain transactions in range [0, inf)
+//! TxNum is contiguous (no holes) and canonical, i.e. universal among all client nodes
+//! \see txnum.go in Erigon
+using TxNum = uint64_t;
+
+//! Return the maximum TxNum in specified \code block_number
+Task<TxNum> max_tx_num(kv::api::Transaction& tx, BlockNum block_number);
+
+//! Return the minimum TxNum in specified \code block_number
+Task<TxNum> min_tx_num(kv::api::Transaction& tx, BlockNum block_number);
+
+using BlockNumAndTxnNumber = std::pair<BlockNum, TxNum>;
+
+//! Return the first assigned TxNum
+Task<BlockNumAndTxnNumber> first_tx_num(kv::api::Transaction& tx);
+
+//! Return the last assigned TxNum
+Task<BlockNumAndTxnNumber> last_tx_num(kv::api::Transaction& tx);
+
+}  // namespace silkworm::db::txn

--- a/silkworm/db/kv/txn_num_test.cpp
+++ b/silkworm/db/kv/txn_num_test.cpp
@@ -1,0 +1,147 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "txn_num.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <gmock/gmock.h>
+
+#include <silkworm/db/test_util/mock_cursor.hpp>
+#include <silkworm/db/test_util/mock_transaction.hpp>
+#include <silkworm/infra/test_util/context_test_base.hpp>
+#include <silkworm/infra/test_util/fixture.hpp>
+
+#include "../tables.hpp"
+
+namespace silkworm::db::txn {
+
+using silkworm::test_util::ContextTestBase;
+using silkworm::test_util::Fixtures;
+using test_util::MockCursor;
+using test_util::MockTransaction;
+using testing::_;
+using testing::Invoke;
+using testing::Unused;
+
+struct TxNumText : ContextTestBase {
+    MockTransaction transaction;
+};
+
+TEST_CASE_METHOD(TxNumText, "max_tx_num", "[db][txn][tx_num]") {
+    auto cursor = std::make_shared<MockCursor>();
+    EXPECT_CALL(transaction, cursor(table::kMaxTxNumName)).WillOnce(Invoke([&cursor](Unused) -> Task<std::shared_ptr<kv::api::Cursor>> {
+        co_return cursor;
+    }));
+    struct BlockNumAndKeyValue {
+        BlockNum block_number;
+        kv::api::KeyValue key_value;
+    };
+    const Fixtures<BlockNumAndKeyValue, TxNum> fixtures{
+        {{0, {*from_hex("0000000000000000"), *from_hex("000000000000000A")}}, 10},
+        {{1, {*from_hex("0000000000000001"), *from_hex("000000000000000F")}}, 15},
+    };
+    for (const auto& [block_num_and_kv, expected_max_tx_num] : fixtures) {
+        const auto [block_number, key_value] = block_num_and_kv;
+        SECTION("block_number: " + std::to_string(block_number)) {
+            EXPECT_CALL(*cursor, seek_exact(_)).WillOnce(Invoke([=](Unused) -> Task<kv::api::KeyValue> {
+                co_return key_value;
+            }));
+            CHECK(spawn_and_wait(max_tx_num(transaction, block_number)) == expected_max_tx_num);
+        }
+    }
+}
+
+TEST_CASE_METHOD(TxNumText, "min_tx_num", "[db][txn][tx_num]") {
+    auto cursor = std::make_shared<MockCursor>();
+    struct BlockNumAndKeyValue {
+        BlockNum block_number;
+        kv::api::KeyValue key_value;
+    };
+    const Fixtures<BlockNumAndKeyValue, TxNum> fixtures{
+        {{0, {*from_hex("0000000000000000"), *from_hex("0000000000000000")}}, 0},
+        {{1, {*from_hex("0000000000000000"), *from_hex("000000000000000E")}}, 15},
+    };
+    for (const auto& [block_num_and_kv, expected_max_tx_num] : fixtures) {
+        const auto [block_number, key_value] = block_num_and_kv;
+        SECTION("block_number: " + std::to_string(block_number)) {
+            if (block_number != 0) {
+                EXPECT_CALL(transaction, cursor(table::kMaxTxNumName)).WillOnce(Invoke([&cursor](Unused) -> Task<std::shared_ptr<kv::api::Cursor>> {
+                    co_return cursor;
+                }));
+                EXPECT_CALL(*cursor, seek_exact(_)).WillOnce(Invoke([=](Unused) -> Task<kv::api::KeyValue> {
+                    co_return key_value;
+                }));
+            }
+            CHECK(spawn_and_wait(min_tx_num(transaction, block_number)) == expected_max_tx_num);
+        }
+    }
+}
+
+TEST_CASE_METHOD(TxNumText, "first_tx_num", "[db][txn][tx_num]") {
+    auto cursor = std::make_shared<MockCursor>();
+    const Fixtures<kv::api::KeyValue, std::optional<BlockNumAndTxnNumber>> fixtures{
+        {{*from_hex(""), *from_hex("")}, BlockNumAndTxnNumber{}},
+        {{*from_hex("0000000000000000"), *from_hex("0000000000000001")}, BlockNumAndTxnNumber{0, 1}},
+        {{*from_hex("0000000000000001"), *from_hex("000000000000000E")}, BlockNumAndTxnNumber{1, 14}},
+        {{*from_hex("00000000000000"), *from_hex("000000000000000E")}, std::nullopt},  // wrong key format
+        {{*from_hex("0000000000000001"), *from_hex("00")}, std::nullopt},              // wrong value format
+    };
+    for (size_t i{0}; i < fixtures.size(); ++i) {
+        const auto& [key_value, expected_block_and_txn_num] = fixtures[i];
+        SECTION("sequence: " + std::to_string(i)) {
+            EXPECT_CALL(transaction, cursor(table::kMaxTxNumName)).WillOnce(Invoke([&cursor](Unused) -> Task<std::shared_ptr<kv::api::Cursor>> {
+                co_return cursor;
+            }));
+            EXPECT_CALL(*cursor, first()).WillOnce(Invoke([=]() -> Task<kv::api::KeyValue> {
+                co_return key_value;
+            }));
+            if (expected_block_and_txn_num) {
+                CHECK(spawn_and_wait(first_tx_num(transaction)) == *expected_block_and_txn_num);
+            } else {
+                CHECK_THROWS_AS(spawn_and_wait(first_tx_num(transaction)), std::length_error);
+            }
+        }
+    }
+}
+
+TEST_CASE_METHOD(TxNumText, "last_tx_num", "[db][txn][tx_num]") {
+    auto cursor = std::make_shared<MockCursor>();
+    const Fixtures<kv::api::KeyValue, std::optional<BlockNumAndTxnNumber>> fixtures{
+        {{*from_hex(""), *from_hex("")}, BlockNumAndTxnNumber{}},
+        {{*from_hex("0000000000000000"), *from_hex("0000000000000001")}, BlockNumAndTxnNumber{0, 1}},
+        {{*from_hex("0000000000000001"), *from_hex("000000000000000E")}, BlockNumAndTxnNumber{1, 14}},
+        {{*from_hex("00000000000000"), *from_hex("000000000000000E")}, std::nullopt},  // wrong key format
+        {{*from_hex("0000000000000001"), *from_hex("00")}, std::nullopt},              // wrong value format
+    };
+    for (size_t i{0}; i < fixtures.size(); ++i) {
+        const auto& [key_value, expected_block_and_txn_num] = fixtures[i];
+        SECTION("sequence: " + std::to_string(i)) {
+            EXPECT_CALL(transaction, cursor(table::kMaxTxNumName)).WillOnce(Invoke([&cursor](Unused) -> Task<std::shared_ptr<kv::api::Cursor>> {
+                co_return cursor;
+            }));
+            EXPECT_CALL(*cursor, last()).WillOnce(Invoke([=]() -> Task<kv::api::KeyValue> {
+                co_return key_value;
+            }));
+            if (expected_block_and_txn_num) {
+                CHECK(spawn_and_wait(last_tx_num(transaction)) == *expected_block_and_txn_num);
+            } else {
+                CHECK_THROWS_AS(spawn_and_wait(last_tx_num(transaction)), std::length_error);
+            }
+        }
+    }
+}
+
+}  // namespace silkworm::db::txn

--- a/silkworm/db/tables.hpp
+++ b/silkworm/db/tables.hpp
@@ -360,6 +360,15 @@ inline constexpr db::MapConfig kTxLookup{kTxLookupName};
 inline constexpr const char* kLastForkchoiceName{"LastForkchoice"};
 inline constexpr db::MapConfig kLastForkchoice{kLastForkchoiceName};
 
+//! \brief Hold the maximum canonical transaction number for each block
+//! \verbatim
+//!  key: block_number_u64 (BE)
+//!  value: max_tx_num_in_block_u64 (BE)
+//! \endverbatim
+//! \details In Erigon3: table MaxTxNum storing TxNum (not TxnID). History/Indices are using TxNum (not TxnID).
+inline constexpr const char* kMaxTxNumName{"MaxTxNum"};
+inline constexpr db::MapConfig kMaxTxNum{kMaxTxNumName};
+
 inline constexpr db::MapConfig kChainDataTables[]{
     kAccountChangeSet,
     kAccountHistory,
@@ -386,6 +395,7 @@ inline constexpr db::MapConfig kChainDataTables[]{
     kLogAddressIndex,
     kLogTopicIndex,
     kLogs,
+    kMaxTxNum,
     kMigrations,
     kPlainCodeHash,
     kPlainState,


### PR DESCRIPTION
This PR introduces a basic facility wrapped around `KV` API to read the blockchain transaction (i.e. `txn`) unique numbering by querying `MaxTxNum` table.

See also https://github.com/erigontech/erigon/blob/main/erigon-lib/kv/rawdbv3/txnum.go for reference.