### PR TITLE
rpcdaemon: fix JWT file creation if path not existent

### DIFF
--- a/silkworm/rpc/commands/eth_api.cpp
+++ b/silkworm/rpc/commands/eth_api.cpp
@@ -1349,7 +1349,7 @@ Task<void> EthereumRpcApi::handle_eth_create_access_list(const nlohmann::json& r
     co_await tx->close();  // RAII not (yet) available with coroutines
 }
 
-// https://docs.flashbots.net/flashbots-auction/miners/mev-geth-spec/v06-rpc/eth_callBundle
+// https://docs.flashbots.net/flashbots-auction/advanced/rpc-endpoint#eth_callbundle
 Task<void> EthereumRpcApi::handle_eth_call_bundle(const nlohmann::json& request, nlohmann::json& reply) {
     auto params = request["params"];
     if (params.size() != 3) {
@@ -1359,7 +1359,7 @@ Task<void> EthereumRpcApi::handle_eth_call_bundle(const nlohmann::json& request,
         co_return;
     }
 
-    auto tx_hash_list = params[0].get<std::vector<evmc::bytes32>>();
+    const auto tx_hash_list = params[0].get<std::vector<evmc::bytes32>>();
     const auto block_number_or_hash = params[1].get<BlockNumberOrHash>();
     const auto timeout = params[2].get<uint64_t>();
 

--- a/silkworm/rpc/http/jwt.cpp
+++ b/silkworm/rpc/http/jwt.cpp
@@ -50,12 +50,7 @@ std::string generate_jwt_token(const std::filesystem::path& file_path) {
         throw std::runtime_error{error_msg};
     }
     if (!std::filesystem::exists(file_path)) {
-        const bool dirs_created = std::filesystem::create_directories(file_path.parent_path());
-        if (!dirs_created) {
-            const auto error_msg{"Cannot create directories " + file_path.parent_path().string()};
-            SILK_ERROR << error_msg;
-            throw std::runtime_error{error_msg};
-        }
+        std::filesystem::create_directories(file_path.parent_path());
     }
 
     std::string jwt_token;

--- a/silkworm/rpc/http/jwt.cpp
+++ b/silkworm/rpc/http/jwt.cpp
@@ -49,6 +49,14 @@ std::string generate_jwt_token(const std::filesystem::path& file_path) {
         SILK_ERROR << error_msg;
         throw std::runtime_error{error_msg};
     }
+    if (!std::filesystem::exists(file_path)) {
+        const bool dirs_created = std::filesystem::create_directories(file_path.parent_path());
+        if (!dirs_created) {
+            const auto error_msg{"Cannot create directories " + file_path.parent_path().string()};
+            SILK_ERROR << error_msg;
+            throw std::runtime_error{error_msg};
+        }
+    }
 
     std::string jwt_token;
     jwt_token.reserve(kTokenSize);

--- a/silkworm/rpc/http/jwt_test.cpp
+++ b/silkworm/rpc/http/jwt_test.cpp
@@ -17,6 +17,7 @@
 #include "jwt.hpp"
 
 #include <fstream>
+#include <string>
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -67,6 +68,17 @@ TEST_CASE("generate_jwt_token", "[silkworm][rpc][http][jwt]") {
         REQUIRE(jwt_token_hex.size() == kExpectedJwtTokenHexSize);
         jwt_token_hex = jwt_token_hex.substr(2);
         CHECK(jwt_token == test_util::ascii_from_hex(jwt_token_hex));
+    }
+
+    SECTION("file path contains . or ..") {
+        const std::vector<std::filesystem::path> kJwtFilePaths{
+            TemporaryDirectory::get_unique_temporary_path() / "../jwt.hex",
+            TemporaryDirectory::get_unique_temporary_path() / "./jwt.hex"};
+        for (const auto& jwt_file_path : kJwtFilePaths) {
+            std::string jwt_token;
+            CHECK_NOTHROW((jwt_token = generate_jwt_token(jwt_file_path)));
+            REQUIRE(std::filesystem::exists(jwt_file_path));
+        }
     }
 }
 


### PR DESCRIPTION
This PR introduces creation of intermediate folders if configured JWT path does not exist.

*Extras*
- add missing `const` specifier
- fix link in comment