### PR TITLE
tidy: include db headers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 FormatStyle: file
-HeaderFilterRegex: 'silkworm/(capi|core|infra|node|rpc|sentry|sync|wasm)/.+\.hpp$'
+HeaderFilterRegex: 'silkworm/(capi|core|db|execution|infra|node|rpc|sentry|sync|wasm)/.+\.hpp$'
 WarningsAsErrors: '*'
 Checks: >
   abseil-*,

--- a/silkworm/db/access_layer.cpp
+++ b/silkworm/db/access_layer.cpp
@@ -149,7 +149,7 @@ size_t process_headers_at_height(ROTxn& txn, BlockNum height, std::function<void
             success_or_throw(rlp::decode(encoded_header, header));
             process_func(std::move(header));
         },
-        db::CursorMoveDirection::Forward);
+        db::CursorMoveDirection::kForward);
 
     return count;
 }
@@ -446,7 +446,7 @@ size_t process_blocks_at_height(ROTxn& txn, BlockNum height, std::function<void(
             // invoke handler
             process_func(block);
         },
-        db::CursorMoveDirection::Forward);
+        db::CursorMoveDirection::kForward);
 
     return count;
 }

--- a/silkworm/db/db_utils.cpp
+++ b/silkworm/db/db_utils.cpp
@@ -53,7 +53,7 @@ std::tuple<BlockNum, Hash> header_with_biggest_td(db::ROTxn& txn, const std::set
         // TODO: check if we really need to parse all the table
     };
 
-    db::cursor_for_each(*td_cursor, find_max, db::CursorMoveDirection::Reverse);
+    db::cursor_for_each(*td_cursor, find_max, db::CursorMoveDirection::kReverse);
 
     return {max_block_num, max_hash};
 }

