### PR TITLE
cmake: update min macOS to 14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ delivering the first release of [Erigon++] starting from Erigon 2.59.0.
 Erigon++ is supported on platforms:
 
 * Linux x86_64 with glibc 34+, glibcpp 30+ (such as Debian 12+, Ubuntu 22+, etc.)
-* macOS 13.3+ arm64
+* macOS 14+ arm64
 
 It is not supported on any arm64 Linux, Alpine Linux.
 Test compatibility by running [silkworm_compat_check.sh](https://github.com/erigontech/erigon/blob/main/turbo/silkworm/silkworm_compat_check.sh)

--- a/cmake/toolchain/cxx20.cmake
+++ b/cmake/toolchain/cxx20.cmake
@@ -26,6 +26,6 @@ cmake_policy(SET CMP0063 NEW)
 cmake_policy(SET CMP0074 NEW)
 
 set(CMAKE_OSX_DEPLOYMENT_TARGET
-    "13.3"
+    "14.0"
     CACHE STRING ""
 )

--- a/cmd/capi/sample-go-client/README.md
+++ b/cmd/capi/sample-go-client/README.md
@@ -13,5 +13,5 @@ go run main.go
 
 on macOS:
 ```bash
-CGO_LDFLAGS=-mmacosx-version-min=13.3 go run main.go
+CGO_LDFLAGS=-mmacosx-version-min=14.0 go run main.go
 ```


### PR DESCRIPTION
fixes ld: warning: object file libtorrent-rasterbar.a[2](add_torrent_params.cpp.o) was built for newer 'macOS' version (14.0) than being linked (13.3)