### PR TITLE
clang-tidy: fix some readability warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -75,7 +75,6 @@ Checks: >
   -readability-named-parameter,
   -readability-qualified-auto,
   -readability-redundant-member-init,
-  -readability-redundant-smartptr-get,
   -readability-simplify-boolean-expr,
   -readability-suspicious-call-argument,
   -readability-uppercase-literal-suffix

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -75,6 +75,8 @@ Checks: >
   -readability-named-parameter,
   -readability-qualified-auto,
   -readability-redundant-member-init,
-  -readability-simplify-boolean-expr,
   -readability-suspicious-call-argument,
   -readability-uppercase-literal-suffix
+CheckOptions:
+- key: readability-simplify-boolean-expr.SimplifyDeMorgan
+  value: false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -74,7 +74,6 @@ Checks: >
   -readability-magic-numbers,
   -readability-named-parameter,
   -readability-qualified-auto,
-  -readability-redundant-inline-specifier,
   -readability-redundant-member-init,
   -readability-redundant-smartptr-get,
   -readability-simplify-boolean-expr,

--- a/cmd/dev/db_toolbox.cpp
+++ b/cmd/dev/db_toolbox.cpp
@@ -265,11 +265,7 @@ bool user_confirmation(const std::string& message = {"Confirm ?"}) {
         std::cout << "Unexpected user input: " << user_input << "\n";
     } while (true);
 
