### PR TITLE
clang-tidy: readability-else-after-return

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -64,7 +64,6 @@ Checks: >
   -performance-enum-size,
   portability-*,
   readability-*,
-  -readability-avoid-nested-conditional-operator,
   -readability-braces-around-statements,
   -readability-container-data-pointer,
   -readability-convert-member-functions-to-static,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -67,7 +67,6 @@ Checks: >
   -readability-braces-around-statements,
   -readability-container-data-pointer,
   -readability-convert-member-functions-to-static,
-  -readability-else-after-return,
   -readability-function-cognitive-complexity,
   -readability-identifier-length,
   -readability-implicit-bool-conversion,

--- a/cmd/capi/execute.cpp
+++ b/cmd/capi/execute.cpp
@@ -316,9 +316,8 @@ int execute_blocks(SilkwormHandle handle, ExecuteBlocksSettings settings, Snapsh
     // Execute blocks
     if (settings.use_internal_txn) {
         return execute_with_internal_txn(handle, settings, env);
-    } else {
-        return execute_with_external_txn(handle, settings, env);
     }
+    return execute_with_external_txn(handle, settings, env);
 }
 
 int build_indexes(SilkwormHandle handle, const BuildIndexesSettings& settings, const DataDirectory& data_dir) {

--- a/cmd/common/db_checklist.cpp
+++ b/cmd/common/db_checklist.cpp
@@ -110,42 +110,41 @@ void run_db_checklist(NodeSettings& node_settings, bool init_if_empty) {
 
                     new_members_added = true;
                     continue;
+                }
 
-                } else {
-                    const auto active_value{active_chain_config_json[known_key]};
-                    if (active_value.type_name() != known_value.type_name()) {
-                        throw std::runtime_error("Hard-coded chain config key " + known_key + " has type " +
-                                                 std::string(known_value.type_name()) +
-                                                 " whilst persisted config has type " +
-                                                 std::string(active_value.type_name()));
-                    }
+                const auto active_value{active_chain_config_json[known_key]};
+                if (active_value.type_name() != known_value.type_name()) {
+                    throw std::runtime_error("Hard-coded chain config key " + known_key + " has type " +
+                                             std::string(known_value.type_name()) +
+                                             " whilst persisted config has type " +
+                                             std::string(active_value.type_name()));
+                }
 
-                    if (known_value.is_number()) {
-                        // Check whether activation value has been modified
-                        const auto known_value_activation{known_value.get<uint64_t>()};
-                        const auto active_value_activation{active_value.get<uint64_t>()};
-                        if (known_value_activation != active_value_activation) {
-                            const bool must_throw{
-                                // Can't de-activate an already activated fork block
-                                (!known_value_activation && active_value_activation &&
-                                 active_value_activation <= header_download_progress) ||
-                                // Can't activate a fork block BEFORE current height
-                                (!active_value_activation && known_value_activation &&
-                                 known_value_activation <= header_download_progress) ||
-                                // Can change activation height BEFORE current height
-                                (known_value_activation && active_value_activation &&
-                                 std::min(known_value_activation, active_value_activation) <=
-                                     header_download_progress)};
-                            if (must_throw) {
-                                throw std::runtime_error("Can't apply modified chain config key " +
-                                                         known_key + " from " +
-                                                         std::to_string(active_value_activation) + " to " +
-                                                         std::to_string(known_value_activation) +
-                                                         " as the database has already headers up to " +
-                                                         std::to_string(header_download_progress));
-                            }
-                            old_members_changed = true;
+                if (known_value.is_number()) {
+                    // Check whether activation value has been modified
+                    const auto known_value_activation{known_value.get<uint64_t>()};
+                    const auto active_value_activation{active_value.get<uint64_t>()};
+                    if (known_value_activation != active_value_activation) {
+                        const bool must_throw{
+                            // Can't de-activate an already activated fork block
+                            (!known_value_activation && active_value_activation &&
+                             active_value_activation <= header_download_progress) ||
+                            // Can't activate a fork block BEFORE current height
+                            (!active_value_activation && known_value_activation &&
+                             known_value_activation <= header_download_progress) ||
+                            // Can change activation height BEFORE current height
+                            (known_value_activation && active_value_activation &&
+                             std::min(known_value_activation, active_value_activation) <=
+                                 header_download_progress)};
+                        if (must_throw) {
+                            throw std::runtime_error("Can't apply modified chain config key " +
+                                                     known_key + " from " +
+                                                     std::to_string(active_value_activation) + " to " +
+                                                     std::to_string(known_value_activation) +
+                                                     " as the database has already headers up to " +
+                                                     std::to_string(header_download_progress));
                         }
+                        old_members_changed = true;
                     }
                 }
             }

--- a/cmd/common/shutdown_signal.cpp
+++ b/cmd/common/shutdown_signal.cpp
@@ -35,10 +35,9 @@ void ShutdownSignal::on_signal(std::function<void(SignalNumber)> callback) {
         if (error) {
             log::Error() << "ShutdownSignal.on_signal async_wait error: " << error;
             throw boost::system::system_error(error);
-        } else {
-            log_signal(signal_number);
-            callback(signal_number);
         }
+        log_signal(signal_number);
+        callback(signal_number);
     });
 }
 

--- a/cmd/dev/db_toolbox.cpp
+++ b/cmd/dev/db_toolbox.cpp
@@ -1674,7 +1674,8 @@ void do_trie_integrity(db::EnvConfig& config, bool with_state_coverage, bool con
             if (data1_v.length() < 6) {
                 throw std::runtime_error("At key " + to_hex(data1_k, true) + " invalid value length " +
                                          std::to_string(data1_v.length()) + ". Expected >= 6");
-            } else if ((data1_v.length() - 6) % kHashLength != 0) {
+            }
+            if ((data1_v.length() - 6) % kHashLength != 0) {
                 throw std::runtime_error("At key " + to_hex(data1_k, true) + " invalid hashes count " +
                                          std::to_string(data1_v.length() - 6) + ". Expected multiple of " +
                                          std::to_string(kHashLength));
@@ -1766,15 +1767,13 @@ void do_trie_integrity(db::EnvConfig& config, bool with_state_coverage, bool con
                                                  std::bitset<16>(node_tree_mask).to_string() +
                                                  " but there is no child " + std::to_string(i) +
                                                  " in db. LTE found is : null");
-                    } else {
-                        auto data2_k{db::from_slice(data2.key)};
-
-                        if (!data2_k.starts_with(buffer)) {
-                            throw std::runtime_error("At key " + to_hex(data1_k, true) + " tree mask is " +
-                                                     std::bitset<16>(node_tree_mask).to_string() +
-                                                     " but there is no child " + std::to_string(i) +
-                                                     " in db. LTE found is : " + to_hex(data2_k, true));
-                        }
+                    }
+                    auto data2_k{db::from_slice(data2.key)};
+                    if (!data2_k.starts_with(buffer)) {
+                        throw std::runtime_error("At key " + to_hex(data1_k, true) + " tree mask is " +
+                                                 std::bitset<16>(node_tree_mask).to_string() +
+                                                 " but there is no child " + std::to_string(i) +
+                                                 " in db. LTE found is : " + to_hex(data2_k, true));
                     }
                 }
             }