--- a/silkworm/db/etl/buffer.hpp
+++ b/silkworm/db/etl/buffer.hpp
@@ -38,7 +38,7 @@ class Buffer {
 
     void put(Entry entry) {
         // Add a new entry to the buffer
-        size_ += entry.size() + sizeof(head_t);
+        size_ += entry.size() + sizeof(EntryHeader);
         buffer_.push_back(std::move(entry));
     }
 

--- a/silkworm/db/etl/collector.cpp
+++ b/silkworm/db/etl/collector.cpp
@@ -165,7 +165,7 @@ std::filesystem::path Collector::set_work_path(const std::optional<std::filesyst
     // If something provided ensure exists as a directory
     if (provided_work_path.has_value()) {
         if (fs::exists(provided_work_path.value()) && !fs::is_directory(provided_work_path.value())) {
-            throw etl_error("Invalid collector directory name");
+            throw EtlError("Invalid collector directory name");
         }
         res = provided_work_path.value();
     } else {

--- a/silkworm/db/etl/collector.hpp
+++ b/silkworm/db/etl/collector.hpp
@@ -90,7 +90,7 @@ class Collector {
 
     //! \brief Returns the hex representation of current load key (for progress tracking)
     [[nodiscard]] std::string get_load_key() const {
-        std::unique_lock l{mutex_};
+        std::unique_lock lock{mutex_};
         return loading_key_;
     }
 
@@ -100,7 +100,7 @@ class Collector {
     void flush_buffer();  // Write buffer to file
 
     void set_loading_key(ByteView key) {
-        std::unique_lock l{mutex_};
+        std::unique_lock lock{mutex_};
         loading_key_ = to_hex(key, true);
     }
 

--- a/silkworm/db/etl/util.hpp
+++ b/silkworm/db/etl/util.hpp
@@ -23,13 +23,13 @@
 
 namespace silkworm::db::etl {
 
-class etl_error : public std::runtime_error {
+class EtlError : public std::runtime_error {
   public:
     using std::runtime_error::runtime_error;
 };
 
 // Head of each data chunk on file
-union head_t {
+union EntryHeader {
     uint32_t lengths[2];
     uint8_t bytes[8];
 };

--- a/silkworm/db/mdbx/mdbx.cpp
+++ b/silkworm/db/mdbx/mdbx.cpp
@@ -63,8 +63,8 @@ static inline CursorResult adjust_cursor_position_if_unpositioned(
     // that are not positioned, but also for those pointing to the end of data.
     // Unfortunately, there's no MDBX API to differentiate the two.
     if (c.eof()) {
-        return (d == CursorMoveDirection::Forward) ? c.to_first(/*throw_notfound=*/false)
-                                                   : c.to_last(/*throw_notfound=*/false);
+        return (d == CursorMoveDirection::kForward) ? c.to_first(/*throw_notfound=*/false)
+                                                    : c.to_last(/*throw_notfound=*/false);
     }
     return c.current(/*throw_notfound=*/false);
 }
@@ -80,7 +80,7 @@ static inline CursorResult strict_lower_bound(ROCursor& cursor, const ByteView k
 }
 
 static inline mdbx::cursor::move_operation move_operation(CursorMoveDirection direction) {
-    return direction == CursorMoveDirection::Forward
+    return direction == CursorMoveDirection::kForward
                ? mdbx::cursor::move_operation::next
                : mdbx::cursor::move_operation::previous;
 }
@@ -272,7 +272,7 @@ void RWTxnManaged::commit_and_stop() {
     }
 }
 
-thread_local ObjectPool<MDBX_cursor, detail::cursor_handle_deleter> PooledCursor::handles_pool_{};
+thread_local ObjectPool<MDBX_cursor, detail::CursorHandleDeleter> PooledCursor::handles_pool_{};
 
 PooledCursor::PooledCursor() {
     handle_ = handles_pool_.acquire();
@@ -633,7 +633,7 @@ size_t cursor_for_count(ROCursor& cursor, WalkFuncRef walker, size_t count,
 
 size_t cursor_erase(RWCursor& cursor, const ByteView set_key, const CursorMoveDirection direction) {
     CursorResult data{
-        direction == CursorMoveDirection::Forward
+        direction == CursorMoveDirection::kForward
             ? cursor.lower_bound(set_key, /*throw_notfound=*/false)
             : strict_lower_bound(cursor, set_key)};
 

--- a/silkworm/db/mdbx/mdbx.hpp
+++ b/silkworm/db/mdbx/mdbx.hpp
@@ -66,8 +66,8 @@ inline bool operator==(const CursorResult& lhs, const CursorResult& rhs) noexcep
 }
 
 namespace detail {
-    struct cursor_handle_deleter {  // default deleter for pooled cursors
-        constexpr cursor_handle_deleter() noexcept = default;
+    struct CursorHandleDeleter {  // default deleter for pooled cursors
+        constexpr CursorHandleDeleter() noexcept = default;
         void operator()(MDBX_cursor* ptr) const noexcept { mdbx_cursor_close(ptr); }
     };
 
@@ -205,7 +205,7 @@ class ROTxn {
     // Access to the underling raw mdbx transaction
     mdbx::txn& operator*() { return txn_ref_; }
     mdbx::txn* operator->() { return &txn_ref_; }
-    operator mdbx::txn&() { return txn_ref_; }  // NOLINT(google-explicit-constructor)
+    operator mdbx::txn&() { return txn_ref_; }  // NOLINT(google-explicit-constructor, hicpp-explicit-conversions)
 
     [[nodiscard]] uint64_t id() const { return txn_ref_.id(); }
     [[nodiscard]] virtual bool is_open() const { return txn_ref_.txn::operator bool(); }
@@ -510,10 +510,10 @@ class PooledCursor : public RWCursorDupSort, protected ::mdbx::cursor {
     bool erase(const Slice& key, const Slice& value) override;
 
     //! \brief Exposes handles cache
-    static const ObjectPool<MDBX_cursor, detail::cursor_handle_deleter>& handles_cache() { return handles_pool_; }
+    static const ObjectPool<MDBX_cursor, detail::CursorHandleDeleter>& handles_cache() { return handles_pool_; }
 
   private:
-    static thread_local ObjectPool<MDBX_cursor, detail::cursor_handle_deleter> handles_pool_;
+    static thread_local ObjectPool<MDBX_cursor, detail::CursorHandleDeleter> handles_pool_;
 };
 
 //! \brief Checks whether a provided map name exists in database
@@ -536,8 +536,8 @@ inline std::filesystem::path get_datafile_path(const std::filesystem::path& base
 
 //! \brief Defines the direction of cursor while looping by cursor_for_each or cursor_for_count
 enum class CursorMoveDirection : uint8_t {
-    Forward,
-    Reverse
+    kForward,
+    kReverse
 };
 
 //! \brief Executes a function on each record reachable by the provided cursor
@@ -549,7 +549,7 @@ enum class CursorMoveDirection : uint8_t {
 //! \remarks If the provided cursor is *not* positioned on any record it will be moved to either the beginning or the
 //! end of the table on behalf of the move criteria
 size_t cursor_for_each(ROCursor& cursor, WalkFuncRef walker,
-                       CursorMoveDirection direction = CursorMoveDirection::Forward);
+                       CursorMoveDirection direction = CursorMoveDirection::kForward);
 
 //! \brief Executes a function on each record reachable by the provided cursor asserting keys start with provided prefix
 //! \param [in] cursor : A reference to a cursor opened on a map
@@ -559,7 +559,7 @@ size_t cursor_for_each(ROCursor& cursor, WalkFuncRef walker,
 //! \param [in] direction : Whether the cursor should navigate records forward (default) or backwards
 //! \return The overall number of processed records
 size_t cursor_for_prefix(ROCursor& cursor, ByteView prefix, WalkFuncRef walker,
-                         CursorMoveDirection direction = CursorMoveDirection::Forward);
+                         CursorMoveDirection direction = CursorMoveDirection::kForward);
 
 //! \brief Executes a function on each record reachable by the provided cursor up to a max number of iterations
 //! \param [in] cursor : A reference to a cursor opened on a map
@@ -572,7 +572,7 @@ size_t cursor_for_prefix(ROCursor& cursor, ByteView prefix, WalkFuncRef walker,
 //! \remarks If the provided cursor is *not* positioned on any record it will be moved to either the beginning or the
 //! end of the table on behalf of the move criteria
 size_t cursor_for_count(ROCursor& cursor, WalkFuncRef walker, size_t max_count,
-                        CursorMoveDirection direction = CursorMoveDirection::Forward);
+                        CursorMoveDirection direction = CursorMoveDirection::kForward);
 
 //! \brief Erases map records by cursor until any record is found
 //! \param [in] cursor : A reference to a cursor opened on a map
@@ -582,7 +582,7 @@ size_t cursor_for_count(ROCursor& cursor, WalkFuncRef walker, size_t max_count,
 //! \remarks When direction is forward all keys greater equal set_key will be deleted. When direction is reverse all
 //! keys lower than set_key will be deleted.
 size_t cursor_erase(RWCursor& cursor, ByteView set_key,
-                    CursorMoveDirection direction = CursorMoveDirection::Forward);
+                    CursorMoveDirection direction = CursorMoveDirection::kForward);
 
 //! \brief Erases all records whose key starts with a prefix
 //! \param [in] cursor : A reference to a cursor opened on a map

--- a/silkworm/db/mdbx_test.cpp
+++ b/silkworm/db/mdbx_test.cpp
@@ -262,12 +262,12 @@ TEST_CASE("RWTxn") {
     const TemporaryDirectory tmp_dir;
     db::EnvConfig db_config{.path = tmp_dir.path().string(), .create = true, .in_memory = true};
     auto env{db::open_env(db_config)};
-    static const char* table_name{"GeneticCode"};
+    static const char* kTableName{"GeneticCode"};
 
     SECTION("Managed: commit_and_renew") {
         {
             auto tx{db::RWTxnManaged(env)};
-            db::PooledCursor table_cursor(*tx, {table_name});
+            db::PooledCursor table_cursor(*tx, {kTableName});
 
             // populate table
             for (const auto& [key, value] : kGeneticCode) {
@@ -278,14 +278,14 @@ TEST_CASE("RWTxn") {
         }
 
         auto tx{env.start_read()};
-        db::PooledCursor table_cursor(tx, {table_name});
+        db::PooledCursor table_cursor(tx, {kTableName});
         REQUIRE(table_cursor.empty() == false);
     }
 
     SECTION("Managed: commit_and_stop") {
         {
             auto tx{db::RWTxnManaged(env)};
-            db::PooledCursor table_cursor(*tx, {table_name});
+            db::PooledCursor table_cursor(*tx, {kTableName});
 
             // populate table
             for (const auto& [key, value] : kGeneticCode) {
@@ -296,7 +296,7 @@ TEST_CASE("RWTxn") {
         }
 
         auto tx{env.start_read()};
-        db::PooledCursor table_cursor(tx, {table_name});
+        db::PooledCursor table_cursor(tx, {kTableName});
         REQUIRE(table_cursor.empty() == false);
     }
 
@@ -304,33 +304,33 @@ TEST_CASE("RWTxn") {
         RWTxnManaged tx{env};
         tx.disable_commit();
         {
-            (void)tx->create_map(table_name, mdbx::key_mode::usual, mdbx::value_mode::single);
+            (void)tx->create_map(kTableName, mdbx::key_mode::usual, mdbx::value_mode::single);
             tx.commit_and_renew();  // Does not have any effect
         }
         tx.abort();
         RWTxnManaged tx2{env};
-        REQUIRE(db::has_map(tx2, table_name) == false);
+        REQUIRE(db::has_map(tx2, kTableName) == false);
     }
 
     SECTION("External: commit_and_stop") {
         RWTxnManaged tx{env};
         tx.disable_commit();
         {
-            (void)tx->create_map(table_name, mdbx::key_mode::usual, mdbx::value_mode::single);
+            (void)tx->create_map(kTableName, mdbx::key_mode::usual, mdbx::value_mode::single);
             tx.commit_and_stop();  // Does not have any effect
         }
         tx.abort();
         RWTxnManaged tx2{env};
-        REQUIRE(db::has_map(tx2, table_name) == false);
+        REQUIRE(db::has_map(tx2, kTableName) == false);
     }
 
     SECTION("Cursor from RWTxn") {
         auto tx{db::RWTxnManaged(env)};
-        db::PooledCursor table_cursor(tx, {table_name});
+        db::PooledCursor table_cursor(tx, {kTableName});
         REQUIRE(table_cursor.empty());
-        REQUIRE_NOTHROW(table_cursor.bind(tx, {table_name}));
+        REQUIRE_NOTHROW(table_cursor.bind(tx, {kTableName}));
         table_cursor.close();
-        REQUIRE_THROWS(table_cursor.bind(tx, {table_name}));
+        REQUIRE_THROWS(table_cursor.bind(tx, {kTableName}));
     }
 
     SECTION("Unmanaged: commit_and_renew") {
@@ -339,7 +339,7 @@ TEST_CASE("RWTxn") {
             ::mdbx::error::success_or_throw(::mdbx_txn_begin(env, nullptr, MDBX_TXN_READWRITE, &rw_txn));
 
             auto tx{db::RWTxnUnmanaged(rw_txn)};
-            db::PooledCursor table_cursor(*tx, {table_name});
+            db::PooledCursor table_cursor(*tx, {kTableName});
 
             // populate table
             for (const auto& [key, value] : kGeneticCode) {
@@ -351,7 +351,7 @@ TEST_CASE("RWTxn") {
             ::mdbx::error::success_or_throw(::mdbx_txn_commit(rw_txn));
         }
         auto ro_txn{env.start_read()};
-        db::PooledCursor cursor(ro_txn, {table_name});
+        db::PooledCursor cursor(ro_txn, {kTableName});
         CHECK(cursor.empty() == false);
     }
 
@@ -361,7 +361,7 @@ TEST_CASE("RWTxn") {
             ::mdbx::error::success_or_throw(::mdbx_txn_begin(env, nullptr, MDBX_TXN_READWRITE, &rw_txn));
 
             auto tx{db::RWTxnUnmanaged(rw_txn)};
-            db::PooledCursor table_cursor(*tx, {table_name});
+            db::PooledCursor table_cursor(*tx, {kTableName});
 
             // populate table
             for (const auto& [key, value] : kGeneticCode) {
@@ -373,7 +373,7 @@ TEST_CASE("RWTxn") {
             ::mdbx::error::success_or_throw(::mdbx_txn_commit(rw_txn));
         }
         auto ro_txn{env.start_read()};
-        db::PooledCursor cursor(ro_txn, {table_name});
+        db::PooledCursor cursor(ro_txn, {kTableName});
         CHECK(cursor.empty() == false);
     }
 }
@@ -384,9 +384,9 @@ TEST_CASE("Cursor walk") {
     auto env{db::open_env(db_config)};
     auto txn{env.start_write()};
 
-    static const char* table_name{"GeneticCode"};
+    static const char* kTableName{"GeneticCode"};
 
-    db::PooledCursor table_cursor(txn, {table_name});
+    db::PooledCursor table_cursor(txn, {kTableName});
 
     // A map to collect data
     std::map<std::string, std::string> data_map;
@@ -414,7 +414,7 @@ TEST_CASE("Cursor walk") {
         REQUIRE(table_cursor.empty() == false);
 
         // Rebind cursor so its position is undefined
-        table_cursor.bind(txn, {table_name});
+        table_cursor.bind(txn, {kTableName});
         REQUIRE(table_cursor.eof() == true);
 
         // read entire table forward
@@ -423,13 +423,13 @@ TEST_CASE("Cursor walk") {
         data_map.clear();
 
         // read entire table backwards
-        table_cursor.bind(txn, {table_name});
+        table_cursor.bind(txn, {kTableName});
         cursor_for_each(table_cursor, save_all_data_map, CursorMoveDirection::kReverse);
         CHECK(data_map == kGeneticCode);
         data_map.clear();
 
         // Ensure the order is reversed
-        table_cursor.bind(txn, {table_name});
+        table_cursor.bind(txn, {kTableName});
         cursor_for_each(table_cursor, save_all_data_vec, CursorMoveDirection::kReverse);
         CHECK(data_vec.back().second == kGeneticCode.at("AAA"));
 
@@ -551,7 +551,7 @@ TEST_CASE("Cursor walk") {
         }
 
         // Erase all records in forward order
-        table_cursor.bind(txn, {table_name});
+        table_cursor.bind(txn, {kTableName});
         cursor_erase(table_cursor, {});
         REQUIRE(txn.get_map_stat(table_cursor.map()).ms_entries == 0);
 
@@ -565,7 +565,7 @@ TEST_CASE("Cursor walk") {
         set_key[0] = 'X';
         set_key[1] = 'X';
         set_key[2] = 'X';
-        table_cursor.bind(txn, {table_name});
+        table_cursor.bind(txn, {kTableName});
         cursor_erase(table_cursor, set_key, CursorMoveDirection::kReverse);
         REQUIRE(txn.get_map_stat(table_cursor.map()).ms_entries == 0);
 

--- a/silkworm/db/mdbx_test.cpp
+++ b/silkworm/db/mdbx_test.cpp
@@ -424,13 +424,13 @@ TEST_CASE("Cursor walk") {
 
         // read entire table backwards
         table_cursor.bind(txn, {table_name});
-        cursor_for_each(table_cursor, save_all_data_map, CursorMoveDirection::Reverse);
+        cursor_for_each(table_cursor, save_all_data_map, CursorMoveDirection::kReverse);
         CHECK(data_map == kGeneticCode);
         data_map.clear();
 
         // Ensure the order is reversed
         table_cursor.bind(txn, {table_name});
-        cursor_for_each(table_cursor, save_all_data_vec, CursorMoveDirection::Reverse);
+        cursor_for_each(table_cursor, save_all_data_vec, CursorMoveDirection::kReverse);
         CHECK(data_vec.back().second == kGeneticCode.at("AAA"));
 
         // late start
@@ -512,7 +512,7 @@ TEST_CASE("Cursor walk") {
 
         // reverse read
         table_cursor.to_last();
-        cursor_for_count(table_cursor, save_all_data_map, /*max_count=*/4, CursorMoveDirection::Reverse);
+        cursor_for_count(table_cursor, save_all_data_map, /*max_count=*/4, CursorMoveDirection::kReverse);
         REQUIRE(data_map.size() == 4);
         CHECK(data_map.at("UUA") == "Leucine");
         CHECK(data_map.at("UUC") == "Phenylalanine");
@@ -566,7 +566,7 @@ TEST_CASE("Cursor walk") {
         set_key[1] = 'X';
         set_key[2] = 'X';
         table_cursor.bind(txn, {table_name});
-        cursor_erase(table_cursor, set_key, CursorMoveDirection::Reverse);
+        cursor_erase(table_cursor, set_key, CursorMoveDirection::kReverse);
         REQUIRE(txn.get_map_stat(table_cursor.map()).ms_entries == 0);
 
         // populate table
@@ -578,7 +578,7 @@ TEST_CASE("Cursor walk") {
         set_key[0] = 'C';
         set_key[1] = 'A';
         set_key[2] = 'A';
-        cursor_erase(table_cursor, set_key, CursorMoveDirection::Reverse);
+        cursor_erase(table_cursor, set_key, CursorMoveDirection::kReverse);
         cursor_for_each(table_cursor, save_all_data_map);
         REQUIRE(data_map.begin()->second == "Glutamine");
 
@@ -586,7 +586,7 @@ TEST_CASE("Cursor walk") {
         set_key[0] = 'U';
         set_key[1] = 'A';
         set_key[2] = 'A';
-        cursor_erase(table_cursor, set_key, CursorMoveDirection::Forward);
+        cursor_erase(table_cursor, set_key, CursorMoveDirection::kForward);
         data_map.clear();
         cursor_for_each(table_cursor, save_all_data_map);
         REQUIRE(data_map.rbegin()->second == "Valine");

--- a/silkworm/db/snapshots/common/iterator/iterator_read_into_vector.hpp
+++ b/silkworm/db/snapshots/common/iterator/iterator_read_into_vector.hpp
@@ -22,14 +22,14 @@
 
 namespace silkworm {
 
-template <std::input_iterator It>
-void iterator_read_into(It it, size_t count, std::vector<typename It::value_type>& out) {
+template <std::input_iterator InputIt>
+void iterator_read_into(InputIt it, size_t count, std::vector<typename InputIt::value_type>& out) {
     std::copy_n(std::make_move_iterator(std::move(it)), count, std::back_inserter(out));
 }
 
-template <std::input_iterator It>
-std::vector<typename It::value_type> iterator_read_into_vector(It it, size_t count) {
-    std::vector<typename It::value_type> out;
+template <std::input_iterator InputIt>
+std::vector<typename InputIt::value_type> iterator_read_into_vector(InputIt it, size_t count) {
+    std::vector<typename InputIt::value_type> out;
     out.reserve(count);
     iterator_read_into(std::move(it), count, out);
     return out;

--- a/silkworm/db/snapshots/index_builder.hpp
+++ b/silkworm/db/snapshots/index_builder.hpp
@@ -47,6 +47,7 @@ struct IndexDescriptor {
 struct IndexInputDataQuery {
     class Iterator {
       public:
+        // NOLINTNEXTLINE(readability-identifier-naming)
         struct value_type {
             ByteView key_data;
             uint64_t value{};

--- a/silkworm/db/snapshots/rec_split/common/common.hpp
+++ b/silkworm/db/snapshots/rec_split/common/common.hpp
@@ -58,10 +58,6 @@
 
 #include <silkworm/core/common/assert.hpp>
 
-// Explicit branch predictions
-#define likely(x) __builtin_expect(!!(x), 1)
-#define unlikely(x) __builtin_expect(!!(x), 0)
-
 namespace silkworm::snapshots::rec_split {
 
 using std::memcpy;

--- a/silkworm/db/snapshots/rec_split/common/common.hpp
+++ b/silkworm/db/snapshots/rec_split/common/common.hpp
@@ -141,9 +141,9 @@ inline int lambda(uint64_t word) { return 63 ^ std::countl_zero(word); }
 //! distributed over the range [0..n), under assumption that n is less than 2^16
 inline uint64_t remap16(uint64_t x, uint64_t n) {
     SILKWORM_ASSERT(n < (1 << 16));
-    static const int masklen = 48;
-    static const uint64_t mask = (uint64_t{1} << masklen) - 1;
-    return ((x & mask) * n) >> masklen;
+    static const int kMaskLen = 48;
+    static const uint64_t kMask = (uint64_t{1} << kMaskLen) - 1;
+    return ((x & kMask) * n) >> kMaskLen;
 }
 
 inline uint64_t remap128(uint64_t x, uint64_t n) {

--- a/silkworm/db/snapshots/rec_split/rec_split.cpp
+++ b/silkworm/db/snapshots/rec_split/rec_split.cpp
@@ -23,6 +23,6 @@ const std::size_t RecSplit8::kLowerAggregationBound = RecSplit8::SplitStrategy::
 template <>
 const std::size_t RecSplit8::kUpperAggregationBound = RecSplit8::SplitStrategy::kUpperAggregationBound;
 template <>
-const std::array<uint32_t, kMaxBucketSize> RecSplit8::memo = RecSplit8::fill_golomb_rice();
+const std::array<uint32_t, kMaxBucketSize> RecSplit8::kMemo = RecSplit8::fill_golomb_rice();
 
 }  // namespace silkworm::snapshots::rec_split

--- a/silkworm/db/snapshots/rec_split/rec_split.hpp
+++ b/silkworm/db/snapshots/rec_split/rec_split.hpp
@@ -114,18 +114,17 @@ uint64_t inline remix(uint64_t z) {
 
 //! 128-bit hash used in the construction of RecSplit (first of all keys are hashed using MurmurHash3)
 //! Moreover, it is possible to build and query RecSplit instances using 128-bit random hashes (mainly for test purposes)
-struct hash128_t {
+struct Hash128 {
     uint64_t first;   // The high 64-bit hash half
     uint64_t second;  // The low 64-bit hash half
 
-    bool operator<(const hash128_t& o) const { return first < o.first || second < o.second; }
+    bool operator<(const Hash128& o) const { return first < o.first || second < o.second; }
 };
 
 // Optimal Golomb-Rice parameters for leaves
 static constexpr uint8_t kBijMemo[] = {0, 0, 0, 1, 3, 4, 5, 7, 8, 10, 11, 12, 14, 15, 16, 18, 19, 21, 22, 23, 25, 26, 28, 29, 30};
 
 //! The splitting strategy of Recsplit algorithm is embedded into the generation code, which uses only the public fields
-//! SplittingStrategy::lower_aggr and SplittingStrategy::upper_aggr.
 template <std::size_t LEAF_SIZE>
 class SplittingStrategy {
     static_assert(1 <= LEAF_SIZE && LEAF_SIZE <= kMaxLeafSize);
@@ -139,17 +138,17 @@ class SplittingStrategy {
     static constexpr std::size_t kUpperAggregationBound = kLowerAggregationBound * (LEAF_SIZE < 7 ? std::size_t{2}
                                                                                                   : math::int_ceil<std::size_t>(0.21 * LEAF_SIZE + 0.9));
 
-    static inline std::pair<std::size_t, std::size_t> split_params(const std::size_t m) {
+    static std::pair<std::size_t, std::size_t> split_params(const std::size_t m) {
         std::size_t fanout{0}, unit{0};
         if (m > kUpperAggregationBound) {  // High-level aggregation (fanout 2)
-            unit = kUpperAggregationBound * (uint16_t((m + 1) / 2 + kUpperAggregationBound - 1) / kUpperAggregationBound);
+            unit = kUpperAggregationBound * (static_cast<uint16_t>((m + 1) / 2 + kUpperAggregationBound - 1) / kUpperAggregationBound);
             fanout = 2;
         } else if (m > kLowerAggregationBound) {  // Second-level aggregation
             unit = kLowerAggregationBound;
-            fanout = uint16_t(m + kLowerAggregationBound - 1) / kLowerAggregationBound;
+            fanout = static_cast<uint16_t>(m + kLowerAggregationBound - 1) / kLowerAggregationBound;
         } else {  // First-level aggregation
             unit = LEAF_SIZE;
-            fanout = uint16_t(m + LEAF_SIZE - 1) / LEAF_SIZE;
+            fanout = static_cast<uint16_t>(m + LEAF_SIZE - 1) / LEAF_SIZE;
         }
         return {fanout, unit};
     }
@@ -235,7 +234,7 @@ template <std::size_t LEAF_SIZE>
 class RecSplit {
   public:
     using SplitStrategy = SplittingStrategy<LEAF_SIZE>;
-    using GolombRiceBuilder = typename encoding::GolombRiceVector::Builder;
+    using GolombRiceBuilder = encoding::GolombRiceVector::Builder;
     using EliasFano = encoding::EliasFanoList32;
     using DoubleEliasFano = encoding::DoubleEliasFanoList16;
 
@@ -405,7 +404,7 @@ class RecSplit {
         built_ = true;
     }
 
-    void add_key(const hash128_t& key_hash, uint64_t offset) {
+    void add_key(const Hash128& key_hash, uint64_t offset) {
         if (built_) {
             throw std::logic_error{"cannot add key after perfect hash function has been built"};
         }
@@ -501,9 +500,9 @@ class RecSplit {
         SILK_TRACE << "[index] written murmur3 salt: " << salt_ << " [" << to_hex(uint64_buffer) << "]";
 
         // Write out start seeds
-        constexpr uint8_t start_seed_length = kStartSeed.size();
-        index_output_stream.write(reinterpret_cast<const char*>(&start_seed_length), sizeof(uint8_t));
-        SILK_TRACE << "[index] written start seed length: " << int{start_seed_length};
+        constexpr uint8_t kStartSeedLength = kStartSeed.size();
+        index_output_stream.write(reinterpret_cast<const char*>(&kStartSeedLength), sizeof(uint8_t));
+        SILK_TRACE << "[index] written start seed length: " << int{kStartSeedLength};
 
         for (const uint64_t s : kStartSeed) {
             endian::store_big_u64(uint64_buffer.data(), s);
@@ -582,7 +581,7 @@ class RecSplit {
 
     //! Check if the given bucket hash is present as i-th element in the index
     //! \return true if hash is present as i-th element, false otherwise
-    bool has(const hash128_t& hash, std::size_t i) const {
+    bool has(const Hash128& hash, std::size_t i) const {
         if (less_false_positives_ && i < existence_filter_.size()) {
             return existence_filter_.at(i) == static_cast<uint8_t>(hash.first);
         }
@@ -593,7 +592,7 @@ class RecSplit {
     //! Return the value associated with the given 128-bit bucket hash
     //! \param hash a 128-bit bucket hash
     //! \return the associated value
-    std::size_t operator()(const hash128_t& hash) const {
+    std::size_t operator()(const Hash128& hash) const {
         ensure(built_, "RecSplit: perfect hash function not built yet");
         ensure(key_count_ > 0, "RecSplit: invalid lookup with zero keys, use empty() to guard");
 
@@ -612,7 +611,7 @@ class RecSplit {
         int level = 0;
 
         while (m > kUpperAggregationBound) {  // fanout = 2
-            const auto d = reader.read_next(golomb_param(m, memo));
+            const auto d = reader.read_next(golomb_param(m, kMemo));
             const std::size_t hmod = remap16(remix(hash.second + d + kStartSeed[level]), m);
 
             const std::size_t split = ((static_cast<uint16_t>((m + 1) / 2 + kUpperAggregationBound - 1) / kUpperAggregationBound)) * kUpperAggregationBound;
@@ -626,10 +625,10 @@ class RecSplit {
             level++;
         }
         if (m > kLowerAggregationBound) {
-            const auto d = reader.read_next(golomb_param(m, memo));
+            const auto d = reader.read_next(golomb_param(m, kMemo));
             const size_t hmod = remap16(remix(hash.second + d + kStartSeed[level]), m);
 
-            const int part = uint16_t(hmod) / kLowerAggregationBound;
+            const int part = static_cast<uint16_t>(hmod) / kLowerAggregationBound;
             m = std::min(kLowerAggregationBound, m - part * kLowerAggregationBound);
             cum_keys += kLowerAggregationBound * part;
             if (part) reader.skip_subtree(skip_nodes(kLowerAggregationBound) * part, skip_bits(kLowerAggregationBound) * part);
@@ -637,17 +636,17 @@ class RecSplit {
         }
 
         if (m > LEAF_SIZE) {
-            const auto d = reader.read_next(golomb_param(m, memo));
+            const auto d = reader.read_next(golomb_param(m, kMemo));
             const size_t hmod = remap16(remix(hash.second + d + kStartSeed[level]), m);
 
-            const int part = uint16_t(hmod) / LEAF_SIZE;
+            const int part = static_cast<uint16_t>(hmod) / LEAF_SIZE;
             m = std::min(LEAF_SIZE, m - part * LEAF_SIZE);
             cum_keys += LEAF_SIZE * part;
             if (part) reader.skip_subtree(part, skip_bits(LEAF_SIZE) * part);
             level++;
         }
 
-        const auto b = reader.read_next(golomb_param(m, memo));
+        const auto b = reader.read_next(golomb_param(m, kMemo));
         return cum_keys + remap16(remix(hash.second + b + kStartSeed[level]), m);
     }
 
@@ -665,7 +664,7 @@ class RecSplit {
 
     //! Return the value associated with the given key within the index
     LookupResult lookup(ByteView key) const {
-        const hash128_t& hashed_key{murmur_hash_3(key)};
+        const Hash128& hashed_key{murmur_hash_3(key)};
         const auto record = operator()(hashed_key);
         const auto position = 1 + 8 + bytes_per_record_ * (record + 1);
 
@@ -723,17 +722,19 @@ class RecSplit {
     [[nodiscard]] MemoryMappedRegion memory_file_region() const { return encoded_file_ ? encoded_file_->region() : MemoryMappedRegion{}; }
 
   private:
-    static inline std::size_t skip_bits(std::size_t m) { return memo[m] & 0xFFFF; }
+    static std::size_t skip_bits(std::size_t m) { return kMemo[m] & 0xFFFF; }
 
-    static inline std::size_t skip_nodes(std::size_t m) { return (memo[m] >> 16) & 0x7FF; }
+    static std::size_t skip_nodes(std::size_t m) { return (kMemo[m] >> 16) & 0x7FF; }
 
-    static inline uint64_t golomb_param(const std::size_t m,
-                                        const std::array<uint32_t, kMaxBucketSize>& memo) {
+    static uint64_t golomb_param(
+        const std::size_t m,
+        const std::array<uint32_t, kMaxBucketSize>& memo) {
         return memo[m] >> 27;
     }
-    static inline uint64_t golomb_param_with_max_calculation(const std::size_t m,
-                                                             const std::array<uint32_t, kMaxBucketSize>& memo,
-                                                             uint16_t& golomb_param_max_index) {
+    static uint64_t golomb_param_with_max_calculation(
+        const std::size_t m,
+        const std::array<uint32_t, kMaxBucketSize>& memo,
+        uint16_t& golomb_param_max_index) {
         if (m > golomb_param_max_index) golomb_param_max_index = gsl::narrow<uint16_t>(m);
         return golomb_param(m, memo);
     }
@@ -831,7 +832,7 @@ class RecSplit {
                 uint32_t mask{0};
                 bool fail{false};
                 for (uint16_t i{0}; !fail && i < m; i++) {
-                    uint32_t bit = uint32_t(1) << remap16(remix(keys[start + i] + salt), m);
+                    uint32_t bit = uint32_t{1} << remap16(remix(keys[start + i] + salt), m);
                     if ((mask & bit) != 0) {
                         fail = true;
                     } else {
@@ -854,7 +855,7 @@ class RecSplit {
                 }
             }
             salt -= kStartSeed[level];
-            const auto log2golomb = golomb_param_with_max_calculation(m, memo, golomb_param_max_index);
+            const auto log2golomb = golomb_param_with_max_calculation(m, kMemo, golomb_param_max_index);
             gr_builder.append_fixed(salt, log2golomb);
             gr_builder.append_unary(static_cast<uint32_t>(salt >> log2golomb));
         } else {
@@ -867,7 +868,7 @@ class RecSplit {
             while (true) {
                 std::fill(count.begin(), count.end(), 0);
                 for (std::size_t i{0}; i < m; i++) {
-                    count[uint16_t(remap16(remix(keys[start + i] + salt), m)) / unit]++;
+                    count[static_cast<uint16_t>(remap16(remix(keys[start + i] + salt), m)) / unit]++;
                 }
                 bool broken{false};
                 for (std::size_t i = 0; i < fanout - 1; i++) {
@@ -880,7 +881,7 @@ class RecSplit {
                 count[i] = c;
             }
             for (std::size_t i{0}; i < m; i++) {
-                auto j = uint16_t(remap16(remix(keys[start + i] + salt), m)) / unit;
+                auto j = static_cast<uint16_t>(remap16(remix(keys[start + i] + salt), m)) / unit;
                 buffer_keys[count[j]] = keys[start + i];
                 buffer_offsets[count[j]] = offsets[start + i];
                 count[j]++;
@@ -889,7 +890,7 @@ class RecSplit {
             std::copy(buffer_offsets.data(), buffer_offsets.data() + m, offsets.data() + start);
 
             salt -= kStartSeed[level];
-            const auto log2golomb = golomb_param_with_max_calculation(m, memo, golomb_param_max_index);
+            const auto log2golomb = golomb_param_with_max_calculation(m, kMemo, golomb_param_max_index);
             gr_builder.append_fixed(salt, log2golomb);
             gr_builder.append_unary(static_cast<uint32_t>(salt >> log2golomb));
 
@@ -910,14 +911,14 @@ class RecSplit {
         }
     }
 
-    hash128_t inline murmur_hash_3(ByteView data) const {
-        hash128_t h{};
+    Hash128 murmur_hash_3(ByteView data) const {
+        Hash128 h{};
         hasher_->hash_x64_128(data.data(), data.size(), &h);
         return h;
     }
 
     //! Maps a 128-bit to a bucket using the first 64-bit half
-    [[nodiscard]] inline uint64_t hash128_to_bucket(const hash128_t& hash) const { return remap128(hash.first, bucket_count_); }
+    [[nodiscard]] uint64_t hash128_to_bucket(const Hash128& hash) const { return remap128(hash.first, bucket_count_); }
 
     void check_minimum_length(std::size_t minimum_length) {
         if (encoded_file_ && encoded_file_->size() < minimum_length) {
@@ -932,7 +933,7 @@ class RecSplit {
         }
         if (RecSplitFeatures{features} != RecSplitFeatures::kNone) {
             throw std::runtime_error("index " + encoded_file_->path().filename().string() + " has unsupported features: " +
-                                     std::to_string(uint8_t(features)));
+                                     std::to_string(static_cast<uint8_t>(features)));
         }
     }
 
@@ -968,7 +969,7 @@ class RecSplit {
 
     //! For each bucket size, the Golomb-Rice parameter (upper 8 bits) and the number of bits to
     //! skip in the fixed part of the tree (lower 24 bits).
-    static const std::array<uint32_t, kMaxBucketSize> memo;
+    static const std::array<uint32_t, kMaxBucketSize> kMemo;
 
     //! The size in bytes of each Recsplit bucket (possibly except the last one)
     uint16_t bucket_size_;
@@ -1032,7 +1033,7 @@ constexpr std::size_t kLeafSize{8};
 using RecSplit8 = RecSplit<kLeafSize>;
 
 template <>
-const std::array<uint32_t, kMaxBucketSize> RecSplit8::memo;
+const std::array<uint32_t, kMaxBucketSize> RecSplit8::kMemo;
 
 using RecSplitIndex = RecSplit8;
 

--- a/silkworm/db/snapshots/rec_split/rec_split.hpp
+++ b/silkworm/db/snapshots/rec_split/rec_split.hpp
@@ -122,7 +122,7 @@ struct hash128_t {
 };
 
 // Optimal Golomb-Rice parameters for leaves
-static constexpr uint8_t bij_memo[] = {0, 0, 0, 1, 3, 4, 5, 7, 8, 10, 11, 12, 14, 15, 16, 18, 19, 21, 22, 23, 25, 26, 28, 29, 30};
+static constexpr uint8_t kBijMemo[] = {0, 0, 0, 1, 3, 4, 5, 7, 8, 10, 11, 12, 14, 15, 16, 18, 19, 21, 22, 23, 25, 26, 28, 29, 30};
 
 //! The splitting strategy of Recsplit algorithm is embedded into the generation code, which uses only the public fields
 //! SplittingStrategy::lower_aggr and SplittingStrategy::upper_aggr.
@@ -781,7 +781,7 @@ class RecSplit {
         std::array<uint32_t, kMaxBucketSize> memo{0};
         std::size_t s{0};
         for (; s <= LEAF_SIZE; ++s) {
-            memo[s] = bij_memo[s] << 27 | (s > 1) << 16 | bij_memo[s];
+            memo[s] = kBijMemo[s] << 27 | (s > 1) << 16 | kBijMemo[s];
         }
         for (; s < kMaxBucketSize; ++s) {
             precompute_golomb_rice(static_cast<int>(s), &memo);

--- a/silkworm/db/snapshots/rec_split/rec_split_par_test.cpp
+++ b/silkworm/db/snapshots/rec_split/rec_split_par_test.cpp
@@ -96,7 +96,7 @@ TEST_CASE("RecSplit8-Par key_count=2", "[silkworm][node][recsplit]") {
 }
 
 template <typename RS>
-static void check_bijection(RS& rec_split, const std::vector<hash128_t>& keys) {
+static void check_bijection(RS& rec_split, const std::vector<Hash128>& keys) {
     // RecSplit implements a MPHF K={k1...kN} -> V={0..N-1} so we must check all codomain is exhausted
     std::vector<uint64_t> recsplit_values(keys.size());
     // Fill the codomain values w/ zero, so we can easily check if a value is already used or not
@@ -126,8 +126,7 @@ const std::size_t RecSplit4::kLowerAggregationBound;
 template <>
 const std::size_t RecSplit4::kUpperAggregationBound;
 template <>
-// NOLINTNEXTLINE(readability-identifier-naming)
-const std::array<uint32_t, kMaxBucketSize> RecSplit4::memo;
+const std::array<uint32_t, kMaxBucketSize> RecSplit4::kMemo;
 
 auto par_build_strategy_4(ThreadPool& tp) { return std::make_unique<RecSplit4::ParallelBuildingStrategy>(tp); }
 
@@ -139,7 +138,7 @@ TEST_CASE("RecSplit4-Par: keys=1000 buckets=128", "[silkworm][node][recsplit]") 
     constexpr int kTestNumKeys{1'000};
     constexpr int kTestBucketSize{128};
 
-    std::vector<hash128_t> hashed_keys;
+    std::vector<Hash128> hashed_keys;
     for (std::size_t i{0}; i < kTestNumKeys; ++i) {
         hashed_keys.push_back({next_pseudo_random(), next_pseudo_random()});
     }
@@ -188,7 +187,7 @@ TEST_CASE("RecSplit4-Par: multiple keys-buckets", "[silkworm][node][recsplit]") 
     };
     for (const auto [key_count, bucket_size] : recsplit_params_sequence) {
         SECTION("random_hash128 OK [" + std::to_string(key_count) + "-" + std::to_string(bucket_size) + "]") {  // NOLINT
-            std::vector<hash128_t> hashed_keys;
+            std::vector<Hash128> hashed_keys;
             for (std::size_t i{0}; i < key_count; ++i) {
                 hashed_keys.push_back({next_pseudo_random(), next_pseudo_random()});
             }

--- a/silkworm/db/snapshots/rec_split/rec_split_seq_test.cpp
+++ b/silkworm/db/snapshots/rec_split/rec_split_seq_test.cpp
@@ -95,7 +95,7 @@ TEST_CASE("RecSplit8: key_count=2", "[silkworm][snapshots][recsplit]") {
 }
 
 template <typename RS>
-static void check_bijection(RS& rec_split, const std::vector<hash128_t>& keys) {
+static void check_bijection(RS& rec_split, const std::vector<Hash128>& keys) {
     // RecSplit implements a MPHF K={k1...kN} -> V={0..N-1} so we must check all codomain is exhausted
     std::vector<uint64_t> recsplit_values(keys.size());
     // Fill the codomain values w/ zero, so we can easily check if a value is already used or not
@@ -124,8 +124,7 @@ const std::size_t RecSplit4::kLowerAggregationBound = RecSplit4::SplitStrategy::
 template <>
 const std::size_t RecSplit4::kUpperAggregationBound = RecSplit4::SplitStrategy::kUpperAggregationBound;
 template <>
-// NOLINTNEXTLINE(readability-identifier-naming)
-const std::array<uint32_t, kMaxBucketSize> RecSplit4::memo = RecSplit4::fill_golomb_rice();
+const std::array<uint32_t, kMaxBucketSize> RecSplit4::kMemo = RecSplit4::fill_golomb_rice();
 
 using RecSplit4 = RecSplit<kTestLeaf>;
 auto seq_build_strategy_4() { return std::make_unique<RecSplit4::SequentialBuildingStrategy>(db::etl::kOptimalBufferSize); }
@@ -137,7 +136,7 @@ TEST_CASE("RecSplit4: keys=1000 buckets=128", "[silkworm][snapshots][recsplit]")
     constexpr int kTestNumKeys{1'000};
     constexpr int kTestBucketSize{128};
 
-    std::vector<hash128_t> hashed_keys;
+    std::vector<Hash128> hashed_keys;
     for (std::size_t i{0}; i < kTestNumKeys; ++i) {
         hashed_keys.push_back({next_pseudo_random(), next_pseudo_random()});
     }
@@ -185,7 +184,7 @@ TEST_CASE("RecSplit4: multiple keys-buckets", "[silkworm][snapshots][recsplit]")
     };
     for (const auto [key_count, bucket_size] : recsplit_params_sequence) {
         SECTION("random_hash128 OK [" + std::to_string(key_count) + "-" + std::to_string(bucket_size) + "]") {  // NOLINT
-            std::vector<hash128_t> hashed_keys;
+            std::vector<Hash128> hashed_keys;
             for (std::size_t i{0}; i < key_count; ++i) {
                 hashed_keys.push_back({next_pseudo_random(), next_pseudo_random()});
             }

--- a/silkworm/db/snapshots/seg/compressor/pattern_extractor.hpp
+++ b/silkworm/db/snapshots/seg/compressor/pattern_extractor.hpp
@@ -42,7 +42,7 @@ class Superstring {
     size_t size() const { return superstring_.size(); }
     void clear() { superstring_.clear(); }
 
-    inline bool has_same_chars(int i1, int j1) const {
+    bool has_same_chars(int i1, int j1) const {
         auto i = static_cast<size_t>(i1);
         auto j = static_cast<size_t>(j1);
         return superstring_[i * 2] && superstring_[j * 2] && (superstring_[i * 2 + 1] == superstring_[j * 2 + 1]);

--- a/silkworm/db/snapshots/seg/decompressor.cpp
+++ b/silkworm/db/snapshots/seg/decompressor.cpp
@@ -109,7 +109,7 @@ static PatternTable::WordDistances build_word_distances() {
 }
 
 //! Initialize once and for all the word distances in the data for each power of 2
-const PatternTable::WordDistances PatternTable::word_distances_{build_word_distances()};
+const PatternTable::WordDistances PatternTable::kWordDistances{build_word_distances()};
 
 //! Initialize condensed table threshold for bit length using default value
 std::size_t PatternTable::condensed_table_bit_length_threshold_{kDefaultCondensedTableBitLengthThreshold};
@@ -228,7 +228,7 @@ const CodeWord* PatternTable::search_condensed(uint16_t code) const {
 }
 
 bool PatternTable::check_distance(std::size_t power, int distance) {
-    const auto& distances = PatternTable::word_distances_[power];
+    const auto& distances = PatternTable::kWordDistances[power];
     auto it = std::find_if(distances.cbegin(), distances.cend(), [distance](const int d) {
         return d == distance;
     });

--- a/silkworm/db/snapshots/seg/decompressor.hpp
+++ b/silkworm/db/snapshots/seg/decompressor.hpp
@@ -106,7 +106,7 @@ class PatternTable : public DecodingTable {
     std::size_t build_condensed(std::span<Pattern> patterns);
 
   private:
-    static const WordDistances word_distances_;
+    static const WordDistances kWordDistances;
     static std::size_t condensed_table_bit_length_threshold_;
 
     [[nodiscard]] static bool check_distance(std::size_t power, int distance);

--- a/silkworm/db/snapshots/snapshot_type.hpp
+++ b/silkworm/db/snapshots/snapshot_type.hpp
@@ -23,11 +23,13 @@ namespace silkworm::snapshots {
 //! The snapshot category corresponding to the snapshot file type
 //! @remark item names do NOT follow Google style to obtain the tag used in file names from magic_enum::enum_name
 //! @see SnapshotPath#build_filename
+// NOLINTBEGIN(readability-identifier-naming)
 enum SnapshotType : uint8_t {
     headers = 0,
     bodies = 1,
     transactions = 2,
     transactions_to_block = 3,
 };
+// NOLINTEND(readability-identifier-naming)
 
 }  // namespace silkworm::snapshots

--- a/silkworm/db/stage.hpp
+++ b/silkworm/db/stage.hpp
@@ -71,10 +71,10 @@ class Stage : public Stoppable {
     };
 
     enum class OperationType {
-        None,     // Actually no operation running
-        Forward,  // Executing Forward
-        Unwind,   // Executing Unwind
-        Prune,    // Executing Prune
+        kNone,     // Actually no operation running
+        kForward,  // Executing Forward
+        kUnwind,   // Executing Unwind
+        kPrune,    // Executing Prune
     };
 
     Stage(SyncContext* sync_context, const char* stage_name);
@@ -125,11 +125,13 @@ class Stage : public Stoppable {
     void throw_if_stopping();
 
   protected:
-    SyncContext* sync_context_;                                  // Shared context across stages
-    const char* stage_name_;                                     // Human friendly identifier of the stage
-    std::atomic<OperationType> operation_{OperationType::None};  // Actual operation being carried out
-    std::mutex sl_mutex_;                                        // To synchronize access by outer sync loop
-    std::string log_prefix_;                                     // Log lines prefix holding the progress among stages
+    // Shared context across stages
+    SyncContext* sync_context_;
+    const char* stage_name_;
+    std::atomic<OperationType> operation_{OperationType::kNone};
+    // To synchronize access by outer sync loop
+    std::mutex sl_mutex_;
+    std::string log_prefix_;
 
     //! \brief Throws if actual block != expected block
     static void check_block_sequence(BlockNum actual, BlockNum expected);

--- a/silkworm/db/test_util/temp_snapshots.hpp
+++ b/silkworm/db/test_util/temp_snapshots.hpp
@@ -170,7 +170,7 @@ class HelloWorldSnapshotFile : public TemporarySnapshotFile {
 //! At least 2 blocks are required because RecSplit key set must have at least *2* keys
 class SampleHeaderSnapshotFile : public TemporarySnapshotFile {
   public:
-    inline static constexpr const char* kHeadersSnapshotFileName{"v1-001500-001500-headers.seg"};
+    static constexpr const char* kHeadersSnapshotFileName{"v1-001500-001500-headers.seg"};
 
     //! This ctor lets you pass any snapshot content and is used to produce broken snapshots
     SampleHeaderSnapshotFile(const std::filesystem::path& tmp_dir, std::string_view hex)
@@ -212,7 +212,7 @@ class SampleHeaderSnapshotFile : public TemporarySnapshotFile {
 //! Sample Bodies snapshot file: it contains the mainnet block bodies in range [1'500'012, 1'500'013]
 class SampleBodySnapshotFile : public TemporarySnapshotFile {
   public:
-    inline static constexpr const char* kBodiesSnapshotFileName{"v1-001500-001500-bodies.seg"};
+    static constexpr const char* kBodiesSnapshotFileName{"v1-001500-001500-bodies.seg"};
 
     //! This ctor lets you pass any snapshot content and is used to produce broken snapshots
     SampleBodySnapshotFile(const std::filesystem::path& tmp_dir, std::string_view hex)
@@ -253,7 +253,7 @@ class SampleBodySnapshotFile : public TemporarySnapshotFile {
 //! Sample Transactions snapshot file: it contains the mainnet block transactions in range [1'500'012, 1'500'013]
 class SampleTransactionSnapshotFile : public TemporarySnapshotFile {
   public:
-    inline static constexpr const char* kTransactionsSnapshotFileName{"v1-001500-001500-transactions.seg"};
+    static constexpr const char* kTransactionsSnapshotFileName{"v1-001500-001500-transactions.seg"};
 
     //! This ctor lets you pass any snapshot content and is used to produce broken snapshots
     SampleTransactionSnapshotFile(const std::filesystem::path& tmp_dir, std::string_view hex)

--- a/silkworm/db/transactions/txs_and_bodies_query.hpp
+++ b/silkworm/db/transactions/txs_and_bodies_query.hpp
@@ -46,6 +46,7 @@ class TxsAndBodiesQuery {
             uint64_t expected_tx_count,
             std::string log_title);
 
+        // NOLINTNEXTLINE(readability-identifier-naming)
         struct value_type {
             BlockNum block_number{};
             ByteView body_rlp;

--- a/silkworm/node/stagedsync/stages/stage_blockhashes.cpp
+++ b/silkworm/node/stagedsync/stages/stage_blockhashes.cpp
@@ -33,7 +33,7 @@ Stage::Result BlockHashes::forward(db::RWTxn& txn) {
      */
 
     Stage::Result ret{Stage::Result::kSuccess};
-    operation_ = OperationType::Forward;
+    operation_ = OperationType::kForward;
     try {
         throw_if_stopping();
 
@@ -43,7 +43,7 @@ Stage::Result BlockHashes::forward(db::RWTxn& txn) {
 
         if (previous_progress == headers_stage_progress) {
             // Nothing to process
-            operation_ = OperationType::None;
+            operation_ = OperationType::kNone;
             return ret;
         }
         if (previous_progress > headers_stage_progress) {
@@ -85,7 +85,7 @@ Stage::Result BlockHashes::forward(db::RWTxn& txn) {
         ret = Stage::Result::kUnexpectedError;
     }
 
-    operation_ = OperationType::None;
+    operation_ = OperationType::kNone;
     collector_.reset();
     return ret;
 }
@@ -95,14 +95,14 @@ Stage::Result BlockHashes::unwind(db::RWTxn& txn) {
     if (!sync_context_->unwind_point.has_value()) return ret;
     const BlockNum to{sync_context_->unwind_point.value()};
 
-    operation_ = OperationType::Unwind;
+    operation_ = OperationType::kUnwind;
     try {
         throw_if_stopping();
 
         const auto previous_progress{get_progress(txn)};
         if (previous_progress <= to) {
             // Nothing to process
-            operation_ = OperationType::None;
+            operation_ = OperationType::kNone;
             return ret;
         }
         const BlockNum segment_width{previous_progress - to};
@@ -135,7 +135,7 @@ Stage::Result BlockHashes::unwind(db::RWTxn& txn) {
         ret = Stage::Result::kUnexpectedError;
     }
 
-    operation_ = OperationType::None;
+    operation_ = OperationType::kNone;
     return ret;
 }
 
@@ -181,7 +181,7 @@ void BlockHashes::collect_and_load(db::RWTxn& txn, const BlockNum from, const Bl
                                                           " expected " + std::to_string(kHashLength));
         }
 
-        collector_->collect(Entry{Bytes{db::from_slice(data.value)}, operation_ == OperationType::Forward
+        collector_->collect(Entry{Bytes{db::from_slice(data.value)}, operation_ == OperationType::kForward
                                                                          ? Bytes{db::from_slice(data.key)}
                                                                          : Bytes{}});
 

--- a/silkworm/node/stagedsync/stages/stage_bodies.cpp
+++ b/silkworm/node/stagedsync/stages/stage_bodies.cpp
@@ -108,7 +108,7 @@ Stage::Result BodiesStage::forward(db::RWTxn& tx) {
     using namespace std::chrono;
 
     Stage::Result result = Stage::Result::kUnspecified;
-    operation_ = OperationType::Forward;
+    operation_ = OperationType::kForward;
 
     try {
         current_height_ = db::stages::read_stage_progress(tx, db::stages::kBlockBodiesKey);
@@ -175,7 +175,7 @@ Stage::Result BodiesStage::forward(db::RWTxn& tx) {
         result = Stage::Result::kUnexpectedError;
     }
 
-    operation_ = OperationType::None;
+    operation_ = OperationType::kNone;
     return result;
 }
 
@@ -188,7 +188,7 @@ Stage::Result BodiesStage::unwind(db::RWTxn& tx) {
     auto new_height = sync_context_->unwind_point.value();
     if (current_height_ <= new_height) return Stage::Result::kSuccess;
 
-    operation_ = OperationType::Unwind;
+    operation_ = OperationType::kUnwind;
 
     const BlockNum segment_width{current_height_ - new_height};
     if (segment_width > db::stages::kSmallBlockSegmentWidth) {
@@ -218,7 +218,7 @@ Stage::Result BodiesStage::unwind(db::RWTxn& tx) {
         result = Stage::Result::kUnexpectedError;
     }
 
-    operation_ = OperationType::None;
+    operation_ = OperationType::kNone;
     return result;
 }
 

--- a/silkworm/node/stagedsync/stages/stage_execution.cpp
+++ b/silkworm/node/stagedsync/stages/stage_execution.cpp
@@ -348,7 +348,7 @@ Stage::Result Execution::unwind(db::RWTxn& txn) {
         Bytes start_key{db::block_key(to + 1)};
         for (const auto& map_config : kUnwindTables) {
             auto unwind_cursor = txn.rw_cursor(map_config);
-            auto erased{db::cursor_erase(*unwind_cursor, start_key, db::CursorMoveDirection::Forward)};
+            auto erased{db::cursor_erase(*unwind_cursor, start_key, db::CursorMoveDirection::kForward)};
             log::Info() << "Erased " << erased << " records from " << map_config.name;
         }
         db::stages::write_stage_progress(txn, db::stages::kExecutionKey, to);
@@ -461,7 +461,7 @@ Stage::Result Execution::prune(db::RWTxn& txn) {
             }
             auto key{db::block_key(prune_threshold)};
             auto source = txn.rw_cursor(db::table::kBlockReceipts);
-            size_t erased = db::cursor_erase(*source, key, db::CursorMoveDirection::Reverse);
+            size_t erased = db::cursor_erase(*source, key, db::CursorMoveDirection::kReverse);
             if (stop_watch) {
                 const auto [_, duration] = stop_watch->lap();
                 log::Trace(log_prefix_,
@@ -471,7 +471,7 @@ Stage::Result Execution::prune(db::RWTxn& txn) {
             }
 
             source->bind(txn, db::table::kLogs);
-            erased = db::cursor_erase(*source, key, db::CursorMoveDirection::Reverse);
+            erased = db::cursor_erase(*source, key, db::CursorMoveDirection::kReverse);
             if (stop_watch) {
                 const auto [_, duration] = stop_watch->lap();
                 log::Trace(log_prefix_,
@@ -493,7 +493,7 @@ Stage::Result Execution::prune(db::RWTxn& txn) {
             }
             auto key{db::block_key(prune_threshold)};
             auto source = txn.rw_cursor_dup_sort(db::table::kCallTraceSet);
-            size_t erased = db::cursor_erase(*source, key, db::CursorMoveDirection::Reverse);
+            size_t erased = db::cursor_erase(*source, key, db::CursorMoveDirection::kReverse);
             if (stop_watch) {
                 const auto [_, duration] = stop_watch->lap();
                 log::Trace(log_prefix_,

--- a/silkworm/node/stagedsync/stages/stage_execution.cpp
+++ b/silkworm/node/stagedsync/stages/stage_execution.cpp
@@ -35,7 +35,7 @@ namespace silkworm::stagedsync {
 
 Stage::Result Execution::forward(db::RWTxn& txn) {
     Stage::Result ret{Stage::Result::kSuccess};
-    operation_ = OperationType::Forward;
+    operation_ = OperationType::kForward;
     try {
         throw_if_stopping();
         if (!rule_set_) {
@@ -52,7 +52,7 @@ Stage::Result Execution::forward(db::RWTxn& txn) {
 
         if (previous_progress == senders_stage_progress) {
             // Nothing to process
-            operation_ = OperationType::None;
+            operation_ = OperationType::kNone;
             return ret;
         }
         if (previous_progress > senders_stage_progress) {
@@ -140,7 +140,7 @@ Stage::Result Execution::forward(db::RWTxn& txn) {
         ret = Stage::Result::kUnexpectedError;
     }
 
-    operation_ = OperationType::None;
+    operation_ = OperationType::kNone;
     return ret;
 }
 
@@ -314,15 +314,15 @@ Stage::Result Execution::unwind(db::RWTxn& txn) {
     if (!sync_context_->unwind_point.has_value()) return ret;
     const BlockNum to{sync_context_->unwind_point.value()};
 
-    operation_ = OperationType::Unwind;
+    operation_ = OperationType::kUnwind;
     try {
         BlockNum previous_progress{db::stages::read_stage_progress(txn, db::stages::kExecutionKey)};
         if (to >= previous_progress) {
-            operation_ = OperationType::None;
+            operation_ = OperationType::kNone;
             return Stage::Result::kSuccess;
         }
 
-        operation_ = OperationType::Unwind;
+        operation_ = OperationType::kUnwind;
         const BlockNum segment_width{previous_progress - to};
         if (segment_width > db::stages::kSmallBlockSegmentWidth) {
             log::Info(log_prefix_,
@@ -372,13 +372,13 @@ Stage::Result Execution::unwind(db::RWTxn& txn) {
         ret = Stage::Result::kUnexpectedError;
     }
 
-    operation_ = OperationType::None;
+    operation_ = OperationType::kNone;
     return ret;
 }
 
 Stage::Result Execution::prune(db::RWTxn& txn) {
     Stage::Result ret{Stage::Result::kSuccess};
-    operation_ = OperationType::Prune;
+    operation_ = OperationType::kPrune;
 
     std::unique_ptr<StopWatch> stop_watch;
     if (log::test_verbosity(log::Level::kTrace)) {
@@ -389,14 +389,14 @@ Stage::Result Execution::prune(db::RWTxn& txn) {
         if (!prune_mode_.history().enabled() &&
             !prune_mode_.receipts().enabled() &&
             !prune_mode_.call_traces().enabled()) {
-            operation_ = OperationType::None;
+            operation_ = OperationType::kNone;
             return ret;
         }
 
         BlockNum forward_progress{get_progress(txn)};
         BlockNum prune_progress{get_prune_progress(txn)};
         if (prune_progress >= forward_progress) {
-            operation_ = OperationType::None;
+            operation_ = OperationType::kNone;
             return ret;
         }
 
@@ -524,7 +524,7 @@ Stage::Result Execution::prune(db::RWTxn& txn) {
         ret = Stage::Result::kUnexpectedError;
     }
 
-    operation_ = OperationType::None;
+    operation_ = OperationType::kNone;
     return ret;
 }
 

--- a/silkworm/node/stagedsync/stages/stage_finish.cpp
+++ b/silkworm/node/stagedsync/stages/stage_finish.cpp
@@ -25,7 +25,7 @@ namespace silkworm::stagedsync {
 
 Stage::Result Finish::forward(db::RWTxn& txn) {
     Stage::Result ret{Stage::Result::kSuccess};
-    operation_ = OperationType::Forward;
+    operation_ = OperationType::kForward;
     try {
         throw_if_stopping();
 
@@ -73,7 +73,7 @@ Stage::Result Finish::forward(db::RWTxn& txn) {
         ret = Stage::Result::kUnexpectedError;
     }
 
-    operation_ = OperationType::None;
+    operation_ = OperationType::kNone;
     return ret;
 }
 
@@ -81,7 +81,7 @@ Stage::Result Finish::unwind(db::RWTxn& txn) {
     Stage::Result ret{Stage::Result::kSuccess};
     if (!sync_context_->unwind_point.has_value()) return ret;
     const BlockNum to{sync_context_->unwind_point.value()};
-    operation_ = OperationType::Unwind;
+    operation_ = OperationType::kUnwind;
     try {
         throw_if_stopping();
         auto previous_progress{db::stages::read_stage_progress(txn, stage_name_)};
@@ -117,7 +117,7 @@ Stage::Result Finish::unwind(db::RWTxn& txn) {
         ret = Stage::Result::kUnexpectedError;
     }
 
-    operation_ = OperationType::None;
+    operation_ = OperationType::kNone;
     return ret;
 }
 

--- a/silkworm/node/stagedsync/stages/stage_headers.cpp
+++ b/silkworm/node/stagedsync/stages/stage_headers.cpp
@@ -101,7 +101,7 @@ Stage::Result HeadersStage::forward(db::RWTxn& tx) {
 
     Stage::Result result = Stage::Result::kUnspecified;
     std::thread message_receiving;
-    operation_ = OperationType::Forward;
+    operation_ = OperationType::kForward;
 
     try {
         auto initial_height = current_height_ = db::stages::read_stage_progress(tx, db::stages::kHeadersKey);
@@ -159,7 +159,7 @@ Stage::Result HeadersStage::forward(db::RWTxn& tx) {
         result = Stage::Result::kUnexpectedError;
     }
 
-    operation_ = OperationType::None;
+    operation_ = OperationType::kNone;
     return result;
 }
 
@@ -172,7 +172,7 @@ Stage::Result HeadersStage::unwind(db::RWTxn& tx) {
     auto new_height = sync_context_->unwind_point.value();
     if (current_height_ <= new_height) return Stage::Result::kSuccess;
 
-    operation_ = OperationType::Unwind;
+    operation_ = OperationType::kUnwind;
 
     const BlockNum segment_width{current_height_ - new_height};
     if (segment_width > db::stages::kSmallBlockSegmentWidth) {
@@ -205,7 +205,7 @@ Stage::Result HeadersStage::unwind(db::RWTxn& tx) {
         result = Stage::Result::kUnexpectedError;
     }
 
-    operation_ = OperationType::None;
+    operation_ = OperationType::kNone;
     return result;
 }
 

--- a/silkworm/node/stagedsync/stages/stage_interhashes.cpp
+++ b/silkworm/node/stagedsync/stages/stage_interhashes.cpp
@@ -37,7 +37,7 @@ using db::etl_mdbx::Collector;
 
 Stage::Result InterHashes::forward(db::RWTxn& txn) {
     Stage::Result ret{Stage::Result::kSuccess};
-    operation_ = OperationType::Forward;
+    operation_ = OperationType::kForward;
 
     try {
         throw_if_stopping();
@@ -48,7 +48,7 @@ Stage::Result InterHashes::forward(db::RWTxn& txn) {
         auto hashstate_stage_progress{db::stages::read_stage_progress(txn, db::stages::kHashStateKey)};
         if (previous_progress == hashstate_stage_progress) {
             // Nothing to process
-            operation_ = OperationType::None;
+            operation_ = OperationType::kNone;
             return Stage::Result::kSuccess;
         }
         if (previous_progress > hashstate_stage_progress) {
@@ -120,7 +120,7 @@ Stage::Result InterHashes::forward(db::RWTxn& txn) {
         ret = Stage::Result::kUnexpectedError;
     }
 
-    operation_ = OperationType::None;
+    operation_ = OperationType::kNone;
     return ret;
 }
 
@@ -130,7 +130,7 @@ Stage::Result InterHashes::unwind(db::RWTxn& txn) {
     if (!sync_context_->unwind_point.has_value()) return ret;
     const BlockNum to{sync_context_->unwind_point.value()};
 
-    operation_ = OperationType::Unwind;
+    operation_ = OperationType::kUnwind;
 
     try {
         throw_if_stopping();
@@ -139,7 +139,7 @@ Stage::Result InterHashes::unwind(db::RWTxn& txn) {
         BlockNum previous_progress{get_progress(txn)};
         if (to >= previous_progress) {
             // Actually nothing to unwind
-            operation_ = OperationType::None;
+            operation_ = OperationType::kNone;
             return Stage::Result::kSuccess;
         }
         const BlockNum segment_width{previous_progress - to};
@@ -199,7 +199,7 @@ Stage::Result InterHashes::unwind(db::RWTxn& txn) {
         ret = Stage::Result::kUnexpectedError;
     }
 
-    operation_ = OperationType::None;
+    operation_ = OperationType::kNone;
     return ret;
 }
 

--- a/silkworm/node/stagedsync/stages/stage_log_index.cpp
+++ b/silkworm/node/stagedsync/stages/stage_log_index.cpp
@@ -58,7 +58,7 @@ namespace {
 
 Stage::Result LogIndex::forward(db::RWTxn& txn) {
     Stage::Result ret{Stage::Result::kSuccess};
-    operation_ = OperationType::Forward;
+    operation_ = OperationType::kForward;
     try {
         throw_if_stopping();
 
@@ -67,7 +67,7 @@ Stage::Result LogIndex::forward(db::RWTxn& txn) {
         const auto target_progress{db::stages::read_stage_progress(txn, db::stages::kExecutionKey)};
         if (previous_progress == target_progress) {
             // Nothing to process
-            operation_ = OperationType::None;
+            operation_ = OperationType::kNone;
             return ret;
         }
         if (previous_progress > target_progress) {
@@ -119,7 +119,7 @@ Stage::Result LogIndex::forward(db::RWTxn& txn) {
         ret = Stage::Result::kUnexpectedError;
     }
 
-    operation_ = OperationType::None;
+    operation_ = OperationType::kNone;
     addresses_collector_.reset();
     topics_collector_.reset();
     return ret;
@@ -131,7 +131,7 @@ Stage::Result LogIndex::unwind(db::RWTxn& txn) {
     if (!sync_context_->unwind_point.has_value()) return ret;
     const BlockNum to{sync_context_->unwind_point.value()};
 
-    operation_ = OperationType::Unwind;
+    operation_ = OperationType::kUnwind;
     try {
         throw_if_stopping();
 
@@ -140,7 +140,7 @@ Stage::Result LogIndex::unwind(db::RWTxn& txn) {
         const auto execution_stage_progress{db::stages::read_stage_progress(txn, db::stages::kExecutionKey)};
         if (previous_progress <= to || execution_stage_progress <= to) {
             // Nothing to process
-            operation_ = OperationType::None;
+            operation_ = OperationType::kNone;
             return ret;
         }
 
@@ -181,25 +181,25 @@ Stage::Result LogIndex::unwind(db::RWTxn& txn) {
 
     addresses_collector_.reset();
     topics_collector_.reset();
-    operation_ = OperationType::None;
+    operation_ = OperationType::kNone;
     return ret;
 }
 
 Stage::Result LogIndex::prune(db::RWTxn& txn) {
     Stage::Result ret{Stage::Result::kSuccess};
-    operation_ = OperationType::Prune;
+    operation_ = OperationType::kPrune;
 
     try {
         throw_if_stopping();
         if (!prune_mode_history_.enabled()) {
-            operation_ = OperationType::None;
+            operation_ = OperationType::kNone;
             return ret;
         }
 
         const auto forward_progress{get_progress(txn)};
         const auto prune_progress{get_prune_progress(txn)};
         if (prune_progress >= forward_progress) {
-            operation_ = OperationType::None;
+            operation_ = OperationType::kNone;
             return ret;
         }
 
@@ -207,7 +207,7 @@ Stage::Result LogIndex::prune(db::RWTxn& txn) {
         // If threshold is zero we don't have anything to prune
         const auto prune_threshold{prune_mode_history_.value_from_head(forward_progress)};
         if (!prune_threshold) {
-            operation_ = OperationType::None;
+            operation_ = OperationType::kNone;
             return ret;
         }
 
@@ -259,7 +259,7 @@ void LogIndex::forward_impl(db::RWTxn& txn, const BlockNum from, const BlockNum 
     const db::MapConfig source_config{db::table::kLogs};
 
     std::unique_lock log_lck(sl_mutex_);
-    operation_ = OperationType::Forward;
+    operation_ = OperationType::kForward;
     loading_ = false;
     topics_collector_ = std::make_unique<Collector>(etl_settings_);
     addresses_collector_ = std::make_unique<Collector>(etl_settings_);
@@ -299,7 +299,7 @@ void LogIndex::unwind_impl(db::RWTxn& txn, BlockNum from, BlockNum to) {
     const db::MapConfig source_config{db::table::kLogs};
 
     std::unique_lock log_lck(sl_mutex_);
-    operation_ = OperationType::Unwind;
+    operation_ = OperationType::kUnwind;
     loading_ = false;
     current_source_ = std::string(source_config.name);
     current_key_.clear();
@@ -458,7 +458,7 @@ void LogIndex::collect_unique_keys_from_logs(db::RWTxn& txn,
 
 void LogIndex::prune_impl(db::RWTxn& txn, BlockNum threshold, const db::MapConfig& target) {
     std::unique_lock log_lck(sl_mutex_);
-    operation_ = OperationType::Prune;
+    operation_ = OperationType::kPrune;
     loading_ = false;
     current_source_ = target.name;
     current_target_ = current_source_;
@@ -483,7 +483,7 @@ std::vector<std::string> LogIndex::get_log_progress() {
         ret.insert(ret.end(), {"db", "waiting ..."});
     } else {
         switch (operation_) {
-            case OperationType::Forward:
+            case OperationType::kForward:
                 if (loading_) {
                     if (current_target_ == db::table::kLogAddressIndex.name) {
                         current_key_ = abridge(addresses_collector_->get_load_key(), kAddressLength);
@@ -497,7 +497,7 @@ std::vector<std::string> LogIndex::get_log_progress() {
                     ret.insert(ret.end(), {"from", current_source_, "to", "etl", "key", current_key_});
                 }
                 break;
-            case OperationType::Unwind:
+            case OperationType::kUnwind:
                 if (index_loader_) {
                     current_key_ = index_loader_->get_current_key();
                     ret.insert(ret.end(), {"from", "etl", "to", current_target_, "key", current_key_});
@@ -505,7 +505,7 @@ std::vector<std::string> LogIndex::get_log_progress() {
                     ret.insert(ret.end(), {"from", current_source_, "to", "etl", "key", current_key_});
                 }
                 break;
-            case OperationType::Prune:
+            case OperationType::kPrune:
                 if (index_loader_) {
                     current_key_ = index_loader_->get_current_key();
                     ret.insert(ret.end(), {"to", current_target_, "key", current_key_});


### PR DESCRIPTION
The `silkworm/db` module was excluded due to omission by the `.clang-tidy` config HeaderFilterRegex. Including it opened a can of worms 🥫 