### PR TITLE
wasm: fix interface after PR 2253

### DIFF
--- a/silkworm/rpc/daemon.cpp
+++ b/silkworm/rpc/daemon.cpp
@@ -319,13 +319,12 @@ std::unique_ptr<db::kv::api::Client> Daemon::make_kv_client(rpc::ClientContext& 
     if (settings_.standalone) {
         return std::make_unique<db::kv::grpc::client::RemoteClient>(
             create_channel_, grpc_context, state_cache, block_provider(backend), block_number_from_txn_hash_provider(backend));
-    } else {
-        // TODO(canepat) finish implementation and clean-up composition of objects here
-        db::kv::api::StateChangeRunner runner{io_context.get_executor()};
-        db::kv::api::ServiceRouter router{runner.state_changes_calls_channel()};
-        return std::make_unique<db::kv::api::DirectClient>(
-            std::make_shared<db::kv::api::DirectService>(router, *chaindata_env_, state_cache));
     }
+    // TODO(canepat) finish implementation and clean-up composition of objects here
+    db::kv::api::StateChangeRunner runner{io_context.get_executor()};
+    db::kv::api::ServiceRouter router{runner.state_changes_calls_channel()};
+    return std::make_unique<db::kv::api::DirectClient>(
+        std::make_shared<db::kv::api::DirectService>(router, *chaindata_env_, state_cache));
 }
 
 void Daemon::schedule_data_format_retrieval() {

--- a/silkworm/wasm/silkworm_wasm_api.cpp
+++ b/silkworm/wasm/silkworm_wasm_api.cpp
@@ -157,9 +157,9 @@ Account* state_read_account_new(const State* state, const uint8_t* address) {
     return out;
 }
 
-Bytes* state_read_code_new(const State* state, const uint8_t* code_hash) {
+Bytes* state_read_code_new(const State* state, const uint8_t* address, const uint8_t* code_hash) {
     auto out{new Bytes};
-    *out = state->read_code(bytes32_from_ptr(code_hash));
+    *out = state->read_code(address_from_ptr(address), bytes32_from_ptr(code_hash));
     return out;
 }
 

--- a/silkworm/wasm/silkworm_wasm_api.hpp
+++ b/silkworm/wasm/silkworm_wasm_api.hpp
@@ -100,7 +100,7 @@ SILKWORM_EXPORT uint8_t* state_root_hash_new(const silkworm::InMemoryState* stat
 SILKWORM_EXPORT silkworm::Account* state_read_account_new(const silkworm::State* state, const uint8_t* address);
 
 // Result has to be freed with delete_bytes
-SILKWORM_EXPORT silkworm::Bytes* state_read_code_new(const silkworm::State* state, const uint8_t* code_hash);
+SILKWORM_EXPORT silkworm::Bytes* state_read_code_new(const silkworm::State* state, const uint8_t* address, const uint8_t* code_hash);
 
 // Result has to be freed with delete_bytes
 SILKWORM_EXPORT silkworm::Bytes* state_read_storage_new(const silkworm::State* state, const uint8_t* address,


### PR DESCRIPTION
This PR fixes the WASM build broken after PR #2253 that changed the signature of `silkworm::State::read_code` method to include the account address, necessary for E3 Temporal KV `DomainGet`.