### PR TITLE
db, rpcdaemon: flag to support E3 data storage

### DIFF
--- a/cmd/common/rpcdaemon_options.cpp
+++ b/cmd/common/rpcdaemon_options.cpp
@@ -136,12 +136,16 @@ void add_rpcdaemon_options(CLI::App& cli, silkworm::rpc::DaemonSettings& setting
         ->description("Enable WebSocket protocol for Execution Layer and Engine JSON RPC API, same port as HTTP(S)")
         ->capture_default_str();
 
-    cli.add_flag("--ws-compression", settings.ws_compression)
+    cli.add_flag("--ws.compression", settings.ws_compression)
         ->description("Enable compression on WebSocket protocol for Execution Layer and Engine JSON RPC API")
         ->capture_default_str();
 
-    cli.add_flag("--http-compression", settings.http_compression)
+    cli.add_flag("--http.compression", settings.http_compression)
         ->description("Enable compression on HTTP protocol for Execution Layer and Engine JSON RPC API")
+        ->capture_default_str();
+
+    cli.add_flag("--erigon3", settings.use_erigon3_data_format)
+        ->description("Enable usage of Erigon3 data storage model")
         ->capture_default_str();
 }
 

--- a/silkworm/db/state/version.cpp
+++ b/silkworm/db/state/version.cpp
@@ -16,53 +16,17 @@
 
 #include "version.hpp"
 
-#include <mutex>
-#include <string>
-
-#include <silkworm/core/common/bytes_to_string.hpp>
-#include <silkworm/infra/common/log.hpp>
-#include <silkworm/infra/concurrency/sleep.hpp>
-#include <silkworm/infra/grpc/client/reconnect.hpp>
-
-#include "../tables.hpp"
-
 namespace silkworm::db::state {
 
-static std::once_flag erigon_data_format_flag;
+//! Flag indicating if version of Erigon data format for state is V3 or not
+static bool data_format_v3{false};
 
-//! Version of Erigon data format for state
-static std::string erigon_data_format_version;
-
-//! String key in DbInfo table identifying the Erigon version
-constexpr auto kErigonVersionFinished{"ErigonVersionFinished"};
-
-Task<void> set_data_format(kv::api::Client& kv_client) {
-    const auto kv_service = kv_client.service();
-    bool warning_emitted{false};
-    while (true) {
-        try {
-            const auto tx = co_await kv_service->begin_transaction();
-            const auto version_bytes = co_await tx->get_one(table::kDatabaseInfoName, string_to_bytes(kErigonVersionFinished));
-            std::call_once(erigon_data_format_flag, [&]() {
-                erigon_data_format_version = bytes_to_string(version_bytes);
-                SILK_INFO << "Erigon data format version: " << (is_data_format_v3() ? "v3" : "v2")
-                          << (erigon_data_format_version.empty() ? "" : " [" + erigon_data_format_version + "]");
-            });
-            co_await tx->close();
-            SILK_TRACE << "Erigon data format: " << (is_data_format_v3() ? "v3" : "v2");
-            break;
-        } catch (const boost::system::system_error& se) {
-            if (!warning_emitted) {
-                SILK_WARN << "Cannot retrieve Erigon data format: " << se.what();
-                warning_emitted = true;
-            }
-        }
-        co_await sleep(std::chrono::milliseconds(rpc::kDefaultMinBackoffReconnectTimeout));
-    }
+void set_data_format_v3(bool is_data_format_v3) {
+    data_format_v3 = is_data_format_v3;
 }
 
 bool is_data_format_v3() {
-    return erigon_data_format_version.starts_with("3");
+    return data_format_v3;
 }
 
 }  // namespace silkworm::db::state

--- a/silkworm/db/state/version.hpp
+++ b/silkworm/db/state/version.hpp
@@ -16,14 +16,9 @@
 
 #pragma once
 
-#include <silkworm/infra/concurrency/task.hpp>
-
-#include <silkworm/db/kv/api/client.hpp>
-#include <silkworm/db/kv/api/transaction.hpp>
-
 namespace silkworm::db::state {
 
-Task<void> set_data_format(kv::api::Client& kv_client);
+void set_data_format_v3(bool is_data_format_v3);
 
 bool is_data_format_v3();
 

--- a/silkworm/rpc/daemon.hpp
+++ b/silkworm/rpc/daemon.hpp
@@ -69,7 +69,6 @@ class Daemon {
     void add_private_services();
     void add_shared_services();
     std::unique_ptr<db::kv::api::Client> make_kv_client(rpc::ClientContext& context);
-    void schedule_data_format_retrieval();
 
     //! The RPC daemon configuration settings.
     DaemonSettings settings_;

--- a/silkworm/rpc/settings.hpp
+++ b/silkworm/rpc/settings.hpp
@@ -49,6 +49,7 @@ struct DaemonSettings {
     bool use_websocket{false};
     bool ws_compression{false};
     bool http_compression{true};
+    bool use_erigon3_data_format{false};
 };
 
 }  // namespace silkworm::rpc


### PR DESCRIPTION
This PR introduces a new command-line flag `--erigon3` in standalone `rpcdaemon` to indicate that Erigon3 data storage is expected.

The existing automatic mechanism of retrieving the data storage version from Erigon database has been removed because dealing with corner cases (e.g. timeout, periodic retries in case of shutdown and restart...) seems too much effort.

*Extras*
rename other two command-line options for naming coherency