### PR TITLE
node: refactor NodeSettings.asio_context

### DIFF
--- a/cmd/dev/backend_kv_server.cpp
+++ b/cmd/dev/backend_kv_server.cpp
@@ -141,7 +141,7 @@ std::shared_ptr<silkworm::sentry::api::SentryClient> make_sentry_client(
             // wrap remote client in a session client
             auto session_sentry_client = std::make_shared<silkworm::sentry::SessionSentryClient>(
                 remote_sentry_client,
-                silkworm::sentry::eth::StatusDataProvider::to_factory_function(std::move(eth_status_data_provider)));
+                silkworm::sentry::eth::StatusDataProvider::to_factory_function(eth_status_data_provider));
             clients.push_back(session_sentry_client);
         }
 

--- a/silkworm/capi/fork_validator.cpp
+++ b/silkworm/capi/fork_validator.cpp
@@ -112,7 +112,7 @@ SILKWORM_EXPORT int silkworm_start_fork_validator(SilkwormHandle handle, MDBX_en
     silkworm::db::EnvUnmanaged unmanaged_env{mdbx_env};
     silkworm::db::RWAccess rw_access{unmanaged_env};
     handle->execution_engine = std::make_unique<silkworm::stagedsync::ExecutionEngine>(
-        boost::asio::io_context().get_executor(),  // TODO: fix
+        /* executor = */ std::nullopt,  // ExecutionEngine manages an internal io_context
         handle->node_settings,
         /* log_timer_factory = */ std::nullopt,
         make_bodies_stage_factory(*handle->node_settings.chain_config),

--- a/silkworm/capi/fork_validator.cpp
+++ b/silkworm/capi/fork_validator.cpp
@@ -112,8 +112,9 @@ SILKWORM_EXPORT int silkworm_start_fork_validator(SilkwormHandle handle, MDBX_en
     silkworm::db::EnvUnmanaged unmanaged_env{mdbx_env};
     silkworm::db::RWAccess rw_access{unmanaged_env};
     handle->execution_engine = std::make_unique<silkworm::stagedsync::ExecutionEngine>(
-        handle->node_settings.asio_context,
+        boost::asio::io_context().get_executor(),  // TODO: fix
         handle->node_settings,
+        /* log_timer_factory = */ std::nullopt,
         make_bodies_stage_factory(*handle->node_settings.chain_config),
         rw_access);
 

--- a/silkworm/node/common/node_settings.hpp
+++ b/silkworm/node/common/node_settings.hpp
@@ -21,8 +21,6 @@
 #include <string>
 #include <vector>
 
-#include <boost/asio/io_context.hpp>
-
 #include <silkworm/core/chain/config.hpp>
 #include <silkworm/core/common/base.hpp>
 #include <silkworm/db/etl/collector_settings.hpp>
@@ -35,7 +33,6 @@ namespace silkworm {
 
 struct NodeSettings {
     ApplicationInfo build_info;                            // Application build info (human-readable)
-    boost::asio::io_context asio_context;                  // Async context (e.g. for timers)
     std::unique_ptr<DataDirectory> data_directory;         // Pointer to data folder
     db::EnvConfig chaindata_env_config{};                  // Chaindata db config
     uint64_t network_id{kMainnetConfig.chain_id};          // Network/Chain id

--- a/silkworm/node/execution/active_direct_service_test.cpp
+++ b/silkworm/node/execution/active_direct_service_test.cpp
@@ -52,7 +52,7 @@ struct ActiveDirectServiceTest : public TaskRunner {
           dba{tmp_chaindata.env()} {
         tmp_chaindata.add_genesis_data();
         tmp_chaindata.commit_txn();
-        mock_execution_engine = std::make_unique<NiceMock<MockExecutionEngine>>(context(), settings, dba);
+        mock_execution_engine = std::make_unique<NiceMock<MockExecutionEngine>>(executor(), settings, dba);
         direct_service = std::make_unique<ActiveDirectServiceForTest>(*mock_execution_engine, execution_context);
         execution_context_thread = std::thread{[this]() {
             direct_service->execution_loop();

--- a/silkworm/node/execution/direct_service_test.cpp
+++ b/silkworm/node/execution/direct_service_test.cpp
@@ -44,7 +44,7 @@ struct DirectServiceTest : public TaskRunner {
           dba{tmp_chaindata.env()} {
         tmp_chaindata.add_genesis_data();
         tmp_chaindata.commit_txn();
-        mock_execution_engine = std::make_unique<MockExecutionEngine>(context(), settings, dba);
+        mock_execution_engine = std::make_unique<MockExecutionEngine>(executor(), settings, dba);
         direct_service = std::make_unique<DirectService>(*mock_execution_engine);
     }
 

--- a/silkworm/node/execution/header_chain_plus_exec_test.cpp
+++ b/silkworm/node/execution/header_chain_plus_exec_test.cpp
@@ -91,8 +91,9 @@ TEST_CASE("Headers receiving and saving") {
 
     // creating the ExecutionEngine
     ExecutionEngineForTest exec_engine{
-        runner.context(),
+        runner.executor(),
         node_settings,
+        /* log_timer_factory = */ std::nullopt,
         std::move(bodies_stage_factory),
         db_access,
     };

--- a/silkworm/node/node.cpp
+++ b/silkworm/node/node.cpp
@@ -65,7 +65,6 @@ class NodeImpl final {
   private:
     Task<void> run_execution_server();
     Task<void> run_backend_kv_grpc_server();
-    Task<void> start_execution_log_timer();
     Task<void> embedded_sentry_run_if_needed();
 
     Settings& settings_;
@@ -115,6 +114,17 @@ static chainsync::EngineRpcSettings make_sync_engine_rpc_settings(
     };
 }
 
+static stagedsync::TimerFactory make_log_timer_factory(
+    const boost::asio::any_io_executor& executor,
+    uint32_t sync_loop_log_interval_seconds) {
+    return [=](std::function<bool()> callback) {
+        return std::make_shared<Timer>(
+            executor,
+            sync_loop_log_interval_seconds * 1'000,
+            std::move(callback));
+    };
+}
+
 static stagedsync::BodiesStageFactory make_bodies_stage_factory(
     const ChainConfig& chain_config,
     const NodeImpl& node) {
@@ -144,8 +154,9 @@ NodeImpl::NodeImpl(
       chain_config_{*settings_.node_settings.chain_config},
       chaindata_env_{std::move(chaindata_env)},
       execution_engine_{
-          execution_context_,
+          execution_context_.get_executor(),
           settings_.node_settings,
+          make_log_timer_factory(context_pool.any_executor(), settings_.node_settings.sync_loop_log_interval_seconds),
           make_bodies_stage_factory(chain_config_, *this),
           db::RWAccess{chaindata_env_},
       },
@@ -197,7 +208,6 @@ Task<void> NodeImpl::run_tasks() {
     co_await (
         run_execution_server() &&
         resource_usage_log_.run() &&
-        start_execution_log_timer() &&
         chain_sync_.async_run() &&
         run_backend_kv_grpc_server());
 }
@@ -220,22 +230,6 @@ Task<void> NodeImpl::run_backend_kv_grpc_server() {
         backend_kv_rpc_server_->shutdown();
     };
     co_await concurrency::async_thread(std::move(run), std::move(stop), "bekv-server");
-}
-
-Task<void> NodeImpl::start_execution_log_timer() {
-    // Run Asio context in settings for execution timers // TODO(canepat) we need a better solution
-    auto& asio_context = settings_.node_settings.asio_context;
-    using asio_guard_type = boost::asio::executor_work_guard<boost::asio::io_context::executor_type>;
-    auto asio_guard = std::make_unique<asio_guard_type>(asio_context.get_executor());
-
-    auto run = [&asio_context] {
-        log::set_thread_name("ctx-log-tmr");
-        log::Trace("Asio Timers", {"state", "started"});
-        asio_context.run();
-        log::Trace("Asio Timers", {"state", "stopped"});
-    };
-    auto stop = [&asio_guard] { asio_guard.reset(); };
-    co_await silkworm::concurrency::async_thread(std::move(run), std::move(stop), "ctx-log-tmr");
 }
 
 Task<void> NodeImpl::embedded_sentry_run_if_needed() {

--- a/silkworm/node/stagedsync/execution_engine.hpp
+++ b/silkworm/node/stagedsync/execution_engine.hpp
@@ -18,6 +18,8 @@
 
 #include <atomic>
 #include <concepts>
+#include <memory>
+#include <optional>
 #include <set>
 #include <variant>
 #include <vector>
@@ -31,6 +33,7 @@
 #include <silkworm/db/stage.hpp>
 #include <silkworm/db/stage_scheduler.hpp>
 #include <silkworm/execution/api/execution_engine.hpp>
+#include <silkworm/infra/concurrency/context_pool.hpp>
 #include <silkworm/node/stagedsync/execution_pipeline.hpp>
 
 #include "forks/extending_fork.hpp"
@@ -55,7 +58,7 @@ namespace silkworm::stagedsync {
 class ExecutionEngine : public execution::api::ExecutionEngine, public Stoppable {
   public:
     ExecutionEngine(
-        boost::asio::any_io_executor executor,
+        std::optional<boost::asio::any_io_executor> executor,
         NodeSettings& ns,
         std::optional<TimerFactory> log_timer_factory,
         BodiesStageFactory bodies_stage_factory,
@@ -108,6 +111,7 @@ class ExecutionEngine : public execution::api::ExecutionEngine, public Stoppable
     std::optional<ForkingPath> find_forking_point(const BlockHeader& header) const;
     void discard_all_forks();
 
+    std::unique_ptr<concurrency::ContextPool<>> context_pool_;
     boost::asio::any_io_executor executor_;
     NodeSettings& node_settings_;
 

--- a/silkworm/node/stagedsync/execution_engine.hpp
+++ b/silkworm/node/stagedsync/execution_engine.hpp
@@ -24,7 +24,7 @@
 
 #include <silkworm/infra/concurrency/task.hpp>
 
-#include <boost/asio/io_context.hpp>
+#include <boost/asio/any_io_executor.hpp>
 
 #include <silkworm/core/common/lru_cache.hpp>
 #include <silkworm/core/types/block.hpp>
@@ -36,10 +36,9 @@
 #include "forks/extending_fork.hpp"
 #include "forks/main_chain.hpp"
 #include "stages/stage_bodies_factory.hpp"
+#include "timer_factory.hpp"
 
 namespace silkworm::stagedsync {
-
-namespace asio = boost::asio;
 
 /**
  * ExecutionEngine is the main component of the staged sync.
@@ -56,10 +55,11 @@ namespace asio = boost::asio;
 class ExecutionEngine : public execution::api::ExecutionEngine, public Stoppable {
   public:
     ExecutionEngine(
-        asio::io_context&,
-        NodeSettings&,
+        boost::asio::any_io_executor executor,
+        NodeSettings& ns,
+        std::optional<TimerFactory> log_timer_factory,
         BodiesStageFactory bodies_stage_factory,
-        db::RWAccess);
+        db::RWAccess dba);
     ~ExecutionEngine() override = default;
 
     // needed to circumvent mdbx threading model limitations
@@ -108,7 +108,7 @@ class ExecutionEngine : public execution::api::ExecutionEngine, public Stoppable
     std::optional<ForkingPath> find_forking_point(const BlockHeader& header) const;
     void discard_all_forks();
 
-    asio::io_context& io_context_;
+    boost::asio::any_io_executor executor_;
     NodeSettings& node_settings_;
 
     MainChain main_chain_;

--- a/silkworm/node/stagedsync/execution_engine_test.cpp
+++ b/silkworm/node/stagedsync/execution_engine_test.cpp
@@ -75,8 +75,9 @@ TEST_CASE("ExecutionEngine Integration Test", "[node][execution][execution_engin
     db::RWAccess db_access{db_context.mdbx_env()};
 
     ExecutionEngineForTest exec_engine{
-        runner.context(),
+        runner.executor(),
         node_settings,
+        /* log_timer_factory = */ std::nullopt,
         make_bodies_stage_factory(*node_settings.chain_config),
         db_access,
     };
@@ -822,8 +823,9 @@ TEST_CASE("ExecutionEngine") {
     NodeSettings node_settings = node::test_util::make_node_settings_from_temp_chain_data(context);
     db::RWAccess db_access{context.env()};
     ExecutionEngineForTest exec_engine{
-        runner.context(),
+        runner.executor(),
         node_settings,
+        /* log_timer_factory = */ std::nullopt,
         make_bodies_stage_factory(*node_settings.chain_config),
         db_access,
     };

--- a/silkworm/node/stagedsync/execution_pipeline.cpp
+++ b/silkworm/node/stagedsync/execution_pipeline.cpp
@@ -47,8 +47,10 @@ static const std::chrono::milliseconds kStageDurationThresholdForLog{0};
 
 ExecutionPipeline::ExecutionPipeline(
     silkworm::NodeSettings* node_settings,
+    std::optional<TimerFactory> log_timer_factory,
     BodiesStageFactory bodies_stage_factory)
     : node_settings_{node_settings},
+      log_timer_factory_{std::move(log_timer_factory)},
       bodies_stage_factory_{std::move(bodies_stage_factory)},
       sync_context_{std::make_unique<SyncContext>()} {
     load_stages();
@@ -206,7 +208,9 @@ Stage::Result ExecutionPipeline::forward(db::RWTxn& cycle_txn, BlockNum target_h
                 break;
             }
 
-            log_timer->reset();  // Resets the interval for next log line from now
+            if (log_timer) {
+                log_timer->reset();  // Resets the interval for next log line from now
+            }
 
             // forward
             const auto stage_result = current_stage_->second->forward(cycle_txn);
@@ -273,7 +277,10 @@ Stage::Result ExecutionPipeline::unwind(db::RWTxn& cycle_txn, BlockNum unwind_po
             }
             ++current_stage_number_;
             current_stage_->second->set_log_prefix(get_log_prefix());
-            log_timer->reset();  // Resets the interval for next log line from now
+
+            if (log_timer) {
+                log_timer->reset();  // Resets the interval for next log line from now
+            }
 
             // Do unwind on current stage
             const auto stage_result = current_stage_->second->unwind(cycle_txn);
@@ -332,7 +339,10 @@ Stage::Result ExecutionPipeline::prune(db::RWTxn& cycle_txn) {
             ++current_stage_number_;
             current_stage_->second->set_log_prefix(get_log_prefix());
 
-            log_timer->reset();  // Resets the interval for next log line from now
+            if (log_timer) {
+                log_timer->reset();  // Resets the interval for next log line from now
+            }
+
             const auto stage_result{current_stage_->second->prune(cycle_txn)};
             if (stage_result != Stage::Result::kSuccess) {
                 log::Error(get_log_prefix(), {"op", "Prune", "returned",
@@ -369,11 +379,10 @@ std::string ExecutionPipeline::get_log_prefix() const {
 }
 
 std::shared_ptr<Timer> ExecutionPipeline::make_log_timer() {
-    return std::make_shared<Timer>(
-        this->node_settings_->asio_context.get_executor(),
-        this->node_settings_->sync_loop_log_interval_seconds * 1'000,
-        [this]() { return log_timer_expired(); },
-        /*auto_start=*/true);
+    if (log_timer_factory_) {
+        return log_timer_factory_.value()([this]() { return log_timer_expired(); });
+    }
+    return {};
 }
 
 bool ExecutionPipeline::log_timer_expired() {

--- a/silkworm/node/stagedsync/execution_pipeline.hpp
+++ b/silkworm/node/stagedsync/execution_pipeline.hpp
@@ -19,7 +19,10 @@
 #include <atomic>
 #include <map>
 #include <memory>
+#include <optional>
 #include <vector>
+
+#include <boost/asio/any_io_executor.hpp>
 
 #include <silkworm/core/types/hash.hpp>
 #include <silkworm/db/stage.hpp>
@@ -28,6 +31,7 @@
 #include <silkworm/node/common/node_settings.hpp>
 
 #include "stages/stage_bodies_factory.hpp"
+#include "timer_factory.hpp"
 
 namespace silkworm::stagedsync {
 
@@ -35,6 +39,7 @@ class ExecutionPipeline : public Stoppable {
   public:
     explicit ExecutionPipeline(
         NodeSettings* node_settings,
+        std::optional<TimerFactory> log_timer_factory,
         BodiesStageFactory bodies_stage_factory);
     ~ExecutionPipeline() override = default;
 
@@ -53,6 +58,7 @@ class ExecutionPipeline : public Stoppable {
 
   private:
     silkworm::NodeSettings* node_settings_;
+    std::optional<TimerFactory> log_timer_factory_;
     BodiesStageFactory bodies_stage_factory_;
     std::unique_ptr<SyncContext> sync_context_;  // context shared across stages
 

--- a/silkworm/node/stagedsync/forks/extending_fork.hpp
+++ b/silkworm/node/stagedsync/forks/extending_fork.hpp
@@ -18,6 +18,7 @@
 
 #include <silkworm/infra/concurrency/task.hpp>
 
+#include <boost/asio/any_io_executor.hpp>
 #include <boost/asio/io_context.hpp>
 
 #include <silkworm/db/mdbx/memory_mutation.hpp>
@@ -35,7 +36,10 @@ namespace silkworm::stagedsync {
 
 class ExtendingFork {
   public:
-    explicit ExtendingFork(BlockId forking_point, MainChain&, boost::asio::io_context&);
+    explicit ExtendingFork(
+        BlockId forking_point,
+        MainChain& main_chain,
+        boost::asio::any_io_executor external_executor);
     ExtendingFork(const ExtendingFork&) = delete;
     ExtendingFork(ExtendingFork&& orig) = delete;  // not movable, it schedules methods execution in another thread
     ~ExtendingFork();
@@ -67,7 +71,7 @@ class ExtendingFork {
 
     BlockId forking_point_;                              // starting point
     MainChain& main_chain_;                              // main chain
-    boost::asio::io_context& io_context_;                // for io
+    boost::asio::any_io_executor external_executor_;     // for promises
     std::unique_ptr<Fork> fork_;                         // for domain logic
     std::unique_ptr<boost::asio::io_context> executor_;  // for pipeline execution
     std::thread thread_;                                 // for executor

--- a/silkworm/node/stagedsync/forks/fork.cpp
+++ b/silkworm/node/stagedsync/forks/fork.cpp
@@ -49,13 +49,18 @@ static db::MemoryOverlay create_memory_db(const std::filesystem::path& base_path
 Fork::Fork(
     BlockId forking_point,
     db::ROTxnManaged&& main_chain_tx,
+    std::optional<TimerFactory> log_timer_factory,
     BodiesStageFactory bodies_stage_factory,
     NodeSettings& ns)
     : main_tx_{std::move(main_chain_tx)},
       memory_db_{create_memory_db(ns.data_directory->forks().path(), main_tx_)},
       memory_tx_{memory_db_},
       data_model_{memory_tx_},
-      pipeline_{&ns, std::move(bodies_stage_factory)},
+      pipeline_{
+          &ns,
+          std::move(log_timer_factory),
+          std::move(bodies_stage_factory),
+      },
       canonical_chain_(memory_tx_),
       current_head_{forking_point}  // actual head
 {

--- a/silkworm/node/stagedsync/forks/fork.hpp
+++ b/silkworm/node/stagedsync/forks/fork.hpp
@@ -18,6 +18,7 @@
 
 #include <atomic>
 #include <concepts>
+#include <optional>
 #include <set>
 #include <variant>
 #include <vector>
@@ -28,6 +29,7 @@
 #include <silkworm/node/stagedsync/execution_pipeline.hpp>
 
 #include "../stages/stage_bodies_factory.hpp"
+#include "../timer_factory.hpp"
 #include "canonical_chain.hpp"
 
 namespace silkworm::stagedsync {
@@ -39,6 +41,7 @@ class Fork {
     explicit Fork(
         BlockId forking_point,
         db::ROTxnManaged&& main_chain_tx,
+        std::optional<TimerFactory> log_timer_factory,
         BodiesStageFactory bodies_stage_factory,
         NodeSettings&);
     Fork(const Fork&) = delete;

--- a/silkworm/node/stagedsync/forks/fork_test.cpp
+++ b/silkworm/node/stagedsync/forks/fork_test.cpp
@@ -72,8 +72,9 @@ TEST_CASE("Fork") {
     };
 
     MainChain main_chain{
-        io,
+        io.get_executor(),
         node_settings,
+        /* log_timer_factory = */ std::nullopt,
         std::move(bodies_stage_factory),
         db_access,
     };
@@ -129,6 +130,7 @@ TEST_CASE("Fork") {
                 ForkForTest fork{
                     forking_point,
                     db::ROTxnManaged(main_chain.tx().db()),  // this need to be on a different thread than main_chain
+                    /* log_timer_factory = */ std::nullopt,
                     main_chain.bodies_stage_factory(),
                     node_settings,
                 };

--- a/silkworm/node/stagedsync/forks/main_chain_test.cpp
+++ b/silkworm/node/stagedsync/forks/main_chain_test.cpp
@@ -79,8 +79,9 @@ TEST_CASE("MainChain transaction handling") {
             node_settings.keep_db_txn_open = keep_db_txn_open;
             db::RWAccess db_access{context.env()};
             MainChainForTest main_chain{
-                io,
+                io.get_executor(),
                 node_settings,
+                /* log_timer_factory = */ std::nullopt,
                 make_bodies_stage_factory(*node_settings.chain_config),
                 db_access,
             };
@@ -174,8 +175,9 @@ TEST_CASE("MainChain") {
     NodeSettings node_settings = node::test_util::make_node_settings_from_temp_chain_data(context);
     db::RWAccess db_access{context.env()};
     MainChainForTest main_chain{
-        io,
+        io.get_executor(),
         node_settings,
+        /* log_timer_factory = */ std::nullopt,
         make_bodies_stage_factory(*node_settings.chain_config),
         db_access,
     };
@@ -464,8 +466,9 @@ TEST_CASE("MainChain") {
 
         // opening another main chain (-> application start up)
         MainChainForTest main_chain2{
-            io,
+            io.get_executor(),
             node_settings,
+            /* log_timer_factory = */ std::nullopt,
             main_chain.bodies_stage_factory(),
             db_access,
         };

--- a/silkworm/node/stagedsync/timer_factory.hpp
+++ b/silkworm/node/stagedsync/timer_factory.hpp
@@ -1,0 +1,28 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <functional>
+#include <memory>
+
+#include <silkworm/infra/common/timer.hpp>
+
+namespace silkworm::stagedsync {
+
+using TimerFactory = std::function<std::shared_ptr<Timer>(std::function<bool()> callback)>;
+
+}  // namespace silkworm::stagedsync

--- a/silkworm/node/test_util/mock_execution_engine.hpp
+++ b/silkworm/node/test_util/mock_execution_engine.hpp
@@ -40,8 +40,8 @@ class MockExecutionEngine : public stagedsync::ExecutionEngine {
         };
     };
 
-    MockExecutionEngine(boost::asio::io_context& ioc, NodeSettings& ns, db::RWAccess dba)
-        : ExecutionEngine(ioc, ns, empty_bodies_stage_factory(), std::move(dba)) {}
+    MockExecutionEngine(boost::asio::any_io_executor executor, NodeSettings& ns, db::RWAccess dba)
+        : ExecutionEngine(std::move(executor), ns, /* log_timer_factory = */ std::nullopt, empty_bodies_stage_factory(), std::move(dba)) {}
     ~MockExecutionEngine() override = default;
 
     MOCK_METHOD((void), open, (), (override));


### PR DESCRIPTION
* pass TimerFactory instead of using NodeSettings.asio_context in ExecutionPipeline
* pass asio::any_io_executor via constructor instead of using io_context
* C API `silkworm_start_fork_validator`: previously it was passing a dead NodeSettings.asio_context, now ExecutionEngine can manage an internal executor via a private context pool
* extra: rename `start_*` to `run_*` in NodeImpl
