### PR TITLE
sentry: move make_client_id to ApplicationInfo

### DIFF
--- a/cmd/sentry.cpp
+++ b/cmd/sentry.cpp
@@ -23,6 +23,7 @@
 #include <grpcpp/grpcpp.h>
 
 #include <silkworm/buildinfo.h>
+#include <silkworm/infra/common/application_info.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/concurrency/awaitable_wait_for_one.hpp>
 #include <silkworm/infra/grpc/client/client_context_pool.hpp>
@@ -41,7 +42,7 @@ Settings sentry_parse_cli_settings(int argc, char* argv[]) {
     CLI::App cli{"Sentry - P2P proxy"};
 
     Settings settings;
-    settings.client_id = Sentry::make_client_id(*silkworm_get_buildinfo());
+    settings.client_id = make_client_id_from_build_info(*silkworm_get_buildinfo());
 
     add_logging_options(cli, settings.log_settings);
     add_option_data_dir(cli, settings.data_dir_path);

--- a/cmd/silkworm.cpp
+++ b/cmd/silkworm.cpp
@@ -34,7 +34,6 @@
 #include <silkworm/infra/concurrency/awaitable_wait_for_one.hpp>
 #include <silkworm/infra/grpc/client/client_context_pool.hpp>
 #include <silkworm/node/node.hpp>
-#include <silkworm/sentry/sentry.hpp>
 
 #include "common/common.hpp"
 #include "common/db_checklist.hpp"
@@ -195,7 +194,7 @@ void parse_silkworm_command_line(CLI::App& cli, int argc, char* argv[], node::Se
     snapshot_settings.bittorrent_settings.repository_path = snapshot_settings.repository_dir;
 
     // sentry::Settings
-    settings.sentry_settings.client_id = sentry::Sentry::make_client_id(*build_info);
+    settings.sentry_settings.client_id = node_settings.build_info.client_id;
     settings.sentry_settings.data_dir_path = node_settings.data_directory->path();
     settings.sentry_settings.network_id = node_settings.network_id;
 }

--- a/silkworm/infra/common/application_info.cpp
+++ b/silkworm/infra/common/application_info.cpp
@@ -21,7 +21,8 @@
 namespace silkworm {
 
 std::string get_node_name_from_build_info(const buildinfo* info) {
-    std::string node_name{"silkworm/"};
+    std::string node_name = info->project_name;
+    node_name.append("/");
     node_name.append(info->git_branch);
     node_name.append(info->project_version);
     node_name.append("/");
@@ -35,6 +36,13 @@ std::string get_node_name_from_build_info(const buildinfo* info) {
     node_name.append("-");
     node_name.append(info->compiler_version);
     return node_name;
+}
+
+std::string make_client_id_from_build_info(const buildinfo& info) {
+    return std::string(info.project_name) +
+           "/v" + info.project_version +
+           "/" + info.system_name + "-" + info.system_processor +
+           "/" + info.compiler_id + "-" + info.compiler_version;
 }
 
 std::string get_description_from_build_info(const buildinfo* info) {
@@ -60,6 +68,7 @@ ApplicationInfo make_application_info(const buildinfo* info) {
         .commit_hash = info->git_commit_hash,
         .build_description = get_description_from_build_info(info),
         .node_name = get_node_name_from_build_info(info),
+        .client_id = make_client_id_from_build_info(*info),
     };
 }
 

--- a/silkworm/infra/common/application_info.hpp
+++ b/silkworm/infra/common/application_info.hpp
@@ -30,10 +30,14 @@ struct ApplicationInfo {
     std::string commit_hash;        // Extracted from version control system
     std::string build_description;  // Containing compiler and platform
     std::string node_name;          // Complete node name with identifier and build info
+    std::string client_id;          // P2P RLPx clientId
 };
 
 //! Assemble the complete node name using the Cable build information
 std::string get_node_name_from_build_info(const buildinfo* info);
+
+//! P2P RLPx clientId from the Cable build information
+std::string make_client_id_from_build_info(const buildinfo& info);
 
 //! Assemble the build description using the Cable build information
 std::string get_description_from_build_info(const buildinfo* info);

--- a/silkworm/sentry/sentry.cpp
+++ b/silkworm/sentry/sentry.cpp
@@ -313,13 +313,6 @@ Task<void> SentryImpl::run_grpc_server() {
     }
 }
 
-std::string Sentry::make_client_id(const buildinfo& info) {
-    return std::string(info.project_name) +
-           "/v" + info.project_version +
-           "/" + info.system_name + "-" + info.system_processor +
-           "/" + info.compiler_id + "-" + info.compiler_version;
-}
-
 std::string SentryImpl::client_id() const {
     return settings_.client_id;
 }

--- a/silkworm/sentry/sentry.hpp
+++ b/silkworm/sentry/sentry.hpp
@@ -47,8 +47,6 @@ class Sentry final : public api::SentryClient {
     void on_disconnect(std::function<Task<void>()> callback) override;
     Task<void> reconnect() override;
 
-    static std::string make_client_id(const buildinfo& info);
-
   private:
     std::unique_ptr<SentryImpl> p_impl_;
 };


### PR DESCRIPTION
The logic is close to get_node_name_from_build_info