-    if (matches[2].length()) {
-        return false;
-    }
-
-    return true;
+    return matches[2].length() == 0;
 }
 
 void do_clear(db::EnvConfig& config, bool dry, bool always_yes, const std::vector<std::string>& table_names,

--- a/silkworm/core/protocol/intrinsic_gas.hpp
+++ b/silkworm/core/protocol/intrinsic_gas.hpp
@@ -23,7 +23,7 @@
 namespace silkworm {
 
 // Words in EVM are 32-bytes long
-inline constexpr uint64_t num_words(uint64_t num_bytes) noexcept {
+constexpr uint64_t num_words(uint64_t num_bytes) noexcept {
     return num_bytes / 32 + static_cast<uint64_t>(num_bytes % 32 != 0);
 }
 

--- a/silkworm/db/snapshots/seg/compressor/lcp_kasai.cpp
+++ b/silkworm/db/snapshots/seg/compressor/lcp_kasai.cpp
@@ -21,7 +21,7 @@ namespace silkworm::snapshots::seg {
 void lcp_kasai(const uint8_t* data, const int* sa, const int* inv, int* lcp, int n) {
     struct DataPosComparator {
         const uint8_t* data;
-        inline bool has_same_chars(int i, int j) const {
+        bool has_same_chars(int i, int j) const {
             return data[i] == data[j];
         }
     } comparator{data};

--- a/silkworm/infra/common/log.hpp
+++ b/silkworm/infra/common/log.hpp
@@ -89,7 +89,7 @@ class BufferBase {
 
     // Accumulators
     template <class T>
-    inline void append(const T& t) {
+    void append(const T& t) {
         if (should_print_) ss_ << t;
     }
     template <class T>
@@ -97,16 +97,16 @@ class BufferBase {
         append(t);
         return *this;
     }
-    inline void append(const Args& args) {
+    void append(const Args& args) {
         append("", args);
     }
-    inline BufferBase& operator<<(const Args& args) {
+    BufferBase& operator<<(const Args& args) {
         append(args);
         return *this;
     }
 
   protected:
-    inline void append(std::string_view msg, const Args& args) {
+    void append(std::string_view msg, const Args& args) {
         if (!should_print_) return;
         ss_ << std::left << std::setw(41) << std::setfill(' ') << msg;
         bool left{true};

--- a/silkworm/infra/concurrency/idle_strategy.hpp
+++ b/silkworm/infra/concurrency/idle_strategy.hpp
@@ -50,11 +50,10 @@ class SleepingIdleStrategy {
   public:
     explicit SleepingIdleStrategy(std::chrono::milliseconds duration = 1ms) : duration_(duration) {}
 
-    inline void idle(std::size_t work_count) {
+    void idle(std::size_t work_count) {
         if (work_count > 0) {
             return;
         }
-
         std::this_thread::sleep_for(duration_);
     }
 
@@ -64,18 +63,17 @@ class SleepingIdleStrategy {
 
 class YieldingIdleStrategy {
   public:
-    static inline void idle(std::size_t work_count) {
+    static void idle(std::size_t work_count) {
         if (work_count > 0) {
             return;
         }
-
         std::this_thread::yield();
     }
 };
 
 class BusySpinIdleStrategy {
   public:
-    inline void idle(std::size_t /*work_count*/) {
+    void idle(std::size_t /*work_count*/) {
     }
 };
 

--- a/silkworm/node/common/node_settings.hpp
+++ b/silkworm/node/common/node_settings.hpp
@@ -55,7 +55,7 @@ struct NodeSettings {
     bool parallel_fork_tracking_enabled{false};            // Whether to track multiple parallel forks at head
     bool keep_db_txn_open{true};                           // Whether to keep db transaction open between requests
 
-    inline db::etl::CollectorSettings etl() const {
+    db::etl::CollectorSettings etl() const {
         return {data_directory->temp().path(), etl_buffer_size};
     }
 };

--- a/silkworm/rpc/common/util.cpp
+++ b/silkworm/rpc/common/util.cpp
@@ -81,12 +81,8 @@ bool check_tx_fee_less_cap(float cap, const intx::uint256& max_fee_per_gas, uint
     if (cap == 0) {
         return true;
     }
-
     float fee_eth = (to_float(max_fee_per_gas) * static_cast<float>(gas_limit)) / static_cast<float>(silkworm::kEther);
-    if (fee_eth > cap) {
-        return false;
-    }
-    return true;
+    return fee_eth <= cap;
 }
 
 bool is_replay_protected(const silkworm::Transaction& txn) {
@@ -94,10 +90,7 @@ bool is_replay_protected(const silkworm::Transaction& txn) {
         return true;
     }
     intx::uint256 v = txn.v();
-    if (v != 27 && v != 28 && v != 0 && v != 1) {
-        return true;
-    }
-    return false;
+    return v != 27 && v != 28 && v != 0 && v != 1;
 }
 
 std::string decoding_result_to_string(silkworm::DecodingError decode_result) {

--- a/silkworm/rpc/core/evm_access_list_tracer.hpp
+++ b/silkworm/rpc/core/evm_access_list_tracer.hpp
@@ -62,7 +62,7 @@ class AccessListTracer : public silkworm::EvmTracer {
 };
 
 inline bool operator!=(const AccessList& acl1, const AccessList& acl2) {
-    return AccessListTracer::compare(acl1, acl2) == false;
+    return !AccessListTracer::compare(acl1, acl2);
 }
 
 inline bool operator==(const AccessList& acl1, const AccessList& acl2) {

--- a/silkworm/sync/internals/chain_elements.hpp
+++ b/silkworm/sync/internals/chain_elements.hpp
@@ -193,13 +193,13 @@ using LinkLIFOQueue = std::stack<std::shared_ptr<Link>>;
 
 using Headers = std::vector<std::shared_ptr<BlockHeader>>;
 
-inline BlockHeader& header_at(Headers::iterator it) { return *it->get(); }
+inline BlockHeader& header_at(Headers::iterator it) { return **it; }
 
-inline BlockHeader& header_at(Headers::reverse_iterator it) { return *it->get(); }
+inline BlockHeader& header_at(Headers::reverse_iterator it) { return **it; }
 
-inline const BlockHeader& header_at(Headers::const_iterator it) { return *it->get(); }
+inline const BlockHeader& header_at(Headers::const_iterator it) { return **it; }
 
-inline const BlockHeader& header_at(Headers::const_reverse_iterator it) { return *it->get(); }
+inline const BlockHeader& header_at(Headers::const_reverse_iterator it) { return **it; }
 
 struct Segment;  // forward declaration
 


### PR DESCRIPTION
[redundant-inline-specifier](https://clang.llvm.org/extra/clang-tidy/checks/readability/redundant-inline-specifier.html)
[redundant-smartptr-get](https://clang.llvm.org/extra/clang-tidy/checks/readability/redundant-smartptr-get.html)
[simplify-boolean-expr](https://clang.llvm.org/extra/clang-tidy/checks/readability/simplify-boolean-expr.html)
