### PR TITLE
infra: fix timer cancellation using RAII

### DIFF
--- a/silkworm/infra/common/timer.cpp
+++ b/silkworm/infra/common/timer.cpp
@@ -18,13 +18,109 @@
 
 namespace silkworm {
 
-std::shared_ptr<Timer> Timer::create(const boost::asio::any_io_executor& executor,
-                                     uint32_t interval,
-                                     std::function<bool()> call_back,
-                                     bool auto_start) {
-    auto timer = std::shared_ptr<Timer>(new Timer{executor, interval, std::move(call_back)});
-    if (auto_start) timer->start();
-    return timer;
+//! \brief Implementation of an asynchronous periodic timer relying on boost:asio timer facility
+//! \warning At least one TimerImpl shared pointer must exist when using it (precondition of shared_from_this())
+//! \warning This is achieved by static TimerImpl::create and non-public constructor, subclasses must obey the same rule
+class TimerImpl : public std::enable_shared_from_this<TimerImpl> {
+  public:
+    //! Factory method enforcing instances are managed *only* through shared pointers
+    //! \param executor [in] : executor running the timer
+    //! \param interval [in] : length of wait interval (in milliseconds)
+    //! \param callback [in] : the call back function to be called
+    //! \param auto_start [in] : whether to start the timer immediately
+    static std::shared_ptr<TimerImpl> create(const boost::asio::any_io_executor& executor,
+                                             uint32_t interval,
+                                             std::function<bool()> callback,
+                                             bool auto_start = true) {
+        auto timer = std::shared_ptr<TimerImpl>(new TimerImpl{executor, interval, std::move(callback)});
+        if (auto_start) timer->start();
+        return timer;
+    }
+
+    ~TimerImpl() { stop(); }
+
+    //! \brief Start timer asynchronously. Eventually callback action is executed and timer automatically rescheduled
+    //! for another interval
+    void start() {
+        bool expected_running{false};
+        if (is_running_.compare_exchange_strong(expected_running, true)) {
+            launch();
+        }
+    }
+
+    //! \brief Stop timer and cancel any pending execution. Callback may still be executed *once* if timer gets cancelled
+    //! after expiration but before completion handler dispatching.
+    void stop() {
+        bool expected_running{true};
+        if (is_running_.compare_exchange_strong(expected_running, false)) {
+            (void)timer_.cancel();
+        }
+    }
+
+    //! \brief Cancel next execution of awaiting callback and reschedule for a new interval if still running
+    void reset() {
+        (void)timer_.cancel();
+        if (is_running_) {
+            launch();
+        }
+    }
+
+  protected:
+    //! \brief Not public to force creation only through TimerImpl::create
+    //! \param executor [in] : executor running the timer
+    //! \param interval [in] : length of wait interval (in milliseconds)
+    //! \param call_back [in] : the call back function to be called
+    TimerImpl(const boost::asio::any_io_executor& executor, uint32_t interval, std::function<bool()> call_back)
+        : interval_(interval), timer_(executor), callback_(std::move(call_back)) {
+        SILKWORM_ASSERT(interval > 0);
+    };
+
+  private:
+    //! \brief Launches async timer
+    void launch() {
+        timer_.expires_after(std::chrono::milliseconds(interval_));
+
+        // Start the timer and capture it as shared pointer to extend its lifetime to the completion handler invocation
+        (void)timer_.async_wait([self = shared_from_this()](const boost::system::error_code& ec) {
+            if (ec == boost::asio::error::operation_aborted) {  // If timer gets cancelled before expiration
+                return;
+            }
+            // If timer gets cancelled after expiration but before completion handler dispatching, we may arrive here
+            if (!ec && self->callback_) {
+                self->callback_();
+            }
+            if (self->is_running_) {
+                self->launch();
+            }
+        });
+    }
+
+    std::atomic_bool is_running_{false};
+    const uint32_t interval_;
+    boost::asio::steady_timer timer_;
+    std::function<bool()> callback_;
+};
+
+Timer::Timer(const boost::asio::any_io_executor& executor,
+             uint32_t interval,
+             std::function<bool()> callback,
+             bool auto_start)
+    : p_impl_{TimerImpl::create(executor, interval, std::move(callback), auto_start)} {}
+
+Timer::~Timer() {
+    p_impl_->stop();
+}
+
+void Timer::start() {
+    p_impl_->start();
+}
+
+void Timer::stop() {
+    p_impl_->stop();
+}
+
+void Timer::reset() {
+    p_impl_->reset();
 }
 
 }  // namespace silkworm

--- a/silkworm/infra/common/timer.hpp
+++ b/silkworm/infra/common/timer.hpp
@@ -32,83 +32,42 @@ namespace silkworm {
 
 using namespace std::chrono_literals;
 
-//! \brief Implementation of an asynchronous periodic timer relying on boost:asio timer facility
-//! \warning At least one Timer shared pointer must exist when using it (precondition of shared_from_this())
-//! \warning This is achieved by static Timer::create and non-public constructor, subclasses must obey the same rule
-class Timer : public std::enable_shared_from_this<Timer> {
+class TimerImpl;
+
+//! \brief Asynchronous periodic timer relying on boost:asio timer facility
+//! \note This class supports RAII pattern: the Timer destructor will stop the timer
+//! \warning after stop the timer expiration callback *may* be called once more
+class Timer {
   public:
-    //! Factory method enforcing instances are managed *only* through shared pointers
+    //! Create a new periodic timer
     //! \param executor [in] : executor running the timer
     //! \param interval [in] : length of wait interval (in milliseconds)
-    //! \param call_back [in] : the call back function to be called
+    //! \param callback [in] : the call back function to be called
     //! \param auto_start [in] : whether to start the timer immediately
-    static std::shared_ptr<Timer> create(const boost::asio::any_io_executor& executor,
-                                         uint32_t interval,
-                                         std::function<bool()> call_back,
-                                         bool auto_start = true);
+    Timer(const boost::asio::any_io_executor& executor,
+          uint32_t interval,
+          std::function<bool()> callback,
+          bool auto_start = true);
 
-    ~Timer() { stop(); }
+    //! Stop and destroy the timer
+    //! \warning after stop the timer expiration callback *may* be called once more
+    ~Timer();
 
-    //! \brief Start timer asynchronously. Eventually callback action is executed and timer automatically rescheduled
-    //! for another interval
-    void start() {
-        bool expected_running{false};
-        if (is_running_.compare_exchange_strong(expected_running, true)) {
-            launch();
-        }
-    }
+    //! \brief Start the timer asynchronously. Eventually callback gets executed and timer automatically rescheduled
+    //! \details this call is idempotent
+    void start();
 
-    //! \brief Stop timer and cancel any pending execution. Callback may still be executed *once* if timer gets cancelled
-    //! after expiration but before completion handler dispatching.
-    void stop() {
-        bool expected_running{true};
-        if (is_running_.compare_exchange_strong(expected_running, false)) {
-            (void)timer_.cancel();
-        }
-    }
+    //! \brief Stop the timer and cancel any pending expiration
+    //! \details Callback may still be executed *once* if timer gets cancelled after expiration but before completion
+    //! handler dispatching
+    //! \details this call is idempotent
+    void stop();
 
-    //! \brief Cancel next execution of awaiting callback and reschedule for a new interval if still in running state
-    void reset() {
-        (void)timer_.cancel();
-        if (is_running_) {
-            launch();
-        }
-    }
-
-  protected:
-    //! \brief Not public to force creation only through Timer::create
-    //! \param executor [in] : executor running the timer
-    //! \param interval [in] : length of wait interval (in milliseconds)
-    //! \param call_back [in] : the call back function to be called
-    Timer(const boost::asio::any_io_executor& executor, uint32_t interval, std::function<bool()> call_back)
-        : interval_(interval), timer_(executor), call_back_(std::move(call_back)) {
-        SILKWORM_ASSERT(interval > 0);
-    };
+    //! \brief Cancel the next timer expiration and reschedule for a new interval if still running
+    void reset();
 
   private:
-    //! \brief Launches async timer
-    void launch() {
-        timer_.expires_after(std::chrono::milliseconds(interval_));
-
-        // Start the timer and capture it as shared pointer to extend its lifetime to the completion handler invocation
-        (void)timer_.async_wait([self = shared_from_this()](const boost::system::error_code& ec) {
-            if (ec == boost::asio::error::operation_aborted) {  // If timer gets cancelled before expiration
-                return;
-            }
-            // If timer gets cancelled after expiration but before completion handler dispatching, we may arrive here
-            if (!ec && self->call_back_) {
-                self->call_back_();
-            }
-            if (self->is_running_) {
-                self->launch();
-            }
-        });
-    }
-
-    std::atomic_bool is_running_{false};
-    const uint32_t interval_;
-    boost::asio::steady_timer timer_;
-    std::function<bool()> call_back_;
+    std::shared_ptr<TimerImpl> p_impl_;
 };
 
 }  // namespace silkworm

--- a/silkworm/node/stagedsync/stages/stage_headers.cpp
+++ b/silkworm/node/stagedsync/stages/stage_headers.cpp
@@ -16,7 +16,6 @@
 
 #include "stage_headers.hpp"
 
-#include <set>
 #include <thread>
 
 #include <magic_enum.hpp>
@@ -110,13 +109,12 @@ Stage::Result HeadersStage::forward(db::RWTxn& tx) {
 
         if (forced_target_block_ && current_height_ >= *forced_target_block_) {
             tx.commit_and_renew();
-            log::Info(log_prefix_) << "End, forward skipped due to 'stop-at-block', current block= "
-                                   << current_height_.load() << ")";
+            log::Trace(log_prefix_) << "End, forward skipped due to STOP_AT_BLOCK, block=" << current_height_.load();
             return Stage::Result::kSuccess;
         }
         if (current_height_ >= target_height) {
             tx.commit_and_renew();
-            log::Info(log_prefix_) << "End, forward skipped, we are already at the target block (" << target_height << ")";
+            log::Trace(log_prefix_) << "End, forward skipped, we are already at target block=" << target_height;
             return Stage::Result::kSuccess;
         }
         const BlockNum segment_width{target_height - current_height_};


### PR DESCRIPTION
Fixes #2296 

The previous `Timer` class has been renamed as `TimerImpl` and used as implementation facility, wrapped around the new `Timer` which uses RAII to guarantee cancellation on destruction.

*Extras*
- node: demote log traces in stage Headers
- node: add warning in case of sync interrupted by STOP_AT_BLOCK env variable