### PR TITLE
tests: disable merge corpus option for fuzzer

### DIFF
--- a/.github/workflows/rpc-fuzzer-tests.yml
+++ b/.github/workflows/rpc-fuzzer-tests.yml
@@ -66,7 +66,7 @@ jobs:
         working-directory: ${{runner.workspace}}/silkworm/build/cmd/test
         run: |
           # Single thread execution
-          ./rpcdaemon_fuzzer_test -max_total_time=86300 -detect_leaks=0 -rss_limit_mb=32768 -merge=1 $RPC_PAST_TEST_DIR/silkworm-fuzzer/corpus artifacts
+          ./rpcdaemon_fuzzer_test -max_total_time=86300 -detect_leaks=0 -rss_limit_mb=65536 $RPC_PAST_TEST_DIR/silkworm-fuzzer/corpus artifacts
 
           # Multi-thread execution
           # ./rpcdaemon_fuzzer_test -max_total_time=86300 -detect_leaks=0 -jobs=3 -rss_limit_mb=10922 $RPC_PAST_TEST_DIR/silkworm-fuzzer/corpus artifacts


### PR DESCRIPTION
Enabling the merge corpus option did not bring the expected benefits. Moreover, since enabling it, the fuzzer terminates early and reports a successful return code. 

This PR disables it and let us investigate it further. 