--- a/cmd/state-transition/state_transition.cpp
+++ b/cmd/state-transition/state_transition.cpp
@@ -183,23 +183,20 @@ Transaction StateTransition::get_transaction(const ExpectedSubState& expected_su
 
     if (expected_sub_state.dataIndex >= j_transaction.at("data").size()) {
         throw std::runtime_error("data index out of range");
-    } else {
-        txn.data = from_hex(j_transaction.at("data").at(expected_sub_state.dataIndex).get<std::string>()).value();
     }
+    txn.data = from_hex(j_transaction.at("data").at(expected_sub_state.dataIndex).get<std::string>()).value();
 
     if (expected_sub_state.gasIndex >= j_transaction.at("gasLimit").size()) {
         throw std::runtime_error("gas limit index out of range");
-    } else {
-        txn.gas_limit = std::stoull(j_transaction.at("gasLimit").at(expected_sub_state.gasIndex).get<std::string>(), nullptr, 16);
     }
+    txn.gas_limit = std::stoull(j_transaction.at("gasLimit").at(expected_sub_state.gasIndex).get<std::string>(), nullptr, 16);
 
     if (expected_sub_state.valueIndex >= j_transaction.at("value").size()) {
         throw std::runtime_error("value index out of range");
-    } else {
-        auto value_str = j_transaction.at("value").at(expected_sub_state.valueIndex).get<std::string>();
-        // in case of bigint, set max value; compatible with all test cases so far
-        txn.value = (value_str.starts_with("0x:bigint ")) ? std::numeric_limits<intx::uint256>::max() : intx::from_string<intx::uint256>(value_str);
     }
+    auto value_str = j_transaction.at("value").at(expected_sub_state.valueIndex).get<std::string>();
+    // in case of bigint, set max value; compatible with all test cases so far
+    txn.value = (value_str.starts_with("0x:bigint ")) ? std::numeric_limits<intx::uint256>::max() : intx::from_string<intx::uint256>(value_str);
 
     if (j_transaction.contains("accessLists")) {
         auto j_access_list = j_transaction.at("accessLists").at(expected_sub_state.dataIndex);

--- a/cmd/test/backend_kv_test.cpp
+++ b/cmd/test/backend_kv_test.cpp
@@ -695,29 +695,27 @@ class AsyncTxCall
             if (cursor_id_ == kInvalidCursorId) {
                 SILK_DEBUG << "Tx cursor closed, closing tx";
                 return true;  // reads done, close tx
-            } else {
-                SILK_INFO << "Tx queried: " << reply_ << ", queries done closing cursor";
-                request_.set_op(remote::Op::CLOSE);
-                request_.set_cursor(cursor_id_);
-                cursor_id_ = kInvalidCursorId;
-                return false;
             }
-        } else {
-            if (cursor_id_ == kInvalidCursorId) {
-                SILK_INFO << "Tx opened: cursor=" << reply_.cursor_id();
-                cursor_id_ = reply_.cursor_id();
-                SILK_DEBUG << "Tx: prepare request FIRST cursor=" << cursor_id_;
-                request_.set_op(remote::Op::FIRST);
-                request_.set_cursor(cursor_id_);
-            } else {
-                SILK_INFO << "Tx queried: " << reply_;
-                --query_count_;
-                SILK_DEBUG << "Tx: prepare request NEXT cursor=" << cursor_id_;
-                request_.set_op(remote::Op::NEXT);
-                request_.set_cursor(cursor_id_);
-            }
+            SILK_INFO << "Tx queried: " << reply_ << ", queries done closing cursor";
+            request_.set_op(remote::Op::CLOSE);
+            request_.set_cursor(cursor_id_);
+            cursor_id_ = kInvalidCursorId;
             return false;
         }
+        if (cursor_id_ == kInvalidCursorId) {
+            SILK_INFO << "Tx opened: cursor=" << reply_.cursor_id();
+            cursor_id_ = reply_.cursor_id();
+            SILK_DEBUG << "Tx: prepare request FIRST cursor=" << cursor_id_;
+            request_.set_op(remote::Op::FIRST);
+            request_.set_cursor(cursor_id_);
+        } else {
+            SILK_INFO << "Tx queried: " << reply_;
+            --query_count_;
+            SILK_DEBUG << "Tx: prepare request NEXT cursor=" << cursor_id_;
+            request_.set_op(remote::Op::NEXT);
+            request_.set_cursor(cursor_id_);
+        }
+        return false;
     }
 
     bool handle_write() override {

--- a/cmd/test/ethereum.cpp
+++ b/cmd/test/ethereum.cpp
@@ -240,16 +240,14 @@ RunResults blockchain_test(const nlohmann::json& json_test) {
             std::cout << "postStateHash mismatch:\n"
                       << to_hex(state_root) << " != " << expected_hex << std::endl;
             return Status::kFailed;
-        } else {
-            return Status::kPassed;
         }
+        return Status::kPassed;
     }
 
     if (post_check(state, json_test["postState"])) {
         return Status::kPassed;
-    } else {
-        return Status::kFailed;
     }
