### PR TITLE
infra: fix ClientContextPool destruction after mixed dispatching

### DIFF
--- a/silkworm/infra/grpc/client/client_context_pool.hpp
+++ b/silkworm/infra/grpc/client/client_context_pool.hpp
@@ -45,6 +45,8 @@ class ClientContext : public concurrency::Context {
     void execute_loop() override;
 
   private:
+    void destroy_grpc_context();
+
     //! Execute back-off loop until stopped.
     void execute_loop_backoff();
 
@@ -60,6 +62,8 @@ class ClientContext : public concurrency::Context {
 
     //! The work-tracking executor that keep the asio-grpc scheduler running.
     boost::asio::executor_work_guard<agrpc::GrpcContext::executor_type> grpc_context_work_;
+
+    friend class ClientContextPool;
 };
 
 std::ostream& operator<<(std::ostream& out, const ClientContext& c);
@@ -70,6 +74,7 @@ class ClientContextPool : public concurrency::ContextPool<ClientContext>, public
   public:
     explicit ClientContextPool(std::size_t pool_size, concurrency::WaitMode wait_mode = concurrency::WaitMode::blocking);
     explicit ClientContextPool(concurrency::ContextPoolSettings settings);
+    ~ClientContextPool() override;
 
     ClientContextPool(const ClientContextPool&) = delete;
     ClientContextPool& operator=(const ClientContextPool&) = delete;


### PR DESCRIPTION
This PR fixes a nasty bug that _may_ happen during closure of `rpcdaemon` because of the interaction between how our gRPC client context-pool-based threading model works and its cleanup during shutdown.

Some background:
- the `concurrency::ContextPool` class models a pool of task schedulers a.k.a. execution contexts used to process tasks asynchronously and is based on `boost::asio::io_context` abstraction. When using the multi-threaded scheduling strategy (the default one), `concurrency::ContextPool` uses a pool of N threads and each of them runs exactly one `boost::asio::io_context` task loop
- the `rpc::ClientContextPool` class extends `concurrency::ContextPool` by adding support for gRPC-based execution contexts, specifically using N `agrpc::GrpcContext` objects from [asio-grpc](https://github.com/Tradias/asio-grpc) library. Each `agrpc::GrpcContext` instance runs exactly one `grpc::CompletionQueue` message queue from [gRPC asynchronous API](https://grpc.io/docs/languages/cpp/async/) and is logically tied to one `boost::asio::io_context` object because dispatches the asynchronous completion handler back onto the calling `boost::asio::io_context` thread.

The problem arises when you use the `rpc::ClientContextPool` API to inadvertently spawn on the i-th `boost::asio::io_context` instance any asynchronous task handled by the j-th `agrpc::GrpcContext` instance and i != j. Such interleaved dispatching requires a specific destruction order between the two objects, which was not guaranteed in the implementation. This could lead to the `agrpc::GrpcContext` instance posting work to an already destroyed `boost::asio::io_context` instance.

The solution is enforcing a precise destruction order among all the context objects in `rpc::ClientContextPool`, i.e. destroying *all* the `agrpc::GrpcContext` objects before destroying any `boost::asio::io_context` object.

The unit tests added for `rpc::ClientContextPool` cover exactly the crash scenario *but* you need to run them many times to reproduce it because it's a race condition between context threads and main thread executing the test. In order to reproduce it in a practically predictable way, you need to run such unit test in tight loop using our `tests/unit/run_unit_test_loop` script doing e.g. 10'000 iterations:

```
./run_unit_test_loop.py -i 10000 -t "ClientContextPool: start/stop/join w/ tasks enqueued" ../../cmake-build-clang-debug/silkworm/infra/silkworm_infra_test
```

*Extras*
- unit test for plain non-gRPC `ContextPool`