### PR TITLE
db: move snapshots management from node to snapshot_sync

### DIFF
--- a/cmd/dev/snapshots.cpp
+++ b/cmd/dev/snapshots.cpp
@@ -382,7 +382,7 @@ void open_index(const SnapSettings& settings) {
 }
 
 static TorrentInfoPtrList download_web_seed(const DownloadSettings& settings) {
-    const auto known_config{snapshots::Config::lookup_known_config(settings.chain_id, /*whitelist=*/{})};
+    const auto known_config{snapshots::Config::lookup_known_config(settings.chain_id)};
     WebSeedClient web_client{/*url_seeds=*/{settings.url_seed}, known_config.preverified_snapshots()};
 
     boost::asio::io_context scheduler;
@@ -819,11 +819,7 @@ void sync(const SnapSettings& settings) {
     std::chrono::time_point start{std::chrono::steady_clock::now()};
     SnapshotRepository snapshot_repository{settings, bundle_factory()};  // NOLINT(cppcoreguidelines-slicing)
     db::SnapshotSync snapshot_sync{&snapshot_repository, kMainnetConfig};
-    std::vector<std::string> snapshot_file_names;
-    if (settings.snapshot_file_name) {
-        snapshot_file_names.push_back(*settings.snapshot_file_name);
-    }
-    snapshot_sync.download_snapshots(snapshot_file_names);
+    snapshot_sync.download_snapshots();
     std::chrono::duration elapsed{std::chrono::steady_clock::now() - start};
 
     SILK_INFO << "Sync elapsed: " << duration_as<std::chrono::seconds>(elapsed) << " sec";

--- a/cmd/dev/snapshots.cpp
+++ b/cmd/dev/snapshots.cpp
@@ -204,10 +204,6 @@ void parse_command_line(int argc, char* argv[], CLI::App& app, SnapshotToolboxSe
                         "Max number of downloads active simultaneously")
             ->capture_default_str()
             ->check(CLI::Range(3, 20));
-        cmd->add_flag("--seeding",
-                      bittorrent_settings.seeding,
-                      "Flag indicating if torrents should be seeded when download is finished")
-            ->capture_default_str();
     }
     for (auto& cmd : {commands[SnapshotTool::create_index],
                       commands[SnapshotTool::open_index],

--- a/cmd/dev/snapshots.cpp
+++ b/cmd/dev/snapshots.cpp
@@ -828,7 +828,7 @@ void sync(const SnapSettings& settings) {
     auto chaindata_env = db::open_env(chaindata_env_config);
     test_util::TaskRunner runner;
     NoopStageSchedulerAdapter stage_scheduler;
-    db::SnapshotSync snapshot_sync{runner.executor(), settings, kMainnetConfig.chain_id, chaindata_env, tmp_dir.path(), stage_scheduler};
+    db::SnapshotSync snapshot_sync{settings, kMainnetConfig.chain_id, chaindata_env, tmp_dir.path(), stage_scheduler};
     runner.run(snapshot_sync.download_snapshots());
     std::chrono::duration elapsed{std::chrono::steady_clock::now() - start};
 

--- a/silkworm/db/access_layer.cpp
+++ b/silkworm/db/access_layer.cpp
@@ -79,23 +79,6 @@ void write_build_info_height(RWTxn& txn, const Bytes& key, BlockNum height) {
     cursor->upsert(db::to_slice(key), db::to_slice(value));
 }
 
-std::vector<std::string> read_snapshots(ROTxn& txn) {
-    auto db_info_cursor = txn.ro_cursor(table::kDatabaseInfo);
-    if (!db_info_cursor->seek(mdbx::slice{kDbSnapshotsKey})) {
-        return {};
-    }
-    const auto data{db_info_cursor->current()};
-    // https://github.com/nlohmann/json/issues/2204
-    const auto json = nlohmann::json::parse(data.value.as_string(), nullptr, /*.allow_exceptions=*/false);
-    return json.get<std::vector<std::string>>();
-}
-
-void write_snapshots(RWTxn& txn, const std::vector<std::string>& snapshot_file_names) {
-    auto db_info_cursor = txn.rw_cursor(table::kDatabaseInfo);
-    nlohmann::json json_value = snapshot_file_names;
-    db_info_cursor->upsert(mdbx::slice{kDbSnapshotsKey}, mdbx::slice(json_value.dump().data()));
-}
-
 std::optional<BlockHeader> read_header(ROTxn& txn, BlockNum block_number, const evmc::bytes32& hash) {
     return read_header(txn, block_number, hash.bytes);
 }

--- a/silkworm/db/access_layer.hpp
+++ b/silkworm/db/access_layer.hpp
@@ -53,12 +53,6 @@ void write_schema_version(RWTxn& txn, const VersionBase& schema_version);
 //! upgrades or downgrades of Silkworm's build
 void write_build_info_height(RWTxn& txn, const Bytes& key, BlockNum height);
 
-//! \brief Read the list of snapshot file names
-std::vector<std::string> read_snapshots(ROTxn& txn);
-
-//! \brief Write the list of snapshot file names
-void write_snapshots(RWTxn& txn, const std::vector<std::string>& snapshot_file_names);
-
 //! \brief Reads a header with the specified key (block number, hash)
 std::optional<BlockHeader> read_header(ROTxn& txn, BlockNum block_number, const uint8_t (&hash)[kHashLength]);
 std::optional<BlockHeader> read_header(ROTxn& txn, BlockNum block_number, const evmc::bytes32&);

--- a/silkworm/db/access_layer_test.cpp
+++ b/silkworm/db/access_layer_test.cpp
@@ -442,20 +442,6 @@ TEST_CASE("Stages", "[db][access_layer]") {
     CHECK(stages::read_stage_prune_progress(txn, stages::kBlockBodiesKey) == 0);
 }
 
-TEST_CASE("Snapshots", "[db][access_layer]") {
-    db::test_util::TempChainData context;
-    auto& txn{context.rw_txn()};
-
-    const std::vector<std::string> snapshot_list{
-        "v1-000000-000500-bodies.seg",
-        "v1-000000-000500-headers.seg",
-        "v1-000000-000500-transactions.seg",
-    };
-
-    CHECK_NOTHROW(write_snapshots(txn, snapshot_list));
-    CHECK(read_snapshots(txn) == snapshot_list);
-}
-
 TEST_CASE("Difficulty", "[db][access_layer]") {
     db::test_util::TempChainData context;
     auto& txn{context.rw_txn()};

--- a/silkworm/db/snapshot_sync.hpp
+++ b/silkworm/db/snapshot_sync.hpp
@@ -16,16 +16,16 @@
 
 #pragma once
 
+#include <atomic>
 #include <filesystem>
 #include <functional>
 #include <latch>
+#include <mutex>
 #include <string>
 #include <thread>
 #include <vector>
 
 #include <silkworm/infra/concurrency/task.hpp>
-
-#include <boost/asio/any_io_executor.hpp>
 
 #include <silkworm/core/chain/config.hpp>
 #include <silkworm/db/access_layer.hpp>
@@ -37,7 +37,7 @@
 #include <silkworm/db/snapshots/snapshot_repository.hpp>
 #include <silkworm/db/snapshots/snapshot_settings.hpp>
 #include <silkworm/db/stage_scheduler.hpp>
-#include <silkworm/infra/concurrency/awaitable_future.hpp>
+#include <silkworm/infra/concurrency/awaitable_condition_variable.hpp>
 #include <silkworm/infra/concurrency/stoppable.hpp>
 
 namespace silkworm::db {
@@ -45,7 +45,6 @@ namespace silkworm::db {
 class SnapshotSync {
   public:
     SnapshotSync(
-        boost::asio::any_io_executor executor,
         snapshots::SnapshotSettings settings,
         ChainId chain_id,
         mdbx::env& chaindata_env,
@@ -81,7 +80,9 @@ class SnapshotSync {
     db::SnapshotMerger snapshot_merger_;
 
     std::latch is_stopping_latch_;
-    concurrency::AwaitablePromise<bool> setup_done_promise_;
+    std::atomic_bool setup_done_;
+    concurrency::AwaitableConditionVariable setup_done_cond_var_;
+    std::mutex setup_done_mutex_;
 };
 
 }  // namespace silkworm::db

--- a/silkworm/db/snapshot_sync.hpp
+++ b/silkworm/db/snapshot_sync.hpp
@@ -37,7 +37,7 @@ class SnapshotSync : public Stoppable {
     bool stop() override;
 
     bool download_and_index_snapshots(db::RWTxn& txn);
-    bool download_snapshots(const std::vector<std::string>& snapshot_file_names);
+    bool download_snapshots();
 
   protected:
     void build_missing_indexes();

--- a/silkworm/db/snapshot_sync.hpp
+++ b/silkworm/db/snapshot_sync.hpp
@@ -16,42 +16,71 @@
 
 #pragma once
 
+#include <filesystem>
+#include <functional>
+#include <latch>
 #include <string>
 #include <thread>
 #include <vector>
 
+#include <silkworm/infra/concurrency/task.hpp>
+
+#include <boost/asio/any_io_executor.hpp>
+
 #include <silkworm/core/chain/config.hpp>
 #include <silkworm/db/access_layer.hpp>
+#include <silkworm/db/freezer.hpp>
+#include <silkworm/db/mdbx/mdbx.hpp>
+#include <silkworm/db/snapshot_merger.hpp>
 #include <silkworm/db/snapshots/bittorrent/client.hpp>
 #include <silkworm/db/snapshots/snapshot_repository.hpp>
 #include <silkworm/db/snapshots/snapshot_settings.hpp>
+#include <silkworm/db/stage_scheduler.hpp>
+#include <silkworm/infra/concurrency/awaitable_future.hpp>
 #include <silkworm/infra/concurrency/stoppable.hpp>
 
 namespace silkworm::db {
 
-class SnapshotSync : public Stoppable {
+class SnapshotSync {
   public:
-    SnapshotSync(snapshots::SnapshotRepository* repository, const ChainConfig& config);
-    ~SnapshotSync() override;
+    SnapshotSync(
+        boost::asio::any_io_executor executor,
+        snapshots::SnapshotSettings settings,
+        ChainId chain_id,
+        mdbx::env& chaindata_env,
+        std::filesystem::path tmp_dir_path,
+        stagedsync::StageScheduler& stage_scheduler);
 
-    bool stop() override;
+    Task<void> run();
 
-    bool download_and_index_snapshots(db::RWTxn& txn);
-    bool download_snapshots();
+    Task<void> download_and_index_snapshots();
+    Task<void> download_snapshots();
+    Task<void> wait_for_setup();
 
   protected:
-    void build_missing_indexes();
-    void update_database(db::RWTxn& txn, BlockNum max_block_available);
-    void update_block_headers(db::RWTxn& txn, BlockNum max_block_available);
+    Task<void> setup_and_run();
+    Task<void> setup();
+    Task<void> build_missing_indexes();
+    void update_database(db::RWTxn& txn, BlockNum max_block_available, std::function<bool()> is_stopping);
+    void update_block_headers(db::RWTxn& txn, BlockNum max_block_available, std::function<bool()> is_stopping);
     void update_block_bodies(db::RWTxn& txn, BlockNum max_block_available);
     static void update_block_hashes(db::RWTxn& txn, BlockNum max_block_available);
     static void update_block_senders(db::RWTxn& txn, BlockNum max_block_available);
+    snapshots::SnapshotRepository& repository() { return repository_; };
 
-    snapshots::SnapshotRepository* repository_;
-    const snapshots::SnapshotSettings& settings_;
-    const ChainConfig& config_;
+    snapshots::SnapshotSettings settings_;
+    ChainId chain_id_;
+    mdbx::env& chaindata_env_;
+
+    snapshots::SnapshotRepository repository_;
+
     snapshots::bittorrent::BitTorrentClient client_;
-    std::thread client_thread_;
+
+    db::Freezer snapshot_freezer_;
+    db::SnapshotMerger snapshot_merger_;
+
+    std::latch is_stopping_latch_;
+    concurrency::AwaitablePromise<bool> setup_done_promise_;
 };
 
 }  // namespace silkworm::db

--- a/silkworm/db/snapshot_sync.hpp
+++ b/silkworm/db/snapshot_sync.hpp
@@ -33,6 +33,7 @@
 #include <silkworm/db/mdbx/mdbx.hpp>
 #include <silkworm/db/snapshot_merger.hpp>
 #include <silkworm/db/snapshots/bittorrent/client.hpp>
+#include <silkworm/db/snapshots/config.hpp>
 #include <silkworm/db/snapshots/snapshot_repository.hpp>
 #include <silkworm/db/snapshots/snapshot_settings.hpp>
 #include <silkworm/db/stage_scheduler.hpp>
@@ -69,7 +70,7 @@ class SnapshotSync {
     snapshots::SnapshotRepository& repository() { return repository_; };
 
     snapshots::SnapshotSettings settings_;
-    ChainId chain_id_;
+    const snapshots::Config snapshots_config_;
     mdbx::env& chaindata_env_;
 
     snapshots::SnapshotRepository repository_;

--- a/silkworm/db/snapshot_sync_test.cpp
+++ b/silkworm/db/snapshot_sync_test.cpp
@@ -83,7 +83,6 @@ struct SnapshotSyncForTest : public SnapshotSync {
 
     SnapshotSyncForTest(SnapshotSyncTest& test, SettingsOverrides overrides = {})
         : SnapshotSync{
-              test.runner.executor(),
               make_settings(test.tmp_dir.path(), overrides),
               kMainnetConfig.chain_id,
               test.context.env(),

--- a/silkworm/db/snapshot_sync_test.cpp
+++ b/silkworm/db/snapshot_sync_test.cpp
@@ -21,13 +21,13 @@
 #include <silkworm/core/chain/config.hpp>
 #include <silkworm/db/blocks/bodies/body_index.hpp>
 #include <silkworm/db/blocks/headers/header_index.hpp>
-#include <silkworm/db/snapshot_bundle_factory_impl.hpp>
 #include <silkworm/db/test_util/temp_chain_data.hpp>
 #include <silkworm/db/test_util/temp_snapshots.hpp>
 #include <silkworm/db/transactions/txn_index.hpp>
 #include <silkworm/db/transactions/txn_to_block_index.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/test_util/log.hpp>
+#include <silkworm/infra/test_util/task_runner.hpp>
 #include <silkworm/infra/test_util/temporary_file.hpp>
 
 namespace silkworm::db {
@@ -35,103 +35,107 @@ namespace silkworm::db {
 using namespace snapshots;
 using namespace silkworm::test_util;
 
-static std::unique_ptr<SnapshotBundleFactory> bundle_factory() {
-    return std::make_unique<db::SnapshotBundleFactoryImpl>();
-}
+struct SettingsOverrides {
+    bool enabled{true};
+    bool no_downloader{false};
+    bool verify_on_startup{false};
+};
 
-TEST_CASE("SnapshotSync::SnapshotSync", "[db][snapshot][sync]") {
+class NoopStageSchedulerAdapter : public stagedsync::StageScheduler {
+  public:
+    explicit NoopStageSchedulerAdapter() {}
+    ~NoopStageSchedulerAdapter() override = default;
+    Task<void> schedule(std::function<void(db::RWTxn&)> /*callback*/) override {
+        co_return;
+    }
+};
+
+struct SnapshotSyncTest {
     SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryDirectory tmp_dir;
-    SnapshotSettings settings{
-        .bittorrent_settings = bittorrent::BitTorrentSettings{
-            .repository_path = tmp_dir.path() / bittorrent::BitTorrentSettings::kDefaultTorrentRepoPath,
-        },
-    };
-    SnapshotRepository repository{settings, bundle_factory()};
-    CHECK_NOTHROW(SnapshotSync{&repository, kMainnetConfig});
-}
-
-TEST_CASE("SnapshotSync::download_and_index_snapshots", "[db][snapshot][sync]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
     db::test_util::TempChainData context;
-    TemporaryDirectory tmp_dir;
-    bittorrent::BitTorrentSettings bittorrent_settings{
-        .repository_path = tmp_dir.path() / bittorrent::BitTorrentSettings::kDefaultTorrentRepoPath,
-    };
-
-    SECTION("snapshots disabled") {
-        SnapshotSettings settings{
-            .repository_dir = tmp_dir.path(),
-            .enabled = false,
-            .bittorrent_settings = bittorrent_settings,
-        };
-        SnapshotRepository repository{settings, bundle_factory()};
-        SnapshotSync sync{&repository, kMainnetConfig};
-        CHECK(sync.download_and_index_snapshots(context.rw_txn()));
-    }
-
-    SECTION("no download, just reopen") {
-        SnapshotSettings settings{
-            .repository_dir = tmp_dir.path(),
-            .no_downloader = true,
-            .bittorrent_settings = bittorrent_settings,
-        };
-        SnapshotRepository repository{settings, bundle_factory()};
-        SnapshotSync sync{&repository, kMainnetConfig};
-        CHECK(sync.download_and_index_snapshots(context.rw_txn()));
-    }
-
-    SECTION("no download, just reopen and verify") {
-        SnapshotSettings settings{
-            .repository_dir = tmp_dir.path(),
-            .no_downloader = true,
-            .bittorrent_settings = bittorrent_settings,
-        };
-        settings.bittorrent_settings.verify_on_startup = true;
-        SnapshotRepository repository{settings, bundle_factory()};
-        SnapshotSync sync{&repository, kMainnetConfig};
-        CHECK(sync.download_and_index_snapshots(context.rw_txn()));
-    }
-}
+    TaskRunner runner;
+    NoopStageSchedulerAdapter stage_scheduler;
+};
 
 struct SnapshotSyncForTest : public SnapshotSync {
     using SnapshotSync::build_missing_indexes;
-    using SnapshotSync::SnapshotSync;
+    using SnapshotSync::repository;
     using SnapshotSync::update_block_bodies;
     using SnapshotSync::update_block_hashes;
     using SnapshotSync::update_block_headers;
     using SnapshotSync::update_block_senders;
     using SnapshotSync::update_database;
+
+    static SnapshotSettings make_settings(
+        const std::filesystem::path& tmp_dir_path,
+        const SettingsOverrides& overrides) {
+        return SnapshotSettings{
+            .repository_dir = tmp_dir_path,
+            .enabled = overrides.enabled,
+            .no_downloader = overrides.no_downloader,
+            .bittorrent_settings = bittorrent::BitTorrentSettings{
+                .repository_path = tmp_dir_path / bittorrent::BitTorrentSettings::kDefaultTorrentRepoPath,
+                .verify_on_startup = overrides.verify_on_startup,
+            },
+        };
+    }
+
+    SnapshotSyncForTest(SnapshotSyncTest& test, SettingsOverrides overrides = {})
+        : SnapshotSync{
+              test.runner.executor(),
+              make_settings(test.tmp_dir.path(), overrides),
+              kMainnetConfig.chain_id,
+              test.context.env(),
+              test.tmp_dir.path(),
+              test.stage_scheduler} {}
 };
 
+TEST_CASE("SnapshotSync::SnapshotSync", "[db][snapshot][sync]") {
+    SnapshotSyncTest test;
+    CHECK_NOTHROW(SnapshotSyncForTest{test});
+}
+
+TEST_CASE("SnapshotSync::download_and_index_snapshots", "[db][snapshot][sync]") {
+    SnapshotSyncTest test;
+
+    SECTION("snapshots disabled") {
+        SnapshotSyncForTest sync{test, SettingsOverrides{.enabled = false}};
+        test.runner.run(sync.download_and_index_snapshots());
+    }
+
+    SECTION("no download, just reopen") {
+        SnapshotSyncForTest sync{test, SettingsOverrides{.no_downloader = true}};
+        test.runner.run(sync.download_and_index_snapshots());
+    }
+
+    SECTION("no download, just reopen and verify") {
+        SnapshotSyncForTest sync{test, SettingsOverrides{.no_downloader = true, .verify_on_startup = true}};
+        test.runner.run(sync.download_and_index_snapshots());
+    }
+}
+
 TEST_CASE("SnapshotSync::update_block_headers", "[db][snapshot][sync]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
-    TemporaryDirectory tmp_dir;
-    SnapshotSettings settings{
-        .repository_dir = tmp_dir.path(),
-        .bittorrent_settings = bittorrent::BitTorrentSettings{
-            .repository_path = tmp_dir.path() / bittorrent::BitTorrentSettings::kDefaultTorrentRepoPath,
-        },
-    };
-    SnapshotRepository repository{settings, bundle_factory()};
-    db::test_util::TempChainData tmp_db;
+    SnapshotSyncTest test;
+    SnapshotSyncForTest snapshot_sync{test};
+    auto tmp_dir_path = test.tmp_dir.path();
 
     // Create a sample Header snapshot+index
-    snapshots::test_util::SampleHeaderSnapshotFile header_snapshot_file{tmp_dir.path()};
+    snapshots::test_util::SampleHeaderSnapshotFile header_snapshot_file{tmp_dir_path};
     snapshots::test_util::SampleHeaderSnapshotPath header_snapshot_path{header_snapshot_file.path()};
     snapshots::Snapshot header_snapshot{header_snapshot_path};
     REQUIRE_NOTHROW(snapshots::HeaderIndex::make(header_snapshot_path).build());
     snapshots::Index idx_header_hash{header_snapshot_path.index_file()};
 
     // Create a sample Body snapshot+index
-    snapshots::test_util::SampleBodySnapshotFile body_snapshot_file{tmp_dir.path()};
+    snapshots::test_util::SampleBodySnapshotFile body_snapshot_file{tmp_dir_path};
     snapshots::test_util::SampleBodySnapshotPath body_snapshot_path{body_snapshot_file.path()};
     snapshots::Snapshot body_snapshot{body_snapshot_path};
     REQUIRE_NOTHROW(snapshots::BodyIndex::make(body_snapshot_path).build());
     snapshots::Index idx_body_number{body_snapshot_path.index_file()};
 
     // Create a sample Transaction snapshot+indexes
-    snapshots::test_util::SampleTransactionSnapshotFile txn_snapshot_file{tmp_dir.path()};
+    snapshots::test_util::SampleTransactionSnapshotFile txn_snapshot_file{tmp_dir_path};
     snapshots::test_util::SampleTransactionSnapshotPath txn_snapshot_path{txn_snapshot_file.path()};
     snapshots::Snapshot txn_snapshot{txn_snapshot_path};
     REQUIRE_NOTHROW(snapshots::TransactionIndex::make(body_snapshot_path, txn_snapshot_path).build());
@@ -151,11 +155,13 @@ TEST_CASE("SnapshotSync::update_block_headers", "[db][snapshot][sync]") {
         .idx_txn_hash = std::move(idx_txn_hash),
         .idx_txn_hash_2_block = std::move(idx_txn_hash_2_block),
     }};
+    auto& repository = snapshot_sync.repository();
     repository.add_snapshot_bundle(std::move(bundle));
 
     // Update the block headers in the database according to the repository content
-    SnapshotSyncForTest snapshot_sync{&repository, kMainnetConfig};
-    CHECK_NOTHROW(snapshot_sync.update_block_headers(tmp_db.rw_txn(), repository.max_block_available()));
+    auto& tmp_db = test.context;
+    auto is_stopping = [] { return false; };
+    CHECK_NOTHROW(snapshot_sync.update_block_headers(tmp_db.rw_txn(), repository.max_block_available(), is_stopping));
 
     // Expect that the database is correctly populated (N.B. cannot check Difficulty table because of sample snapshots)
     auto block_is_in_header_numbers = [&](Hash block_hash, BlockNum expected_block_number) {

--- a/silkworm/db/snapshots/bittorrent/client_test.cpp
+++ b/silkworm/db/snapshots/bittorrent/client_test.cpp
@@ -198,16 +198,6 @@ TEST_CASE("BitTorrentClient::stop", "[silkworm][snapshot][bittorrent]") {
         ClientThread client_thread{client};
         CHECK_NOTHROW(client.stop());
     }
-
-// Exclude from sanitizer builds due to false positive: https://gcc.gnu.org/bugzilla//show_bug.cgi?id=101978
-#ifndef SILKWORM_SANITIZE
-    SECTION("interrupt seeding execution loop on separate thread") {
-        settings.seeding = true;
-        BitTorrentClient client{settings};
-        ClientThread client_thread{client};
-        CHECK_NOTHROW(client.stop());
-    }
-#endif  // SILKWORM_SANITIZE
 }
 
 TEST_CASE("BitTorrentClient::request_torrent_updates", "[silkworm][snapshot][bittorrent]") {

--- a/silkworm/db/snapshots/bittorrent/settings.hpp
+++ b/silkworm/db/snapshots/bittorrent/settings.hpp
@@ -42,9 +42,6 @@ struct BitTorrentSettings {
     //! Flag indicating if snapshots will be verified on startup
     bool verify_on_startup{false};
 
-    //! Flag indicating if the client should seed torrents when done or not
-    bool seeding{false};
-
     //! Flag indicating if BitTorrent failure/error alerts should be treated as warnings
     bool warn_on_error_alerts{false};
 

--- a/silkworm/db/snapshots/bittorrent/web_seed_client_test.cpp
+++ b/silkworm/db/snapshots/bittorrent/web_seed_client_test.cpp
@@ -89,7 +89,7 @@ static boost::urls::url make_e2_snapshots_provider_url() {
 }
 
 struct WebSeedClientTest : public test_util::ContextTestBase {
-    snapshots::Config known_config{snapshots::Config::lookup_known_config(/*chain_id=*/1, /*whitelist=*/{})};
+    snapshots::Config known_config{snapshots::Config::lookup_known_config(/*chain_id=*/1)};
     std::unique_ptr<WebSessionMock> session{std::make_unique<WebSessionMock>()};
     WebSeedClientForTest client{{kErigon2Snapshots}, known_config.preverified_snapshots()};
 };

--- a/silkworm/db/snapshots/config.cpp
+++ b/silkworm/db/snapshots/config.cpp
@@ -26,22 +26,12 @@
 
 namespace silkworm::snapshots {
 
-Config Config::lookup_known_config(ChainId chain_id, const std::vector<std::string>& whitelist) {
+Config Config::lookup_known_config(ChainId chain_id) {
     const auto config = kKnownSnapshotConfigs.find(chain_id);
     if (!config) {
         return Config{PreverifiedList{}};
     }
-    if (whitelist.empty()) {
-        return Config{PreverifiedList(config->begin(), config->end())};
-    }
-
-    PreverifiedList filtered_preverified;
-    for (const auto& preverified_entry : *config) {
-        if (std::find(whitelist.cbegin(), whitelist.cend(), preverified_entry.file_name) != whitelist.cend()) {
-            filtered_preverified.push_back(preverified_entry);
-        }
-    }
-    return Config{filtered_preverified};
+    return Config{PreverifiedList(config->begin(), config->end())};
 }
 
 Config::Config(PreverifiedList preverified_snapshots)

--- a/silkworm/db/snapshots/config.hpp
+++ b/silkworm/db/snapshots/config.hpp
@@ -34,7 +34,7 @@ using PreverifiedList = std::vector<Entry>;
 
 class Config {
   public:
-    static Config lookup_known_config(ChainId chain_id, const std::vector<std::string>& whitelist);
+    static Config lookup_known_config(ChainId chain_id);
 
     explicit Config(PreverifiedList preverified_snapshots);
 

--- a/silkworm/db/snapshots/config_test.cpp
+++ b/silkworm/db/snapshots/config_test.cpp
@@ -27,14 +27,14 @@ namespace silkworm::snapshots {
 
 TEST_CASE("Config::lookup_known_config", "[silkworm][snapshot][config]") {
     SECTION("nonexistent") {
-        const auto nonexistent_snapshot_config = Config::lookup_known_config(0, {});
+        const auto nonexistent_snapshot_config = Config::lookup_known_config(0);
         CHECK(nonexistent_snapshot_config.preverified_snapshots().empty());
         CHECK(nonexistent_snapshot_config.max_block_number() == 0);
     }
 
     SECTION("mainnet") {
         constexpr std::size_t kMaxBlockNumber{20'461'000};
-        const auto mainnet_snapshot_config = Config::lookup_known_config(1, {});
+        const auto mainnet_snapshot_config = Config::lookup_known_config(1);
         CHECK(mainnet_snapshot_config.max_block_number() == kMaxBlockNumber - 1);
     }
 }

--- a/silkworm/db/util.hpp
+++ b/silkworm/db/util.hpp
@@ -54,9 +54,6 @@ struct VersionBase {
 //! Key for DbInfo bucket storing db schema version
 inline constexpr const char* kDbSchemaVersionKey{"dbVersion"};
 
-//! Key for DbInfo bucket storing snapshot file names
-inline constexpr const char* kDbSnapshotsKey{"snapshots"};
-
 inline constexpr size_t kIncarnationLength{8};
 inline constexpr size_t kLocationLength{32};
 static_assert(kIncarnationLength == sizeof(uint64_t));

--- a/silkworm/infra/concurrency/awaitable_condition_variable.hpp
+++ b/silkworm/infra/concurrency/awaitable_condition_variable.hpp
@@ -32,18 +32,18 @@ https://docs.rs/tokio/1.25.0/tokio/sync/struct.Notify.html
 It supports multiple waiters unlike EventNotifier.
 
 Synchronize waiter()/notify_all() calls with your producer state to avoid a deadlock.
-It happens if the producer readiness is able to be updated right before calling waiter().
+It happens if the producer readiness updates right before calling waiter().
 
 Example:
     // consumers
-    std::scoped_lock lock(mutex_);
+    std::unique_lock lock{mutex_};
     if (ready_) co_return;
     auto waiter = cond_var.waiter();
     lock.unlock();
     co_await waiter();
 
     // producer
-    std::scoped_lock lock(mutex_);
+    std::scoped_lock lock{mutex_};
     ready_ = true;
     cond_var.notify_all();
 

--- a/silkworm/node/node.cpp
+++ b/silkworm/node/node.cpp
@@ -95,7 +95,7 @@ static auto make_execution_server_settings() {
 }
 
 NodeImpl::NodeImpl(
-    boost::asio::any_io_executor executor,
+    [[maybe_unused]] boost::asio::any_io_executor executor,
     Settings& settings,
     SentryClientPtr sentry_client,
     mdbx::env chaindata_env)
@@ -105,7 +105,7 @@ NodeImpl::NodeImpl(
       execution_service_{std::make_shared<execution::api::ActiveDirectService>(execution_engine_, execution_context_)},
       execution_server_{make_execution_server_settings(), execution_service_},
       execution_direct_client_{execution_service_},
-      snapshot_sync_{executor, settings.snapshot_settings, settings.chain_config->chain_id, chaindata_env_, settings_.data_directory->temp().path(), execution_engine_.stage_scheduler()},
+      snapshot_sync_{settings.snapshot_settings, settings.chain_config->chain_id, chaindata_env_, settings_.data_directory->temp().path(), execution_engine_.stage_scheduler()},
       sentry_client_{std::move(sentry_client)},
       resource_usage_log_{*settings_.data_directory} {
     backend_ = std::make_unique<EthereumBackEnd>(settings_, &chaindata_env_, sentry_client_);

--- a/silkworm/node/node.cpp
+++ b/silkworm/node/node.cpp
@@ -55,6 +55,7 @@ class NodeImpl final {
     std::shared_ptr<sentry::api::SentryClient> sentry_client() { return sentry_client_; }
 
     Task<void> run();
+    Task<void> run_tasks();
     Task<void> wait_for_setup();
 
   private:
@@ -121,13 +122,18 @@ Task<void> NodeImpl::wait_for_setup() {
 Task<void> NodeImpl::run() {
     using namespace concurrency::awaitable_wait_for_all;
 
+    co_await (run_tasks() && snapshot_sync_.run());
+}
+
+Task<void> NodeImpl::run_tasks() {
+    using namespace concurrency::awaitable_wait_for_all;
+
     co_await wait_for_setup();
 
     co_await (
         start_execution_server() &&
         start_resource_usage_log() &&
         start_execution_log_timer() &&
-        snapshot_sync_.run() &&
         start_backend_kv_grpc_server());
 }
 

--- a/silkworm/node/node.hpp
+++ b/silkworm/node/node.hpp
@@ -20,13 +20,12 @@
 
 #include <silkworm/infra/concurrency/task.hpp>
 
+#include <boost/asio/any_io_executor.hpp>
+
 #include <silkworm/db/mdbx/mdbx.hpp>
-#include <silkworm/db/snapshots/snapshot_settings.hpp>
-#include <silkworm/node/common/node_settings.hpp>
 #include <silkworm/node/execution/api/direct_client.hpp>
 #include <silkworm/node/settings.hpp>
 #include <silkworm/sentry/api/common/sentry_client.hpp>
-#include <silkworm/sentry/settings.hpp>
 
 namespace silkworm::node {
 
@@ -34,9 +33,11 @@ class NodeImpl;
 
 class Node {
   public:
-    Node(Settings& settings,
-         std::shared_ptr<sentry::api::SentryClient> sentry_client,
-         mdbx::env chaindata_db);
+    Node(
+        boost::asio::any_io_executor executor,
+        Settings& settings,
+        std::shared_ptr<sentry::api::SentryClient> sentry_client,
+        mdbx::env chaindata_env);
     ~Node();
 
     Node(const Node&) = delete;
@@ -44,9 +45,8 @@ class Node {
 
     execution::api::DirectClient& execution_direct_client();
 
-    void setup();
-
     Task<void> run();
+    Task<void> wait_for_setup();
 
   private:
     std::unique_ptr<NodeImpl> p_impl_;


### PR DESCRIPTION
* Expand SnapshotSync to be responsible for snapshots management including: owning SnapshotRepository, running Freezer and SnapshotMerger, owning BitTorrentClient and seeding snapshots.
* Node contains SnapshotSync. It waits for the SnapshotSync setup before running other components.
* chainsync::Sync also waits for the SnapshotSync setup before starting.
* BitTorrentClient runs all the time in SnapshotSync (before and after setup) to provide seeding. A torrent client is removed from Node.
* download and related methods use async logic instead of is_stopping flag.
* download_snapshots: adding torrents happens after subscriptions, because the client always runs
* update_database are kept sync and use a dedicated is_stopping_latch_ to quit ASAP
* snapshot_sync_test: refactoring to minimize setup boilerplate


Extra:
* remove snapshots whitelist support (kDbSnapshotsKey), because the logic is not complete and likely won't be needed
* remove --seeding flag (seeding always by default)
