### PR TITLE
db: rename mdbx::env db to env

### DIFF
--- a/cmd/silkworm.cpp
+++ b/cmd/silkworm.cpp
@@ -236,7 +236,7 @@ int main(int argc, char* argv[]) {
         // Prepare database for takeoff
         cmd::common::run_db_checklist(node_settings);
 
-        auto chaindata_db{db::open_env(node_settings.chaindata_env_config)};
+        mdbx::env_managed chaindata_env = db::open_env(node_settings.chaindata_env_config);
 
         silkworm::rpc::ClientContextPool context_pool{
             settings.node_settings.server_settings.context_pool_settings,
@@ -247,7 +247,7 @@ int main(int argc, char* argv[]) {
         settings.sentry_settings.data_dir_path = node_settings.data_directory->path();
         settings.sentry_settings.network_id = node_settings.network_id;
 
-        auto chain_head_provider = [db_access = db::ROAccess{chaindata_db}] {
+        auto chain_head_provider = [db_access = db::ROAccess{chaindata_env}] {
             return db::read_chain_head(db_access);
         };
         sentry::eth::StatusDataProvider eth_status_data_provider{std::move(chain_head_provider), node_settings.chain_config.value()};
@@ -265,8 +265,7 @@ int main(int argc, char* argv[]) {
         };
 
         // Execution: the execution layer engine
-        // NOLINTNEXTLINE(cppcoreguidelines-slicing)
-        silkworm::node::Node execution_node{context_pool.any_executor(), settings.node_settings, sentry_client, chaindata_db};
+        silkworm::node::Node execution_node{context_pool.any_executor(), settings.node_settings, sentry_client, mdbx::env{chaindata_env}};
         execution::api::DirectClient& execution_client{execution_node.execution_direct_client()};
 
         // ChainSync: the chain synchronization process based on the consensus protocol
@@ -280,7 +279,7 @@ int main(int argc, char* argv[]) {
         };
         chainsync::Sync chain_sync_process{
             context_pool.any_executor(),
-            chaindata_db,  // NOLINT(cppcoreguidelines-slicing)
+            mdbx::env{chaindata_env},
             execution_client,
             sentry_client,
             *node_settings.chain_config,

--- a/silkworm/capi/silkworm.cpp
+++ b/silkworm/capi/silkworm.cpp
@@ -131,12 +131,12 @@ static log::Args log_args_for_exec_flush(const db::Buffer& state_buffer, uint64_
 }
 
 //! Generate log arguments for execution commit at specified block
-static log::Args log_args_for_exec_commit(StopWatch::Duration elapsed, const std::filesystem::path& db_path) {
+static log::Args log_args_for_exec_commit(StopWatch::Duration elapsed, const std::filesystem::path& env_path) {
     return {
         "in",
         StopWatch::format(elapsed),
         "chaindata",
-        std::to_string(Directory{db_path}.size())};
+        std::to_string(Directory{env_path}.size())};
 }
 
 //! Generate log arguments for execution progress at specified block
@@ -642,7 +642,7 @@ int silkworm_execute_blocks_perpetual(SilkwormHandle handle, MDBX_env* mdbx_env,
         // Wrap MDBX env into an internal *unmanaged* env, i.e. MDBX env is only used but its lifecycle is untouched
         db::EnvUnmanaged unmanaged_env{mdbx_env};
         auto txn = db::RWTxnManaged{unmanaged_env};
-        const auto db_path{unmanaged_env.get_path()};
+        const auto env_path = unmanaged_env.get_path();
 
         db::Buffer state_buffer{txn};
         state_buffer.set_memory_limit(batch_size);
@@ -698,7 +698,7 @@ int silkworm_execute_blocks_perpetual(SilkwormHandle handle, MDBX_env* mdbx_env,
             txn.commit_and_renew();
             const auto elapsed_time_and_duration = sw.stop();
             log::Info("[4/12 Execution] Commit state+history",  // NOLINT(*-unused-raii)
-                      log_args_for_exec_commit(elapsed_time_and_duration.second, db_path));
+                      log_args_for_exec_commit(elapsed_time_and_duration.second, env_path));
 
             if (last_executed_block) {
                 *last_executed_block = last_block_number;

--- a/silkworm/capi/silkworm_test.cpp
+++ b/silkworm/capi/silkworm_test.cpp
@@ -45,7 +45,8 @@ namespace snapshot_test = snapshots::test_util;
 struct CApiTest : public db::test_util::TestDatabaseContext {
     TemporaryDirectory tmp_dir;
     SilkwormSettings settings{.log_verbosity = SilkwormLogLevel::SILKWORM_LOG_NONE};
-    mdbx::env_managed& db{get_mdbx_env()};
+    mdbx::env& env{mdbx_env()};
+    std::filesystem::path env_path() { return mdbx_env().get_path(); }
 };
 
 //! Utility to copy `src` C-string to `dst` fixed-size char array
@@ -84,7 +85,7 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_init: empty data folder path", "[silkw
 }
 
 TEST_CASE_METHOD(CApiTest, "CAPI silkworm_init: empty MDBX version", "[silkworm][capi]") {
-    copy_path(settings.data_dir_path, db.get_path().string().c_str());
+    copy_path(settings.data_dir_path, env_path().string().c_str());
     copy_git_version(settings.libmdbx_version, "");
     SilkwormHandle handle{nullptr};
     CHECK(silkworm_init(&handle, &settings) == SILKWORM_INCOMPATIBLE_LIBMDBX);
@@ -92,7 +93,7 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_init: empty MDBX version", "[silkworm]
 }
 
 TEST_CASE_METHOD(CApiTest, "CAPI silkworm_init: incompatible MDBX version", "[silkworm][capi]") {
-    copy_path(settings.data_dir_path, db.get_path().string().c_str());
+    copy_path(settings.data_dir_path, env_path().string().c_str());
     copy_git_version(settings.libmdbx_version, "v0.1.0");
     SilkwormHandle handle{nullptr};
     CHECK(silkworm_init(&handle, &settings) == SILKWORM_INCOMPATIBLE_LIBMDBX);
@@ -100,7 +101,7 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_init: incompatible MDBX version", "[si
 }
 
 TEST_CASE_METHOD(CApiTest, "CAPI silkworm_init: OK", "[silkworm][capi]") {
-    copy_path(settings.data_dir_path, db.get_path().string().c_str());
+    copy_path(settings.data_dir_path, env_path().string().c_str());
     copy_git_version(settings.libmdbx_version, silkworm_libmdbx_version());
     SilkwormHandle handle{nullptr};
     CHECK(silkworm_init(&handle, &settings) == SILKWORM_OK);
@@ -114,7 +115,7 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_fini: not initialized", "[silkworm][ca
 }
 
 TEST_CASE_METHOD(CApiTest, "CAPI silkworm_fini: OK", "[silkworm][capi]") {
-    copy_path(settings.data_dir_path, db.get_path().string().c_str());
+    copy_path(settings.data_dir_path, env_path().string().c_str());
     copy_git_version(settings.libmdbx_version, silkworm_libmdbx_version());
     SilkwormHandle handle{nullptr};
     REQUIRE(silkworm_init(&handle, &settings) == SILKWORM_OK);
@@ -124,9 +125,9 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_fini: OK", "[silkworm][capi]") {
 //! \brief Utility class using RAII pattern to wrap the Silkworm C API.
 //! \note This is useful for tests that do *not* specifically play with silkworm_init/silkworm_fini or invalid handles
 struct SilkwormLibrary {
-    explicit SilkwormLibrary(const std::filesystem::path& db_path) {
+    explicit SilkwormLibrary(const std::filesystem::path& env_path) {
         SilkwormSettings settings{.log_verbosity = SilkwormLogLevel::SILKWORM_LOG_NONE};
-        copy_path(settings.data_dir_path, db_path.string().c_str());
+        copy_path(settings.data_dir_path, env_path.string().c_str());
         copy_git_version(settings.libmdbx_version, silkworm_libmdbx_version());
         silkworm_init(&handle_, &settings);
     }
@@ -221,13 +222,13 @@ struct SilkwormLibrary {
 
 TEST_CASE_METHOD(CApiTest, "CAPI silkworm_execute_blocks_ephemeral: block not found", "[silkworm][capi]") {
     // Use Silkworm as a library with silkworm_init/silkworm_fini automated by RAII
-    SilkwormLibrary silkworm_lib{db.get_path()};
+    SilkwormLibrary silkworm_lib{env_path()};
 
     const int chain_id{1};
     const uint64_t batch_size{256 * kMebi};
     BlockNum start_block{10};  // This does not exist, TestDatabaseContext db contains up to block 9
     BlockNum end_block{100};
-    db::RWTxnManaged external_txn{db};
+    db::RWTxnManaged external_txn{env};
     const auto result0{
         silkworm_lib.execute_blocks(*external_txn, chain_id, start_block, end_block, batch_size,
                                     true, true, true)};
@@ -239,14 +240,14 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_execute_blocks_ephemeral: block not fo
 
 TEST_CASE_METHOD(CApiTest, "CAPI silkworm_execute_blocks_perpetual: block not found", "[silkworm][capi]") {
     // Use Silkworm as a library with silkworm_init/silkworm_fini automated by RAII
-    SilkwormLibrary silkworm_lib{db.get_path()};
+    SilkwormLibrary silkworm_lib{env_path()};
 
     const int chain_id{1};
     const uint64_t batch_size{256 * kMebi};
     BlockNum start_block{10};  // This does not exist, TestDatabaseContext db contains up to block 9
     BlockNum end_block{100};
     const auto result0{
-        silkworm_lib.execute_blocks_perpetual(db, chain_id, start_block, end_block, batch_size,
+        silkworm_lib.execute_blocks_perpetual(env, chain_id, start_block, end_block, batch_size,
                                               true, true, true)};
     CHECK(result0.execute_block_result == SILKWORM_BLOCK_NOT_FOUND);
     CHECK(result0.last_executed_block == 0);
@@ -255,13 +256,13 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_execute_blocks_perpetual: block not fo
 
 TEST_CASE_METHOD(CApiTest, "CAPI silkworm_execute_blocks_ephemeral: chain id not found", "[silkworm][capi]") {
     // Use Silkworm as a library with silkworm_init/silkworm_fini automated by RAII
-    SilkwormLibrary silkworm_lib{db.get_path()};
+    SilkwormLibrary silkworm_lib{env_path()};
 
     const uint64_t chain_id{1000000};
     const uint64_t batch_size{256 * kMebi};
     BlockNum start_block{1};
     BlockNum end_block{2};
-    db::RWTxnManaged external_txn{db};
+    db::RWTxnManaged external_txn{env};
     const auto result0{
         silkworm_lib.execute_blocks(*external_txn, chain_id, start_block, end_block, batch_size,
                                     true, true, true)};
@@ -273,14 +274,14 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_execute_blocks_ephemeral: chain id not
 
 TEST_CASE_METHOD(CApiTest, "CAPI silkworm_execute_blocks_perpetual: chain id not found", "[silkworm][capi]") {
     // Use Silkworm as a library with silkworm_init/silkworm_fini automated by RAII
-    SilkwormLibrary silkworm_lib{db.get_path()};
+    SilkwormLibrary silkworm_lib{env_path()};
 
     const uint64_t chain_id{1000000};
     const uint64_t batch_size{256 * kMebi};
     BlockNum start_block{1};
     BlockNum end_block{2};
     const auto result0{
-        silkworm_lib.execute_blocks_perpetual(db, chain_id, start_block, end_block, batch_size,
+        silkworm_lib.execute_blocks_perpetual(env, chain_id, start_block, end_block, batch_size,
                                               true, true, true)};
     CHECK(result0.execute_block_result == SILKWORM_UNKNOWN_CHAIN_ID);
     CHECK(result0.last_executed_block == 0);
@@ -311,7 +312,7 @@ static void insert_block(mdbx::env& env, Block& block) {
 
 TEST_CASE_METHOD(CApiTest, "CAPI silkworm_execute_blocks_ephemeral single block: OK", "[silkworm][capi]") {
     // Use Silkworm as a library with silkworm_init/silkworm_fini automated by RAII
-    SilkwormLibrary silkworm_lib{db.get_path()};
+    SilkwormLibrary silkworm_lib{env_path()};
 
     const int chain_id{1};
     const uint64_t batch_size{256 * kMebi};
@@ -358,10 +359,10 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_execute_blocks_ephemeral single block:
     block.transactions[0].s = 1;  // dummy
     block.transactions[0].set_sender(from);
 
-    insert_block(db, block);
+    insert_block(env, block);
 
     // Execute block 11 using an *external* txn, then commit
-    db::RWTxnManaged external_txn0{db};
+    db::RWTxnManaged external_txn0{env};
     BlockNum start_block{10}, end_block{10};
     const auto result0{execute_blocks(*external_txn0, start_block, end_block)};
     CHECK_NOTHROW(external_txn0.commit_and_stop());
@@ -369,7 +370,7 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_execute_blocks_ephemeral single block:
     CHECK(result0.last_executed_block == end_block);
     CHECK(result0.mdbx_error_code == 0);
 
-    db::ROTxnManaged ro_txn{db};
+    db::ROTxnManaged ro_txn{env};
     REQUIRE(db::read_account(ro_txn, to));
     CHECK(db::read_account(ro_txn, to)->balance == value);
     ro_txn.abort();
@@ -380,10 +381,10 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_execute_blocks_ephemeral single block:
     block.header.number = 11;
     block.transactions[0].nonce++;
 
-    insert_block(db, block);
+    insert_block(env, block);
 
     // Execute block 11 using an *external* txn, then commit
-    db::RWTxnManaged external_txn1{db};
+    db::RWTxnManaged external_txn1{env};
 
     start_block = 11, end_block = 11;
     const auto result1{execute_blocks(*external_txn1, start_block, end_block)};
@@ -392,14 +393,14 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_execute_blocks_ephemeral single block:
     CHECK(result1.last_executed_block == end_block);
     CHECK(result1.mdbx_error_code == 0);
 
-    ro_txn = db::ROTxnManaged{db};
+    ro_txn = db::ROTxnManaged{env};
     REQUIRE(db::read_account(ro_txn, to));
     CHECK(db::read_account(ro_txn, to)->balance == 2 * value);
 }
 
 TEST_CASE_METHOD(CApiTest, "CAPI silkworm_execute_blocks_perpetual single block: OK", "[silkworm][capi]") {
     // Use Silkworm as a library with silkworm_init/silkworm_fini automated by RAII
-    SilkwormLibrary silkworm_lib{db.get_path()};
+    SilkwormLibrary silkworm_lib{env_path()};
 
     const int chain_id{1};
     const uint64_t batch_size{256 * kMebi};
@@ -408,7 +409,7 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_execute_blocks_perpetual single block:
     const bool write_call_traces{false};  // For coherence but don't care
 
     auto execute_blocks = [&](auto start_block, auto end_block) {
-        return silkworm_lib.execute_blocks_perpetual(db,
+        return silkworm_lib.execute_blocks_perpetual(env,
                                                      chain_id,
                                                      start_block,
                                                      end_block,
@@ -446,7 +447,7 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_execute_blocks_perpetual single block:
     block.transactions[0].s = 1;  // dummy
     block.transactions[0].set_sender(from);
 
-    insert_block(db, block);
+    insert_block(env, block);
 
     // Execute block 10 using an *internal* txn
     BlockNum start_block{10}, end_block{10};
@@ -455,7 +456,7 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_execute_blocks_perpetual single block:
     CHECK(result0.last_executed_block == end_block);
     CHECK(result0.mdbx_error_code == 0);
 
-    db::ROTxnManaged ro_txn{db};
+    db::ROTxnManaged ro_txn{env};
     REQUIRE(db::read_account(ro_txn, to));
     CHECK(db::read_account(ro_txn, to)->balance == value);
     ro_txn.abort();
@@ -466,7 +467,7 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_execute_blocks_perpetual single block:
     block.header.number = 11;
     block.transactions[0].nonce++;
 
-    insert_block(db, block);
+    insert_block(env, block);
 
     // Execute block 11 using an *internal* txn
     start_block = 11, end_block = 11;
@@ -475,14 +476,14 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_execute_blocks_perpetual single block:
     CHECK(result1.last_executed_block == end_block);
     CHECK(result1.mdbx_error_code == 0);
 
-    ro_txn = db::ROTxnManaged{db};
+    ro_txn = db::ROTxnManaged{env};
     REQUIRE(db::read_account(ro_txn, to));
     CHECK(db::read_account(ro_txn, to)->balance == 2 * value);
 }
 
 TEST_CASE_METHOD(CApiTest, "CAPI silkworm_execute_blocks_ephemeral multiple blocks: OK", "[silkworm][capi]") {
     // Use Silkworm as a library with silkworm_init/silkworm_fini automated by RAII
-    SilkwormLibrary silkworm_lib{db.get_path()};
+    SilkwormLibrary silkworm_lib{env_path()};
 
     const int chain_id{1};
     const uint64_t batch_size{256 * kMebi};
@@ -533,14 +534,14 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_execute_blocks_ephemeral multiple bloc
     // Insert N blocks
     for (size_t i{10}; i < 10 + kBlocks; ++i) {
         block.header.number = i;
-        insert_block(db, block);
+        insert_block(env, block);
         block.transactions.erase(block.transactions.cbegin());
         block.transactions.pop_back();
         block.transactions[0].nonce++;
     }
 
     // Execute N blocks using an *external* txn, then commit
-    db::RWTxnManaged external_txn0{db};
+    db::RWTxnManaged external_txn0{env};
     BlockNum start_block{10}, end_block{10 + kBlocks - 1};
     const auto result0{execute_blocks(*external_txn0, start_block, end_block)};
     CHECK_NOTHROW(external_txn0.commit_and_stop());
@@ -548,7 +549,7 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_execute_blocks_ephemeral multiple bloc
     CHECK(result0.last_executed_block == end_block);
     CHECK(result0.mdbx_error_code == 0);
 
-    db::ROTxnManaged ro_txn{db};
+    db::ROTxnManaged ro_txn{env};
     REQUIRE(db::read_account(ro_txn, to));
     CHECK(db::read_account(ro_txn, to)->balance == kBlocks * value);
     ro_txn.abort();
@@ -556,14 +557,14 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_execute_blocks_ephemeral multiple bloc
     // Insert N blocks again
     for (size_t i{10 + kBlocks}; i < (10 + 2 * kBlocks); ++i) {
         block.header.number = i;
-        insert_block(db, block);
+        insert_block(env, block);
         block.transactions.erase(block.transactions.cbegin());
         block.transactions.pop_back();
         block.transactions[0].nonce++;
     }
 
     // Execute N blocks using an *external* txn, then commit
-    db::RWTxnManaged external_txn1{db};
+    db::RWTxnManaged external_txn1{env};
 
     start_block = 10 + kBlocks, end_block = 10 + 2 * kBlocks - 1;
     const auto result1{execute_blocks(*external_txn1, start_block, end_block)};
@@ -572,14 +573,14 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_execute_blocks_ephemeral multiple bloc
     CHECK(result1.last_executed_block == end_block);
     CHECK(result1.mdbx_error_code == 0);
 
-    ro_txn = db::ROTxnManaged{db};
+    ro_txn = db::ROTxnManaged{env};
     REQUIRE(db::read_account(ro_txn, to));
     CHECK(db::read_account(ro_txn, to)->balance == 2 * kBlocks * value);
 }
 
 TEST_CASE_METHOD(CApiTest, "CAPI silkworm_execute_blocks_perpetual multiple blocks: OK", "[silkworm][capi]") {
     // Use Silkworm as a library with silkworm_init/silkworm_fini automated by RAII
-    SilkwormLibrary silkworm_lib{db.get_path()};
+    SilkwormLibrary silkworm_lib{env_path()};
 
     const int chain_id{1};
     const uint64_t batch_size{256 * kMebi};
@@ -588,7 +589,7 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_execute_blocks_perpetual multiple bloc
     const bool write_call_traces{false};  // For coherence but don't care
 
     auto execute_blocks = [&](auto start_block, auto end_block) {
-        return silkworm_lib.execute_blocks_perpetual(db,
+        return silkworm_lib.execute_blocks_perpetual(env,
                                                      chain_id,
                                                      start_block,
                                                      end_block,
@@ -630,7 +631,7 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_execute_blocks_perpetual multiple bloc
     // Insert N blocks
     for (size_t i{10}; i < 10 + kBlocks; ++i) {
         block.header.number = i;
-        insert_block(db, block);
+        insert_block(env, block);
         block.transactions.erase(block.transactions.cbegin());
         block.transactions.pop_back();
         block.transactions[0].nonce++;
@@ -643,7 +644,7 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_execute_blocks_perpetual multiple bloc
     CHECK(result0.last_executed_block == end_block);
     CHECK(result0.mdbx_error_code == 0);
 
-    db::ROTxnManaged ro_txn{db};
+    db::ROTxnManaged ro_txn{env};
     REQUIRE(db::read_account(ro_txn, to));
     CHECK(db::read_account(ro_txn, to)->balance == kBlocks * value);
     ro_txn.abort();
@@ -651,7 +652,7 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_execute_blocks_perpetual multiple bloc
     // Insert N blocks again
     for (size_t i{10 + kBlocks}; i < (10 + 2 * kBlocks); ++i) {
         block.header.number = i;
-        insert_block(db, block);
+        insert_block(env, block);
         block.transactions.erase(block.transactions.cbegin());
         block.transactions.pop_back();
         block.transactions[0].nonce++;
@@ -664,7 +665,7 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_execute_blocks_perpetual multiple bloc
     CHECK(result1.last_executed_block == end_block);
     CHECK(result1.mdbx_error_code == 0);
 
-    ro_txn = db::ROTxnManaged{db};
+    ro_txn = db::ROTxnManaged{env};
     REQUIRE(db::read_account(ro_txn, to));
     CHECK(db::read_account(ro_txn, to)->balance == 2 * kBlocks * value);
 }
@@ -761,7 +762,7 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_add_snapshot", "[silkworm][capi]") {
     }
 
     // Use Silkworm as a library with silkworm_init/silkworm_fini automated by RAII
-    SilkwormLibrary silkworm_lib{db.get_path()};
+    SilkwormLibrary silkworm_lib{env_path()};
 
     SECTION("invalid header segment path") {
         SilkwormHeadersSnapshot invalid_shs{valid_shs};
@@ -859,25 +860,25 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_start_rpcdaemon", "[silkworm][capi]") 
     SECTION("invalid handle") {
         // We purposely do not call silkworm_init to provide a null handle
         SilkwormHandle handle{nullptr};
-        CHECK(silkworm_start_rpcdaemon(handle, db, &kValidRpcSettings) == SILKWORM_INVALID_HANDLE);
+        CHECK(silkworm_start_rpcdaemon(handle, env, &kValidRpcSettings) == SILKWORM_INVALID_HANDLE);
     }
 
     // Use Silkworm as a library with silkworm_init/silkworm_fini automated by RAII
-    SilkwormLibrary silkworm_lib{db.get_path()};
+    SilkwormLibrary silkworm_lib{env_path()};
 
     SECTION("invalid settings") {
-        CHECK(silkworm_lib.start_rpcdaemon(db, nullptr) == SILKWORM_INVALID_SETTINGS);
+        CHECK(silkworm_lib.start_rpcdaemon(env, nullptr) == SILKWORM_INVALID_SETTINGS);
     }
 
     // The following test fails on Windows with silkworm_start_rpcdaemon returning SILKWORM_OK
 #ifndef _WIN32
     SECTION("test settings: invalid port") {
-        CHECK(silkworm_lib.start_rpcdaemon(db, &kInvalidRpcSettings) == SILKWORM_INTERNAL_ERROR);
+        CHECK(silkworm_lib.start_rpcdaemon(env, &kInvalidRpcSettings) == SILKWORM_INTERNAL_ERROR);
     }
 #endif  // _WIN32
 
     SECTION("test settings: valid port") {
-        CHECK(silkworm_lib.start_rpcdaemon(db, &kValidRpcSettings) == SILKWORM_OK);
+        CHECK(silkworm_lib.start_rpcdaemon(env, &kValidRpcSettings) == SILKWORM_OK);
         REQUIRE(silkworm_lib.stop_rpcdaemon() == SILKWORM_OK);
     }
 }
@@ -890,14 +891,14 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_stop_rpcdaemon", "[silkworm][capi]") {
     }
 
     // Use Silkworm as a library with silkworm_init/silkworm_fini automated by RAII
-    SilkwormLibrary silkworm_lib{db.get_path()};
+    SilkwormLibrary silkworm_lib{env_path()};
 
     SECTION("not yet started") {
         CHECK(silkworm_lib.stop_rpcdaemon() == SILKWORM_OK);
     }
 
     SECTION("already started") {
-        REQUIRE(silkworm_lib.start_rpcdaemon(db, &kValidRpcSettings) == SILKWORM_OK);
+        REQUIRE(silkworm_lib.start_rpcdaemon(env, &kValidRpcSettings) == SILKWORM_OK);
         CHECK(silkworm_lib.stop_rpcdaemon() == SILKWORM_OK);
     }
 }
@@ -919,25 +920,25 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_fork_validator", "[silkworm][capi]") {
     test_util::SetLogVerbosityGuard log_guard(log::Level::kNone);
 
     // Use Silkworm as a library with silkworm_init/silkworm_fini automated by RAII
-    SilkwormLibrary silkworm_lib{db.get_path()};
+    SilkwormLibrary silkworm_lib{env_path()};
 
     SECTION("invalid handle") {
         // We purposely do not call silkworm_init to provide a null handle
         SilkwormHandle handle{nullptr};
-        CHECK(silkworm_start_fork_validator(handle, db, &kValidForkValidatorSettings) == SILKWORM_INVALID_HANDLE);
+        CHECK(silkworm_start_fork_validator(handle, env, &kValidForkValidatorSettings) == SILKWORM_INVALID_HANDLE);
     }
 
     SECTION("invalid settings") {
-        CHECK(silkworm_lib.start_fork_validator(db, nullptr) == SILKWORM_INVALID_SETTINGS);
+        CHECK(silkworm_lib.start_fork_validator(env, nullptr) == SILKWORM_INVALID_SETTINGS);
     }
 
     SECTION("starts fork validator with valid settings") {
-        CHECK(silkworm_lib.start_fork_validator(db, &kValidForkValidatorSettings) == SILKWORM_OK);
+        CHECK(silkworm_lib.start_fork_validator(env, &kValidForkValidatorSettings) == SILKWORM_OK);
         REQUIRE(silkworm_lib.stop_fork_validator() == SILKWORM_OK);
     }
 
     SECTION("validates chain") {
-        silkworm_lib.start_fork_validator(db, &kValidForkValidatorSettings);
+        silkworm_lib.start_fork_validator(env, &kValidForkValidatorSettings);
 
         auto const current_head_id = silkworm_lib.execution_engine().last_finalized_block();
         CHECK(current_head_id.number == 9);
@@ -954,7 +955,7 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_fork_validator", "[silkworm][capi]") {
     }
 
     SECTION("executes fork choice update") {
-        silkworm_lib.start_fork_validator(db, &kValidForkValidatorSettings);
+        silkworm_lib.start_fork_validator(env, &kValidForkValidatorSettings);
 
         auto const current_head_id = silkworm_lib.execution_engine().last_finalized_block();
         auto const current_head = silkworm_lib.execution_engine().get_header(current_head_id.number, current_head_id.hash).value();
@@ -973,7 +974,7 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_fork_validator", "[silkworm][capi]") {
     }
 
     SECTION("executes fork choice update with final and safe blocks") {
-        silkworm_lib.start_fork_validator(db, &kValidForkValidatorSettings);
+        silkworm_lib.start_fork_validator(env, &kValidForkValidatorSettings);
 
         auto const current_head_id = silkworm_lib.execution_engine().last_finalized_block();
         auto const current_head = silkworm_lib.execution_engine().get_header(current_head_id.number, current_head_id.hash).value();

--- a/silkworm/db/db_utils_test.cpp
+++ b/silkworm/db/db_utils_test.cpp
@@ -30,8 +30,8 @@ TEST_CASE("db access layer addendum") {
 
     db::EnvConfig db_config{.path = tmp_dir.path().string(), .create = true, .in_memory = true};
 
-    auto db = db::open_env(db_config);
-    db::RWAccess rw_access(db);
+    auto env = db::open_env(db_config);
+    db::RWAccess rw_access{env};
     db::RWTxnManaged tx = rw_access.start_rw_tx();
 
     db::table::check_or_create_chaindata_tables(tx);

--- a/silkworm/db/mdbx/mdbx.cpp
+++ b/silkworm/db/mdbx/mdbx.cpp
@@ -93,17 +93,17 @@ static inline mdbx::cursor::move_operation move_operation(CursorMoveDirection di
     }
 
     // Check datafile exists if create is not set
-    fs::path db_path{config.path};
-    if (db_path.has_filename()) {
-        db_path += std::filesystem::path::preferred_separator;  // Remove ambiguity. It has to be a directory
+    fs::path env_path{config.path};
+    if (env_path.has_filename()) {
+        env_path += std::filesystem::path::preferred_separator;  // Remove ambiguity. It has to be a directory
     }
-    if (!fs::exists(db_path)) {
-        fs::create_directories(db_path);
-    } else if (!fs::is_directory(db_path)) {
-        throw std::runtime_error("Path " + db_path.string() + " is not valid");
+    if (!fs::exists(env_path)) {
+        fs::create_directories(env_path);
+    } else if (!fs::is_directory(env_path)) {
+        throw std::runtime_error("Path " + env_path.string() + " is not valid");
     }
 
-    fs::path db_file{db::get_datafile_path(db_path)};
+    fs::path db_file{db::get_datafile_path(env_path)};
     const size_t db_file_size{fs::exists(db_file) ? fs::file_size(db_file) : 0};
 
     if (!config.create && !db_file_size) {
@@ -169,7 +169,7 @@ static inline mdbx::cursor::move_operation move_operation(CursorMoveDirection di
     op.max_maps = config.max_tables;
     op.max_readers = config.max_readers;
 
-    ::mdbx::env_managed env{db_path.native(), cp, op, config.shared};
+    ::mdbx::env_managed env{env_path.native(), cp, op, config.shared};
 
     // MDBX will not change the page size if db already exists, so we need to read value
     config.page_size = env.get_pagesize();

--- a/silkworm/db/snapshot_sync.cpp
+++ b/silkworm/db/snapshot_sync.cpp
@@ -56,12 +56,12 @@ struct PathHasher {
 SnapshotSync::SnapshotSync(
     snapshots::SnapshotSettings settings,
     ChainId chain_id,
-    mdbx::env& chaindata_env,
+    mdbx::env chaindata_env,
     std::filesystem::path tmp_dir_path,
     stagedsync::StageScheduler& stage_scheduler)
     : settings_{std::move(settings)},
       snapshots_config_{Config::lookup_known_config(chain_id)},
-      chaindata_env_{chaindata_env},
+      chaindata_env_{std::move(chaindata_env)},
       repository_{settings_, std::make_unique<db::SnapshotBundleFactoryImpl>()},
       client_{settings_.bittorrent_settings},
       snapshot_freezer_{db::ROAccess{chaindata_env_}, repository_, stage_scheduler, tmp_dir_path, settings_.keep_blocks},

--- a/silkworm/db/snapshot_sync.hpp
+++ b/silkworm/db/snapshot_sync.hpp
@@ -49,7 +49,7 @@ class SnapshotSync {
     SnapshotSync(
         snapshots::SnapshotSettings settings,
         ChainId chain_id,
-        mdbx::env& chaindata_env,
+        mdbx::env chaindata_env,
         std::filesystem::path tmp_dir_path,
         stagedsync::StageScheduler& stage_scheduler);
 
@@ -78,7 +78,7 @@ class SnapshotSync {
 
     snapshots::SnapshotSettings settings_;
     const snapshots::Config snapshots_config_;
-    mdbx::env& chaindata_env_;
+    mdbx::env chaindata_env_;
 
     snapshots::SnapshotRepository repository_;
 

--- a/silkworm/db/test_util/test_database_context.cpp
+++ b/silkworm/db/test_util/test_database_context.cpp
@@ -176,22 +176,22 @@ namespace {
     mdbx::env_managed initialize_test_database() {
         const auto tests_dir = get_tests_dir();
         const auto db_dir = TemporaryDirectory::get_unique_temporary_path();
-        auto db = open_db(db_dir.string());
-        db::RWTxnManaged txn{db};
+        auto env = open_db(db_dir.string());
+        db::RWTxnManaged txn{env};
         db::table::check_or_create_chaindata_tables(txn);
         auto state_buffer = populate_genesis(txn, tests_dir);
         populate_blocks(txn, tests_dir, state_buffer);
         txn.commit_and_stop();
 
-        return db;
+        return env;
     }
 
 }  // namespace
 
-TestDatabaseContext::TestDatabaseContext() : db_{initialize_test_database()} {}
+TestDatabaseContext::TestDatabaseContext() : env_{initialize_test_database()} {}
 
 silkworm::ChainConfig TestDatabaseContext::get_chain_config() {
-    db::ROTxnManaged txn{db_};
+    db::ROTxnManaged txn{env_};
     auto chain_config = db::read_chain_config(txn);
     return chain_config ? *chain_config : silkworm::ChainConfig{};
 }

--- a/silkworm/db/test_util/test_database_context.hpp
+++ b/silkworm/db/test_util/test_database_context.hpp
@@ -34,18 +34,17 @@ class TestDatabaseContext {
     TestDatabaseContext();
 
     ~TestDatabaseContext() {
-        auto db_path = db_.get_path();
-        db_.close();
-        std::filesystem::remove_all(db_path);
+        auto env_path = env_.get_path();
+        env_.close();
+        std::filesystem::remove_all(env_path);
     }
 
-    mdbx::env& mdbx_env() { return db_; }
-    mdbx::env_managed& get_mdbx_env() { return db_; }
+    mdbx::env& mdbx_env() { return env_; }
     db::EnvConfig get_env_config() { return env_config_; }
     silkworm::ChainConfig get_chain_config();
 
   private:
-    mdbx::env_managed db_;
+    mdbx::env_managed env_;
     db::EnvConfig env_config_;
 };
 

--- a/silkworm/node/stagedsync/execution_engine_test.cpp
+++ b/silkworm/node/stagedsync/execution_engine_test.cpp
@@ -55,14 +55,14 @@ TEST_CASE("ExecutionEngine Integration Test", "[node][execution][execution_engin
 
     auto db_context = db::test_util::TestDatabaseContext();
     auto node_settings = NodeSettings{
-        .data_directory = std::make_unique<DataDirectory>(db_context.get_mdbx_env().get_path(), false),
+        .data_directory = std::make_unique<DataDirectory>(db_context.mdbx_env().get_path(), false),
         .chaindata_env_config = db_context.get_env_config(),
         .chain_config = db_context.get_chain_config(),
         .parallel_fork_tracking_enabled = false,
         .keep_db_txn_open = true,
     };
 
-    db::RWAccess db_access{db_context.get_mdbx_env()};
+    db::RWAccess db_access{db_context.mdbx_env()};
 
     ExecutionEngineForTest exec_engine{runner.context(), node_settings, db_access};
     exec_engine.open();

--- a/silkworm/node/stagedsync/forks/fork.cpp
+++ b/silkworm/node/stagedsync/forks/fork.cpp
@@ -25,7 +25,7 @@
 namespace silkworm::stagedsync {
 
 static db::MemoryOverlay create_memory_db(const std::filesystem::path& base_path, db::ROTxn& main_tx) {
-    db::MemoryOverlay memory_db{
+    db::MemoryOverlay memory_overlay{
         TemporaryDirectory::get_unique_temporary_path(base_path),
         &main_tx,
         db::table::get_map_config,
@@ -33,12 +33,12 @@ static db::MemoryOverlay create_memory_db(const std::filesystem::path& base_path
     };
 
     // Create predefined tables for chaindata schema
-    auto txn = memory_db.start_rw_txn();
+    auto txn = memory_overlay.start_rw_txn();
     db::RWTxnUnmanaged txn_ref{txn};
     db::table::check_or_create_chaindata_tables(txn_ref);
     txn.commit();
 
-    return memory_db;
+    return memory_overlay;
 }
 
 Fork::Fork(BlockId forking_point, db::ROTxnManaged&& main_chain_tx, NodeSettings& ns)

--- a/silkworm/rpc/commands/rpc_api_test.cpp
+++ b/silkworm/rpc/commands/rpc_api_test.cpp
@@ -108,7 +108,7 @@ TEST_CASE("rpc_api io (all files)", "[rpc][rpc_api]") {
 
             SECTION("RPC IO test " + group_name + " | " + test_name) {  // NOLINT(*-inefficient-string-concatenation)
                 auto context = db::test_util::TestDatabaseContext();
-                RpcApiTestBase<RequestHandlerForTest> test_base{context.get_mdbx_env()};
+                RpcApiTestBase<RequestHandlerForTest> test_base{context.mdbx_env()};
 
                 std::string line_out;
                 std::string line_in;
@@ -141,7 +141,7 @@ TEST_CASE("rpc_api io (all files)", "[rpc][rpc_api]") {
 TEST_CASE("rpc_api io (individual)", "[rpc][rpc_api][ignore]") {
     SetLogVerbosityGuard log_guard{log::Level::kNone};
     auto context = db::test_util::TestDatabaseContext();
-    RpcApiTestBase<RequestHandlerForTest> test_base{context.get_mdbx_env()};
+    RpcApiTestBase<RequestHandlerForTest> test_base{context.mdbx_env()};
 
     SECTION("sample test") {
         auto request = R"({"jsonrpc":"2.0","id":1,"method":"debug_getRawTransaction","params":["0x74e41d593675913d6d5521f46523f1bd396dff1891bdb35f59be47c7e5e0b34b"]})"_json;

--- a/silkworm/rpc/test_util/api_test_database.hpp
+++ b/silkworm/rpc/test_util/api_test_database.hpp
@@ -112,7 +112,7 @@ class RpcApiTestBase : public LocalContextTestBase {
 
 class RpcApiE2ETest : public db::test_util::TestDatabaseContext, RpcApiTestBase<RequestHandlerForTest> {
   public:
-    explicit RpcApiE2ETest() : RpcApiTestBase<RequestHandlerForTest>(get_mdbx_env()) {
+    explicit RpcApiE2ETest() : RpcApiTestBase<RequestHandlerForTest>(mdbx_env()) {
         // Ensure JSON RPC spec has been loaded into the validator
         if (!jsonrpc_spec_loaded) {
             json_rpc::Validator::load_specification();


### PR DESCRIPTION
Rename some variables to follow a convention that `db::open_env()` result is either `chaindata_env` or just `env`.
The majority of places already used this naming.

* SnapshotSync: pass env by value copy as in the other places (Node, Sync, Daemon)
* cmd/silkworm.cpp: get rid of `NOLINT(cppcoreguidelines-slicing)` by explicit casts
