### PR TITLE
snapshots: fix torrent.verify_on_startup

### DIFF
--- a/cmd/common/snapshot_options.cpp
+++ b/cmd/common/snapshot_options.cpp
@@ -33,7 +33,7 @@ void add_snapshot_options(CLI::App& cli, snapshots::SnapshotSettings& snapshot_s
         ->capture_default_str();
 
     // TODO(canepat) add options for the other snapshot settings and for all bittorrent settings
-    cli.add_option("--torrent.verify_on_startup", snapshot_settings.bittorrent_settings.verify_on_startup)
+    cli.add_option("--torrent.verify_on_startup", snapshot_settings.verify_on_startup)
         ->description(
             "If set, the snapshot downloader will verify snapshots on startup."
             " It will not report founded problems but just re-download broken pieces")

--- a/silkworm/db/snapshot_sync.cpp
+++ b/silkworm/db/snapshot_sync.cpp
@@ -126,6 +126,10 @@ Task<void> SnapshotSync::setup() {
 
     seed_frozen_local_snapshots();
 
+    if (settings_.verify_on_startup) {
+        client_.recheck_all_finished_torrents();
+    }
+
     std::scoped_lock lock{setup_done_mutex_};
     setup_done_ = true;
     setup_done_cond_var_.notify_all();

--- a/silkworm/db/snapshot_sync_test.cpp
+++ b/silkworm/db/snapshot_sync_test.cpp
@@ -38,7 +38,6 @@ using namespace silkworm::test_util;
 struct SettingsOverrides {
     bool enabled{true};
     bool no_downloader{false};
-    bool verify_on_startup{false};
 };
 
 class NoopStageSchedulerAdapter : public stagedsync::StageScheduler {
@@ -77,7 +76,6 @@ struct SnapshotSyncForTest : public SnapshotSync {
             .no_downloader = overrides.no_downloader,
             .bittorrent_settings = bittorrent::BitTorrentSettings{
                 .repository_path = tmp_dir_path / bittorrent::BitTorrentSettings::kDefaultTorrentRepoPath,
-                .verify_on_startup = overrides.verify_on_startup,
             },
         };
     }
@@ -106,11 +104,6 @@ TEST_CASE("SnapshotSync::download_and_index_snapshots", "[db][snapshot][sync]") 
 
     SECTION("no download, just reopen") {
         SnapshotSyncForTest sync{test, SettingsOverrides{.no_downloader = true}};
-        test.runner.run(sync.download_snapshots_if_needed());
-    }
-
-    SECTION("no download, just reopen and verify") {
-        SnapshotSyncForTest sync{test, SettingsOverrides{.no_downloader = true, .verify_on_startup = true}};
         test.runner.run(sync.download_snapshots_if_needed());
     }
 }

--- a/silkworm/db/snapshots/bittorrent/client.cpp
+++ b/silkworm/db/snapshots/bittorrent/client.cpp
@@ -195,10 +195,6 @@ bool BitTorrentClient::exists_resume_file(const lt::info_hash_t& info_hashes) co
 void BitTorrentClient::execution_loop() {
     SILK_TRACE << "BitTorrentClient::execution_loop start";
 
-    if (settings_.verify_on_startup) {
-        recheck_all_finished_torrents();
-    }
-
     stats_metrics_ = lt::session_stats_metrics();
 
     int poll_count{0};

--- a/silkworm/db/snapshots/bittorrent/client.hpp
+++ b/silkworm/db/snapshots/bittorrent/client.hpp
@@ -90,6 +90,8 @@ class BitTorrentClient : public ActiveComponent {
     //! Ask the client to stop execution
     bool stop() override;
 
+    void recheck_all_finished_torrents() const;
+
   protected:
     static std::vector<char> load_file(const std::filesystem::path& filename);
     static void save_file(const std::filesystem::path& filename, const std::vector<char>& data);
@@ -99,7 +101,6 @@ class BitTorrentClient : public ActiveComponent {
     [[nodiscard]] std::filesystem::path resume_file_path(const lt::info_hash_t& info_hashes) const;
     [[nodiscard]] bool exists_resume_file(const lt::info_hash_t& info_hashes) const;
 
-    void recheck_all_finished_torrents() const;
     void request_torrent_updates(bool stats_included);
     void request_save_resume_data(lt::resume_data_flags_t flags);
     void process_alerts();

--- a/silkworm/db/snapshots/bittorrent/client_test.cpp
+++ b/silkworm/db/snapshots/bittorrent/client_test.cpp
@@ -182,14 +182,6 @@ TEST_CASE("BitTorrentClient::execute_loop", "[silkworm][snapshot][bittorrent]") 
         ClientThread client_thread{client};
         CHECK_NOTHROW(client.stop());
     }
-
-    SECTION("nonempty magnet file w/ startup verification") {
-        settings.verify_on_startup = true;
-        BitTorrentClient client{settings};
-        client.add_magnet_uri("magnet:?xt=urn:btih:df09957d8a28af3bc5137478885a8003677ca878");
-        ClientThread client_thread{client};
-        CHECK_NOTHROW(client.stop());
-    }
 }
 
 TEST_CASE("BitTorrentClient::stop", "[silkworm][snapshot][bittorrent]") {

--- a/silkworm/db/snapshots/bittorrent/settings.hpp
+++ b/silkworm/db/snapshots/bittorrent/settings.hpp
@@ -39,9 +39,6 @@ struct BitTorrentSettings {
     //! Time interval between two resume data savings
     std::chrono::seconds resume_data_save_interval{60};
 
-    //! Flag indicating if snapshots will be verified on startup
-    bool verify_on_startup{false};
-
     //! Flag indicating if BitTorrent failure/error alerts should be treated as warnings
     bool warn_on_error_alerts{false};
 

--- a/silkworm/db/snapshots/snapshot_settings.hpp
+++ b/silkworm/db/snapshots/snapshot_settings.hpp
@@ -29,6 +29,7 @@ struct SnapshotSettings {
     bool no_downloader{false};                                                 // Flag indicating if snapshots download is disabled
     bittorrent::BitTorrentSettings bittorrent_settings;                        // The Bittorrent protocol settings
     bool keep_blocks{false};                                                   // Flag indicating if exported blocks should be kept in mdbx
+    bool verify_on_startup{false};                                             // Flag indicating if snapshots will be verified on startup
 };
 
 }  // namespace silkworm::snapshots


### PR DESCRIPTION
* schedule verification in SnapshotSync::setup after all torrents are seeded
* move verify_on_startup flag
* remove related tests that did nothing