+    return Status::kFailed;
 }
 
 static void print_test_status(std::string_view key, const RunResults& res) {
@@ -321,9 +319,8 @@ RunResults transaction_test(const nlohmann::json& j) {
             if (should_be_valid) {
                 std::cout << "Failed to decode valid transaction" << std::endl;
                 return Status::kFailed;
-            } else {
-                continue;
             }
+            continue;
         }
 
         const ChainConfig& config{test::kNetworkConfig.at(entry.key())};
@@ -336,9 +333,8 @@ RunResults transaction_test(const nlohmann::json& j) {
             if (should_be_valid) {
                 std::cout << "Validation error " << magic_enum::enum_name<ValidationResult>(err) << std::endl;
                 return Status::kFailed;
-            } else {
-                continue;
             }
+            continue;
         }
 
         if (should_be_valid && !txn.sender()) {
@@ -401,11 +397,10 @@ Status individual_difficulty_test(const nlohmann::json& j, const ChainConfig& co
                                                                   parent_timestamp, parent_has_uncles, config)};
     if (calculated_difficulty == current_difficulty) {
         return Status::kPassed;
-    } else {
-        std::cout << "Difficulty mismatch for block " << block_number << "\n"
-                  << hex(calculated_difficulty) << " != " << hex(current_difficulty) << std::endl;
-        return Status::kFailed;
     }
+    std::cout << "Difficulty mismatch for block " << block_number << "\n"
+              << hex(calculated_difficulty) << " != " << hex(current_difficulty) << std::endl;
+    return Status::kFailed;
 }
 
 RunResults difficulty_tests(const nlohmann::json& outer) {

--- a/silkworm/capi/fork_validator.cpp
+++ b/silkworm/capi/fork_validator.cpp
@@ -190,13 +190,10 @@ SILKWORM_EXPORT int silkworm_fork_validator_fork_choice_update(SilkwormHandle ha
 
     try {
         auto result = handle->execution_engine->notify_fork_choice_update(head_hash, finalized_hash_opt, safe_hash_opt);
-
         if (result) {
             return SILKWORM_OK;
-        } else {
-            SILK_ERROR << "[Silkworm Fork Validator] Fork Choice Update failed with unknown error";
         }
-
+        SILK_ERROR << "[Silkworm Fork Validator] Fork Choice Update failed with unknown error";
     } catch (const std::exception& ex) {
         SILK_ERROR << "[Silkworm Fork Validator] Fork Choice Update failed: " << ex.what();
     }

--- a/silkworm/core/common/lru_cache.hpp
+++ b/silkworm/core/common/lru_cache.hpp
@@ -134,10 +134,9 @@ class lru_cache {
         auto it = _cache_items_map.find(key);
         if (it == _cache_items_map.end()) {
             return nullptr;
-        } else {
-            _cache_items_list.splice(_cache_items_list.begin(), _cache_items_list, it->second);
-            return &(it->second->second);
         }
+        _cache_items_list.splice(_cache_items_list.begin(), _cache_items_list, it->second);
+        return &(it->second->second);
     }
 
     std::list<key_value_pair_t> _cache_items_list;

--- a/silkworm/core/execution/precompile.cpp
+++ b/silkworm/core/execution/precompile.cpp
@@ -116,11 +116,11 @@ static intx::uint256 mult_complexity_eip198(const intx::uint256& x) noexcept {
     const intx::uint256 x_squared{x * x};
     if (x <= 64) {
         return x_squared;
-    } else if (x <= 1024) {
-        return (x_squared >> 2) + 96 * x - 3072;
-    } else {
-        return (x_squared >> 4) + 480 * x - 199680;
     }
+    if (x <= 1024) {
+        return (x_squared >> 2) + 96 * x - 3072;
+    }
+    return (x_squared >> 4) + 480 * x - 199680;
 }
 
 static intx::uint256 mult_complexity_eip2565(const intx::uint256& max_length) noexcept {
@@ -187,9 +187,8 @@ uint64_t expmod_gas(ByteView input_view, evmc_revision rev) noexcept {
 
     if (intx::count_significant_words(gas) > 1) {
         return UINT64_MAX;
-    } else {
-        return std::max(min_gas, static_cast<uint64_t>(gas));
     }
+    return std::max(min_gas, static_cast<uint64_t>(gas));
 }
 
 std::optional<Bytes> expmod_run(ByteView input_view) noexcept {

--- a/silkworm/core/protocol/ethash_rule_set.cpp
+++ b/silkworm/core/protocol/ethash_rule_set.cpp
@@ -82,7 +82,8 @@ void EthashRuleSet::finalize(IntraBlockState& state, const Block& block) {
 static intx::uint256 block_reward_base(const evmc_revision rev) {
     if (rev >= EVMC_CONSTANTINOPLE) {
         return kBlockRewardConstantinople;
-    } else if (rev >= EVMC_BYZANTIUM) {
+    }
+    if (rev >= EVMC_BYZANTIUM) {
         return kBlockRewardByzantium;
     }
     return kBlockRewardFrontier;

--- a/silkworm/core/protocol/rule_set.cpp
+++ b/silkworm/core/protocol/rule_set.cpp
@@ -72,7 +72,8 @@ ValidationResult RuleSet::pre_validate_block_body(const Block& block, const Bloc
 
     if (block.ommers.empty()) {
         return header.ommers_hash == kEmptyListHash ? ValidationResult::kOk : ValidationResult::kWrongOmmersHash;
-    } else if (prohibit_ommers_) {
+    }
+    if (prohibit_ommers_) {
         return ValidationResult::kTooManyOmmers;
     }
 
@@ -86,11 +87,7 @@ ValidationResult RuleSet::pre_validate_block_body(const Block& block, const Bloc
 
 ValidationResult RuleSet::validate_ommers(const Block& block, const BlockState& state) {
     if (prohibit_ommers_) {
-        if (block.ommers.empty()) {
-            return ValidationResult::kOk;
-        } else {
-            return ValidationResult::kTooManyOmmers;
-        }
+        return block.ommers.empty() ? ValidationResult::kOk : ValidationResult::kTooManyOmmers;
     }
 
     if (block.ommers.size() > 2) {

--- a/silkworm/core/protocol/validation.cpp
+++ b/silkworm/core/protocol/validation.cpp
@@ -179,16 +179,15 @@ intx::uint256 expected_base_fee_per_gas(const BlockHeader& parent) {
             base_fee_per_gas_delta = 1;
         }
         return parent_base_fee_per_gas + base_fee_per_gas_delta;
-    } else {
-        const intx::uint256 gas_used_delta{parent_gas_target - parent.gas_used};
-        const intx::uint256 base_fee_per_gas_delta{parent_base_fee_per_gas * gas_used_delta / parent_gas_target /
-                                                   kBaseFeeMaxChangeDenominator};
-        if (parent_base_fee_per_gas > base_fee_per_gas_delta) {
-            return parent_base_fee_per_gas - base_fee_per_gas_delta;
-        } else {
-            return 0;
-        }
     }
+
+    const intx::uint256 gas_used_delta{parent_gas_target - parent.gas_used};
+    const intx::uint256 base_fee_per_gas_delta{parent_base_fee_per_gas * gas_used_delta / parent_gas_target /
+                                               kBaseFeeMaxChangeDenominator};
+    if (parent_base_fee_per_gas > base_fee_per_gas_delta) {
+        return parent_base_fee_per_gas - base_fee_per_gas_delta;
+    }
+    return 0;
 }
 
 uint64_t calc_excess_blob_gas(const BlockHeader& parent) {
@@ -197,9 +196,8 @@ uint64_t calc_excess_blob_gas(const BlockHeader& parent) {
 
     if (parent_excess_blob_gas + consumed_blob_gas < kTargetBlobGasPerBlock) {
         return 0;
-    } else {
-        return parent_excess_blob_gas + consumed_blob_gas - kTargetBlobGasPerBlock;
     }
+    return parent_excess_blob_gas + consumed_blob_gas - kTargetBlobGasPerBlock;
 }
 
 evmc::bytes32 compute_transaction_root(const BlockBody& body) {

--- a/silkworm/core/rlp/encode.cpp
+++ b/silkworm/core/rlp/encode.cpp
@@ -33,9 +33,8 @@ void encode_header(Bytes& to, Header header) {
 size_t length_of_length(uint64_t payload_length) noexcept {
     if (payload_length < 56) {
         return 1;
-    } else {
-        return 1 + intx::count_significant_bytes(payload_length);
     }
+    return 1 + intx::count_significant_bytes(payload_length);
 }
 
 void encode(Bytes& to, bool x) {

--- a/silkworm/core/rlp/encode.hpp
+++ b/silkworm/core/rlp/encode.hpp
@@ -62,10 +62,9 @@ template <UnsignedIntegral T>
 size_t length(const T& n) noexcept {
     if (n < kEmptyStringCode) {
         return 1;
-    } else {
-        const size_t n_bytes{intx::count_significant_bytes(n)};
-        return n_bytes + length_of_length(n_bytes);
     }
+    const size_t n_bytes{intx::count_significant_bytes(n)};
+    return n_bytes + length_of_length(n_bytes);
 }
 
 inline size_t length(bool) noexcept {

--- a/silkworm/core/trie/node.cpp
+++ b/silkworm/core/trie/node.cpp
@@ -91,7 +91,8 @@ DecodingResult Node::decode_from_storage(ByteView raw, Node& node) {
     size_t delta{effective_num_hashes - expected_num_hashes};
     if (delta > 1) {
         return tl::unexpected{DecodingError::kInvalidHashesLength};
-    } else if (delta == 1) {
+    }
+    if (delta == 1) {
         node.root_hash_.emplace();
         std::memcpy(node.root_hash_->bytes, raw.data(), kHashLength);
         raw.remove_prefix(kHashLength);

--- a/silkworm/core/trie/vector_root.hpp
+++ b/silkworm/core/trie/vector_root.hpp
@@ -30,11 +30,11 @@ namespace silkworm::trie {
 inline size_t adjust_index_for_rlp(size_t i, size_t len) {
     if (i > 0x7f) {
         return i;
-    } else if (i == 0x7f || i + 1 == len) {
-        return 0;
-    } else {
-        return i + 1;
     }
+    if (i == 0x7f || i + 1 == len) {
+        return 0;
+    }
+    return i + 1;
 }
 
 // Trie root hash of RLP-encoded values, the keys are RLP-encoded integers.

--- a/silkworm/core/types/account.cpp
+++ b/silkworm/core/types/account.cpp
@@ -100,11 +100,12 @@ static inline tl::expected<uint8_t, DecodingError> validate_encoded_head(ByteVie
 }
 
 tl::expected<Account, DecodingError> Account::from_encoded_storage(ByteView encoded_payload) noexcept {
-    Account a;
     const tl::expected<uint8_t, DecodingError> field_set{validate_encoded_head(encoded_payload)};
     if (!field_set) {
         return tl::unexpected{field_set.error()};
-    } else if (field_set == 0) {
+    }
+    Account a;
+    if (field_set == 0) {
         return a;
     }
 
@@ -204,7 +205,8 @@ tl::expected<uint64_t, DecodingError> Account::incarnation_from_encoded_storage(
     const tl::expected<uint8_t, DecodingError> field_set{validate_encoded_head(encoded_payload)};
     if (!field_set) {
         return tl::unexpected{field_set.error()};
-    } else if (!(*field_set & /*incarnation mask*/ 4)) {
+    }
+    if (!(*field_set & /*incarnation mask*/ 4)) {
         return 0;
     }
 

--- a/silkworm/core/types/address.cpp
+++ b/silkworm/core/types/address.cpp
@@ -83,9 +83,8 @@ evmc::address hex_to_address(std::string_view hex, bool return_zero_on_err) {
     if (!bytes) {
         if (return_zero_on_err) {
             return evmc::address{};
-        } else {
-            abort_due_to_assertion_failure("invalid hex encoding", __FILE__, __LINE__);
         }
+        abort_due_to_assertion_failure("invalid hex encoding", __FILE__, __LINE__);
     }
     return bytes_to_address(*bytes);
 }

--- a/silkworm/core/types/transaction.cpp
+++ b/silkworm/core/types/transaction.cpp
@@ -132,9 +132,8 @@ namespace rlp {
         size_t rlp_len{length_of_length(h.payload_length) + h.payload_length};
         if (txn.type != TransactionType::kLegacy && wrap_eip2718_into_string) {
             return length_of_length(rlp_len + 1) + rlp_len + 1;
-        } else {
-            return rlp_len;
         }
+        return rlp_len;
     }
 
     static void legacy_encode_base(Bytes& to, const UnsignedTransaction& txn) {

--- a/silkworm/core/types/y_parity_and_chain_id.cpp
+++ b/silkworm/core/types/y_parity_and_chain_id.cpp
@@ -21,9 +21,8 @@ namespace silkworm {
 intx::uint256 y_parity_and_chain_id_to_v(bool odd, const std::optional<intx::uint256>& chain_id) noexcept {
     if (chain_id.has_value()) {
         return chain_id.value() * 2 + 35 + odd;
-    } else {
-        return odd ? 28 : 27;
     }
+    return odd ? 28 : 27;
 }
 
 std::optional<YParityAndChainId> v_to_y_parity_and_chain_id(const intx::uint256& v) noexcept {

--- a/silkworm/db/access_layer.cpp
+++ b/silkworm/db/access_layer.cpp
@@ -1081,18 +1081,16 @@ std::optional<BlockHeader> DataModel::read_header(BlockNum block_number, const H
             return header;
         }
         return {};
-    } else {
-        return db::read_header(txn_, block_number, block_hash);
     }
+    return db::read_header(txn_, block_number, block_hash);
 }
 
 std::optional<BlockHeader> DataModel::read_header(BlockNum block_number) const {
     if (repository_ && block_number <= repository_->max_block_available()) {
         return read_header_from_snapshot(block_number);
-    } else {
-        auto hash = db::read_canonical_header_hash(txn_, block_number);
-        return db::read_header(txn_, block_number, *hash);
     }
+    auto hash = db::read_canonical_header_hash(txn_, block_number);
+    return db::read_header(txn_, block_number, *hash);
 }
 
 std::optional<BlockHeader> DataModel::read_header(const Hash& block_hash) const {

--- a/silkworm/db/buffer.cpp
+++ b/silkworm/db/buffer.cpp
@@ -529,11 +529,8 @@ ByteView Buffer::read_code(const evmc::bytes32& code_hash) const noexcept {
         return it->second;
     }
     std::optional<ByteView> code{db::read_code(txn_, code_hash)};
-    if (code.has_value()) {
-        return *code;
-    } else {
-        return {};
-    }
+    ByteView empty;
+    return code.value_or(empty);
 }
 
 evmc::bytes32 Buffer::read_storage(const evmc::address& address, uint64_t incarnation,

--- a/silkworm/db/etl_collector_test.cpp
+++ b/silkworm/db/etl_collector_test.cpp
@@ -44,9 +44,8 @@ static std::vector<Entry> generate_entry_set(size_t size) {
         if (keys.contains(key)) {
             // we want unique keys
             continue;
-        } else {
-            keys.insert(key);
         }
+        keys.insert(key);
         if (pairs.size() % 100) {
             Bytes value(8, '\0');
             endian::store_big_u64(&value[0], rnd.generate_one());

--- a/silkworm/db/etl_in_memory_collector_test.cpp
+++ b/silkworm/db/etl_in_memory_collector_test.cpp
@@ -81,9 +81,8 @@ static std::vector<Entry> generate_entry_set(size_t size) {
         if (keys.contains(key)) {
             // we want unique keys
             continue;
-        } else {
-            keys.insert(key);
         }
+        keys.insert(key);
         if (pairs.size() % 100) {
             Bytes value(8, '\0');
             endian::store_big_u64(&value[0], rnd.generate_one());

--- a/silkworm/db/kv/api/endpoint/paginated_sequence_benchmark.cpp
+++ b/silkworm/db/kv/api/endpoint/paginated_sequence_benchmark.cpp
@@ -101,9 +101,8 @@ class PaginatedSequence2 {
             if (it_ == current_.values.cend()) {
                 if (current_.has_more) {
                     return true;
-                } else {
-                    it_ = typename Page::const_iterator();  // empty i.e. sentinel value
                 }
+                it_ = typename Page::const_iterator();  // empty i.e. sentinel value
             }
             return false;
         }

--- a/silkworm/db/mdbx/mdbx.cpp
+++ b/silkworm/db/mdbx/mdbx.cpp
@@ -108,7 +108,8 @@ static inline mdbx::cursor::move_operation move_operation(CursorMoveDirection di
 
     if (!config.create && !db_file_size) {
         throw std::runtime_error("Unable to locate " + db_file.string() + ", which is required to exist");
-    } else if (config.create && db_file_size) {
+    }
+    if (config.create && db_file_size) {
         throw std::runtime_error("File " + db_file.string() + " already exists but create was set");
     }
 

--- a/silkworm/db/snapshots/seg/decompressor.cpp
+++ b/silkworm/db/snapshots/seg/decompressor.cpp
@@ -198,29 +198,28 @@ CodeWord* PatternTable::insert_word(CodeWord* codeword) {
 const CodeWord* PatternTable::search_condensed(uint16_t code) const {
     if (bit_length_ <= condensed_table_bit_length_threshold_) {
         return codeword(code);
-    } else {
-        CodeWord* previous{nullptr};
-        for (auto* current = head_; current != nullptr; previous = current, current = current->next()) {
-            if (current->code() == code) {
-                if (previous != nullptr) {
-                    previous->set_next(current->next());
-                    current->set_next(head_);
-                    head_ = current;
-                }
-                return current;
+    }
+    CodeWord* previous{nullptr};
+    for (auto* current = head_; current != nullptr; previous = current, current = current->next()) {
+        if (current->code() == code) {
+            if (previous != nullptr) {
+                previous->set_next(current->next());
+                current->set_next(head_);
+                head_ = current;
             }
-            const auto distance = code - current->code();
-            if ((distance & 0x1) != 0) {
-                continue;
+            return current;
+        }
+        const auto distance = code - current->code();
+        if ((distance & 0x1) != 0) {
+            continue;
+        }
+        if (check_distance(current->code_length(), distance)) {
+            if (previous != nullptr) {
+                previous->set_next(current->next());
+                current->set_next(head_);
+                head_ = current;
             }
-            if (check_distance(current->code_length(), distance)) {
-                if (previous != nullptr) {
-                    previous->set_next(current->next());
-                    current->set_next(head_);
-                    head_ = current;
-                }
-                return current;
-            }
+            return current;
         }
     }
     return nullptr;

--- a/silkworm/db/stages.cpp
+++ b/silkworm/db/stages.cpp
@@ -37,7 +37,8 @@ static BlockNum get_stage_data(ROTxn& txn, const char* stage_name, const db::Map
         auto data{cursor->find(mdbx::slice(item_key.c_str()), /*throw_notfound*/ false)};
         if (!data) {
             return 0;
-        } else if (data.value.size() != sizeof(uint64_t)) {
+        }
+        if (data.value.size() != sizeof(uint64_t)) {
             throw std::length_error("Expected 8 bytes of data got " + std::to_string(data.value.size()));
         }
         return endian::load_big_u64(static_cast<uint8_t*>(data.value.data()));

--- a/silkworm/db/util.cpp
+++ b/silkworm/db/util.cpp
@@ -153,7 +153,8 @@ std::pair<Bytes, Bytes> changeset_to_plainstate_format(const ByteView key, ByteV
         const Bytes address{value.substr(0, kAddressLength)};
         const Bytes previous_value{value.substr(kAddressLength)};
         return {address, previous_value};
-    } else if (key.length() == sizeof(BlockNum) + kPlainStoragePrefixLength) {
+    }
+    if (key.length() == sizeof(BlockNum) + kPlainStoragePrefixLength) {
         if (value.length() < kHashLength) {
             throw std::runtime_error("Invalid value length " + std::to_string(value.length()) +
                                      " for storage changeset in " + std::string(__FUNCTION__));

--- a/silkworm/infra/common/log.cpp
+++ b/silkworm/infra/common/log.cpp
@@ -127,10 +127,11 @@ BufferBase::BufferBase(Level level) : should_print_(level <= settings_.log_verbo
 
     // Prefix
     auto log_tag{settings_.log_trim ? absl::StripAsciiWhitespace(log_level).substr(0, 4) : log_level};
+    std::string_view padding = settings_.log_trim ? "" : " ";
     ss_ << kColorReset
-        << (settings_.log_trim && !is_terminal ? "[" : (settings_.log_trim ? "" : " ")) << color << log_tag
+        << (settings_.log_trim && !is_terminal ? "[" : padding) << color << log_tag
         << kColorReset
-        << (settings_.log_trim && !is_terminal ? "] " : (settings_.log_trim ? "" : " "));
+        << (settings_.log_trim && !is_terminal ? "] " : padding);
 
     // TimeStamp
     static const absl::TimeZone tz{settings_.log_utc ? absl::UTCTimeZone() : absl::LocalTimeZone()};

--- a/silkworm/infra/grpc/common/version.cpp
+++ b/silkworm/infra/grpc/common/version.cpp
@@ -41,11 +41,11 @@ ProtocolVersionResult wait_for_protocol_check(const std::unique_ptr<StubInterfac
     vv_stream << "client=" << version << " server=" << server_version;
     if (version.major != server_version.major) {  // NOLINT(bugprone-branch-clone)
         return ProtocolVersionResult{false, name + " incompatible interface: " + vv_stream.str()};
-    } else if (version.minor != server_version.minor) {
-        return ProtocolVersionResult{false, name + " incompatible interface: " + vv_stream.str()};
-    } else {
-        return ProtocolVersionResult{true, name + " compatible interface: " + vv_stream.str()};
     }
+    if (version.minor != server_version.minor) {
+        return ProtocolVersionResult{false, name + " incompatible interface: " + vv_stream.str()};
+    }
+    return ProtocolVersionResult{true, name + " compatible interface: " + vv_stream.str()};
 }
 
 template <auto Func, typename StubInterface>

--- a/silkworm/node/execution/grpc/client/endpoint/getters_test.cpp
+++ b/silkworm/node/execution/grpc/client/endpoint/getters_test.cpp
@@ -38,9 +38,8 @@ namespace proto = ::execution;
 static api::BlockNumberOrHash sample_block_number_or_hash(bool has_number) {
     if (has_number) {
         return kSampleBlockNumber;
-    } else {
-        return kSampleBlockHash;
     }
+    return kSampleBlockHash;
 }
 
 static proto::GetSegmentRequest sample_proto_get_segment_request(std::optional<BlockNum> number,

--- a/silkworm/node/execution/grpc/server/endpoint/getters_test.cpp
+++ b/silkworm/node/execution/grpc/server/endpoint/getters_test.cpp
@@ -38,9 +38,8 @@ namespace proto = ::execution;
 static api::BlockNumberOrHash sample_block_number_or_hash(bool has_number) {
     if (has_number) {
         return kSampleBlockNumber;
-    } else {
-        return kSampleBlockHash;
     }
+    return kSampleBlockHash;
 }
 
 static proto::GetSegmentRequest sample_proto_get_segment_request(std::optional<BlockNum> number,

--- a/silkworm/node/stagedsync/execution_engine.cpp
+++ b/silkworm/node/stagedsync/execution_engine.cpp
@@ -198,10 +198,9 @@ bool ExecutionEngine::notify_fork_choice_update(Hash head_block_hash,
             if (main_chain_.is_finalized_canonical(head_block_hash)) {
                 SILK_DEBUG << "ExecutionEngine: chain " << head_block_hash.to_hex() << " already chosen";
                 return true;
-            } else {
-                SILK_WARN << "ExecutionEngine: chain " << head_block_hash.to_hex() << " not found at fork choice update time";
-                return false;
             }
+            SILK_WARN << "ExecutionEngine: chain " << head_block_hash.to_hex() << " not found at fork choice update time";
+            return false;
         }
 
         // notify the fork of the update - we need to block here to restore the invariant
@@ -277,9 +276,8 @@ std::optional<TotalDifficulty> ExecutionEngine::get_header_td(Hash h, std::optio
     // is a duty of the sync component
     if (bn) {
         return main_chain_.get_header_td(*bn, h);
-    } else {
-        return main_chain_.get_header_td(h);
     }
+    return main_chain_.get_header_td(h);
 }
 
 std::optional<BlockBody> ExecutionEngine::get_body(Hash header_hash) const {

--- a/silkworm/node/stagedsync/execution_pipeline.cpp
+++ b/silkworm/node/stagedsync/execution_pipeline.cpp
@@ -221,10 +221,9 @@ Stage::Result ExecutionPipeline::forward(db::RWTxn& cycle_txn, BlockNum target_h
                 if (start_stage_name != stage_id) {
                     log::Info("Skipping " + std::string(stage_id) + "...", {"START_AT_STAGE", *start_stage_name, "hit", "true"});
                     continue;
-                } else {
-                    // Start stage just found, avoid skipping next stages
-                    start_stage_name = std::nullopt;
                 }
+                // Start stage just found, avoid skipping next stages
+                start_stage_name = std::nullopt;
             }
 
             // Check if we have to stop due to environment variable

--- a/silkworm/node/stagedsync/forks/main_chain.cpp
+++ b/silkworm/node/stagedsync/forks/main_chain.cpp
@@ -223,19 +223,20 @@ VerificationResult MainChain::verify_chain(Hash block_hash) {
         if (block_header->number <= last_fork_choice_.number) {
             // Last FCU block is greater than or equal to incoming canonical block, chain is valid up to last FCU block
             return ValidChain{last_fork_choice_.number, last_fork_choice_.hash};
-        } else if (std::holds_alternative<ValidChain>(interim_head_status_)) {
+        }
+        if (std::holds_alternative<ValidChain>(interim_head_status_)) {
             // Chain is valid up to canonical head
             return ValidChain{interim_canonical_chain_.current_head().number, interim_canonical_chain_.current_head().hash};
-        } else if (std::holds_alternative<InvalidChain>(interim_head_status_)) {
+        }
+        if (std::holds_alternative<InvalidChain>(interim_head_status_)) {
             // Chain is valid up to unwind point
             const auto& invalid_chain{std::get<InvalidChain>(interim_head_status_)};
             if (block_header->number <= invalid_chain.unwind_point.number) {
                 // Unwind point is greater than or equal incoming canonical block, chain is valid up to unwind point
                 return ValidChain{invalid_chain.unwind_point.number, invalid_chain.unwind_point.hash};
-            } else {
-                // Incoming canonical block is greater than unwind point, so chain is invalid
-                return invalid_chain;
             }
+            // Incoming canonical block is greater than unwind point, so chain is invalid
+            return invalid_chain;
         }
     }
 

--- a/silkworm/node/stagedsync/stages/stage_blockhashes.cpp
+++ b/silkworm/node/stagedsync/stages/stage_blockhashes.cpp
@@ -45,7 +45,8 @@ Stage::Result BlockHashes::forward(db::RWTxn& txn) {
             // Nothing to process
             operation_ = OperationType::None;
             return ret;
-        } else if (previous_progress > headers_stage_progress) {
+        }
+        if (previous_progress > headers_stage_progress) {
             // Something bad had happened.
             // Maybe we need to unwind ?
             throw StageError(Stage::Result::kInvalidProgress,

--- a/silkworm/node/stagedsync/stages/stage_bodies.cpp
+++ b/silkworm/node/stagedsync/stages/stage_bodies.cpp
@@ -117,7 +117,8 @@ Stage::Result BodiesStage::forward(db::RWTxn& tx) {
         if (current_height_ == target_height) {
             // Nothing to process
             return Stage::Result::kSuccess;
-        } else if (current_height_ > target_height) {
+        }
+        if (current_height_ > target_height) {
             // Something bad had happened. Maybe we need to unwind ?
             throw StageError(Stage::Result::kInvalidProgress,
                              "Previous progress " + std::to_string(current_height_) +

--- a/silkworm/node/stagedsync/stages/stage_execution.cpp
+++ b/silkworm/node/stagedsync/stages/stage_execution.cpp
@@ -53,7 +53,8 @@ Stage::Result Execution::forward(db::RWTxn& txn) {
             // Nothing to process
             operation_ = OperationType::None;
             return ret;
-        } else if (previous_progress > senders_stage_progress) {
+        }
+        if (previous_progress > senders_stage_progress) {
             // Something bad had happened. Not possible execution stage is ahead of senders
             // Maybe we need to unwind ?
             std::string what{"Bad progress sequence. Execution stage progress " + std::to_string(previous_progress) +
@@ -163,7 +164,8 @@ void Execution::prefetch_blocks(db::RWTxn& txn, const BlockNum from, const Block
             if (reached_block_num != block_num) {
                 throw std::runtime_error("Bad canonical header sequence: expected " + std::to_string(block_num) +
                                          " got " + std::to_string(reached_block_num));
-            } else if (value.length() != kHashLength) {
+            }
+            if (value.length() != kHashLength) {
                 throw std::runtime_error("Invalid value for hash in " +
                                          std::string(db::table::kCanonicalHashes.name) +
                                          " expected=" + std::to_string(kHashLength) +

--- a/silkworm/node/stagedsync/stages/stage_hashstate.cpp
+++ b/silkworm/node/stagedsync/stages/stage_hashstate.cpp
@@ -43,7 +43,8 @@ Stage::Result HashState::forward(db::RWTxn& txn) {
         if (previous_progress == execution_stage_progress) {
             // Nothing to process
             return ret;
-        } else if (previous_progress > execution_stage_progress) {
+        }
+        if (previous_progress > execution_stage_progress) {
             // Something bad had happened. Not possible execution stage is ahead of bodies
             // Maybe we need to unwind ?
             std::string what{std::string(stage_name_) + " progress " + std::to_string(previous_progress) +

--- a/silkworm/node/stagedsync/stages/stage_history_index.cpp
+++ b/silkworm/node/stagedsync/stages/stage_history_index.cpp
@@ -38,7 +38,8 @@ Stage::Result HistoryIndex::forward(db::RWTxn& txn) {
             // Nothing to process
             operation_ = OperationType::None;
             return ret;
-        } else if (previous_progress > target_progress) {
+        }
+        if (previous_progress > target_progress) {
             // Something bad had happened.  Maybe we need to unwind ?
             throw StageError(Stage::Result::kInvalidProgress,
                              "HistoryIndex progress " + std::to_string(previous_progress) +

--- a/silkworm/node/stagedsync/stages/stage_interhashes.cpp
+++ b/silkworm/node/stagedsync/stages/stage_interhashes.cpp
@@ -50,7 +50,8 @@ Stage::Result InterHashes::forward(db::RWTxn& txn) {
             // Nothing to process
             operation_ = OperationType::None;
             return Stage::Result::kSuccess;
-        } else if (previous_progress > hashstate_stage_progress) {
+        }
+        if (previous_progress > hashstate_stage_progress) {
             // Something bad had happened. Not possible hashstate stage is ahead of bodies
             // Maybe we need to unwind ?
             // Something bad had happened.  Maybe we need to unwind ?
@@ -240,7 +241,8 @@ trie::PrefixSet InterHashes::collect_account_changes(db::RWTxn& txn, BlockNum fr
         check_block_sequence(reached_blocknum, expected_blocknum);
         if (reached_blocknum > max_blocknum) {
             break;
-        } else if (auto now{std::chrono::steady_clock::now()}; log_time <= now) {
+        }
+        if (auto now{std::chrono::steady_clock::now()}; log_time <= now) {
             throw_if_stopping();
             log_lck.lock();
             log_time = now + 5s;
@@ -379,7 +381,8 @@ trie::PrefixSet InterHashes::collect_storage_changes(db::RWTxn& txn, BlockNum fr
 
         if (reached_blocknum > to) {
             break;
-        } else if (auto now{std::chrono::steady_clock::now()}; log_time <= now) {
+        }
+        if (auto now{std::chrono::steady_clock::now()}; log_time <= now) {
             throw_if_stopping();
             log_lck.lock();
             log_time = now + 5s;

--- a/silkworm/node/stagedsync/stages/stage_log_index.cpp
+++ b/silkworm/node/stagedsync/stages/stage_log_index.cpp
@@ -69,7 +69,8 @@ Stage::Result LogIndex::forward(db::RWTxn& txn) {
             // Nothing to process
             operation_ = OperationType::None;
             return ret;
-        } else if (previous_progress > target_progress) {
+        }
+        if (previous_progress > target_progress) {
             // Something bad had happened.  Maybe we need to unwind ?
             throw StageError(Stage::Result::kInvalidProgress,
                              "LogIndex progress " + std::to_string(previous_progress) +

--- a/silkworm/node/stagedsync/stages/stage_senders.cpp
+++ b/silkworm/node/stagedsync/stages/stage_senders.cpp
@@ -281,7 +281,8 @@ Stage::Result Senders::parallel_recover(db::RWTxn& txn) {
         if (previous_progress == target_block_num) {
             // Nothing to process
             return ret;
-        } else if (previous_progress > target_block_num) {
+        }
+        if (previous_progress > target_block_num) {
             // Something bad had happened. Maybe we need to unwind ?
             throw StageError(Stage::Result::kInvalidProgress, "Previous progress " + std::to_string(previous_progress) +
                                                                   " > target progress " + std::to_string(target_block_num));
@@ -401,7 +402,8 @@ Stage::Result Senders::add_to_batch(BlockNum block_num, const Hash& block_hash, 
                 log::Error(log_prefix_) << "EIP-155 signature for transaction #" << tx_id << " in block #" << block_num
                                         << " before Spurious Dragon";
                 return Stage::Result::kInvalidTransaction;
-            } else if (transaction.chain_id.value() != chain_config_.chain_id) {
+            }
+            if (transaction.chain_id.value() != chain_config_.chain_id) {
                 log::Error(log_prefix_) << "EIP-155 invalid signature for transaction #" << tx_id << " in block #" << block_num;
                 return Stage::Result::kInvalidTransaction;
             }

--- a/silkworm/node/stagedsync/stages/stage_tx_lookup.cpp
+++ b/silkworm/node/stagedsync/stages/stage_tx_lookup.cpp
@@ -40,7 +40,8 @@ Stage::Result TxLookup::forward(db::RWTxn& txn) {
             // Nothing to process
             operation_ = OperationType::None;
             return ret;
-        } else if (previous_progress > target_progress) {
+        }
+        if (previous_progress > target_progress) {
             // Something bad had happened.  Maybe we need to unwind ?
             throw StageError(Stage::Result::kInvalidProgress,
                              "TxLookup progress " + std::to_string(previous_progress) +

--- a/silkworm/node/test_util/mock_execution_engine.hpp
+++ b/silkworm/node/test_util/mock_execution_engine.hpp
@@ -50,14 +50,11 @@ class MockExecutionEngine : public stagedsync::ExecutionEngine {
                                    std::optional<Hash> safe_block_hash) override {
         if (finalized_block_hash && safe_block_hash) {
             return notify_fork_choice_update3(head_block_hash, *finalized_block_hash, *safe_block_hash);
-        } else {
-            if (finalized_block_hash) {
-                return notify_fork_choice_update2(head_block_hash, *finalized_block_hash);
-            } else {
-                return notify_fork_choice_update1(head_block_hash);
-            }
         }
-        return false;
+        if (finalized_block_hash) {
+            return notify_fork_choice_update2(head_block_hash, *finalized_block_hash);
+        }
+        return notify_fork_choice_update1(head_block_hash);
     }
 
     MOCK_METHOD((BlockId), last_fork_choice, (), (const, override));

--- a/silkworm/rpc/commands/debug_api.cpp
+++ b/silkworm/rpc/commands/debug_api.cpp
@@ -632,7 +632,8 @@ Task<std::set<evmc::address>> get_modified_accounts(db::kv::api::Transaction& tx
         std::stringstream msg;
         msg << "start block (" << start_block_number << ") is later than the latest block (" << latest_block_number << ")";
         throw std::invalid_argument(msg.str());
-    } else if (start_block_number <= end_block_number) {
+    }
+    if (start_block_number <= end_block_number) {
         auto walker = [&](const silkworm::Bytes& key, const silkworm::Bytes& value) {
             auto block_number = static_cast<BlockNum>(std::stol(silkworm::to_hex(key), nullptr, 16));
             if (block_number <= end_block_number) {

--- a/silkworm/rpc/common/util.cpp
+++ b/silkworm/rpc/common/util.cpp
@@ -150,9 +150,8 @@ std::string get_opcode_hex(uint8_t opcode) {
     static constexpr auto hex_digits = "0123456789abcdef";
     if (opcode < 16) {
         return {'0', 'x', hex_digits[opcode]};
-    } else {
-        return {'0', 'x', hex_digits[opcode >> 4], hex_digits[opcode & 0xf]};
     }
+    return {'0', 'x', hex_digits[opcode >> 4], hex_digits[opcode & 0xf]};
 }
 
 std::string get_opcode_name(const char* const* names, std::uint8_t opcode) {

--- a/silkworm/rpc/core/estimate_gas_oracle.cpp
+++ b/silkworm/rpc/core/estimate_gas_oracle.cpp
@@ -130,14 +130,12 @@ void EstimateGasOracle::throw_exception(ExecutionResult& result) {
     if (result.pre_check_error) {
         SILK_DEBUG << "result error " << result.pre_check_error.value();
         throw EstimateGasException{-32000, *result.pre_check_error};
-    } else {
-        auto error_message = result.error_message();
-        SILK_DEBUG << "result message: " << error_message << ", code " << *result.error_code;
-        if (result.data.empty()) {
-            throw EstimateGasException{-32000, error_message};
-        } else {
-            throw EstimateGasException{3, error_message, result.data};
-        }
     }
+    auto error_message = result.error_message();
+    SILK_DEBUG << "result message: " << error_message << ", code " << *result.error_code;
+    if (result.data.empty()) {
+        throw EstimateGasException{-32000, error_message};
+    }
+    throw EstimateGasException{3, error_message, result.data};
 }
 }  // namespace silkworm::rpc

--- a/silkworm/rpc/core/storage_walker.cpp
+++ b/silkworm/rpc/core/storage_walker.cpp
@@ -80,10 +80,12 @@ Task<ethdb::SplittedKeyValue> next(ethdb::SplitCursor& cursor, BlockNum number, 
 }
 
 int StorageWalker::compare_empty_greater(const ByteView& key1, const ByteView& key2) {
-    if (key1.empty() && !key2.empty())
+    if (key1.empty() && !key2.empty()) {
         return 1;
-    else if (!key1.empty() && key2.empty())
+    }
+    if (!key1.empty() && key2.empty()) {
         return -1;
+    }
     return key1.compare(key2);
 }
 

--- a/silkworm/rpc/ethdb/cbor.cpp
+++ b/silkworm/rpc/ethdb/cbor.cpp
@@ -193,12 +193,12 @@ bool cbor_decode(const silkworm::Bytes& bytes, std::vector<Receipt>& receipts) {
     if (json.is_array()) {
         receipts = json.get<std::vector<Receipt>>();
         return true;
-    } else if (json.is_null()) {
-        return true;
-    } else {
-        SILK_ERROR << "cbor_decode<std::vector<Receipt>> unexpected json: " << json.dump();
-        return false;
     }
+    if (json.is_null()) {
+        return true;
+    }
+    SILK_ERROR << "cbor_decode<std::vector<Receipt>> unexpected json: " << json.dump();
+    return false;
 }
 
 }  // namespace silkworm::rpc

--- a/silkworm/rpc/json/types.hpp
+++ b/silkworm/rpc/json/types.hpp
@@ -144,7 +144,8 @@ struct adl_serializer<silkworm::rpc::BlockNumberOrHash> {
     static silkworm::rpc::BlockNumberOrHash from_json(const json& json) {
         if (json.is_string()) {
             return silkworm::rpc::BlockNumberOrHash{json.get<std::string>()};
-        } else if (json.is_number()) {
+        }
+        if (json.is_number()) {
             return silkworm::rpc::BlockNumberOrHash{json.get<silkworm::BlockNum>()};
         }
         return silkworm::rpc::BlockNumberOrHash{0};

--- a/silkworm/rpc/json_rpc/validator.cpp
+++ b/silkworm/rpc/json_rpc/validator.cpp
@@ -96,9 +96,8 @@ ValidationResult Validator::validate_params(const nlohmann::json& request) {
     if (method_spec_field == method_specs_.end()) {
         if (accept_unknown_methods_) {
             return {};
-        } else {
-            return tl::make_unexpected("Method not found in spec: " + method);
         }
+        return tl::make_unexpected("Method not found in spec: " + method);
     }
     const auto& method_spec = method_spec_field->second;
 
@@ -157,19 +156,23 @@ ValidationResult Validator::validate_type(const nlohmann::json& value, const nlo
 
     if (schema_type == "string") {
         return validate_string(value, schema);
-    } else if (schema_type == "array") {
-        return validate_array(value, schema);
-    } else if (schema_type == "object") {
-        return validate_object(value, schema);
-    } else if (schema_type == "boolean") {
-        return validate_boolean(value);
-    } else if (schema_type == "number") {
-        return validate_number(value);
-    } else if (schema_type == "null") {
-        return validate_null(value);
-    } else {
-        return tl::make_unexpected("Invalid schema type: " + schema_type);
     }
+    if (schema_type == "array") {
+        return validate_array(value, schema);
+    }
+    if (schema_type == "object") {
+        return validate_object(value, schema);
+    }
+    if (schema_type == "boolean") {
+        return validate_boolean(value);
+    }
+    if (schema_type == "number") {
+        return validate_number(value);
+    }
+    if (schema_type == "null") {
+        return validate_null(value);
+    }
+    return tl::make_unexpected("Invalid schema type: " + schema_type);
 }
 
 ValidationResult Validator::validate_string(const nlohmann::json& string, const nlohmann::json& schema) {

--- a/silkworm/sentry/discovery/node_db/node_db_sqlite.cpp
+++ b/silkworm/sentry/discovery/node_db/node_db_sqlite.cpp
@@ -593,11 +593,10 @@ class NodeDbSqliteImpl : public NodeDb {
 
     std::optional<Time> get_node_property_time(const NodeId& id, const char* sql) {
         auto value = get_node_property_int(id, sql);
-        if (value) {
-            return time_point_from_unix_timestamp(static_cast<uint64_t>(*value));
-        } else {
+        if (!value) {
             return std::nullopt;
         }
+        return time_point_from_unix_timestamp(static_cast<uint64_t>(*value));
     }
 
     void set_node_property_time(const NodeId& id, const char* sql, Time value) {

--- a/silkworm/sentry/grpc/interfaces/peer_info.cpp
+++ b/silkworm/sentry/grpc/interfaces/peer_info.cpp
@@ -92,12 +92,10 @@ api::PeerInfos peer_infos_from_proto_peers_reply(const ::sentry::PeersReply& rep
 }
 
 std::optional<api::PeerInfo> peer_info_opt_from_proto_peer_reply(const ::sentry::PeerByIdReply& reply) {
-    if (reply.has_peer()) {
-        auto result = peer_info_from_proto_peer_info(reply.peer());
-        return {result};
-    } else {
+    if (!reply.has_peer()) {
         return std::nullopt;
     }
+    return peer_info_from_proto_peer_info(reply.peer());
 }
 
 ::sentry::PeerByIdReply proto_peer_reply_from_peer_info_opt(const std::optional<api::PeerInfo>& peer_opt) {

--- a/silkworm/sentry/node_key_config.cpp
+++ b/silkworm/sentry/node_key_config.cpp
@@ -66,9 +66,8 @@ NodeKey node_key_get_or_generate(
         const Bytes* data = get_if<Bytes>(&node_key_option.value());
         if (data) {
             return NodeKey(*data);
-        } else {
-            config = NodeKeyConfig(get<fs::path>(node_key_option.value()));
         }
+        config = NodeKeyConfig(get<fs::path>(node_key_option.value()));
     }
 
     if (config.exists()) {

--- a/silkworm/sentry/rlpx/auth/handshake.cpp
+++ b/silkworm/sentry/rlpx/auth/handshake.cpp
@@ -75,9 +75,8 @@ Task<Handshake::HandshakeResult> Handshake::execute(SocketStream& stream) {
         if (reply_message.id == DisconnectMessage::kId) {
             auto disconnect_message = DisconnectMessage::from_message(reply_message);
             throw DisconnectError(disconnect_message.reason);
-        } else {
-            throw std::runtime_error("rlpx::auth::Handshake: unexpected RLPx message");
         }
+        throw std::runtime_error("rlpx::auth::Handshake: unexpected RLPx message");
     }
 
     HelloMessage hello_reply_message = HelloMessage::from_message(reply_message);

--- a/silkworm/sentry/rlpx/peer.cpp
+++ b/silkworm/sentry/rlpx/peer.cpp
@@ -402,10 +402,12 @@ Task<void> Peer::receive_messages(framing::MessageStream& message_stream) {
         if (message.id == DisconnectMessage::kId) {
             auto disconnect_message = DisconnectMessage::from_message(message);
             throw auth::Handshake::DisconnectError(disconnect_message.reason);
-        } else if (message.id == PingMessage::kId) {
+        }
+        if (message.id == PingMessage::kId) {
             co_await message_stream.send(PongMessage{}.to_message());
             continue;
-        } else if (message.id == PongMessage::kId) {
+        }
+        if (message.id == PongMessage::kId) {
             try {
                 co_await pong_channel_.send(std::move(message));
             } catch (const boost::system::system_error& ex) {

--- a/silkworm/sentry/rlpx/server.cpp
+++ b/silkworm/sentry/rlpx/server.cpp
@@ -64,9 +64,8 @@ Task<void> Server::run(
     } catch (const boost::system::system_error& ex) {
         if (ex.code() == boost::system::errc::address_in_use) {
             throw std::runtime_error("Sentry RLPx server has failed to start because port " + std::to_string(port_) + " is already in use. Try another one with --port.");
-        } else {
-            throw;
         }
+        throw;
     }
     acceptor.listen();
 
@@ -82,10 +81,9 @@ Task<void> Server::run(
             if (ex.code() == boost::system::errc::invalid_argument) {
                 log::Error("sentry") << "Sentry RLPx server got invalid_argument on accept port=" << port_;
                 continue;
-            } else {
-                log::Critical("sentry") << "Sentry RLPx server unexpected end [" + std::string{ex.what()} + "]";
-                throw;
             }
+            log::Critical("sentry") << "Sentry RLPx server unexpected end [" + std::string{ex.what()} + "]";
+            throw;
         }
 
         auto remote_endpoint = stream.socket().remote_endpoint();

--- a/silkworm/sync/internals/chain_elements.hpp
+++ b/silkworm/sync/internals/chain_elements.hpp
@@ -120,17 +120,25 @@ struct LinkYoungerThan : public std::function<bool(std::shared_ptr<Link>, std::s
 
 struct AnchorYoungerThan : public std::function<bool(std::shared_ptr<Link>, std::shared_ptr<Link>)> {
     bool operator()(const std::shared_ptr<Anchor>& x, const std::shared_ptr<Anchor>& y) const {
-        return x->timestamp != y->timestamp ? x->timestamp > y->timestamp :               // prefer smaller timestamp
-                   (x->blockHeight != y->blockHeight ? x->blockHeight > y->blockHeight :  // when timestamps are the same prioritise low blockHeight
-                        x > y);                                                           // when blockHeight are the same preserve identity
+        if (x->timestamp != y->timestamp) {
+            return x->timestamp > y->timestamp;  // prefer smaller timestamp
+        } else if (x->blockHeight != y->blockHeight) {
+            return x->blockHeight > y->blockHeight;  // when timestamps are the same prioritise low blockHeight
+        } else {
+            return x > y;  // when blockHeight are the same preserve identity
+        }
     }
 };
 
 struct AnchorOlderThan : public std::function<bool(std::shared_ptr<Anchor>, std::shared_ptr<Anchor>)> {
     bool operator()(const std::shared_ptr<Anchor>& x, const std::shared_ptr<Anchor>& y) const {
-        return x->timestamp != y->timestamp ? x->timestamp < y->timestamp :               // prefer smaller timestamp
-                   (x->blockHeight != y->blockHeight ? x->blockHeight < y->blockHeight :  // when timestamps are the same prioritise low blockHeight
-                        x < y);                                                           // when blockHeight are the same preserve identity
+        if (x->timestamp != y->timestamp) {
+            return x->timestamp < y->timestamp;  // prefer smaller timestamp
+        } else if (x->blockHeight != y->blockHeight) {
+            return x->blockHeight < y->blockHeight;  // when timestamps are the same prioritise low blockHeight
+        } else {
+            return x < y;  // when blockHeight are the same preserve identity
+        }
     }
 };
 

--- a/silkworm/sync/internals/chain_elements.hpp
+++ b/silkworm/sync/internals/chain_elements.hpp
@@ -122,11 +122,11 @@ struct AnchorYoungerThan : public std::function<bool(std::shared_ptr<Link>, std:
     bool operator()(const std::shared_ptr<Anchor>& x, const std::shared_ptr<Anchor>& y) const {
         if (x->timestamp != y->timestamp) {
             return x->timestamp > y->timestamp;  // prefer smaller timestamp
-        } else if (x->blockHeight != y->blockHeight) {
-            return x->blockHeight > y->blockHeight;  // when timestamps are the same prioritise low blockHeight
-        } else {
-            return x > y;  // when blockHeight are the same preserve identity
         }
+        if (x->blockHeight != y->blockHeight) {
+            return x->blockHeight > y->blockHeight;  // when timestamps are the same prioritise low blockHeight
+        }
+        return x > y;  // when blockHeight are the same preserve identity
     }
 };
 
@@ -134,11 +134,11 @@ struct AnchorOlderThan : public std::function<bool(std::shared_ptr<Anchor>, std:
     bool operator()(const std::shared_ptr<Anchor>& x, const std::shared_ptr<Anchor>& y) const {
         if (x->timestamp != y->timestamp) {
             return x->timestamp < y->timestamp;  // prefer smaller timestamp
-        } else if (x->blockHeight != y->blockHeight) {
-            return x->blockHeight < y->blockHeight;  // when timestamps are the same prioritise low blockHeight
-        } else {
-            return x < y;  // when blockHeight are the same preserve identity
         }
+        if (x->blockHeight != y->blockHeight) {
+            return x->blockHeight < y->blockHeight;  // when timestamps are the same prioritise low blockHeight
+        }
+        return x < y;  // when blockHeight are the same preserve identity
     }
 };
 

--- a/silkworm/sync/internals/header_chain.cpp
+++ b/silkworm/sync/internals/header_chain.cpp
@@ -355,8 +355,8 @@ std::shared_ptr<OutboundMessage> HeaderChain::anchor_skeleton_request(time_point
         if (*lowest_anchor - highest_in_db_ <= stride) {  // the lowest_anchor is too close to highest_in_db
             skeleton_condition_ = "working";
             return nullptr;
-        } else
-            next_target = *lowest_anchor;
+        }
+        next_target = *lowest_anchor;
     } else {                                   // there are no anchors
         if (top - highest_in_db_ <= stride) {  // the top is too close to highest_in_db
             if (target_block_) {               // we are syncing to a specific block
@@ -365,10 +365,9 @@ std::shared_ptr<OutboundMessage> HeaderChain::anchor_skeleton_request(time_point
                 request_message->packet().requestId = generate_request_id();
                 request_message->packet().request = {{top}, max_len, 0, true};  // request top header only
                 return request_message;
-            } else {
-                skeleton_condition_ = "wait tip announce";
-                return nullptr;
             }
+            skeleton_condition_ = "wait tip announce";
+            return nullptr;
         }
     }
 
@@ -483,14 +482,14 @@ std::shared_ptr<OutboundMessage> HeaderChain::anchor_extension_request(time_poin
 
             extension_condition_ = "ok";
             return request_message;  // try (again) to extend this anchor
-        } else {
-            // ancestors of this anchor seem to be unavailable, invalidate and move on
-            log::Warning("HeaderChain") << "invalidating anchor for suspected unavailability, "
-                                        << "height=" << anchor->blockHeight;
-            // no need to do anchor_queue_.pop(), implicitly done in the following
-            invalidate(anchor);
-            send_penalties->penalties().emplace_back(Penalty::AbandonedAnchorPenalty, anchor->peerId);
         }
+
+        // ancestors of this anchor seem to be unavailable, invalidate and move on
+        log::Warning("HeaderChain") << "invalidating anchor for suspected unavailability, "
+                                    << "height=" << anchor->blockHeight;
+        // no need to do anchor_queue_.pop(), implicitly done in the following
+        invalidate(anchor);
+        send_penalties->penalties().emplace_back(Penalty::AbandonedAnchorPenalty, anchor->peerId);
     }
 
     extension_condition_ = "void anchor queue";
@@ -805,7 +804,8 @@ std::tuple<std::optional<std::shared_ptr<Anchor>>, HeaderChain::DeepLink> Header
 
     if (parent_link->persisted) {
         return {std::nullopt, parent_link};  // ok, no anchor because the link is in a segment attached to a
-    }                                        // persisted link that we return
+                                             // persisted link that we return
+    }
 
     auto a = anchors_.find(parent_link->header->parent_hash);
     if (a == anchors_.end()) {

--- a/silkworm/sync/internals/header_retrieval.cpp
+++ b/silkworm/sync/internals/header_retrieval.cpp
@@ -114,31 +114,36 @@ std::vector<BlockHeader> HeaderRetrieval::recover_by_number(BlockNum origin, uin
 
 std::tuple<Hash, BlockNum> HeaderRetrieval::get_ancestor(Hash hash, BlockNum block_num, BlockNum ancestor_delta,
                                                          uint64_t& max_non_canonical) {
-    if (ancestor_delta > block_num) return {Hash{}, 0};
+    if (ancestor_delta > block_num) {
+        return {Hash{}, 0};
+    }
 
     if (ancestor_delta == 1) {
         auto header = data_model_.read_header(block_num, hash);
         if (header) {
             return {header->parent_hash, block_num - 1};
-        } else {
-            return {Hash{}, 0};
         }
+        return {Hash{}, 0};
     }
 
     while (ancestor_delta != 0) {
         auto h = db::read_canonical_header_hash(db_tx_, block_num);
         if (h == hash) {
             auto ancestorHash = db::read_canonical_header_hash(db_tx_, block_num - ancestor_delta);
-            if (!ancestorHash)
+            if (!ancestorHash) {
                 return {Hash{}, 0};
-            else
-                return {*ancestorHash, block_num - ancestor_delta};
+            }
+            return {*ancestorHash, block_num - ancestor_delta};
         }
-        if (max_non_canonical == 0) return {Hash{}, 0};
+        if (max_non_canonical == 0) {
+            return {Hash{}, 0};
+        }
         max_non_canonical--;
         ancestor_delta--;
         auto header = data_model_.read_header(block_num, hash);
-        if (!header) return {Hash{}, 0};
+        if (!header) {
+            return {Hash{}, 0};
+        }
         hash = header->parent_hash;
         block_num--;
     }

--- a/silkworm/sync/packets/hash_or_number.hpp
+++ b/silkworm/sync/packets/hash_or_number.hpp
@@ -34,17 +34,18 @@ struct HashOrNumber : public std::variant<Hash, BlockNum> {};
 namespace rlp {
 
     inline void encode(Bytes& to, const HashOrNumber& from) {
-        if (std::holds_alternative<Hash>(from))
+        if (std::holds_alternative<Hash>(from)) {
             rlp::encode(to, std::get<Hash>(from));
-        else
+        } else {
             rlp::encode(to, std::get<BlockNum>(from));
+        }
     }
 
     inline size_t length(const HashOrNumber& from) {
-        if (std::holds_alternative<Hash>(from))
+        if (std::holds_alternative<Hash>(from)) {
             return rlp::length(std::get<Hash>(from));
-        else
-            return rlp::length(std::get<BlockNum>(from));
+        }
+        return rlp::length(std::get<BlockNum>(from));
     }
 
     inline DecodingResult decode(ByteView& from, HashOrNumber& to, Leftover mode = Leftover::kProhibit) noexcept {

--- a/silkworm/sync/sentry_client.cpp
+++ b/silkworm/sync/sentry_client.cpp
@@ -263,11 +263,10 @@ Task<void> SentryClient::receive_messages() {
 static std::string describe_peer_info(const std::optional<silkworm::sentry::api::PeerInfo>& peer_info_opt) {
     if (!peer_info_opt) {
         return "-info-not-found-";
-    } else {
-        const auto& peer_info = peer_info_opt.value();
-        std::string info = "client_id=" + peer_info.client_id + " / enode_url=" + peer_info.url.to_string();
-        return info;
     }
+    const auto& peer_info = peer_info_opt.value();
+    std::string info = "client_id=" + peer_info.client_id + " / enode_url=" + peer_info.url.to_string();
+    return info;
 }
 
 static std::string describe_peer_event(


### PR DESCRIPTION
See https://clang.llvm.org/extra/clang-tidy/checks/readability/else-after-return.html. Also fix [readability-avoid-nested-conditional-operator](https://clang.llvm.org/extra/clang-tidy/checks/readability/avoid-nested-conditional-operator.html).