### PR TITLE
style: typedef consistency improvements

### DIFF
--- a/cmd/dev/grpc_toolbox.cpp
+++ b/cmd/dev/grpc_toolbox.cpp
@@ -962,10 +962,10 @@ Task<void> kv_domain_range_query(const std::shared_ptr<db::kv::api::Service>& kv
 }
 
 template <typename Q>
-using TKVQueryFunc = Task<void> (*)(const std::shared_ptr<db::kv::api::Service>&, Q&&, bool);
+using KVQueryFunc = Task<void> (*)(const std::shared_ptr<db::kv::api::Service>&, Q&&, bool);
 
 template <typename Q>
-int execute_temporal_kv_query(const std::string& target, TKVQueryFunc<Q> query_func, Q&& query, const bool verbose) {
+int execute_temporal_kv_query(const std::string& target, KVQueryFunc<Q> query_func, Q&& query, const bool verbose) {
     try {
         ClientContextPool context_pool{1};
         auto& context = context_pool.next_context();

--- a/silkworm/db/snapshots/common/iterator/map_values_view.hpp
+++ b/silkworm/db/snapshots/common/iterator/map_values_view.hpp
@@ -26,17 +26,17 @@ namespace silkworm {
 template <typename TMapKey, typename TMapValue>
 class MapValuesView : std::ranges::view_interface<MapValuesView<TMapKey, TMapValue>> {
   public:
-    using TMap = std::map<TMapKey, TMapValue>;
+    using Map = std::map<TMapKey, TMapValue>;
 
     class Iterator {
       public:
-        using value_type = typename TMap::mapped_type;
-        using iterator_category = std::bidirectional_iterator_tag;
+        using value_type = typename Map::mapped_type;
+        using iterator_category [[maybe_unused]] = std::bidirectional_iterator_tag;
         using difference_type = std::ptrdiff_t;
         using pointer = const value_type*;
         using reference = const value_type&;
 
-        Iterator(typename TMap::const_iterator it) : it_(it) {}
+        Iterator(typename Map::const_iterator it) : it_(it) {}
         Iterator() = default;
 
         reference operator*() const { return it_->second; }
@@ -57,12 +57,12 @@ class MapValuesView : std::ranges::view_interface<MapValuesView<TMapKey, TMapVal
         friend bool operator==(const Iterator& lhs, const Iterator& rhs) = default;
 
       private:
-        typename TMap::const_iterator it_;
+        typename Map::const_iterator it_;
     };
 
     static_assert(std::bidirectional_iterator<Iterator>);
 
-    MapValuesView(const TMap& map)
+    MapValuesView(const Map& map)
         : begin_(Iterator{map.cbegin()}),
           end_(Iterator{map.cend()}) {}
     MapValuesView() = default;

--- a/silkworm/db/snapshots/index_builder.hpp
+++ b/silkworm/db/snapshots/index_builder.hpp
@@ -55,7 +55,7 @@ struct IndexInputDataQuery {
         Iterator(IndexInputDataQuery* query, std::shared_ptr<void> impl, value_type entry)
             : query_(query), impl_(std::move(impl)), entry_(entry) {}
 
-        using iterator_category = std::input_iterator_tag;
+        using iterator_category [[maybe_unused]] = std::input_iterator_tag;
         using difference_type = std::ptrdiff_t;
         using pointer = value_type*;
         using reference = value_type&;

--- a/silkworm/db/snapshots/repository.cpp
+++ b/silkworm/db/snapshots/repository.cpp
@@ -32,7 +32,7 @@ SnapshotRepository::SnapshotRepository(
     std::unique_ptr<SnapshotBundleFactory> bundle_factory)
     : settings_(std::move(settings)),
       bundle_factory_(std::move(bundle_factory)),
-      bundles_(std::make_shared<TBundles>()) {}
+      bundles_(std::make_shared<Bundles>()) {}
 
 SnapshotRepository::~SnapshotRepository() {
     close();
@@ -42,7 +42,7 @@ void SnapshotRepository::add_snapshot_bundle(SnapshotBundle bundle) {
     bundle.reopen();
     std::scoped_lock lock(bundles_mutex_);
     // copy bundles prior to modification
-    auto bundles = std::make_shared<TBundles>(*bundles_);
+    auto bundles = std::make_shared<Bundles>(*bundles_);
     BlockNum block_from = bundle.block_from();
     bundles->insert_or_assign(block_from, std::make_shared<SnapshotBundle>(std::move(bundle)));
     bundles_ = bundles;
@@ -56,7 +56,7 @@ std::size_t SnapshotRepository::bundles_count() const {
 void SnapshotRepository::close() {
     SILK_TRACE << "Close snapshot repository folder: " << settings_.repository_dir.string();
     std::scoped_lock lock(bundles_mutex_);
-    bundles_ = std::make_shared<TBundles>();
+    bundles_ = std::make_shared<Bundles>();
 }
 
 BlockNum SnapshotRepository::max_block_available() const {
@@ -135,7 +135,7 @@ void SnapshotRepository::reopen_folder() {
 
     std::unique_lock lock(bundles_mutex_);
     // copy bundles prior to modification
-    auto bundles = std::make_shared<TBundles>(*bundles_);
+    auto bundles = std::make_shared<Bundles>(*bundles_);
 
     while (groups.contains(num) &&
            (groups[num][false].size() == SnapshotBundle::kSnapshotsCount) &&

--- a/silkworm/db/snapshots/repository.hpp
+++ b/silkworm/db/snapshots/repository.hpp
@@ -74,14 +74,14 @@ class SnapshotRepository {
     [[nodiscard]] std::vector<std::shared_ptr<IndexBuilder>> missing_indexes() const;
     void remove_stale_indexes() const;
 
-    using TBundles = std::map<BlockNum, std::shared_ptr<SnapshotBundle>>;
+    using Bundles = std::map<BlockNum, std::shared_ptr<SnapshotBundle>>;
 
     template <class TBaseView>
     class BundlesView : public std::ranges::view_interface<BundlesView<TBaseView>> {
       public:
         BundlesView(
             TBaseView base_view,
-            std::shared_ptr<TBundles> bundles)
+            std::shared_ptr<Bundles> bundles)
             : base_view_(std::move(base_view)),
               bundles_(std::move(bundles)) {}
 
@@ -90,7 +90,7 @@ class SnapshotRepository {
 
       private:
         TBaseView base_view_;
-        std::shared_ptr<TBundles> bundles_{};
+        std::shared_ptr<Bundles> bundles_{};
     };
 
     auto view_bundles() const {
@@ -127,7 +127,7 @@ class SnapshotRepository {
     std::unique_ptr<SnapshotBundleFactory> bundle_factory_;
 
     //! Full snapshot bundles ordered by block_from
-    std::shared_ptr<TBundles> bundles_;
+    std::shared_ptr<Bundles> bundles_;
     mutable std::mutex bundles_mutex_;
 };
 

--- a/silkworm/db/snapshots/seg/decompressor.hpp
+++ b/silkworm/db/snapshots/seg/decompressor.hpp
@@ -223,7 +223,7 @@ class Decompressor {
 
         //! input_iterator concept boilerplate
 
-        using iterator_category = std::input_iterator_tag;
+        using iterator_category [[maybe_unused]] = std::input_iterator_tag;
         using difference_type = std::ptrdiff_t;
         using value_type = Bytes;
         using pointer = value_type*;

--- a/silkworm/db/snapshots/snapshot_reader.hpp
+++ b/silkworm/db/snapshots/snapshot_reader.hpp
@@ -48,7 +48,7 @@ class Snapshot {
     class Iterator {
       public:
         using value_type = std::shared_ptr<SnapshotWordDeserializer>;
-        using iterator_category = std::input_iterator_tag;
+        using iterator_category [[maybe_unused]] = std::input_iterator_tag;
         using difference_type = std::ptrdiff_t;
         using pointer = value_type*;
         using reference = value_type&;
@@ -121,7 +121,7 @@ class SnapshotReader {
     class Iterator {
       public:
         using value_type = decltype(TWordDeserializer::value);
-        using iterator_category = std::input_iterator_tag;
+        using iterator_category [[maybe_unused]] = std::input_iterator_tag;
         using difference_type = std::ptrdiff_t;
         using pointer = value_type*;
         using reference = value_type&;

--- a/silkworm/db/snapshots/snapshot_writer.hpp
+++ b/silkworm/db/snapshots/snapshot_writer.hpp
@@ -33,7 +33,7 @@ class SnapshotFileWriter {
     class Iterator {
       public:
         using value_type = std::shared_ptr<SnapshotWordSerializer>;
-        using iterator_category = std::output_iterator_tag;
+        using iterator_category [[maybe_unused]] = std::output_iterator_tag;
         using difference_type = std::ptrdiff_t;
         using pointer = void;
         using reference = void;
@@ -86,7 +86,7 @@ class SnapshotWriter {
     class Iterator {
       public:
         using value_type = decltype(TWordSerializer::value);
-        using iterator_category = std::output_iterator_tag;
+        using iterator_category [[maybe_unused]] = std::output_iterator_tag;
         using difference_type = std::ptrdiff_t;
         using pointer = void;
         using reference = void;

--- a/silkworm/db/transactions/txs_and_bodies_query.hpp
+++ b/silkworm/db/transactions/txs_and_bodies_query.hpp
@@ -53,7 +53,7 @@ class TxsAndBodiesQuery {
             ByteView tx_buffer;
         };
 
-        using iterator_category = std::input_iterator_tag;
+        using iterator_category [[maybe_unused]] = std::input_iterator_tag;
         using difference_type = std::ptrdiff_t;
         using pointer = value_type*;
         using reference = value_type&;

--- a/silkworm/rpc/core/filter_storage.hpp
+++ b/silkworm/rpc/core/filter_storage.hpp
@@ -53,7 +53,7 @@ struct FilterEntry {
     std::chrono::system_clock::time_point last_access = std::chrono::system_clock::now();
 };
 
-typedef std::function<std::uint64_t()> Generator;
+using Generator = std::function<std::uint64_t()>;
 
 class FilterStorage {
   public:

--- a/silkworm/rpc/core/gas_price_oracle.hpp
+++ b/silkworm/rpc/core/gas_price_oracle.hpp
@@ -42,7 +42,7 @@ const std::uint8_t kSamples = 3;
 const std::uint8_t kMaxSamples = kCheckBlocks * kSamples;
 const std::uint8_t kPercentile = 60;
 
-typedef std::function<Task<std::shared_ptr<silkworm::BlockWithHash>>(BlockNum)> BlockProvider;
+using BlockProvider = std::function<Task<std::shared_ptr<silkworm::BlockWithHash>>(BlockNum)>;
 
 class GasPriceOracle {
   public:

--- a/silkworm/rpc/types/log.hpp
+++ b/silkworm/rpc/types/log.hpp
@@ -42,7 +42,7 @@ struct Log {
     std::optional<uint64_t> timestamp{std::nullopt};
 };
 
-typedef std::vector<Log> Logs;
+using Logs = std::vector<Log>;
 
 std::ostream& operator<<(std::ostream& out, const Log& log);
 

--- a/silkworm/sentry/api/router/messages_call.hpp
+++ b/silkworm/sentry/api/router/messages_call.hpp
@@ -34,25 +34,25 @@ namespace silkworm::sentry::api::router {
 
 class MessagesCall final {
   public:
-    using TResult = std::shared_ptr<concurrency::Channel<MessageFromPeer>>;
+    using Result = std::shared_ptr<concurrency::Channel<MessageFromPeer>>;
 
     MessagesCall(
         MessageIdSet message_id_filter,
         const boost::asio::any_io_executor& executor)
         : message_id_filter_(std::move(message_id_filter)),
-          result_promise_(std::make_shared<concurrency::AwaitablePromise<TResult>>(executor)),
+          result_promise_(std::make_shared<concurrency::AwaitablePromise<Result>>(executor)),
           unsubscribe_signal_(std::make_shared<concurrency::EventNotifier>(executor)) {}
 
     MessagesCall() = default;
 
     [[nodiscard]] const MessageIdSet& message_id_filter() const { return message_id_filter_; }
 
-    Task<TResult> result() {
+    Task<Result> result() {
         auto future = result_promise_->get_future();
         co_return (co_await future.get_async());
     }
 
-    void set_result(TResult result) {
+    void set_result(Result result) {
         result_promise_->set_value(std::move(result));
     }
 
@@ -62,7 +62,7 @@ class MessagesCall final {
 
   private:
     MessageIdSet message_id_filter_;
-    std::shared_ptr<concurrency::AwaitablePromise<TResult>> result_promise_;
+    std::shared_ptr<concurrency::AwaitablePromise<Result>> result_promise_;
     std::shared_ptr<concurrency::EventNotifier> unsubscribe_signal_;
 };
 

--- a/silkworm/sentry/api/router/peer_events_call.hpp
+++ b/silkworm/sentry/api/router/peer_events_call.hpp
@@ -28,15 +28,15 @@
 namespace silkworm::sentry::api::router {
 
 struct PeerEventsCall {
-    using TResult = std::shared_ptr<concurrency::Channel<PeerEvent>>;
+    using Result = std::shared_ptr<concurrency::Channel<PeerEvent>>;
 
-    std::shared_ptr<concurrency::AwaitablePromise<TResult>> result_promise;
+    std::shared_ptr<concurrency::AwaitablePromise<Result>> result_promise;
     std::shared_ptr<concurrency::EventNotifier> unsubscribe_signal;
 
     PeerEventsCall() = default;
 
     explicit PeerEventsCall(const boost::asio::any_io_executor& executor)
-        : result_promise(std::make_shared<concurrency::AwaitablePromise<TResult>>(executor)),
+        : result_promise(std::make_shared<concurrency::AwaitablePromise<Result>>(executor)),
           unsubscribe_signal(std::make_shared<concurrency::EventNotifier>(executor)) {}
 };
 

--- a/silkworm/sentry/common/random.hpp
+++ b/silkworm/sentry/common/random.hpp
@@ -37,10 +37,10 @@ std::list<T*> random_list_items(std::list<T>& l, size_t max_count) {
     class BackInsertPtrIterator {
       public:
         using iterator_category [[maybe_unused]] = std::output_iterator_tag;
-        using value_type = void;
-        using difference_type = std::ptrdiff_t;
-        using pointer = void;
-        using reference = void;
+        using value_type [[maybe_unused]] = void;
+        using difference_type [[maybe_unused]] = std::ptrdiff_t;
+        using pointer [[maybe_unused]] = void;
+        using reference [[maybe_unused]] = void;
 
         explicit BackInsertPtrIterator(std::list<T*>& container) : container_(&container) {}
 

--- a/silkworm/sentry/common/random.hpp
+++ b/silkworm/sentry/common/random.hpp
@@ -36,11 +36,11 @@ std::list<T*> random_list_items(std::list<T>& l, size_t max_count) {
     // but it inserts pointers to the provided values instead of copying them to the target container
     class BackInsertPtrIterator {
       public:
-        [[maybe_unused]] typedef std::output_iterator_tag iterator_category;
-        [[maybe_unused]] typedef void value_type;
-        [[maybe_unused]] typedef std::ptrdiff_t difference_type;
-        [[maybe_unused]] typedef void pointer;
-        [[maybe_unused]] typedef void reference;
+        using iterator_category [[maybe_unused]] = std::output_iterator_tag;
+        using value_type = void;
+        using difference_type = std::ptrdiff_t;
+        using pointer = void;
+        using reference = void;
 
         explicit BackInsertPtrIterator(std::list<T*>& container) : container_(&container) {}
 

--- a/silkworm/sync/packets/hash_or_number.hpp
+++ b/silkworm/sync/packets/hash_or_number.hpp
@@ -26,7 +26,7 @@
 namespace silkworm {
 
 // HashOrNumber is a variant of Hash and BlockNum
-// It uses struct in place of "using", to obtain a strong typedef and avoid overload resolution ambiguities
+// It uses struct in place of "using", to obtain a strong type and avoid overload resolution ambiguities
 // in the rlp encoding/decoding functions
 struct HashOrNumber : public std::variant<Hash, BlockNum> {};
 


### PR DESCRIPTION
* using instead of typedef
* [[maybe_unused]] for iterator_category
* no T prefix for concrete type aliases