### PR TITLE
rpcdaemon: add STOP opcode as last opcode in specific success cases

### DIFF
--- a/.github/workflows/rpc-integration-tests.yml
+++ b/.github/workflows/rpc-integration-tests.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout RPC Tests Repository & Install Requirements
         run: |
           rm -rf ${{runner.workspace}}/rpc-tests
-          git -c advice.detachedHead=false clone --depth 1 --branch v0.40.0 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
+          git -c advice.detachedHead=false clone --depth 1 --branch v0.41.0 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
           cd ${{runner.workspace}}/rpc-tests
           pip3 install -r requirements.txt
 

--- a/silkworm/rpc/core/evm_debug.hpp
+++ b/silkworm/rpc/core/evm_debug.hpp
@@ -115,6 +115,7 @@ class DebugTracer : public EvmTracer {
     const evmc_instruction_metrics* metrics_ = nullptr;
     std::stack<std::int64_t> start_gas_;
     std::optional<FixCallGasInfo> fix_call_gas_info_;
+    std::optional<uint8_t> last_opcode_;
 };
 
 class AccountTracer : public EvmTracer {

--- a/silkworm/rpc/core/evm_trace.hpp
+++ b/silkworm/rpc/core/evm_trace.hpp
@@ -168,6 +168,7 @@ class VmTraceTracer : public silkworm::EvmTracer {
     std::stack<int64_t> start_gas_;
     std::stack<TraceMemory> trace_memory_stack_;
     std::optional<FixCallGasInfo> fix_call_gas_info_;
+    std::optional<uint8_t> last_opcode_;
 };
 
 struct TraceAction {


### PR DESCRIPTION
Synthesise OP_STOP as last opcode in `trace` and `debug` API if execution is successful and last opcode executed is NOT in [OP_SELFDESTRUCT, OP_RETURN, OP_STOP]