### PR TITLE
qa-tests: fix change point handling

### DIFF
--- a/.github/workflows/rpc-performance-tests.yml
+++ b/.github/workflows/rpc-performance-tests.yml
@@ -207,7 +207,15 @@ jobs:
         if: steps.test_step.outputs.TEST_RESULT == 'success'
         working-directory: ${{runner.workspace}}/rpc-tests/perf/reports/mainnet
         run: |
-          python3 $ERIGON_QA_PATH/test_system/qa-tests/change-points/change_point_analysis.py 
+          set +e # Disable exit on error
+          open_change_points=0
+          python3 $ERIGON_QA_PATH/test_system/qa-tests/change-points/change_point_analysis.py
+          open_change_points=$?
+          cp change_point_analysis.pdf $past_test_dir
+          if [ $open_change_points -ne 0 ]; then
+            echo "Change point analysis found points that need to be investigated"
+            #echo "TEST_RESULT=failure" >> "$GITHUB_OUTPUT"  -- enable in the future
+          fi
 
       - name: Upload test results
         if: always()


### PR DESCRIPTION
This PR
1) fixes the upload of the change-point-analisys.pdf file (which is not currently loaded because it is produced in a different dir than the loaded one)
2) for now avoid failing if there are open CPs because we need to distinguish between failure and open issues; it will be convenient to enable this type of failure after a first analysis of the current CPs