### PR TITLE
db: unify read_canonical_hash/read_canonical_header_hash

### DIFF
--- a/silkworm/db/access_layer.cpp
+++ b/silkworm/db/access_layer.cpp
@@ -208,7 +208,7 @@ std::optional<BlockNum> read_stored_header_number_after(ROTxn& txn, BlockNum min
 }
 
 std::optional<BlockHeader> read_canonical_header(ROTxn& txn, BlockNum b) {  // also known as read-header-by-number
-    std::optional<evmc::bytes32> h = read_canonical_hash(txn, b);
+    std::optional<evmc::bytes32> h = read_canonical_header_hash(txn, b);
     if (!h) {
         return std::nullopt;  // not found
     }
@@ -527,19 +527,19 @@ bool read_body(ROTxn& txn, const evmc::bytes32& h, BlockBody& body) {
 }
 
 bool read_canonical_body(ROTxn& txn, BlockNum block_number, bool read_senders, BlockBody& body) {
-    auto hash = read_canonical_hash(txn, block_number);
+    auto hash = read_canonical_header_hash(txn, block_number);
     if (!hash) return false;
     return read_body(txn, block_number, hash->bytes, read_senders, body);
 }
 
 std::optional<BlockBodyForStorage> read_canonical_body_for_storage(ROTxn& txn, BlockNum height) {
-    auto hash = read_canonical_hash(txn, height);
+    auto hash = read_canonical_header_hash(txn, height);
     if (!hash) return std::nullopt;
     return read_body_for_storage(txn, block_key(height, hash->bytes));
 }
 
 bool read_canonical_block(ROTxn& txn, BlockNum height, Block& block) {
-    std::optional<evmc::bytes32> h = read_canonical_hash(txn, height);
+    std::optional<evmc::bytes32> h = read_canonical_header_hash(txn, height);
     if (!h) return false;
 
     bool present = read_header(txn, *h, height, block.header);
@@ -924,16 +924,6 @@ std::optional<evmc::bytes32> read_head_header_hash(ROTxn& txn) {
     return to_bytes32(from_slice(data.value));
 }
 
-std::optional<evmc::bytes32> read_canonical_hash(ROTxn& txn, BlockNum b) {  // throws db exceptions
-    auto hashes_table = txn.ro_cursor(db::table::kCanonicalHashes);
-    // accessing this table with only b we will get the hash of the canonical block at height b
-    auto key = db::block_key(b);
-    auto data = hashes_table->find(db::to_slice(key), /*throw_notfound*/ false);
-    if (!data) return std::nullopt;  // not found
-    assert(data.value.length() == kHashLength);
-    return to_bytes32(from_slice(data.value));  // copy
-}
-
 void write_canonical_hash(RWTxn& txn, BlockNum b, const evmc::bytes32& hash) {
     Bytes key = db::block_key(b);
     auto skey = db::to_slice(key);
@@ -1100,7 +1090,7 @@ std::optional<BlockHeader> DataModel::read_header(BlockNum block_number) const {
     if (repository_ && block_number <= repository_->max_block_available()) {
         return read_header_from_snapshot(block_number);
     } else {
-        auto hash = db::read_canonical_hash(txn_, block_number);
+        auto hash = db::read_canonical_header_hash(txn_, block_number);
         return db::read_header(txn_, block_number, *hash);
     }
 }
@@ -1169,26 +1159,26 @@ bool DataModel::read_body(const Hash& hash, BlockBody& body) const {
     return false;
 }
 
-std::optional<Hash> DataModel::read_canonical_hash(BlockNum height) const {
-    return db::read_canonical_hash(txn_, height);
+std::optional<Hash> DataModel::read_canonical_header_hash(BlockNum height) const {
+    return db::read_canonical_header_hash(txn_, height);
 }
 
 std::optional<BlockHeader> DataModel::read_canonical_header(BlockNum height) const {
-    const auto canonical_hash{db::read_canonical_hash(txn_, height)};
+    const auto canonical_hash{db::read_canonical_header_hash(txn_, height)};
     if (!canonical_hash) return {};
 
     return read_header(height, *canonical_hash);
 }
 
 bool DataModel::read_canonical_body(BlockNum height, BlockBody& body) const {
-    const auto canonical_hash{db::read_canonical_hash(txn_, height)};
+    const auto canonical_hash{db::read_canonical_header_hash(txn_, height)};
     if (!canonical_hash) return {};
 
     return read_body(*canonical_hash, height, body);
 }
 
 bool DataModel::read_canonical_block(BlockNum height, Block& block) const {
-    const auto canonical_hash{db::read_canonical_hash(txn_, height)};
+    const auto canonical_hash{db::read_canonical_header_hash(txn_, height)};
     if (!canonical_hash) return {};
 
     return read_block(*canonical_hash, height, block);
@@ -1263,7 +1253,7 @@ void DataModel::for_last_n_headers(size_t n, absl::FunctionRef<void(BlockHeader&
 }
 
 bool DataModel::read_block(BlockNum number, bool read_senders, Block& block) const {
-    const auto hash{db::read_canonical_hash(txn_, number)};
+    const auto hash{db::read_canonical_header_hash(txn_, number)};
     if (!hash) {
         return false;
     }

--- a/silkworm/db/access_layer.hpp
+++ b/silkworm/db/access_layer.hpp
@@ -218,9 +218,6 @@ void write_head_header_hash(RWTxn& txn, const evmc::bytes32& hash);
 //! \brief Reads highest header hash from table::kHeadHeader
 std::optional<evmc::bytes32> read_head_header_hash(ROTxn& txn);
 
-//! \brief Reads canonical hash from block number
-std::optional<evmc::bytes32> read_canonical_hash(ROTxn& txn, BlockNum b);
-
 //! \brief Delete a canonical hash associated to a block number
 void delete_canonical_hash(RWTxn& txn, BlockNum b);
 
@@ -318,7 +315,7 @@ class DataModel {
     [[nodiscard]] static std::optional<BlockBodyForStorage> read_body_for_storage_from_snapshot(BlockNum height);
 
     //! Read the canonical block header at specified height
-    [[nodiscard]] std::optional<Hash> read_canonical_hash(BlockNum height) const;
+    [[nodiscard]] std::optional<Hash> read_canonical_header_hash(BlockNum height) const;
 
     //! Read the canonical block header at specified height
     [[nodiscard]] std::optional<BlockHeader> read_canonical_header(BlockNum height) const;

--- a/silkworm/db/blocks/bodies/body_snapshot_freezer.cpp
+++ b/silkworm/db/blocks/bodies/body_snapshot_freezer.cpp
@@ -43,7 +43,7 @@ void BodySnapshotFreezer::copy(ROTxn& txn, const FreezerCommand& command, snapsh
 
 void BodySnapshotFreezer::cleanup(RWTxn& txn, BlockNumRange range) const {
     for (BlockNum i = range.first; i < range.second; i++) {
-        auto hash_opt = read_canonical_hash(txn, i);
+        auto hash_opt = read_canonical_header_hash(txn, i);
         if (!hash_opt) continue;
         auto hash = *hash_opt;
 

--- a/silkworm/db/blocks/headers/header_snapshot_freezer.cpp
+++ b/silkworm/db/blocks/headers/header_snapshot_freezer.cpp
@@ -37,7 +37,7 @@ void HeaderSnapshotFreezer::copy(ROTxn& txn, const FreezerCommand& command, snap
 
 void HeaderSnapshotFreezer::cleanup(RWTxn& txn, BlockNumRange range) const {
     for (BlockNum i = range.first; i < range.second; i++) {
-        auto hash_opt = read_canonical_hash(txn, i);
+        auto hash_opt = read_canonical_header_hash(txn, i);
         if (!hash_opt) continue;
         auto& hash = *hash_opt;
 

--- a/silkworm/db/chain/chain_storage.hpp
+++ b/silkworm/db/chain/chain_storage.hpp
@@ -65,7 +65,7 @@ class ChainStorage {
     virtual Task<bool> read_body(const Hash& hash, BlockBody& body) const = 0;
 
     //! Read the canonical block hash at specified height
-    [[nodiscard]] virtual Task<std::optional<Hash>> read_canonical_hash(BlockNum number) const = 0;
+    [[nodiscard]] virtual Task<std::optional<Hash>> read_canonical_header_hash(BlockNum number) const = 0;
 
     //! Read the canonical block header at specified height
     [[nodiscard]] virtual Task<std::optional<BlockHeader>> read_canonical_header(BlockNum number) const = 0;

--- a/silkworm/db/chain/local_chain_storage.cpp
+++ b/silkworm/db/chain/local_chain_storage.cpp
@@ -89,8 +89,8 @@ Task<bool> LocalChainStorage::read_body(const Hash& hash, BlockBody& body) const
     co_return data_model_.read_body(hash, body);
 }
 
-Task<std::optional<Hash>> LocalChainStorage::read_canonical_hash(BlockNum number) const {
-    co_return data_model_.read_canonical_hash(number);
+Task<std::optional<Hash>> LocalChainStorage::read_canonical_header_hash(BlockNum number) const {
+    co_return data_model_.read_canonical_header_hash(number);
 }
 
 Task<std::optional<BlockHeader>> LocalChainStorage::read_canonical_header(BlockNum number) const {
@@ -122,7 +122,7 @@ Task<bool> LocalChainStorage::read_rlp_transaction(const evmc::bytes32& txn_hash
     if (!block_number) {
         co_return false;
     }
-    auto block_hash = data_model_.read_canonical_hash(*block_number);
+    auto block_hash = data_model_.read_canonical_header_hash(*block_number);
     if (!block_hash) {
         co_return false;
     }

--- a/silkworm/db/chain/local_chain_storage.hpp
+++ b/silkworm/db/chain/local_chain_storage.hpp
@@ -51,7 +51,7 @@ class LocalChainStorage : public ChainStorage {
     Task<bool> read_body(const Hash& hash, BlockNum number, BlockBody& body) const override;
     Task<bool> read_body(const Hash& hash, BlockBody& body) const override;
 
-    [[nodiscard]] Task<std::optional<Hash>> read_canonical_hash(BlockNum number) const override;
+    [[nodiscard]] Task<std::optional<Hash>> read_canonical_header_hash(BlockNum number) const override;
     [[nodiscard]] Task<std::optional<BlockHeader>> read_canonical_header(BlockNum number) const override;
 
     Task<bool> read_canonical_body(BlockNum number, BlockBody& body) const override;

--- a/silkworm/db/chain/remote_chain_storage.cpp
+++ b/silkworm/db/chain/remote_chain_storage.cpp
@@ -124,7 +124,7 @@ Task<bool> RemoteChainStorage::read_body(const Hash& hash, BlockBody& body) cons
     co_return co_await read_body(number, hash.bytes, /*.read_senders=*/false, body);
 }
 
-Task<std::optional<Hash>> RemoteChainStorage::read_canonical_hash(BlockNum number) const {
+Task<std::optional<Hash>> RemoteChainStorage::read_canonical_header_hash(BlockNum number) const {
     co_return co_await read_canonical_block_hash(tx_, number);
 }
 

--- a/silkworm/db/chain/remote_chain_storage.hpp
+++ b/silkworm/db/chain/remote_chain_storage.hpp
@@ -59,7 +59,7 @@ class RemoteChainStorage : public ChainStorage {
     Task<bool> read_body(const Hash& hash, BlockNum number, BlockBody& body) const override;
     Task<bool> read_body(const Hash& hash, BlockBody& body) const override;
 
-    [[nodiscard]] Task<std::optional<Hash>> read_canonical_hash(BlockNum number) const override;
+    [[nodiscard]] Task<std::optional<Hash>> read_canonical_header_hash(BlockNum number) const override;
     [[nodiscard]] Task<std::optional<BlockHeader>> read_canonical_header(BlockNum number) const override;
 
     Task<bool> read_canonical_body(BlockNum number, BlockBody& body) const override;

--- a/silkworm/db/chain_head.cpp
+++ b/silkworm/db/chain_head.cpp
@@ -30,7 +30,7 @@ ChainHead read_chain_head(ROTxn& txn) {
     BlockNum head_height = db::stages::read_stage_progress(txn, db::stages::kBlockBodiesKey);
     chain_head.height = head_height;
 
-    auto head_hash = db::read_canonical_hash(txn, head_height);
+    auto head_hash = db::read_canonical_header_hash(txn, head_height);
     if (head_hash) {
         chain_head.hash = head_hash.value();
     } else {

--- a/silkworm/db/db_utils_test.cpp
+++ b/silkworm/db/db_utils_test.cpp
@@ -66,7 +66,7 @@ TEST_CASE("db access layer addendum") {
 
     SECTION("read/write canonical hash") {
         CHECK_NOTHROW(db::write_canonical_hash(tx, header.number, header.hash()));
-        auto read_hash = db::read_canonical_hash(tx, header.number);
+        auto read_hash = db::read_canonical_header_hash(tx, header.number);
 
         REQUIRE(read_hash != std::nullopt);   // Warning: this is a limited test, we only test that
         REQUIRE(read_hash == header.hash());  // read and write are implemented in a symmetric way
@@ -92,7 +92,7 @@ TEST_CASE("db access layer addendum") {
         REQUIRE_NOTHROW(db::write_canonical_hash(tx, header.number, header.hash()));
         REQUIRE_NOTHROW(db::delete_canonical_hash(tx, header.number));
 
-        auto read_hash = db::read_canonical_hash(tx, header.number);
+        auto read_hash = db::read_canonical_header_hash(tx, header.number);
 
         REQUIRE(read_hash == std::nullopt);
     }

--- a/silkworm/db/snapshot_sync.cpp
+++ b/silkworm/db/snapshot_sync.cpp
@@ -281,7 +281,7 @@ void SnapshotSync::update_block_headers(db::RWTxn& txn, BlockNum max_block_avail
     SILK_INFO << "SnapshotSync: database table HeaderNumbers updated";
 
     // Update head block header in kHeadHeader table
-    const auto canonical_hash{db::read_canonical_hash(txn, max_block_available)};
+    const auto canonical_hash{db::read_canonical_header_hash(txn, max_block_available)};
     ensure(canonical_hash.has_value(), "SnapshotSync::save no canonical head hash found");
     db::write_head_header_hash(txn, *canonical_hash);
     SILK_INFO << "SnapshotSync: database table HeadHeader updated";

--- a/silkworm/db/snapshot_sync_test.cpp
+++ b/silkworm/db/snapshot_sync_test.cpp
@@ -163,7 +163,7 @@ TEST_CASE("SnapshotSync::update_block_headers", "[db][snapshot][sync]") {
         return block_number == expected_block_number;
     };
     auto block_is_canonical = [&](BlockNum block_number, Hash expected_block_hash) {
-        const auto canonical_block_hash = db::read_canonical_hash(tmp_db.rw_txn(), block_number);
+        const auto canonical_block_hash = db::read_canonical_header_hash(tmp_db.rw_txn(), block_number);
         return canonical_block_hash == expected_block_hash;
     };
 

--- a/silkworm/db/state/local_state.cpp
+++ b/silkworm/db/state/local_state.cpp
@@ -68,7 +68,7 @@ BlockNum LocalState::current_canonical_block() const {
 
 std::optional<evmc::bytes32> LocalState::canonical_hash(BlockNum block_number) const {
     // This method should not be called by EVM::execute
-    return data_model_.read_canonical_hash(block_number);
+    return data_model_.read_canonical_header_hash(block_number);
 }
 
 }  // namespace silkworm::db::state

--- a/silkworm/db/state/remote_state.cpp
+++ b/silkworm/db/state/remote_state.cpp
@@ -77,7 +77,7 @@ Task<BlockNum> AsyncRemoteState::current_canonical_block() const {
 
 Task<std::optional<evmc::bytes32>> AsyncRemoteState::canonical_hash(BlockNum block_number) const {
     // This method should not be called by EVM::execute
-    co_return co_await storage_.read_canonical_hash(block_number);
+    co_return co_await storage_.read_canonical_header_hash(block_number);
 }
 
 std::optional<Account> RemoteState::read_account(const evmc::address& address) const noexcept {

--- a/silkworm/db/state/remote_state_test.cpp
+++ b/silkworm/db/state/remote_state_test.cpp
@@ -361,7 +361,7 @@ TEST_CASE_METHOD(RemoteStateTest, "async remote buffer", "[rpc][core][remote_buf
                 co_return Bytes{};
             }));
         const BlockNum block_number = 1'000'000;
-        EXPECT_CALL(chain_storage, read_canonical_hash(block_number))
+        EXPECT_CALL(chain_storage, read_canonical_header_hash(block_number))
             .WillOnce(Invoke([](Unused) -> Task<std::optional<Hash>> { co_return std::nullopt; }));
         AsyncRemoteState state{transaction, chain_storage, block_number};
         const auto canonical_hash{spawn_and_wait(state.canonical_hash(block_number))};

--- a/silkworm/db/test_util/mock_chain_storage.hpp
+++ b/silkworm/db/test_util/mock_chain_storage.hpp
@@ -53,7 +53,7 @@ class MockChainStorage : public chain::ChainStorage {
     MOCK_METHOD((Task<bool>), read_body, (const Hash&, BlockNum, silkworm::BlockBody&), (const override));
     MOCK_METHOD((Task<bool>), read_body, (const Hash&, silkworm::BlockBody&), (const override));
 
-    MOCK_METHOD((Task<std::optional<Hash>>), read_canonical_hash, (BlockNum), (const override));
+    MOCK_METHOD((Task<std::optional<Hash>>), read_canonical_header_hash, (BlockNum), (const override));
 
     MOCK_METHOD((Task<std::optional<BlockHeader>>), read_canonical_header, (BlockNum), (const override));
 

--- a/silkworm/db/transactions/txn_snapshot_freezer.cpp
+++ b/silkworm/db/transactions/txn_snapshot_freezer.cpp
@@ -45,7 +45,7 @@ void TransactionSnapshotFreezer::copy(ROTxn& txn, const FreezerCommand& command,
 
 void TransactionSnapshotFreezer::cleanup(RWTxn& txn, BlockNumRange range) const {
     for (BlockNum i = range.first; i < range.second; i++) {
-        auto hash_opt = read_canonical_hash(txn, i);
+        auto hash_opt = read_canonical_header_hash(txn, i);
         if (!hash_opt) continue;
         auto hash = *hash_opt;
 

--- a/silkworm/node/stagedsync/execution_engine_test.cpp
+++ b/silkworm/node/stagedsync/execution_engine_test.cpp
@@ -812,7 +812,7 @@ TEST_CASE("ExecutionEngine") {
 
     auto& tx = exec_engine.main_chain_.tx();  // mdbx refuses to open a ROTxn when there is a RWTxn in the same thread
 
-    auto header0_hash = db::read_canonical_hash(tx, 0);
+    auto header0_hash = db::read_canonical_header_hash(tx, 0);
     REQUIRE(header0_hash.has_value());
 
     auto header0 = db::read_canonical_header(tx, 0);

--- a/silkworm/node/stagedsync/forks/canonical_chain.cpp
+++ b/silkworm/node/stagedsync/forks/canonical_chain.cpp
@@ -174,7 +174,7 @@ void CanonicalChain::delete_down_to(BlockNum unwind_point) {
 std::optional<Hash> CanonicalChain::get_hash(BlockNum height) const {
     auto canon_hash = canonical_hash_cache_->get_as_copy(height);  // look in the cache first
     if (!canon_hash) {
-        canon_hash = db::read_canonical_header_hash(tx_, height);                // then look in the db
+        canon_hash = db::read_canonical_header_hash(tx_, height);         // then look in the db
         if (canon_hash) canonical_hash_cache_->put(height, *canon_hash);  // and cache it
     }
     return canon_hash;

--- a/silkworm/node/stagedsync/forks/canonical_chain.cpp
+++ b/silkworm/node/stagedsync/forks/canonical_chain.cpp
@@ -131,7 +131,7 @@ void CanonicalChain::update_up_to(BlockNum height, Hash hash) {  // hash can be 
     auto ancestor_hash = hash;
     auto ancestor_height = height;
 
-    std::optional<Hash> persisted_canon_hash = db::read_canonical_hash(tx_, ancestor_height);
+    std::optional<Hash> persisted_canon_hash = db::read_canonical_header_hash(tx_, ancestor_height);
     // while (persisted_canon_hash != ancestor_hash) { // better but gcc12 release erroneously raises a maybe-uninitialized warn
     while (!persisted_canon_hash ||
            std::memcmp(persisted_canon_hash.value().bytes, ancestor_hash.bytes, kHashLength) != 0) {
@@ -146,7 +146,7 @@ void CanonicalChain::update_up_to(BlockNum height, Hash hash) {  // hash can be 
         ancestor_hash = ancestor->parent_hash;
         --ancestor_height;
 
-        persisted_canon_hash = db::read_canonical_hash(tx_, ancestor_height);
+        persisted_canon_hash = db::read_canonical_header_hash(tx_, ancestor_height);
     }
 
     current_head_.number = height;
@@ -160,7 +160,7 @@ void CanonicalChain::delete_down_to(BlockNum unwind_point) {
     }
 
     current_head_.number = unwind_point;
-    auto current_head_hash = db::read_canonical_hash(tx_, unwind_point);
+    auto current_head_hash = db::read_canonical_header_hash(tx_, unwind_point);
     ensure_invariant(current_head_hash.has_value(),
                      [&]() { return "hash not found on canonical at height " + std::to_string(unwind_point); });
 
@@ -174,7 +174,7 @@ void CanonicalChain::delete_down_to(BlockNum unwind_point) {
 std::optional<Hash> CanonicalChain::get_hash(BlockNum height) const {
     auto canon_hash = canonical_hash_cache_->get_as_copy(height);  // look in the cache first
     if (!canon_hash) {
-        canon_hash = db::read_canonical_hash(tx_, height);                // then look in the db
+        canon_hash = db::read_canonical_header_hash(tx_, height);                // then look in the db
         if (canon_hash) canonical_hash_cache_->put(height, *canon_hash);  // and cache it
     }
     return canon_hash;

--- a/silkworm/node/stagedsync/forks/fork_test.cpp
+++ b/silkworm/node/stagedsync/forks/fork_test.cpp
@@ -70,7 +70,7 @@ TEST_CASE("Fork") {
     main_chain.open();
     auto& tx = main_chain.tx();
 
-    auto header0_hash = db::read_canonical_hash(tx, 0);
+    auto header0_hash = db::read_canonical_header_hash(tx, 0);
     REQUIRE(header0_hash.has_value());
 
     auto header0 = db::read_canonical_header(tx, 0);

--- a/silkworm/node/stagedsync/forks/main_chain.cpp
+++ b/silkworm/node/stagedsync/forks/main_chain.cpp
@@ -362,7 +362,7 @@ std::set<Hash> MainChain::collect_bad_headers(db::RWTxn& tx, InvalidChain& inval
     std::set<Hash> bad_headers;
     for (BlockNum current_height = interim_canonical_chain_.current_head().number;
          current_height > invalid_chain.unwind_point.number; current_height--) {
-        auto current_hash = db::read_canonical_hash(tx, current_height);
+        auto current_hash = db::read_canonical_header_hash(tx, current_height);
         bad_headers.insert(*current_hash);
     }
 
@@ -375,7 +375,7 @@ std::set<Hash> MainChain::collect_bad_headers(db::RWTxn& tx, InvalidChain& inval
 
         if (max_block_num == 0) {
             max_block_num = unwind_point;
-            max_hash = *db::read_canonical_hash(tx, max_block_num);
+            max_hash = *db::read_canonical_header_hash(tx, max_block_num);
         }
 
         db::write_head_header_hash(tx, max_hash);

--- a/silkworm/node/stagedsync/forks/main_chain_test.cpp
+++ b/silkworm/node/stagedsync/forks/main_chain_test.cpp
@@ -165,7 +165,7 @@ TEST_CASE("MainChain") {
 
     auto& tx = main_chain.tx();
 
-    auto header0_hash = db::read_canonical_hash(tx, 0);
+    auto header0_hash = db::read_canonical_header_hash(tx, 0);
     REQUIRE(header0_hash.has_value());
 
     auto header0 = db::read_canonical_header(tx, 0);

--- a/silkworm/node/stagedsync/stages/stage_bodies_test.cpp
+++ b/silkworm/node/stagedsync/stages/stage_bodies_test.cpp
@@ -49,7 +49,7 @@ TEST_CASE("BodiesStage - data model") {
     SECTION("one invalid body after the genesis") {
         db::RWTxnManaged tx(context.env());
 
-        auto header0_hash = db::read_canonical_hash(tx, 0);
+        auto header0_hash = db::read_canonical_header_hash(tx, 0);
         REQUIRE(header0_hash.has_value());
 
         auto header0 = db::read_canonical_header(tx, 0);
@@ -84,7 +84,7 @@ TEST_CASE("BodiesStage - data model") {
     SECTION("one valid body after the genesis") {
         db::RWTxnManaged tx(context.env());
 
-        auto header0_hash = db::read_canonical_hash(tx, 0);
+        auto header0_hash = db::read_canonical_header_hash(tx, 0);
         REQUIRE(header0_hash.has_value());
 
         auto header0 = db::read_canonical_header(tx, 0);

--- a/silkworm/node/stagedsync/stages/stage_headers.cpp
+++ b/silkworm/node/stagedsync/stages/stage_headers.cpp
@@ -32,7 +32,7 @@ namespace silkworm::stagedsync {
 
 HeadersStage::HeaderDataModel::HeaderDataModel(db::RWTxn& tx, BlockNum headers_height)
     : tx_(tx), data_model_(tx), previous_height_(headers_height) {
-    auto headers_hash = db::read_canonical_hash(tx, headers_height);
+    auto headers_hash = db::read_canonical_header_hash(tx, headers_height);
     ensure(headers_hash.has_value(),
            [&]() { return "Headers stage, inconsistent canonical table: not found hash at height " + std::to_string(headers_height); });
 
@@ -72,7 +72,7 @@ void HeadersStage::HeaderDataModel::update_tables(const BlockHeader& header) {
 }
 
 void HeadersStage::HeaderDataModel::remove_headers(BlockNum unwind_point, db::RWTxn& tx) {
-    auto canonical_hash = db::read_canonical_hash(tx, unwind_point);
+    auto canonical_hash = db::read_canonical_header_hash(tx, unwind_point);
     ensure(canonical_hash.has_value(), [&]() { return "Headers stage, expected canonical hash at height " + std::to_string(unwind_point); });
 
     db::write_head_header_hash(tx, *canonical_hash);

--- a/silkworm/node/stagedsync/stages/stage_headers_test.cpp
+++ b/silkworm/node/stagedsync/stages/stage_headers_test.cpp
@@ -44,7 +44,7 @@ TEST_CASE("HeadersStage - data model") {
     SECTION("one header after the genesis") {
         db::RWTxnManaged tx(context.env());
 
-        auto header0_hash = db::read_canonical_hash(tx, 0);
+        auto header0_hash = db::read_canonical_header_hash(tx, 0);
         REQUIRE(header0_hash.has_value());
 
         auto header0 = db::read_canonical_header(tx, 0);

--- a/silkworm/node/stagedsync/stages/stage_senders.cpp
+++ b/silkworm/node/stagedsync/stages/stage_senders.cpp
@@ -301,7 +301,7 @@ Stage::Result Senders::parallel_recover(db::RWTxn& txn) {
 
         // Start from first block and read all in sequence
         for (auto current_block_num = start_block_num; current_block_num <= target_block_num; ++current_block_num) {
-            auto current_hash = db::read_canonical_hash(txn, current_block_num);
+            auto current_hash = db::read_canonical_header_hash(txn, current_block_num);
             if (!current_hash) throw StageError(Stage::Result::kBadChainSequence,
                                                 "Canonical hash at height " + std::to_string(current_block_num) + " not found");
             BlockBody block_body;

--- a/silkworm/node/stagedsync/stages/stage_tx_lookup.cpp
+++ b/silkworm/node/stagedsync/stages/stage_tx_lookup.cpp
@@ -344,7 +344,7 @@ void TxLookup::collect_transaction_hashes_from_canonical_bodies(db::RWTxn& txn,
     Bytes etl_value{};
 
     for (BlockNum current_block_num = start_block_num; current_block_num <= target_block_num; ++current_block_num) {
-        auto current_hash = db::read_canonical_hash(txn, current_block_num);
+        auto current_hash = db::read_canonical_header_hash(txn, current_block_num);
         if (!current_hash) throw StageError(Stage::Result::kBadChainSequence,
                                             "Canonical hash at height " + std::to_string(current_block_num) + " not found");
         std::vector<Bytes> rlp_encoded_txs;

--- a/silkworm/rpc/commands/debug_api.cpp
+++ b/silkworm/rpc/commands/debug_api.cpp
@@ -707,7 +707,7 @@ Task<void> DebugRpcApi::handle_debug_get_raw_header(const nlohmann::json& reques
     try {
         const auto chain_storage = tx->create_storage();
         const auto block_number = co_await core::get_block_number(block_id, *tx);
-        const auto block_hash = co_await chain_storage->read_canonical_hash(block_number);
+        const auto block_hash = co_await chain_storage->read_canonical_header_hash(block_number);
         const auto header = co_await chain_storage->read_header(block_number, block_hash->bytes);
         if (!header) {
             throw std::invalid_argument("header " + std::to_string(block_number) + " not found");

--- a/silkworm/rpc/core/cached_chain.cpp
+++ b/silkworm/rpc/core/cached_chain.cpp
@@ -21,7 +21,7 @@
 namespace silkworm::rpc::core {
 
 Task<std::shared_ptr<BlockWithHash>> read_block_by_number(BlockCache& cache, const db::chain::ChainStorage& storage, BlockNum block_number) {
-    const auto block_hash = co_await storage.read_canonical_hash(block_number);
+    const auto block_hash = co_await storage.read_canonical_header_hash(block_number);
     if (!block_hash) {
         co_return nullptr;
     }

--- a/silkworm/sync/internals/header_chain_plus_exec_test.cpp
+++ b/silkworm/sync/internals/header_chain_plus_exec_test.cpp
@@ -211,8 +211,8 @@ TEST_CASE("Headers receiving and saving") {
 
         REQUIRE(db::read_total_difficulty(tx, 2, header2.hash()) == expected_td);
 
-        REQUIRE(db::read_canonical_hash(tx, 1) == header1_hash);
-        REQUIRE(db::read_canonical_hash(tx, 2) == header2_hash);
+        REQUIRE(db::read_canonical_header_hash(tx, 1) == header1_hash);
+        REQUIRE(db::read_canonical_header_hash(tx, 2) == header2_hash);
 
         // update the fork choice
         exec_engine.notify_fork_choice_update(header2_hash, {}, {});
@@ -329,8 +329,8 @@ TEST_CASE("Headers receiving and saving") {
 
         REQUIRE(db::read_total_difficulty(tx, 2, header2.hash()) == expected_td);
 
-        REQUIRE(db::read_canonical_hash(tx, 1) == header1_hash);
-        REQUIRE(db::read_canonical_hash(tx, 2) == header2_hash);
+        REQUIRE(db::read_canonical_header_hash(tx, 1) == header1_hash);
+        REQUIRE(db::read_canonical_header_hash(tx, 2) == header2_hash);
 
         // update the fork choice
         exec_engine.notify_fork_choice_update(header2_hash, {}, {});
@@ -452,8 +452,8 @@ TEST_CASE("Headers receiving and saving") {
         REQUIRE(db::read_total_difficulty(tx, 1, header1b.hash()) == new_expected_td);
         REQUIRE(db::read_total_difficulty(tx, 2, header2.hash()) == expected_td);
 
-        REQUIRE(db::read_canonical_hash(tx, 1) == header1b_hash);
-        REQUIRE(db::read_canonical_hash(tx, 2).has_value() == false);
+        REQUIRE(db::read_canonical_header_hash(tx, 1) == header1b_hash);
+        REQUIRE(db::read_canonical_header_hash(tx, 2).has_value() == false);
 
         REQUIRE(db::read_canonical_head(tx) == std::make_tuple(1, header1b_hash));
 
@@ -576,8 +576,8 @@ TEST_CASE("Headers receiving and saving") {
         REQUIRE(db::read_head_header_hash(tx) == header2_hash);
         REQUIRE(db::read_total_difficulty(tx, 2, header2.hash()) == expected_td_bis);
 
-        REQUIRE(db::read_canonical_hash(tx, 1) == header1_hash);
-        REQUIRE(db::read_canonical_hash(tx, 2) == header2_hash);
+        REQUIRE(db::read_canonical_header_hash(tx, 1) == header1_hash);
+        REQUIRE(db::read_canonical_header_hash(tx, 2) == header2_hash);
 
         REQUIRE(db::read_canonical_head(tx) == std::make_tuple(2, header2_hash));
 

--- a/silkworm/sync/internals/header_retrieval.cpp
+++ b/silkworm/sync/internals/header_retrieval.cpp
@@ -126,9 +126,9 @@ std::tuple<Hash, BlockNum> HeaderRetrieval::get_ancestor(Hash hash, BlockNum blo
     }
 
     while (ancestor_delta != 0) {
-        auto h = db::read_canonical_hash(db_tx_, block_num);
+        auto h = db::read_canonical_header_hash(db_tx_, block_num);
         if (h == hash) {
-            auto ancestorHash = db::read_canonical_hash(db_tx_, block_num - ancestor_delta);
+            auto ancestorHash = db::read_canonical_header_hash(db_tx_, block_num - ancestor_delta);
             if (!ancestorHash)
                 return {Hash{}, 0};
             else


### PR DESCRIPTION
The two functions `read_canonical_header_hash` and `read_canonical_hash` were almost identical and the usage of latter has been replaced with the former one.