### PR TITLE
db: db_toolbox freeze fixes

### DIFF
--- a/cmd/dev/CMakeLists.txt
+++ b/cmd/dev/CMakeLists.txt
@@ -74,4 +74,4 @@ add_executable(snapshots snapshots.cpp)
 target_link_libraries(snapshots PRIVATE silkworm_node cmd_common torrent-rasterbar magic_enum::magic_enum)
 
 add_executable(db_toolbox db_toolbox.cpp)
-target_link_libraries(db_toolbox PRIVATE silkworm_node CLI11::CLI11 magic_enum::magic_enum)
+target_link_libraries(db_toolbox PRIVATE silkworm_node cmd_common CLI11::CLI11 magic_enum::magic_enum)

--- a/cmd/dev/db_toolbox.cpp
+++ b/cmd/dev/db_toolbox.cpp
@@ -63,6 +63,8 @@
 #include <silkworm/node/stagedsync/execution_pipeline.hpp>
 #include <silkworm/node/stagedsync/stages/stage_interhashes/trie_cursor.hpp>
 
+#include "../common/common.hpp"
+
 namespace fs = std::filesystem;
 using namespace silkworm;
 
@@ -2239,6 +2241,8 @@ int main(int argc, char* argv[]) {
     auto app_yes_opt = app_main.add_flag("-Y,--yes", "Assume yes to all requests of confirmation");
     auto app_dry_opt = app_main.add_flag("--dry", "Don't commit to db. Only simulate");
 
+    cmd::common::add_logging_options(app_main, log_settings);
+
     /*
      * Subcommands
      */
@@ -2404,6 +2408,8 @@ int main(int argc, char* argv[]) {
     };
 
     try {
+        log::init(log_settings);
+
         // Set origin data_dir
         DataDirectory data_dir{data_dir_factory()};
 

--- a/cmd/dev/db_toolbox.cpp
+++ b/cmd/dev/db_toolbox.cpp
@@ -2186,7 +2186,6 @@ void do_freeze(db::EnvConfig& config, const DataDirectory& data_dir) {
             co_await concurrency::spawn_task(io_context_, [this, c = std::move(callback)]() -> Task<void> {
                 auto tx = this->db_access_.start_rw_tx();
                 c(tx);
-                tx.commit_and_stop();
                 co_return;
             });
         }

--- a/cmd/dev/db_toolbox.cpp
+++ b/cmd/dev/db_toolbox.cpp
@@ -2201,11 +2201,13 @@ void do_freeze(db::EnvConfig& config, const DataDirectory& data_dir) {
     settings.no_downloader = true;
     auto bundle_factory = std::make_unique<silkworm::db::SnapshotBundleFactoryImpl>();
     snapshots::SnapshotRepository repository{std::move(settings), std::move(bundle_factory)};  // NOLINT(cppcoreguidelines-slicing)
+    repository.reopen_folder();
 
     db::Freezer freezer{db::ROAccess{env}, repository, stage_scheduler, data_dir.temp().path()};
 
     test_util::TaskRunner runner;
     runner.run(freezer.exec() || stage_scheduler.async_run("StageSchedulerAdapter"));
+    stage_scheduler.stop();
 }
 
 int main(int argc, char* argv[]) {

--- a/cmd/dev/db_toolbox.cpp
+++ b/cmd/dev/db_toolbox.cpp
@@ -2202,6 +2202,7 @@ void do_freeze(db::EnvConfig& config, const DataDirectory& data_dir) {
     auto bundle_factory = std::make_unique<silkworm::db::SnapshotBundleFactoryImpl>();
     snapshots::SnapshotRepository repository{std::move(settings), std::move(bundle_factory)};  // NOLINT(cppcoreguidelines-slicing)
     repository.reopen_folder();
+    db::DataModel::set_snapshot_repository(&repository);
 
     db::Freezer freezer{db::ROAccess{env}, repository, stage_scheduler, data_dir.temp().path()};
 

--- a/cmd/dev/db_toolbox.cpp
+++ b/cmd/dev/db_toolbox.cpp
@@ -2186,6 +2186,7 @@ void do_freeze(db::EnvConfig& config, const DataDirectory& data_dir) {
             co_await concurrency::spawn_task(io_context_, [this, c = std::move(callback)]() -> Task<void> {
                 auto tx = this->db_access_.start_rw_tx();
                 c(tx);
+                tx.commit_and_stop();
                 co_return;
             });
         }

--- a/silkworm/db/access_layer.cpp
+++ b/silkworm/db/access_layer.cpp
@@ -200,7 +200,7 @@ void delete_header(RWTxn& txn, BlockNum number, const evmc::bytes32& hash) {
 std::optional<BlockNum> read_stored_header_number_after(ROTxn& txn, BlockNum min_number) {
     auto cursor = txn.ro_cursor(db::table::kHeaders);
     auto key = db::block_key(min_number);
-    auto result = cursor->find(db::to_slice(key), /* throw_notfound = */ false);
+    auto result = cursor->lower_bound(db::to_slice(key), /* throw_notfound = */ false);
     if (!result) {
         return std::nullopt;
     }

--- a/silkworm/db/access_layer.cpp
+++ b/silkworm/db/access_layer.cpp
@@ -393,6 +393,7 @@ void delete_transactions(RWTxn& txn, uint64_t base_id, uint64_t count) {
     auto first_key = db::block_key(base_id);
     auto result = cursor->find(to_slice(first_key), /* throw_notfound = */ false);
     for (uint64_t i = 0; result && (i < count); result = cursor->to_next(/* throw_notfound = */ false), i++) {
+        log::Debug("delete_transactions") << "deleting " << (base_id + i);
         cursor->erase();
     }
 }

--- a/silkworm/db/access_layer.cpp
+++ b/silkworm/db/access_layer.cpp
@@ -393,7 +393,6 @@ void delete_transactions(RWTxn& txn, uint64_t base_id, uint64_t count) {
     auto first_key = db::block_key(base_id);
     auto result = cursor->find(to_slice(first_key), /* throw_notfound = */ false);
     for (uint64_t i = 0; result && (i < count); result = cursor->to_next(/* throw_notfound = */ false), i++) {
-        log::Debug("delete_transactions") << "deleting " << (base_id + i);
         cursor->erase();
     }
 }

--- a/silkworm/db/blocks/bodies/body_snapshot_freezer.cpp
+++ b/silkworm/db/blocks/bodies/body_snapshot_freezer.cpp
@@ -19,6 +19,7 @@
 #include <stdexcept>
 
 #include <silkworm/db/access_layer.hpp>
+#include <silkworm/infra/common/log.hpp>
 
 #include "body_snapshot.hpp"
 
@@ -42,12 +43,16 @@ void BodySnapshotFreezer::copy(ROTxn& txn, const FreezerCommand& command, snapsh
 }
 
 void BodySnapshotFreezer::cleanup(RWTxn& txn, BlockNumRange range) const {
-    for (BlockNum i = range.first; i < range.second; i++) {
+    for (BlockNum i = range.first, count = 1; i < range.second; i++, count++) {
         auto hash_opt = read_canonical_header_hash(txn, i);
         if (!hash_opt) continue;
         auto hash = *hash_opt;
 
         delete_body(txn, hash, i);
+
+        if ((count > 1000) && ((count % 1000) == 0)) {
+            log::Debug("BodySnapshotFreezer") << "cleaned up until block " << i;
+        }
     }
 }
 

--- a/silkworm/db/blocks/bodies/body_snapshot_freezer.cpp
+++ b/silkworm/db/blocks/bodies/body_snapshot_freezer.cpp
@@ -50,7 +50,7 @@ void BodySnapshotFreezer::cleanup(RWTxn& txn, BlockNumRange range) const {
 
         delete_body(txn, hash, i);
 
-        if ((count > 1000) && ((count % 1000) == 0)) {
+        if ((count > 10000) && ((count % 10000) == 0)) {
             log::Debug("BodySnapshotFreezer") << "cleaned up until block " << i;
         }
     }

--- a/silkworm/db/blocks/headers/header_snapshot_freezer.cpp
+++ b/silkworm/db/blocks/headers/header_snapshot_freezer.cpp
@@ -19,6 +19,7 @@
 #include <stdexcept>
 
 #include <silkworm/db/access_layer.hpp>
+#include <silkworm/infra/common/log.hpp>
 
 #include "header_snapshot.hpp"
 
@@ -36,12 +37,16 @@ void HeaderSnapshotFreezer::copy(ROTxn& txn, const FreezerCommand& command, snap
 }
 
 void HeaderSnapshotFreezer::cleanup(RWTxn& txn, BlockNumRange range) const {
-    for (BlockNum i = range.first; i < range.second; i++) {
+    for (BlockNum i = range.first, count = 1; i < range.second; i++, count++) {
         auto hash_opt = read_canonical_header_hash(txn, i);
         if (!hash_opt) continue;
         auto& hash = *hash_opt;
 
         delete_header(txn, i, hash);
+
+        if ((count > 1000) && ((count % 1000) == 0)) {
+            log::Debug("HeaderSnapshotFreezer") << "cleaned up until block " << i;
+        }
     }
 }
 

--- a/silkworm/db/blocks/headers/header_snapshot_freezer.cpp
+++ b/silkworm/db/blocks/headers/header_snapshot_freezer.cpp
@@ -44,7 +44,7 @@ void HeaderSnapshotFreezer::cleanup(RWTxn& txn, BlockNumRange range) const {
 
         delete_header(txn, i, hash);
 
-        if ((count > 1000) && ((count % 1000) == 0)) {
+        if ((count > 10000) && ((count % 10000) == 0)) {
             log::Debug("HeaderSnapshotFreezer") << "cleaned up until block " << i;
         }
     }

--- a/silkworm/db/data_migration.hpp
+++ b/silkworm/db/data_migration.hpp
@@ -35,6 +35,7 @@ struct DataMigration {
     Task<void> run_loop();
 
   protected:
+    virtual const char* name() const = 0;
     virtual std::unique_ptr<DataMigrationCommand> next_command() = 0;
     virtual std::shared_ptr<DataMigrationResult> migrate(std::unique_ptr<DataMigrationCommand> command) = 0;
     virtual void index(std::shared_ptr<DataMigrationResult> result) = 0;

--- a/silkworm/db/data_migration_command.hpp
+++ b/silkworm/db/data_migration_command.hpp
@@ -16,10 +16,13 @@
 
 #pragma once
 
+#include <string>
+
 namespace silkworm::db {
 
 struct DataMigrationCommand {
     virtual ~DataMigrationCommand() = default;
+    virtual std::string description() const = 0;
 };
 
 }  // namespace silkworm::db

--- a/silkworm/db/freezer.cpp
+++ b/silkworm/db/freezer.cpp
@@ -170,9 +170,8 @@ Task<void> Freezer::cleanup() {
     BlockNumRange range = cleanup_range();
     if (range.first >= range.second) co_return;
 
-    co_await stage_scheduler_.schedule([this, range](RWTxn& db_tx) -> Task<void> {
+    co_await stage_scheduler_.schedule([this, range](RWTxn& db_tx) {
         this->cleanup(db_tx, range);
-        co_return;
     });
 }
 

--- a/silkworm/db/freezer.cpp
+++ b/silkworm/db/freezer.cpp
@@ -170,7 +170,7 @@ BlockNumRange Freezer::cleanup_range() {
 Task<void> Freezer::cleanup() {
     BlockNumRange range = cleanup_range();
     if (range.first >= range.second) co_return;
-    log::Debug(name()) << "cleanup[" << range.first << ", " << range.second << ")";
+    log::Debug(name()) << "cleanup [" << range.first << ", " << range.second << ")";
 
     co_await stage_scheduler_.schedule([this, range](RWTxn& db_tx) {
         this->cleanup(db_tx, range);

--- a/silkworm/db/freezer.cpp
+++ b/silkworm/db/freezer.cpp
@@ -177,7 +177,10 @@ Task<void> Freezer::cleanup() {
     });
 }
 
-void Freezer::cleanup(RWTxn&, BlockNumRange) {
+void Freezer::cleanup(RWTxn& db_tx, BlockNumRange range) {
+    get_snapshot_freezer(SnapshotType::transactions).cleanup(db_tx, range);
+    get_snapshot_freezer(SnapshotType::bodies).cleanup(db_tx, range);
+    get_snapshot_freezer(SnapshotType::headers).cleanup(db_tx, range);
 }
 
 }  // namespace silkworm::db

--- a/silkworm/db/freezer.cpp
+++ b/silkworm/db/freezer.cpp
@@ -175,10 +175,7 @@ Task<void> Freezer::cleanup() {
     });
 }
 
-void Freezer::cleanup(RWTxn& db_tx, BlockNumRange range) {
-    get_snapshot_freezer(SnapshotType::transactions).cleanup(db_tx, range);
-    get_snapshot_freezer(SnapshotType::bodies).cleanup(db_tx, range);
-    get_snapshot_freezer(SnapshotType::headers).cleanup(db_tx, range);
+void Freezer::cleanup(RWTxn&, BlockNumRange) {
 }
 
 }  // namespace silkworm::db

--- a/silkworm/db/freezer.cpp
+++ b/silkworm/db/freezer.cpp
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include <silkworm/core/common/base.hpp>
+#include <silkworm/infra/common/log.hpp>
 
 #include "access_layer.hpp"
 #include "blocks/bodies/body_snapshot_freezer.hpp"
@@ -169,6 +170,7 @@ BlockNumRange Freezer::cleanup_range() {
 Task<void> Freezer::cleanup() {
     BlockNumRange range = cleanup_range();
     if (range.first >= range.second) co_return;
+    log::Debug(name()) << "cleanup[" << range.first << ", " << range.second << ")";
 
     co_await stage_scheduler_.schedule([this, range](RWTxn& db_tx) {
         this->cleanup(db_tx, range);

--- a/silkworm/db/freezer.hpp
+++ b/silkworm/db/freezer.hpp
@@ -38,6 +38,7 @@ class Freezer : public DataMigration {
   private:
     static constexpr size_t kChunkSize = 1000;
 
+    const char* name() const override { return "Freezer"; }
     std::unique_ptr<DataMigrationCommand> next_command() override;
     std::shared_ptr<DataMigrationResult> migrate(std::unique_ptr<DataMigrationCommand> command) override;
     void index(std::shared_ptr<DataMigrationResult> result) override;

--- a/silkworm/db/snapshot_freezer.hpp
+++ b/silkworm/db/snapshot_freezer.hpp
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <sstream>
+
 #include <silkworm/core/common/base.hpp>
 
 #include "data_migration_command.hpp"
@@ -32,6 +34,12 @@ struct FreezerCommand : public DataMigrationCommand {
         : range(std::move(range1)),
           base_txn_id(base_txn_id1) {}
     ~FreezerCommand() override = default;
+
+    std::string description() const override {
+        std::stringstream stream;
+        stream << "FreezerCommand[" << range.first << ", " << range.second << ")";
+        return stream.str();
+    }
 };
 
 struct SnapshotFreezer {

--- a/silkworm/db/snapshot_freezer.hpp
+++ b/silkworm/db/snapshot_freezer.hpp
@@ -37,7 +37,7 @@ struct FreezerCommand : public DataMigrationCommand {
 
     std::string description() const override {
         std::stringstream stream;
-        stream << "FreezerCommand[" << range.first << ", " << range.second << ")";
+        stream << "FreezerCommand [" << range.first << ", " << range.second << ")";
         return stream.str();
     }
 };

--- a/silkworm/db/stage_scheduler.hpp
+++ b/silkworm/db/stage_scheduler.hpp
@@ -27,8 +27,8 @@ namespace silkworm::stagedsync {
 struct StageScheduler {
     virtual ~StageScheduler() = default;
 
-    //! Schedule a task to run inside the stage loop.
-    virtual Task<void> schedule(std::function<Task<void>(db::RWTxn&)> task) = 0;
+    //! Schedule a callback to run inside the stage loop.
+    virtual Task<void> schedule(std::function<void(db::RWTxn&)> callback) = 0;
 };
 
 }  // namespace silkworm::stagedsync

--- a/silkworm/db/transactions/txn_snapshot_freezer.cpp
+++ b/silkworm/db/transactions/txn_snapshot_freezer.cpp
@@ -19,6 +19,7 @@
 #include <stdexcept>
 
 #include <silkworm/db/access_layer.hpp>
+#include <silkworm/infra/common/log.hpp>
 
 #include "txn_snapshot.hpp"
 
@@ -44,7 +45,7 @@ void TransactionSnapshotFreezer::copy(ROTxn& txn, const FreezerCommand& command,
 }
 
 void TransactionSnapshotFreezer::cleanup(RWTxn& txn, BlockNumRange range) const {
-    for (BlockNum i = range.first; i < range.second; i++) {
+    for (BlockNum i = range.first, count = 1; i < range.second; i++, count++) {
         auto hash_opt = read_canonical_header_hash(txn, i);
         if (!hash_opt) continue;
         auto hash = *hash_opt;
@@ -55,6 +56,10 @@ void TransactionSnapshotFreezer::cleanup(RWTxn& txn, BlockNumRange range) const 
         if (body_opt) {
             auto& body = *body_opt;
             delete_transactions(txn, body.base_txn_id + 1, body.txn_count - 2);
+        }
+
+        if ((count > 1000) && ((count % 1000) == 0)) {
+            log::Debug("TransactionSnapshotFreezer") << "cleaned up until block " << i;
         }
     }
 }

--- a/silkworm/db/transactions/txn_snapshot_freezer.cpp
+++ b/silkworm/db/transactions/txn_snapshot_freezer.cpp
@@ -58,7 +58,7 @@ void TransactionSnapshotFreezer::cleanup(RWTxn& txn, BlockNumRange range) const 
             delete_transactions(txn, body.base_txn_id + 1, body.txn_count - 2);
         }
 
-        if ((count > 1000) && ((count % 1000) == 0)) {
+        if ((count > 10000) && ((count % 10000) == 0)) {
             log::Debug("TransactionSnapshotFreezer") << "cleaned up until block " << i;
         }
     }

--- a/silkworm/node/stagedsync/stages/stage_triggers.cpp
+++ b/silkworm/node/stagedsync/stages/stage_triggers.cpp
@@ -40,11 +40,12 @@ Stage::Result TriggersStage::forward(db::RWTxn& tx) {
     return Stage::Result::kSuccess;
 }
 
-Task<void> TriggersStage::schedule(std::function<Task<void>(db::RWTxn&)> task) {
-    auto task_caller = [this, t = std::move(task)]() -> Task<void> {
+Task<void> TriggersStage::schedule(std::function<void(db::RWTxn&)> callback) {
+    auto task_caller = [this, c = std::move(callback)]() -> Task<void> {
         db::RWTxn* tx = this->current_tx_;
         assert(tx);
-        co_await t(*tx);
+        c(*tx);
+        co_return;
     };
     return concurrency::spawn_task(io_context_, task_caller());
 }

--- a/silkworm/node/stagedsync/stages/stage_triggers.hpp
+++ b/silkworm/node/stagedsync/stages/stage_triggers.hpp
@@ -33,7 +33,7 @@ class TriggersStage : public Stage, public StageScheduler {
     Stage::Result unwind(db::RWTxn&) override { return Stage::Result::kSuccess; }
     Stage::Result prune(db::RWTxn&) override { return Stage::Result::kSuccess; }
 
-    Task<void> schedule(std::function<Task<void>(db::RWTxn&)> task) override;
+    Task<void> schedule(std::function<void(db::RWTxn&)> callback) override;
 
     bool stop() override;
 


### PR DESCRIPTION
Fixes after testing db_toolbox freeze command:
* dedicated thread for RWTxn, call tx.commit_and_stop
* simplify schedule callback
* SnapshotRepository setup fixes
* DataMigration and cleanup logging
* cursor->lower_bound in read_stored_header_number_after
