### PR TITLE
rpcdaemon: gas cost from EVMONE for debug family API

### DIFF
--- a/.github/workflows/rpc-integration-tests.yml
+++ b/.github/workflows/rpc-integration-tests.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout RPC Tests Repository & Install Requirements
         run: |
           rm -rf ${{runner.workspace}}/rpc-tests
-          git -c advice.detachedHead=false clone --depth 1 --branch v0.48.0 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
+          git -c advice.detachedHead=false clone --depth 1 --branch v0.49.0 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
           cd ${{runner.workspace}}/rpc-tests
           pip3 install -r requirements.txt
 

--- a/.github/workflows/rpc-integration-tests.yml
+++ b/.github/workflows/rpc-integration-tests.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout RPC Tests Repository & Install Requirements
         run: |
           rm -rf ${{runner.workspace}}/rpc-tests
-          git -c advice.detachedHead=false clone --depth 1 --branch v0.49.0 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
+          git -c advice.detachedHead=false clone --depth 1 --branch v0.49.1 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
           cd ${{runner.workspace}}/rpc-tests
           pip3 install -r requirements.txt
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "evmone"]
 	path = third_party/evmone/evmone
-	url = https://github.com/ethereum/evmone.git
+	url = https://github.com/erigontech/evmone.git
+        branch = gas_cost_in_tracers
 [submodule "ethereum-tests"]
 	path = third_party/ethereum-tests
 	url = https://github.com/ethereum/tests.git

