### PR TITLE
node: exec_api_address setting

### DIFF
--- a/cmd/common/node_options.cpp
+++ b/cmd/common/node_options.cpp
@@ -70,6 +70,9 @@ void add_node_options(CLI::App& cli, NodeSettings& settings) {
 
     add_option_remote_sentry_addresses(cli, settings.remote_sentry_addresses, /*is_required=*/false);
 
+    cli.add_option("--exec.api.addr", settings.exec_api_address)
+        ->description("Execution API GRPC server bind address (IP:port) for connecting an external chain sync client");
+
     // Chain options
     add_option_chain(cli, settings.network_id);
 }

--- a/silkworm/node/common/node_settings.hpp
+++ b/silkworm/node/common/node_settings.hpp
@@ -47,6 +47,7 @@ struct NodeSettings {
     uint32_t sync_loop_log_interval_seconds{30};           // Interval for sync loop to emit logs
     bool parallel_fork_tracking_enabled{false};            // Whether to track multiple parallel forks at head
     bool keep_db_txn_open{true};                           // Whether to keep db transaction open between requests
+    std::optional<std::string> exec_api_address;           // Execution API GRPC server bind address (IP:port)
 
     db::etl::CollectorSettings etl() const {
         return {data_directory->temp().path(), etl_buffer_size};

--- a/silkworm/node/settings.hpp
+++ b/silkworm/node/settings.hpp
@@ -34,7 +34,6 @@ struct Settings {
     sentry::Settings sentry_settings;               // Configuration for Sentry client + embedded server
     rpc::ServerSettings server_settings;            // Configuration for the gRPC server
     snapshots::SnapshotSettings snapshot_settings;  // Configuration for the database snapshots
-    bool execution_server_enabled{false};
 };
 
 }  // namespace silkworm::node


### PR DESCRIPTION
Add an option to control if execution API GRPC server is running. It is disabled by default and chain sync uses an internal execution service with a direct client connection. When enabled, a GRPC server starts, and chain sync must be run as a separate process and connect to it. Note: internal execution service runs in both cases.