### PR TITLE
test: switch fuzzer to single thread and increase its memory limit

### DIFF
--- a/.github/workflows/rpc-fuzzer-tests.yml
+++ b/.github/workflows/rpc-fuzzer-tests.yml
@@ -65,11 +65,11 @@ jobs:
         timeout-minutes: 1440
         working-directory: ${{runner.workspace}}/silkworm/build/cmd/test
         run: |
-          # # Single thread execution
-          # ./rpcdaemon_fuzzer_test $RPC_PAST_TEST_DIR/silkworm-fuzzer/corpus artifacts -max_total_time=86300 -detect_leaks=0
+          # Single thread execution
+          ./rpcdaemon_fuzzer_test -max_total_time=86300 -detect_leaks=0 -rss_limit_mb=32768 -merge=1 $RPC_PAST_TEST_DIR/silkworm-fuzzer/corpus artifacts
 
           # Multi-thread execution
-          ./rpcdaemon_fuzzer_test $RPC_PAST_TEST_DIR/silkworm-fuzzer/corpus artifacts -max_total_time=86300 -detect_leaks=0 -jobs=3 -rss_limit_mb=10922
+          # ./rpcdaemon_fuzzer_test -max_total_time=86300 -detect_leaks=0 -jobs=3 -rss_limit_mb=10922 $RPC_PAST_TEST_DIR/silkworm-fuzzer/corpus artifacts
 
       - name: Save Fuzzer Test Results
         if: always()


### PR DESCRIPTION
Also, enable corpus merging to try and minimize its size, see: https://llvm.org/docs/LibFuzzer.html#corpus