### PR TITLE
db: snapshots seeding

### DIFF
--- a/silkworm/db/snapshot_merger.cpp
+++ b/silkworm/db/snapshot_merger.cpp
@@ -146,6 +146,12 @@ void SnapshotMerger::commit(std::shared_ptr<DataMigrationResult> result) {
     for (auto& merged_bundle : merged_bundles) {
         schedule_bundle_cleanup(*merged_bundle);
     }
+
+    on_snapshot_merged_signal_(bundle.block_range());
+}
+
+boost::signals2::scoped_connection SnapshotMerger::on_snapshot_merged(std::function<void(BlockNumRange)> callback) {
+    return on_snapshot_merged_signal_.connect(std::move(callback));
 }
 
 Task<void> SnapshotMerger::cleanup() {

--- a/silkworm/db/snapshot_merger.hpp
+++ b/silkworm/db/snapshot_merger.hpp
@@ -16,8 +16,15 @@
 
 #pragma once
 
+#include <functional>
+
+#include <boost/signals2.hpp>
+
+#include <silkworm/core/common/base.hpp>
+
 #include "data_migration.hpp"
 #include "snapshots/snapshot_repository.hpp"
+#include "snapshots/snapshot_size.hpp"
 
 namespace silkworm::db {
 
@@ -29,9 +36,11 @@ class SnapshotMerger : public DataMigration {
         : snapshots_(snapshots),
           tmp_dir_path_(std::move(tmp_dir_path)) {}
 
+    boost::signals2::scoped_connection on_snapshot_merged(std::function<void(BlockNumRange)> callback);
+
   private:
     static constexpr size_t kBatchSize = 10;
-    static constexpr size_t kMaxSnapshotSize = 100'000;
+    static constexpr size_t kMaxSnapshotSize = snapshots::kMaxMergerSnapshotSize;
 
     const char* name() const override { return "SnapshotMerger"; }
     std::unique_ptr<DataMigrationCommand> next_command() override;
@@ -42,6 +51,7 @@ class SnapshotMerger : public DataMigration {
 
     snapshots::SnapshotRepository& snapshots_;
     std::filesystem::path tmp_dir_path_;
+    boost::signals2::signal<void(BlockNumRange)> on_snapshot_merged_signal_;
 };
 
 }  // namespace silkworm::db

--- a/silkworm/db/snapshot_sync.cpp
+++ b/silkworm/db/snapshot_sync.cpp
@@ -29,6 +29,7 @@
 #include <silkworm/db/blocks/headers/header_snapshot.hpp>
 #include <silkworm/db/mdbx/etl_mdbx_collector.hpp>
 #include <silkworm/db/snapshot_bundle_factory_impl.hpp>
+#include <silkworm/db/snapshots/bittorrent/torrent_file.hpp>
 #include <silkworm/db/snapshots/index_builder.hpp>
 #include <silkworm/db/snapshots/snapshot_path.hpp>
 #include <silkworm/db/stages.hpp>
@@ -87,6 +88,10 @@ Task<void> SnapshotSync::setup_and_run() {
 
     co_await setup();
 
+    [[maybe_unused]] auto snapshot_merged_subscription = snapshot_merger_.on_snapshot_merged([this](BlockNumRange range) {
+        this->seed_frozen_bundle(range);
+    });
+
     co_await (
         snapshot_freezer_.run_loop() &&
         snapshot_merger_.run_loop());
@@ -114,6 +119,8 @@ Task<void> SnapshotSync::setup() {
 
     // Set snapshot repository into snapshot-aware database access
     db::DataModel::set_snapshot_repository(&repository_);
+
+    seed_frozen_local_snapshots();
 
     std::scoped_lock lock{setup_done_mutex_};
     setup_done_ = true;
@@ -165,7 +172,7 @@ Task<void> SnapshotSync::download_snapshots() {
     auto log_added = [](const std::filesystem::path& snapshot_file) {
         SILK_TRACE << "SnapshotSync: download started for: " << snapshot_file.filename().string();
     };
-    const auto added_connection = client_.added_subscription.connect(log_added);
+    boost::signals2::scoped_connection added_subscription{client_.added_subscription.connect(log_added)};
 
     size_t completed = 0;
     auto log_stats = [&](lt::span<const int64_t> counters) {
@@ -187,7 +194,7 @@ Task<void> SnapshotSync::download_snapshots() {
             SILK_TRACE << "SnapshotSync: counters dump [" << counters_dump << "]";
         }
     };
-    const auto stats_connection = client_.stats_subscription.connect(log_stats);
+    boost::signals2::scoped_connection stats_subscription{client_.stats_subscription.connect(log_stats)};
 
     auto executor = co_await boost::asio::this_coro::executor;
     // make the buffer bigger so that try_send always succeeds in case of duplicate files (see snapshot_set below)
@@ -195,7 +202,7 @@ Task<void> SnapshotSync::download_snapshots() {
     auto log_completed = [&](const std::filesystem::path& snapshot_file) {
         completed_channel.try_send(snapshot_file);
     };
-    const auto completed_connection = client_.completed_subscription.connect(log_completed);
+    boost::signals2::scoped_connection completed_subscription{client_.completed_subscription.connect(log_completed)};
 
     for (const auto& preverified_snapshot : snapshot_config.preverified_snapshots()) {
         SILK_TRACE << "SnapshotSync: adding info hash for preverified: " << preverified_snapshot.file_name;
@@ -219,10 +226,6 @@ Task<void> SnapshotSync::download_snapshots() {
     }
 
     SILK_INFO << "SnapshotSync: sync completed: [" << num_snapshots << "/" << num_snapshots << "]";
-
-    added_connection.disconnect();
-    completed_connection.disconnect();
-    stats_connection.disconnect();
 }
 
 Task<void> SnapshotSync::build_missing_indexes() {
@@ -265,6 +268,43 @@ Task<void> SnapshotSync::build_missing_indexes() {
     }
 
     SILK_INFO << "SnapshotSync: built missing indexes";
+}
+
+void SnapshotSync::seed_frozen_local_snapshots() {
+    for (auto& bundle_ptr : repository_.view_bundles()) {
+        auto& bundle = *bundle_ptr;
+        bool is_frozen = bundle.block_range().size() >= kMaxMergerSnapshotSize;
+        bool is_preverified = bundle.block_to() <= snapshots_config_.max_block_number() + 1;
+        if (is_frozen && !is_preverified) {
+            seed_bundle(bundle);
+        }
+    }
+}
+
+void SnapshotSync::seed_frozen_bundle(BlockNumRange range) {
+    bool is_frozen = range.size() >= kMaxMergerSnapshotSize;
+    auto bundle = repository_.find_bundle(range.start);
+    if (bundle && (bundle->block_range() == range) && is_frozen) {
+        seed_bundle(*bundle);
+    }
+}
+
+void SnapshotSync::seed_bundle(SnapshotBundle& bundle) {
+    for (auto& path : bundle.snapshot_paths()) {
+        seed_snapshot(path);
+    }
+}
+
+void SnapshotSync::seed_snapshot(const SnapshotPath& path) {
+    std::filesystem::path torrent_path = path.path().concat(".torrent");
+    auto torrent_file =
+        std::filesystem::exists(torrent_path)
+            ? bittorrent::TorrentFile{torrent_path}
+            : bittorrent::TorrentFile::from_source_file(path.path());
+    if (!std::filesystem::exists(torrent_path)) {
+        torrent_file.save(torrent_path);
+    }
+    client_.add_info_hash(path.path().filename().string(), torrent_file.info_hash());
 }
 
 void SnapshotSync::update_database(db::RWTxn& txn, BlockNum max_block_available, std::function<bool()> is_stopping) {

--- a/silkworm/db/snapshot_sync.hpp
+++ b/silkworm/db/snapshot_sync.hpp
@@ -34,6 +34,8 @@
 #include <silkworm/db/snapshot_merger.hpp>
 #include <silkworm/db/snapshots/bittorrent/client.hpp>
 #include <silkworm/db/snapshots/config.hpp>
+#include <silkworm/db/snapshots/snapshot_bundle.hpp>
+#include <silkworm/db/snapshots/snapshot_path.hpp>
 #include <silkworm/db/snapshots/snapshot_repository.hpp>
 #include <silkworm/db/snapshots/snapshot_settings.hpp>
 #include <silkworm/db/stage_scheduler.hpp>
@@ -61,6 +63,12 @@ class SnapshotSync {
     Task<void> setup_and_run();
     Task<void> setup();
     Task<void> build_missing_indexes();
+
+    void seed_frozen_local_snapshots();
+    void seed_frozen_bundle(BlockNumRange range);
+    void seed_bundle(snapshots::SnapshotBundle& bundle);
+    void seed_snapshot(const snapshots::SnapshotPath& path);
+
     void update_database(db::RWTxn& txn, BlockNum max_block_available, std::function<bool()> is_stopping);
     void update_block_headers(db::RWTxn& txn, BlockNum max_block_available, std::function<bool()> is_stopping);
     void update_block_bodies(db::RWTxn& txn, BlockNum max_block_available);

--- a/silkworm/db/snapshots/bittorrent/client.cpp
+++ b/silkworm/db/snapshots/bittorrent/client.cpp
@@ -44,15 +44,20 @@ namespace fs = std::filesystem;
 using namespace std::chrono_literals;
 
 std::vector<char> BitTorrentClient::load_file(const fs::path& filename) {
-    std::ifstream input_file_stream{filename, std::ios_base::binary};
-    input_file_stream.unsetf(std::ios_base::skipws);
-    return {std::istream_iterator<char>(input_file_stream), std::istream_iterator<char>()};
+    if (!std::filesystem::exists(filename)) return {};
+    std::ifstream input_file_stream{filename, std::ios::binary | std::ios::ate};
+    input_file_stream.exceptions(std::ios::failbit | std::ios::badbit);
+    std::streamsize file_size = input_file_stream.tellg();
+    std::vector<char> contents(static_cast<size_t>(file_size));
+    input_file_stream.seekg(0);
+    input_file_stream.read(contents.data(), file_size);
+    return contents;
 }
 
 void BitTorrentClient::save_file(const fs::path& filename, const std::vector<char>& data) {
     SILK_TRACE << "Save #data=" << data.size() << " in file: " << filename;
-    std::ofstream output_file_stream{filename, std::ios_base::binary};
-    output_file_stream.unsetf(std::ios_base::skipws);
+    std::ofstream output_file_stream{filename, std::ios::binary | std::ios::trunc};
+    output_file_stream.exceptions(std::ios::failbit | std::ios::badbit);
     output_file_stream.write(data.data(), static_cast<std::streamsize>(data.size()));
 }
 

--- a/silkworm/db/snapshots/bittorrent/client_test.cpp
+++ b/silkworm/db/snapshots/bittorrent/client_test.cpp
@@ -105,6 +105,14 @@ static inline std::vector<char> test_resume_data() {
     return resume_data;
 }
 
+TEST_CASE("BitTorrentClient::load_file", "[silkworm][snapshot][bittorrent]") {
+    TemporaryDirectory tmp_dir;
+    const auto path = tmp_dir.path() / "test.resume";
+    const auto resume_data = test_resume_data();
+    BitTorrentClientForTest::save_file(path, resume_data);
+    CHECK(BitTorrentClientForTest::load_file(path) == resume_data);
+}
+
 TEST_CASE("BitTorrentClient::BitTorrentClient", "[silkworm][snapshot][bittorrent]") {
     TemporaryDirectory tmp_dir;
     BitTorrentSettings settings;
@@ -123,16 +131,17 @@ TEST_CASE("BitTorrentClient::BitTorrentClient", "[silkworm][snapshot][bittorrent
     SECTION("nonempty resume dir") {
         const auto resume_dir_path = settings.repository_path / BitTorrentClient::kResumeDirName;
         std::filesystem::create_directories(resume_dir_path);
+
         const auto ignored_file{resume_dir_path / "a.txt"};
         BitTorrentClientForTest::save_file(ignored_file, std::vector<char>{});
+
         const auto empty_resume_file{resume_dir_path / "a.resume"};
         BitTorrentClientForTest::save_file(empty_resume_file, std::vector<char>{});
-        const auto invalid_resume_file{resume_dir_path / "83112dec4bec180cff67e01d6345c88c3134fd26.resume"};
-        std::vector<char> invalid_resume_data{};
-        BitTorrentClientForTest::save_file(invalid_resume_file, invalid_resume_data);
+
         const auto valid_resume_file{resume_dir_path / "83112dec4bec180cff67e01d6345c88c3134fd26.resume"};
         std::vector<char> resume_data{test_resume_data()};
         BitTorrentClientForTest::save_file(valid_resume_file, resume_data);
+
         CHECK_NOTHROW(BitTorrentClient{settings});
     }
 }

--- a/silkworm/db/snapshots/bittorrent/torrent_file.hpp
+++ b/silkworm/db/snapshots/bittorrent/torrent_file.hpp
@@ -31,11 +31,14 @@ namespace silkworm::snapshots::bittorrent {
 class TorrentFile {
   public:
     TorrentFile(ByteView data);
+    TorrentFile(const std::filesystem::path& path);
 
     static TorrentFile from_source_file(const std::filesystem::path& source_file_path, std::time_t creation_date = 0);
 
     const lt::add_torrent_params& params() const { return params_; }
+    std::string info_hash() const;
     Bytes to_bytes() const;
+    void save(const std::filesystem::path& path);
 
   private:
     lt::add_torrent_params params_;

--- a/silkworm/db/snapshots/config.hpp
+++ b/silkworm/db/snapshots/config.hpp
@@ -16,17 +16,12 @@
 
 #pragma once
 
-#include <span>
-#include <string>
 #include <vector>
 
 #include <silkworm/core/chain/config.hpp>
-#include <silkworm/core/common/small_map.hpp>
-#include <silkworm/db/snapshots/config/bor_mainnet.hpp>
-#include <silkworm/db/snapshots/config/mainnet.hpp>
-#include <silkworm/db/snapshots/config/mumbai.hpp>
-#include <silkworm/db/snapshots/config/sepolia.hpp>
-#include <silkworm/db/snapshots/entry.hpp>
+#include <silkworm/core/common/base.hpp>
+
+#include "entry.hpp"
 
 namespace silkworm::snapshots {
 
@@ -36,24 +31,17 @@ class Config {
   public:
     static Config lookup_known_config(ChainId chain_id);
 
-    explicit Config(PreverifiedList preverified_snapshots);
+    explicit Config(PreverifiedList entries);
 
-    [[nodiscard]] const PreverifiedList& preverified_snapshots() const { return preverified_snapshots_; }
+    [[nodiscard]] const PreverifiedList& preverified_snapshots() const { return entries_; }
     [[nodiscard]] BlockNum max_block_number() const { return max_block_number_; }
 
   private:
-    BlockNum compute_max_block();
-    void remove_unsupported_snapshots();
+    static BlockNum compute_max_block(const PreverifiedList& entries);
+    static PreverifiedList remove_unsupported_snapshots(const PreverifiedList& entries);
 
-    PreverifiedList preverified_snapshots_;
+    PreverifiedList entries_;
     BlockNum max_block_number_;
-};
-
-inline constexpr SmallMap<ChainId, std::span<const Entry>> kKnownSnapshotConfigs{
-    {*kKnownChainNameToId.find("mainnet"sv), {kMainnetSnapshots.data(), kMainnetSnapshots.size()}},
-    {*kKnownChainNameToId.find("sepolia"sv), {kSepoliaSnapshots.data(), kSepoliaSnapshots.size()}},
-    {*kKnownChainNameToId.find("bor-mainnet"sv), {kBorMainnetSnapshots.data(), kBorMainnetSnapshots.size()}},
-    {*kKnownChainNameToId.find("mumbai"sv), {kMumbaiSnapshots.data(), kMumbaiSnapshots.size()}},
 };
 
 }  // namespace silkworm::snapshots

--- a/silkworm/db/snapshots/config_test.cpp
+++ b/silkworm/db/snapshots/config_test.cpp
@@ -33,7 +33,7 @@ TEST_CASE("Config::lookup_known_config", "[silkworm][snapshot][config]") {
     }
 
     SECTION("mainnet") {
-        constexpr std::size_t kMaxBlockNumber{20'461'000};
+        constexpr std::size_t kMaxBlockNumber{20'400'000};
         const auto mainnet_snapshot_config = Config::lookup_known_config(1);
         CHECK(mainnet_snapshot_config.max_block_number() == kMaxBlockNumber - 1);
     }

--- a/silkworm/db/snapshots/snapshot_path.hpp
+++ b/silkworm/db/snapshots/snapshot_path.hpp
@@ -63,8 +63,8 @@ class SnapshotPath {
     [[nodiscard]] uint8_t version() const { return version_; }
 
     [[nodiscard]] BlockNum block_from() const { return block_from_; }
-
     [[nodiscard]] BlockNum block_to() const { return block_to_; }
+    [[nodiscard]] BlockNumRange block_range() const { return BlockNumRange{block_from_, block_to_}; }
 
     [[nodiscard]] SnapshotType type() const { return type_; }
 

--- a/silkworm/db/snapshots/snapshot_repository.hpp
+++ b/silkworm/db/snapshots/snapshot_repository.hpp
@@ -108,10 +108,9 @@ class SnapshotRepository {
     }
 
     [[nodiscard]] std::pair<std::optional<SnapshotAndIndex>, std::shared_ptr<SnapshotBundle>> find_segment(SnapshotType type, BlockNum number) const;
-
-  private:
     std::shared_ptr<SnapshotBundle> find_bundle(BlockNum number) const;
 
+  private:
     [[nodiscard]] SnapshotPathList get_segment_files() const {
         return get_files(kSegmentExtension);
     }

--- a/silkworm/db/snapshots/snapshot_size.hpp
+++ b/silkworm/db/snapshots/snapshot_size.hpp
@@ -1,0 +1,25 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <cstddef>
+
+namespace silkworm::snapshots {
+
+static constexpr size_t kMaxMergerSnapshotSize = 100'000;
+
+}  // namespace silkworm::snapshots


### PR DESCRIPTION
* seed locally generated frozen snapshots on startup
* seed locally generated frozen snapshots when they are generated
* exclude small snapshots from seeding/downloading (will be improved later)
* don't ignore IO errors in BitTorrentClient load_file/save_file