--- a/silkworm/core/execution/evm.cpp
+++ b/silkworm/core/execution/evm.cpp
@@ -235,7 +235,7 @@ evmc::Result EVM::call(const evmc_message& message) noexcept {
         } else {
             const std::optional<Bytes> output{contract.run(input)};
             if (output) {
-                res = evmc::Result{EVMC_SUCCESS, message.gas - static_cast<int64_t>(gas), 0,
+                res = evmc::Result{EVMC_SUCCESS, message.gas - static_cast<int64_t>(gas), 0, message.gas_cost,
                                    output->data(), output->size()};
             } else {
                 res.status_code = EVMC_PRECOMPILE_FAILURE;

--- a/silkworm/core/execution/evm.cpp
+++ b/silkworm/core/execution/evm.cpp
@@ -156,6 +156,7 @@ evmc::Result EVM::create(const evmc_message& message) noexcept {
         .kind = message.depth > 0 ? message.kind : EVMC_CALL,
         .depth = message.depth,
         .gas = message.gas,
+        .gas_cost = message.gas_cost,
         .recipient = contract_addr,
         .sender = message.sender,
         .value = message.value,

--- a/silkworm/rpc/core/evm_debug.cpp
+++ b/silkworm/rpc/core/evm_debug.cpp
@@ -114,7 +114,7 @@ void DebugTracer::on_execution_start(evmc_revision rev, const evmc_message& msg,
     const evmc::address sender(msg.sender);
 
     if (!logs_.empty()) {
-        auto &log = logs_[logs_.size() - 1]; // it should be a CALL* opcode
+        auto& log = logs_[logs_.size() - 1];  // it should be a CALL* opcode
         log.gas_cost_check = msg.gas_cost;
     }
 
@@ -190,12 +190,12 @@ void DebugTracer::on_instruction_start(uint32_t pc, const intx::uint256* stack_t
     }
 
     if (!logs_.empty()) {
-        auto &log = logs_[logs_.size() - 1];
+        auto& log = logs_[logs_.size() - 1];
 
         if (log.opcode == OP_RETURN || log.opcode == OP_STOP || log.opcode == OP_REVERT) {
             log.gas_cost_check = 0;
-        } else if (log.depth == execution_state.msg->depth + 1) { //if (log.opcode != OP_CALL && log.opcode != OP_CALLCODE && log.opcode != OP_STATICCALL && log.opcode != OP_DELEGATECALL && log.opcode != OP_CREATE && log.opcode != OP_CREATE2) {
-             log.gas_cost_check = execution_state.last_opcode_gas_cost;
+        } else if (log.depth == execution_state.msg->depth + 1) {  // if (log.opcode != OP_CALL && log.opcode != OP_CALLCODE && log.opcode != OP_STATICCALL && log.opcode != OP_DELEGATECALL && log.opcode != OP_CREATE && log.opcode != OP_CREATE2) {
+            log.gas_cost_check = execution_state.last_opcode_gas_cost;
         }
     }
 
@@ -406,7 +406,7 @@ void DebugTracer::write_log(const DebugLog& log) {
     stream_.open_object();
     stream_.write_field("depth", log.depth);
     stream_.write_field("gas", log.gas);
-//    stream_.write_field("gasCost", log.gas_cost);
+    //    stream_.write_field("gasCost", log.gas_cost);
     stream_.write_field("gasCost", log.gas_cost_check);
     stream_.write_field("op", log.op);
     stream_.write_field("pc", log.pc);

--- a/silkworm/rpc/core/evm_debug.cpp
+++ b/silkworm/rpc/core/evm_debug.cpp
@@ -194,7 +194,7 @@ void DebugTracer::on_instruction_start(uint32_t pc, const intx::uint256* stack_t
 
         if (log.opcode == OP_RETURN || log.opcode == OP_STOP || log.opcode == OP_REVERT) {
             log.gas_cost_check = 0;
-        } else if (log.depth == execution_state.msg->depth + 1) {  // if (log.opcode != OP_CALL && log.opcode != OP_CALLCODE && log.opcode != OP_STATICCALL && log.opcode != OP_DELEGATECALL && log.opcode != OP_CREATE && log.opcode != OP_CREATE2) {
+        } else if (log.depth == execution_state.msg->depth + 1) {
             log.gas_cost_check = execution_state.last_opcode_gas_cost;
         }
     }
@@ -262,6 +262,7 @@ void DebugTracer::on_execution_end(const evmc_result& result, const silkworm::In
             case evmc_status_code::EVMC_STACK_OVERFLOW:
             case evmc_status_code::EVMC_STACK_UNDERFLOW:
                 log.gas_cost = 0;
+                log.gas_cost_check = result.gas_cost;
                 break;
 
             case evmc_status_code::EVMC_OUT_OF_GAS:

--- a/silkworm/rpc/core/evm_debug.cpp
+++ b/silkworm/rpc/core/evm_debug.cpp
@@ -113,6 +113,11 @@ void DebugTracer::on_execution_start(evmc_revision rev, const evmc_message& msg,
     const evmc::address recipient(msg.recipient);
     const evmc::address sender(msg.sender);
 
+    if (!logs_.empty()) {
+        auto &log = logs_[logs_.size() - 1]; // it should be a CALL* opcode
+        log.gas_cost_check = msg.gas_cost;
+    }
+
     SILK_DEBUG << "on_execution_start:"
                << " rev: " << rev
                << " gas: " << std::dec << msg.gas
@@ -162,7 +167,7 @@ void DebugTracer::on_instruction_start(uint32_t pc, const intx::uint256* stack_t
 
     if (!logs_.empty()) {
         auto& log = logs_[logs_.size() - 1];
-        if (fix_call_gas_info_) {  // previuos opcodw was a CALL*
+        if (fix_call_gas_info_) {  // previuos opcode was a CALL*
             if (execution_state.msg->depth == fix_call_gas_info_->depth) {
                 if (fix_call_gas_info_->gas_cost) {
                     log.gas_cost = fix_call_gas_info_->gas_cost + fix_call_gas_info_->code_cost;
@@ -184,6 +189,16 @@ void DebugTracer::on_instruction_start(uint32_t pc, const intx::uint256* stack_t
         }
     }
 
+    if (!logs_.empty()) {
+        auto &log = logs_[logs_.size() - 1];
+
+        if (log.opcode == OP_RETURN || log.opcode == OP_STOP || log.opcode == OP_REVERT) {
+            log.gas_cost_check = 0;
+        } else if (log.depth == execution_state.msg->depth + 1) { //if (log.opcode != OP_CALL && log.opcode != OP_CALLCODE && log.opcode != OP_STATICCALL && log.opcode != OP_DELEGATECALL && log.opcode != OP_CREATE && log.opcode != OP_CREATE2) {
+             log.gas_cost_check = execution_state.last_opcode_gas_cost;
+        }
+    }
+
     if (logs_.size() > 1) {
         auto& log = logs_.front();
         write_log(log);
@@ -194,6 +209,7 @@ void DebugTracer::on_instruction_start(uint32_t pc, const intx::uint256* stack_t
 
     DebugLog log;
     log.pc = pc;
+    log.opcode = opcode;
     log.op = opcode_name;
     log.gas = gas;
     log.gas_cost = metrics_[opcode].gas_cost;
@@ -226,6 +242,9 @@ void DebugTracer::on_precompiled_run(const evmc_result& result, int64_t gas, con
         fix_call_gas_info_->code_cost = 0;
         fix_call_gas_info_->precompiled = true;
     }
+    if (logs_.size() > 1) {
+        flush_logs();
+    }
 }
 
 void DebugTracer::on_execution_end(const evmc_result& result, const silkworm::IntraBlockState& /*intra_block_state*/) noexcept {
@@ -253,6 +272,11 @@ void DebugTracer::on_execution_end(const evmc_result& result, const silkworm::In
                         log.gas_cost += fix_call_gas_info_->gas_cost;
                     }
                 }
+                if (log.opcode == OP_CALL || log.opcode == OP_CALLCODE || log.opcode == OP_STATICCALL || log.opcode == OP_DELEGATECALL || log.opcode == OP_CREATE || log.opcode == OP_CREATE2) {
+                    log.gas_cost_check = log.gas_cost;
+                } else {
+                    log.gas_cost_check = result.gas_cost;
+                }
                 break;
 
             default:
@@ -267,6 +291,11 @@ void DebugTracer::on_execution_end(const evmc_result& result, const silkworm::In
                         fix_call_gas_info_->gas_cost = 0;
                     }
                 }
+                if (log.opcode == OP_CALL || log.opcode == OP_CALLCODE || log.opcode == OP_STATICCALL || log.opcode == OP_DELEGATECALL || log.opcode == OP_CREATE || log.opcode == OP_CREATE2) {
+                    log.gas_cost_check += result.gas_cost;
+                } else {
+                    log.gas_cost_check = log.gas_cost;
+                }
                 break;
         }
 
@@ -275,6 +304,7 @@ void DebugTracer::on_execution_end(const evmc_result& result, const silkworm::In
             DebugLog newlog;
             newlog.pc = log.pc + 1;
             newlog.op = get_opcode_name(opcode_names_, OP_STOP);
+            newlog.opcode = OP_STOP;
             newlog.gas = log.gas - log.gas_cost;
             newlog.gas_cost = 0;
             newlog.depth = log.depth;
@@ -284,9 +314,7 @@ void DebugTracer::on_execution_end(const evmc_result& result, const silkworm::In
     }
 
     if (logs_.size() > 1) {
-        auto& log = logs_.front();
-        write_log(log);
-        logs_.erase(logs_.begin());
+        flush_logs();
     }
 
     SILK_DEBUG << "on_execution_end:"
@@ -299,6 +327,7 @@ void DebugTracer::flush_logs() {
     for (const auto& log : logs_) {
         write_log(log);
     }
+    logs_.clear();
 }
 
 int64_t memory_cost(const evmone::Memory& memory, std::uint64_t offset, std::uint64_t size) noexcept {
@@ -377,7 +406,8 @@ void DebugTracer::write_log(const DebugLog& log) {
     stream_.open_object();
     stream_.write_field("depth", log.depth);
     stream_.write_field("gas", log.gas);
-    stream_.write_field("gasCost", log.gas_cost);
+//    stream_.write_field("gasCost", log.gas_cost);
+    stream_.write_field("gasCost", log.gas_cost_check);
     stream_.write_field("op", log.op);
     stream_.write_field("pc", log.pc);
 

--- a/silkworm/rpc/core/evm_debug.hpp
+++ b/silkworm/rpc/core/evm_debug.hpp
@@ -61,9 +61,11 @@ using Storage = std::map<std::string, std::string>;
 
 struct DebugLog {
     std::uint32_t pc{0};
+    unsigned char opcode;
     std::string op;
     std::int64_t gas{0};
     std::int64_t gas_cost{0};
+    std::int64_t gas_cost_check{0};
     std::int32_t depth{0};
     bool error{false};
     std::vector<std::string> memory;
@@ -114,6 +116,7 @@ class DebugTracer : public EvmTracer {
     const char* const* opcode_names_ = nullptr;
     const evmc_instruction_metrics* metrics_ = nullptr;
     std::stack<std::int64_t> start_gas_;
+//    std::int64_t gas_cost_;
     std::optional<FixCallGasInfo> fix_call_gas_info_;
     std::optional<uint8_t> last_opcode_;
 };

--- a/silkworm/rpc/core/evm_debug.hpp
+++ b/silkworm/rpc/core/evm_debug.hpp
@@ -116,7 +116,7 @@ class DebugTracer : public EvmTracer {
     const char* const* opcode_names_ = nullptr;
     const evmc_instruction_metrics* metrics_ = nullptr;
     std::stack<std::int64_t> start_gas_;
-//    std::int64_t gas_cost_;
+    //    std::int64_t gas_cost_;
     std::optional<FixCallGasInfo> fix_call_gas_info_;
     std::optional<uint8_t> last_opcode_;
 };

--- a/silkworm/rpc/core/evm_debug_test.cpp
+++ b/silkworm/rpc/core/evm_debug_test.cpp
@@ -1230,7 +1230,7 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call with error") {
             {
                 "depth": 1,
                 "gas": 156080,
-                "gasCost": 0,
+                "gasCost": 2,
                 "memory": [],
                 "op": "opcode 0x4b not defined",
                 "pc": 1,


### PR DESCRIPTION
Relevant changes:
- use customised tracing API from our evmone [fork](https://github.com/erigontech/evmone/tree/gas_cost_in_tracers)
- get the _internal_ gas cost from EVMONE for debug_trace* API