### PR TITLE
core: fix decoding account from E3 encoded storage

### DIFF
--- a/silkworm/core/types/account.cpp
+++ b/silkworm/core/types/account.cpp
@@ -192,6 +192,9 @@ tl::expected<Account, DecodingError> Account::from_encoded_storage_v3(ByteView e
                 intx::unreachable();
         }
         pos += len;
+        if (pos >= encoded_payload.length() && i < 3) {
+            return tl::unexpected{DecodingError::kInputTooShort};
+        }
     }
 
     return a;


### PR DESCRIPTION
This PR fixes the unit test failures happening on master branch after merging #2251