### PR TITLE
node: fix Execution stage unwind after invalid block

### DIFF
--- a/silkworm/node/stagedsync/stages/stage_execution.cpp
+++ b/silkworm/node/stagedsync/stages/stage_execution.cpp
@@ -247,7 +247,6 @@ Stage::Result Execution::execute_batch(db::RWTxn& txn, BlockNum max_block_num, A
                         buffer.insert_receipts(block_num_, receipts);
                     }
                     buffer.write_to_db();
-                    prefetched_blocks_.clear();
 
                     // Notify sync_loop we need to unwind
                     sync_context_->unwind_point.emplace(block_num_ - 1u);
@@ -258,6 +257,8 @@ Stage::Result Execution::execute_batch(db::RWTxn& txn, BlockNum max_block_num, A
                                  {"block", std::to_string(block_num_),
                                   "hash", to_hex(block.header.hash().bytes, true),
                                   "error", std::string(magic_enum::enum_name<ValidationResult>(res))});
+
+                    prefetched_blocks_.clear();  // Must stay here to keep `block` reference valid
                     return Result::kInvalidBlock;
                 }
 


### PR DESCRIPTION
Fixes #2359

This PR restores in stage Execution the invalid block handling logic removed in #1511

Also fixes the invalid block reference lifetime issue causing an incorrect block hash to be stored as bad block hash in `SyncContext` and displayed into the warning log, as described in #2358 