### PR TITLE
code style: explicit type instead of auto for constants

### DIFF
--- a/silkworm/core/common/util_test.cpp
+++ b/silkworm/core/common/util_test.cpp
@@ -211,9 +211,9 @@ TEST_CASE("intx::uint256 from scientific notation string") {
     CHECK(from_string_sci<intx::uint256>("18.1e+2") == intx::from_string<intx::uint256>("1810"));
     CHECK(from_string_sci<intx::uint256>("18.12e+2") == intx::from_string<intx::uint256>("1812"));
 
-    const auto kMaxFixedDecimalNotation{"115792089237316195423570985008687907853269984665640564039457584007913129639935"};
+    const char* kMaxFixedDecimalNotation{"115792089237316195423570985008687907853269984665640564039457584007913129639935"};
     CHECK(from_string_sci<intx::uint256>(kMaxFixedDecimalNotation) == std::numeric_limits<intx::uint256>::max());
-    const auto kMaxScientificNotation{"1.15792089237316195423570985008687907853269984665640564039457584007913129639935e+77"};
+    const char* kMaxScientificNotation{"1.15792089237316195423570985008687907853269984665640564039457584007913129639935e+77"};
     CHECK(from_string_sci<intx::uint256>(kMaxScientificNotation) == std::numeric_limits<intx::uint256>::max());
 }
 
@@ -225,7 +225,7 @@ TEST_CASE("intx::uint256 to_float") {
 }
 
 TEST_CASE("print intx::uint256") {
-    const auto i{intx::from_string<intx::uint256>("1000000000000000000000000")};
+    const intx::uint256 i{intx::from_string<intx::uint256>("1000000000000000000000000")};
     CHECK(test_util::null_stream() << i);
 }
 

--- a/silkworm/core/execution/evm_test.cpp
+++ b/silkworm/core/execution/evm_test.cpp
@@ -1107,8 +1107,8 @@ TEST_CASE("State changes for creation+destruction of smart contract", "[core][ex
 
     Block block{};
     block.header.number = *chain_config.constantinople_block;
-    static constexpr auto kZeroAddress = 0x0000000000000000000000000000000000000000_address;
-    const auto caller{0x0a6bb546b9208cfab9e8fa2b9b2c042b18df7030_address};
+    static constexpr evmc::address kZeroAddress = 0x0000000000000000000000000000000000000000_address;
+    const evmc::address caller{0x0a6bb546b9208cfab9e8fa2b9b2c042b18df7030_address};
     const auto contract_address{create_address(caller, 0)};
 
     InMemoryState db;
@@ -1160,7 +1160,7 @@ TEST_CASE("State changes for creation+destruction of smart contract", "[core][ex
 
 // First occurrence at mainnet block 1'639'553
 TEST_CASE("Missing sender in call traces for DELEGATECALL", "[core][execution]") {
-    static constexpr auto kZeroAddress = 0x0000000000000000000000000000000000000000_address;
+    static constexpr evmc::address kZeroAddress = 0x0000000000000000000000000000000000000000_address;
     evmc::address external_account{0xf466859ead1932d743d622cb74fc058882e8648a_address};
     const auto caller_address{create_address(external_account, 0)};
     const auto callee_address{create_address(external_account, 1)};

--- a/silkworm/core/execution/execution_test.cpp
+++ b/silkworm/core/execution/execution_test.cpp
@@ -31,8 +31,8 @@
 
 namespace silkworm {
 
-static constexpr auto kMiner{0x5a0b54d5dc17e0aadc383d2db43b0a0d3e029c4c_address};
-static constexpr auto kSender{0xb685342b8c54347aad148e1f22eff3eb3eb29391_address};
+static constexpr evmc::address kMiner{0x5a0b54d5dc17e0aadc383d2db43b0a0d3e029c4c_address};
+static constexpr evmc::address kSender{0xb685342b8c54347aad148e1f22eff3eb3eb29391_address};
 
 TEST_CASE("Execute two blocks") {
     // ---------------------------------------

--- a/silkworm/core/trie/hash_builder_test.cpp
+++ b/silkworm/core/trie/hash_builder_test.cpp
@@ -34,11 +34,11 @@ TEST_CASE("Empty trie") {
 }
 
 TEST_CASE("HashBuilder1") {
-    const auto key1{0x0000000000000000000000000000000000000000000000000000000000000001_bytes32};
-    const auto key2{0x0000000000000000000000000000000000000000000000000000000000000002_bytes32};
+    const evmc::bytes32 key1{0x0000000000000000000000000000000000000000000000000000000000000001_bytes32};
+    const evmc::bytes32 key2{0x0000000000000000000000000000000000000000000000000000000000000002_bytes32};
 
-    const auto val1{*from_hex("01")};
-    const auto val2{*from_hex("02")};
+    const Bytes val1{*from_hex("01")};
+    const Bytes val2{*from_hex("02")};
 
     HashBuilder hb;
     hb.add_leaf(unpack_nibbles(key1.bytes), val1);
@@ -193,7 +193,7 @@ TEST_CASE("HashBuilder3") {
 */
 
 TEST_CASE("Known root hash") {
-    const auto root_hash{0x9fa752911d55c3a1246133fe280785afbdba41f357e9cae1131d5f5b0a078b9c_bytes32};
+    const evmc::bytes32 root_hash{0x9fa752911d55c3a1246133fe280785afbdba41f357e9cae1131d5f5b0a078b9c_bytes32};
     HashBuilder hb;
     hb.add_branch_node({}, root_hash);
     CHECK(to_hex(hb.root_hash()) == to_hex(root_hash.bytes));

--- a/silkworm/core/types/hash_test.cpp
+++ b/silkworm/core/types/hash_test.cpp
@@ -25,7 +25,7 @@ using namespace evmc::literals;
 TEST_CASE("from_hex") {
     CHECK(Hash::from_hex("foo") == std::nullopt);
 
-    const auto kHashValue{0x2d690516512020171c1ec870f6ff45398cc8609250326be89915fb538e7b_bytes32};
+    const evmc::bytes32 kHashValue{0x2d690516512020171c1ec870f6ff45398cc8609250326be89915fb538e7b_bytes32};
     CHECK(Hash::from_hex("0x2d690516512020171c1ec870f6ff45398cc8609250326be89915fb538e7b") == kHashValue);
 }
 

--- a/silkworm/db/access_layer_test.cpp
+++ b/silkworm/db/access_layer_test.cpp
@@ -86,8 +86,8 @@ static BlockBody sample_block_body() {
 
 // https://etherscan.io/block/17035047
 static BlockBody block_body_17035047() {
-    constexpr auto kRecipient1{0x40458B394D1C2A9aA095dd169a6EB43a73949fa3_address};
-    constexpr auto kRecipient2{0xEdA2B3743d37a2a5bD4EB018d515DC47B7802EB4_address};
+    constexpr evmc::address kRecipient1{0x40458B394D1C2A9aA095dd169a6EB43a73949fa3_address};
+    constexpr evmc::address kRecipient2{0xEdA2B3743d37a2a5bD4EB018d515DC47B7802EB4_address};
     BlockBody body;
     body.withdrawals = std::vector<Withdrawal>{};
     body.withdrawals->reserve(16);
@@ -581,17 +581,17 @@ TEST_CASE("Storage", "[db][access_layer]") {
 
     PooledCursor table{txn, table::kPlainState};
 
-    const auto addr{0xb000000000000000000000000000000000000008_address};
+    const evmc::address addr{0xb000000000000000000000000000000000000008_address};
     const Bytes key{storage_prefix(addr, kDefaultIncarnation)};
 
-    const auto loc1{0x000000000000000000000000000000000000a000000000000000000000000037_bytes32};
-    const auto loc2{0x0000000000000000000000000000000000000000000000000000000000000000_bytes32};
-    const auto loc3{0xff00000000000000000000000000000000000000000000000000000000000017_bytes32};
-    const auto loc4{0x00000000000000000000000000000000000000000000000000000000000f3128_bytes32};
+    const evmc::bytes32 loc1{0x000000000000000000000000000000000000a000000000000000000000000037_bytes32};
+    const evmc::bytes32 loc2{0x0000000000000000000000000000000000000000000000000000000000000000_bytes32};
+    const evmc::bytes32 loc3{0xff00000000000000000000000000000000000000000000000000000000000017_bytes32};
+    const evmc::bytes32 loc4{0x00000000000000000000000000000000000000000000000000000000000f3128_bytes32};
 
-    const auto val1{0x00000000000000000000000000000000000000000000000000000000c9b131a4_bytes32};
-    const auto val2{0x000000000000000000000000000000000000000000005666856076ebaf477f07_bytes32};
-    const auto val3{0x4400000000000000000000000000000000000000000000000000000000000000_bytes32};
+    const evmc::bytes32 val1{0x00000000000000000000000000000000000000000000000000000000c9b131a4_bytes32};
+    const evmc::bytes32 val2{0x000000000000000000000000000000000000000000005666856076ebaf477f07_bytes32};
+    const evmc::bytes32 val3{0x4400000000000000000000000000000000000000000000000000000000000000_bytes32};
 
     upsert_storage_value(table, key, loc1.bytes, val1.bytes);
     upsert_storage_value(table, key, loc2.bytes, val2.bytes);
@@ -612,7 +612,7 @@ TEST_CASE("Account history", "[db][access_layer]") {
     AccountChanges changes{read_account_changes(txn, block_num)};
     CHECK(changes.empty());
 
-    const auto account_address{0x63c696931d3d3fd7cd83472febd193488266660d_address};
+    const evmc::address account_address{0x63c696931d3d3fd7cd83472febd193488266660d_address};
     const Account account{
         .nonce = 21,
         .balance = 1 * kEther,

--- a/silkworm/db/bitmap_test.cpp
+++ b/silkworm/db/bitmap_test.cpp
@@ -112,9 +112,9 @@ TEST_CASE("Bitmap Index Loader") {
     test_util::TempChainData context;
     RWTxn& txn{context.rw_txn()};
 
-    const auto address1{0x00000000000000000001_address};
-    const auto address2{0x00000000000000000002_address};
-    const auto address3{0x00000000000000000003_address};
+    const evmc::address address1{0x00000000000000000001_address};
+    const evmc::address address2{0x00000000000000000002_address};
+    const evmc::address address3{0x00000000000000000003_address};
 
     // Note range is [min,max)
     roaring::Roaring64Map roaring1{roaring::api::roaring_bitmap_from_range(1, 20'001, 1)};

--- a/silkworm/db/buffer_test.cpp
+++ b/silkworm/db/buffer_test.cpp
@@ -35,19 +35,19 @@ TEST_CASE("Buffer storage", "[silkworm][db][buffer]") {
     db::test_util::TempChainData context;
     auto& txn{context.rw_txn()};
 
-    const auto address{0xbe00000000000000000000000000000000000000_address};
+    const evmc::address address{0xbe00000000000000000000000000000000000000_address};
     const Bytes key{storage_prefix(address, kDefaultIncarnation)};
 
-    const auto location_a{0x0000000000000000000000000000000000000000000000000000000000000013_bytes32};
-    const auto value_a1{0x000000000000000000000000000000000000000000000000000000000000006b_bytes32};
-    const auto value_a2{0x0000000000000000000000000000000000000000000000000000000000000085_bytes32};
-    const auto value_a3{0x0000000000000000000000000000000000000000000000000000000000000095_bytes32};
-    const auto value_nil{0x0000000000000000000000000000000000000000000000000000000000000000_bytes32};
+    const evmc::bytes32 location_a{0x0000000000000000000000000000000000000000000000000000000000000013_bytes32};
+    const evmc::bytes32 value_a1{0x000000000000000000000000000000000000000000000000000000000000006b_bytes32};
+    const evmc::bytes32 value_a2{0x0000000000000000000000000000000000000000000000000000000000000085_bytes32};
+    const evmc::bytes32 value_a3{0x0000000000000000000000000000000000000000000000000000000000000095_bytes32};
+    const evmc::bytes32 value_nil{0x0000000000000000000000000000000000000000000000000000000000000000_bytes32};
 
-    const auto location_b{0x0000000000000000000000000000000000000000000000000000000000000002_bytes32};
-    const auto value_b{0x0000000000000000000000000000000000000000000000000000000000000132_bytes32};
+    const evmc::bytes32 location_b{0x0000000000000000000000000000000000000000000000000000000000000002_bytes32};
+    const evmc::bytes32 value_b{0x0000000000000000000000000000000000000000000000000000000000000132_bytes32};
 
-    const auto location_c{0x0000000000000000000000000000000000000000000000000000000000000003_bytes32};
+    const evmc::bytes32 location_c{0x0000000000000000000000000000000000000000000000000000000000000003_bytes32};
 
     auto state = txn.rw_cursor_dup_sort(table::kPlainState);
 
@@ -247,7 +247,7 @@ TEST_CASE("Buffer account", "[silkworm][db][buffer]") {
     auto& txn{context.rw_txn()};
 
     SECTION("New EOA account") {
-        const auto address{0xbe00000000000000000000000000000000000000_address};
+        const evmc::address address{0xbe00000000000000000000000000000000000000_address};
         Account current_account;
         current_account.balance = kEther;
 
@@ -275,7 +275,7 @@ TEST_CASE("Buffer account", "[silkworm][db][buffer]") {
     }
 
     SECTION("Changed EOA account") {
-        const auto address{0xbe00000000000000000000000000000000000000_address};
+        const evmc::address address{0xbe00000000000000000000000000000000000000_address};
         Account initial_account;
         initial_account.nonce = 1;
         initial_account.balance = 0;
@@ -311,7 +311,7 @@ TEST_CASE("Buffer account", "[silkworm][db][buffer]") {
     }
 
     SECTION("Delete contract account") {
-        const auto address{0xbe00000000000000000000000000000000000000_address};
+        const evmc::address address{0xbe00000000000000000000000000000000000000_address};
         Account account;
         account.incarnation = kDefaultIncarnation;
         account.code_hash = to_bytes32(keccak256(address.bytes).bytes);  // Just a fake hash
@@ -332,7 +332,7 @@ TEST_CASE("Buffer account", "[silkworm][db][buffer]") {
     }
 
     SECTION("Delete contract account and recreate as EOA") {
-        const auto address{0xbe00000000000000000000000000000000000000_address};
+        const evmc::address address{0xbe00000000000000000000000000000000000000_address};
         Account account;
         account.incarnation = kDefaultIncarnation;
         account.code_hash = to_bytes32(keccak256(address.bytes).bytes);  // Just a fake hash
@@ -360,7 +360,7 @@ TEST_CASE("Buffer account", "[silkworm][db][buffer]") {
     }
 
     SECTION("Change EOA account w/ new value equal to old one") {
-        const auto address{0xbe00000000000000000000000000000000000000_address};
+        const evmc::address address{0xbe00000000000000000000000000000000000000_address};
         Account initial_account;
         initial_account.nonce = 2;
         initial_account.balance = kEther;

--- a/silkworm/db/chain/chain_test.cpp
+++ b/silkworm/db/chain/chain_test.cpp
@@ -60,7 +60,7 @@ struct ChainTest : public silkworm::test_util::ContextTestBase {
 TEST_CASE_METHOD(ChainTest, "read_header_number") {
     SECTION("existent hash") {
         EXPECT_CALL(transaction, get_one(table::kHeaderNumbersName, _)).WillOnce(InvokeWithoutArgs([]() -> Task<Bytes> { co_return kNumber; }));
-        const auto block_hash{0x439816753229fc0736bf86a5048de4bc9fcdede8c91dadf88c828c76b2281dff_bytes32};
+        const evmc::bytes32 block_hash{0x439816753229fc0736bf86a5048de4bc9fcdede8c91dadf88c828c76b2281dff_bytes32};
         const auto header_number = spawn_and_wait(read_header_number(transaction, block_hash));
         CHECK(header_number == 4'000'000);
     }
@@ -69,7 +69,7 @@ TEST_CASE_METHOD(ChainTest, "read_header_number") {
         EXPECT_CALL(transaction, get_one(table::kHeaderNumbersName, _)).WillOnce(InvokeWithoutArgs([]() -> Task<Bytes> {
             co_return Bytes{};
         }));
-        const auto block_hash{0x0000000000000000000000000000000000000000000000000000000000000000_bytes32};
+        const evmc::bytes32 block_hash{0x0000000000000000000000000000000000000000000000000000000000000000_bytes32};
         auto result = spawn(read_header_number(transaction, block_hash));
 #ifdef SILKWORM_SANITIZE  // Avoid comparison against exception message: it triggers a TSAN data race seemingly related to libstdc++ string implementation
         CHECK_THROWS_AS(result.get(), std::invalid_argument);

--- a/silkworm/db/datastore/snapshots/bittorrent/web_seed_client_test.cpp
+++ b/silkworm/db/datastore/snapshots/bittorrent/web_seed_client_test.cpp
@@ -53,11 +53,11 @@ TEST_CASE("WebSeedClientForTest::is_caplin_segment", "[db][snapshot][bittorrent]
 }
 
 //! Content for manifest file containing one torrent file
-static constexpr auto kValidManifestContent{
+static constexpr std::string_view kValidManifestContent{
     "v1-010000-010500-bodies.seg.torrent\n"sv};
 
 //! Hexadecimal content for torrent file 'v1-010000-010500-bodies.seg'
-static constexpr auto kValidTorrentContent{
+static constexpr std::string_view kValidTorrentContent{
     "6431333a616e6e6f756e63652d6c6973746c6c34323a7564703a2f2f74726163"
     "6b65722e6f70656e747261636b722e6f72673a313333372f616e6e6f756e6365"
     "34363a7564703a2f2f747261636b65722e6f70656e626974746f7272656e742e"

--- a/silkworm/db/datastore/snapshots/rec_split/rec_split_seq_test.cpp
+++ b/silkworm/db/datastore/snapshots/rec_split/rec_split_seq_test.cpp
@@ -281,9 +281,9 @@ TEST_CASE("RecSplit8: unsupported feature", "[silkworm][snapshots][recsplit][ign
     // Purposely alter the index file to insert an unsupported feature value
     std::ifstream input{index_file.path(), std::ios::binary};
     std::vector<unsigned char> buffer{std::istreambuf_iterator<char>(input), {}};
-    const auto feature_flag_offset{394};
-    const auto invalid_feature_value{250};
-    buffer[feature_flag_offset] = invalid_feature_value;
+    static constexpr size_t kFeatureFlagOffset = 394;
+    static constexpr unsigned char kInvalidFeatureValue = 250;
+    buffer[kFeatureFlagOffset] = kInvalidFeatureValue;
     std::ofstream output{index_file.path(), std::ios::binary};
     for (const auto b : buffer) {
         output << b;

--- a/silkworm/db/kv/api/state_cache_test.cpp
+++ b/silkworm/db/kv/api/state_cache_test.cpp
@@ -47,13 +47,13 @@ static constexpr uint64_t kTestViewId0{3'000'000};
 static constexpr uint64_t kTestViewId1{3'000'001};
 static constexpr uint64_t kTestViewId2{3'000'002};
 
-static constexpr auto kTestBlockNumber{1'000'000};
-static constexpr auto kTestBlockHash{0x8e38b4dbf6b11fcc3b9dee84fb7986e29ca0a02cecd8977c161ff7333329681e_bytes32};
+static constexpr BlockNum kTestBlockNumber{1'000'000};
+static constexpr evmc::bytes32 kTestBlockHash{0x8e38b4dbf6b11fcc3b9dee84fb7986e29ca0a02cecd8977c161ff7333329681e_bytes32};
 
-static constexpr auto kTestAddress1{0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6_address};
-static constexpr auto kTestAddress2{0x0715a7794a1dc8e42615f059dd6e406a6594651a_address};
-static constexpr auto kTestAddress3{0x326c977e6efc84e512bb9c30f76e30c160ed06fb_address};
-static constexpr auto kTestAddress4{0x2d3be3b6021606e1af02fccbc6ea5b192e6d412d_address};
+static constexpr evmc::address kTestAddress1{0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6_address};
+static constexpr evmc::address kTestAddress2{0x0715a7794a1dc8e42615f059dd6e406a6594651a_address};
+static constexpr evmc::address kTestAddress3{0x326c977e6efc84e512bb9c30f76e30c160ed06fb_address};
+static constexpr evmc::address kTestAddress4{0x2d3be3b6021606e1af02fccbc6ea5b192e6d412d_address};
 static const std::vector<evmc::address> kTestAddresses{kTestAddress1, kTestAddress2, kTestAddress3, kTestAddress4};
 static constexpr uint64_t kTestIncarnation{3};
 
@@ -69,8 +69,8 @@ static const Bytes kTestCode3{*from_hex("600260020160005500")};
 static const Bytes kTestCode4{*from_hex("60606040526008565b00")};
 static const std::vector<Bytes> kTestCodes{kTestCode1, kTestCode2, kTestCode3, kTestCode4};
 
-static const auto kTestHashedLocation1{0x6677907ab33937e392b9be983b30818f29d594039c9e1e7490bf7b3698888fb1_bytes32};
-static const auto kTestHashedLocation2{0xe046602dcccb1a2f1d176718c8e709a42bba57af2da2379ba7130e2f916c95cd_bytes32};
+static const evmc::bytes32 kTestHashedLocation1{0x6677907ab33937e392b9be983b30818f29d594039c9e1e7490bf7b3698888fb1_bytes32};
+static const evmc::bytes32 kTestHashedLocation2{0xe046602dcccb1a2f1d176718c8e709a42bba57af2da2379ba7130e2f916c95cd_bytes32};
 static const std::vector<evmc::bytes32> kTestHashedLocations{kTestHashedLocation1, kTestHashedLocation2};
 static const std::vector<Bytes> kTestZeroTxs{};
 
@@ -553,7 +553,7 @@ TEST_CASE_METHOD(StateCacheTest, "CoherentStateCache::on_new_block exceed max vi
 }
 
 TEST_CASE_METHOD(StateCacheTest, "CoherentStateCache::on_new_block exceed max keys", "[rpc][ethdb][kv][state_cache]") {
-    constexpr auto kMaxKeys{2u};
+    static constexpr uint64_t kMaxKeys = 2u;
     const CoherentCacheConfig config{kDefaultMaxViews, /*with_storage=*/true, kMaxKeys, kMaxKeys};
     CoherentStateCache cache{config};
 

--- a/silkworm/db/kv/grpc/server/kv_server_test.cpp
+++ b/silkworm/db/kv/grpc/server/kv_server_test.cpp
@@ -1953,7 +1953,7 @@ TEST_CASE("KvServer E2E: bidirectional max TTL duration", "[silkworm][node][rpc]
     KvEnd2EndTest test;
     test.fill_tables();
     auto kv_client = *test.kv_client;
-    constexpr auto kCustomMaxTimeToLive{1000ms};
+    static constexpr std::chrono::milliseconds kCustomMaxTimeToLive = 1000ms;
     TxMaxTimeToLiveGuard ttl_guard{kCustomMaxTimeToLive};
 
     SECTION("Tx: cursor NEXT ops across renew are consecutive") {

--- a/silkworm/db/kv/grpc/server/state_change_collection_test.cpp
+++ b/silkworm/db/kv/grpc/server/state_change_collection_test.cpp
@@ -37,10 +37,10 @@ static constexpr uint64_t kTestPendingBaseFee{10'000};
 static constexpr uint64_t kTestGasLimit{10'000'000};
 static constexpr uint64_t kTestDatabaseViewId{55};
 
-static constexpr auto kTestBlockNumber{1'000'000};
-static constexpr auto kTestBlockHash{0x8e38b4dbf6b11fcc3b9dee84fb7986e29ca0a02cecd8977c161ff7333329681e_bytes32};
+static constexpr BlockNum kTestBlockNumber{1'000'000};
+static constexpr evmc::bytes32 kTestBlockHash{0x8e38b4dbf6b11fcc3b9dee84fb7986e29ca0a02cecd8977c161ff7333329681e_bytes32};
 
-static constexpr auto kTestAddress{0x0a6bb546b9208cfab9e8fa2b9b2c042b18df7030_address};
+static constexpr evmc::address kTestAddress{0x0a6bb546b9208cfab9e8fa2b9b2c042b18df7030_address};
 static constexpr uint64_t kTestIncarnation{3};
 
 static const Bytes kTestData1{*from_hex("600035600055")};
@@ -49,8 +49,8 @@ static const Bytes kTestData2{*from_hex("6000356000550055")};
 static const Bytes kTestCode1{*from_hex("602a6000556101c960015560068060166000396000f3600035600055")};
 static const Bytes kTestCode2{*from_hex("602a5f556101c960015560048060135f395ff35f355f55")};
 
-static const auto kTestHashedLocation1{0x6677907ab33937e392b9be983b30818f29d594039c9e1e7490bf7b3698888fb1_bytes32};
-static const auto kTestHashedLocation2{0xe046602dcccb1a2f1d176718c8e709a42bba57af2da2379ba7130e2f916c95cd_bytes32};
+static const evmc::bytes32 kTestHashedLocation1{0x6677907ab33937e392b9be983b30818f29d594039c9e1e7490bf7b3698888fb1_bytes32};
+static const evmc::bytes32 kTestHashedLocation2{0xe046602dcccb1a2f1d176718c8e709a42bba57af2da2379ba7130e2f916c95cd_bytes32};
 
 static const Bytes kTestValue1{*from_hex("0xABCD")};
 static const Bytes kTestValue2{*from_hex("0x4321")};

--- a/silkworm/db/log_cbor_test.cpp
+++ b/silkworm/db/log_cbor_test.cpp
@@ -39,17 +39,17 @@ TEST_CASE("CBOR encoding of logs") {
 }
 
 TEST_CASE("CBOR decoding of empty logs") {
-    const auto kEmptyEncodedLogs{"80"};
+    static constexpr std::string_view kEmptyEncodedLogs = "80";
     std::vector<Log> logs{};
     CHECK(cbor_decode(*from_hex(kEmptyEncodedLogs), logs));
 }
 
 TEST_CASE("CBOR decoding of logs") {
-    const auto kEncoded{
+    static constexpr std::string_view kEncoded =
         "828354ea674fdde714fd979de3edf0f56aa9716b898ec88043010043835444fd3ab8381cc3d"
         "14afa7c4af7fd13cdc65026e1825820000000000000000000000000000000000000000000000"
         "000000000000000dead582000000000000000000000000000000000000000000000000000000"
-        "0000000abba46aabbff780043"};
+        "0000000abba46aabbff780043";
     std::vector<Log> logs{};
     CHECK(cbor_decode(*from_hex(kEncoded), logs));
     CHECK(logs.size() == 2);

--- a/silkworm/db/state/remote_state_test.cpp
+++ b/silkworm/db/state/remote_state_test.cpp
@@ -67,7 +67,7 @@ TEST_CASE_METHOD(RemoteStateTest, "async remote buffer", "[rpc][core][remote_buf
             }));
         const BlockNum block_number = 1'000'000;
         AsyncRemoteState state{transaction, chain_storage, block_number};
-        const auto code_hash{0x04491edcd115127caedbd478e2e7895ed80c7847e903431f94f9cfa579cad47f_bytes32};
+        const evmc::bytes32 code_hash{0x04491edcd115127caedbd478e2e7895ed80c7847e903431f94f9cfa579cad47f_bytes32};
         const auto code_read{spawn_and_wait(state.read_code(address, code_hash))};
         CHECK(code_read == ByteView{kCode});
     }
@@ -79,7 +79,7 @@ TEST_CASE_METHOD(RemoteStateTest, "async remote buffer", "[rpc][core][remote_buf
                 co_return Bytes{};
             }));
         const BlockNum block_number = 1'000'000;
-        const auto code_hash{0x04491edcd115127caedbd478e2e7895ed80c7847e903431f94f9cfa579cad47f_bytes32};
+        const evmc::bytes32 code_hash{0x04491edcd115127caedbd478e2e7895ed80c7847e903431f94f9cfa579cad47f_bytes32};
         RemoteState state(current_executor, transaction, chain_storage, block_number);
         const auto code_read = state.read_code(address, code_hash);
         CHECK(code_read.empty());
@@ -98,7 +98,7 @@ TEST_CASE_METHOD(RemoteStateTest, "async remote buffer", "[rpc][core][remote_buf
                 co_return Bytes{};
             }));
         const BlockNum block_number = 1'000'000;
-        const auto location{0x04491edcd115127caedbd478e2e7895ed80c7847e903431f94f9cfa579cad47f_bytes32};
+        const evmc::bytes32 location{0x04491edcd115127caedbd478e2e7895ed80c7847e903431f94f9cfa579cad47f_bytes32};
         RemoteState remote_state(current_executor, transaction, chain_storage, block_number);
         const auto storage_read = remote_state.read_storage(address, 0, location);
         CHECK(storage_read == 0x0000000000000000000000000000000000000000000000000000000000000000_bytes32);
@@ -211,7 +211,7 @@ TEST_CASE_METHOD(RemoteStateTest, "async remote buffer", "[rpc][core][remote_buf
             Bytes code{*from_hex("0x0608")};
             test::MockTransaction transaction; + EXPECT_CALL
             const BlockNum block_number = 1'000'000;
-            const auto code_hash{0x04491edcd115127caedbd478e2e7895ed80c7847e903431f94f9cfa579cad47f_bytes32};
+            const evmc::bytes32 code_hash{0x04491edcd115127caedbd478e2e7895ed80c7847e903431f94f9cfa579cad47f_bytes32};
             const RemoteChainStorage storage{transaction, backend.get()};
             RemoteState remote_state(io_context, transaction, storage, block_number);
             auto ret_code = remote_state.read_code(code_hash);
@@ -229,7 +229,7 @@ TEST_CASE_METHOD(RemoteStateTest, "async remote buffer", "[rpc][core][remote_buf
             test::MockTransaction transaction; + EXPECT_CALL
             const BlockNum block_number = 1'000'000;
             evmc::address address{0x0715a7794a1dc8e42615f059dd6e406a6594651a_address};
-            const auto location{0x04491edcd115127caedbd478e2e7895ed80c7847e903431f94f9cfa579cad47f_bytes32};
+            const evmc::bytes32 location{0x04491edcd115127caedbd478e2e7895ed80c7847e903431f94f9cfa579cad47f_bytes32};
             const RemoteChainStorage storage{transaction, backend.get()};
             RemoteState remote_state(io_context, transaction, storage, block_number);
             auto ret_storage = remote_state.read_storage(address, 0, location);
@@ -276,7 +276,7 @@ TEST_CASE_METHOD(RemoteStateTest, "async remote buffer", "[rpc][core][remote_buf
                 co_return Bytes{};
             }));
         const BlockNum block_number = 1'000'000;
-        const auto code_hash{0x04491edcd115127caedbd478e2e7895ed80c7847e903431f94f9cfa579cad47f_bytes32};
+        const evmc::bytes32 code_hash{0x04491edcd115127caedbd478e2e7895ed80c7847e903431f94f9cfa579cad47f_bytes32};
         AsyncRemoteState state{transaction, chain_storage, block_number};
         const auto code_read{spawn_and_wait(state.read_code(address, code_hash))};
         CHECK(code_read.empty());
@@ -292,7 +292,7 @@ TEST_CASE_METHOD(RemoteStateTest, "async remote buffer", "[rpc][core][remote_buf
                 co_return Bytes{};
             }));
         const BlockNum block_number = 1'000'000;
-        const auto location{0x04491edcd115127caedbd478e2e7895ed80c7847e903431f94f9cfa579cad47f_bytes32};
+        const evmc::bytes32 location{0x04491edcd115127caedbd478e2e7895ed80c7847e903431f94f9cfa579cad47f_bytes32};
         AsyncRemoteState state{transaction, chain_storage, block_number};
         const auto storage_read{spawn_and_wait(state.read_storage(address, 0, location))};
         CHECK(storage_read == 0x0000000000000000000000000000000000000000000000000000000000000000_bytes32);

--- a/silkworm/db/util_test.cpp
+++ b/silkworm/db/util_test.cpp
@@ -24,8 +24,8 @@ namespace silkworm::db {
 
 using evmc::literals::operator""_address, evmc::literals::operator""_bytes32;
 
-constexpr auto kZeroAddress = 0x0000000000000000000000000000000000000000_address;
-constexpr auto kZeroHash = 0x0000000000000000000000000000000000000000000000000000000000000000_bytes32;
+constexpr evmc::address kZeroAddress = 0x0000000000000000000000000000000000000000_address;
+constexpr evmc::bytes32 kZeroHash = 0x0000000000000000000000000000000000000000000000000000000000000000_bytes32;
 
 TEST_CASE("all-zero storage prefix", "[core][util]") {
     const auto address_composite_key{storage_prefix(kZeroAddress, 0)};
@@ -48,7 +48,7 @@ TEST_CASE("all-zero composite key", "[rpc][core][rawdb][util]") {
 }
 
 TEST_CASE("non-zero address composite key", "[rpc][core][rawdb][util]") {
-    const auto address = 0x79a4d418f7887dd4d5123a41b6c8c186686ae8cb_address;
+    const evmc::address address = 0x79a4d418f7887dd4d5123a41b6c8c186686ae8cb_address;
     const auto key{composite_storage_key(address, 0, kZeroHash.bytes)};
     CHECK(key == from_hex("79a4d418f7887dd4d5123a41b6c8c186686ae8cb"
                           "0000000000000000"
@@ -63,7 +63,7 @@ TEST_CASE("non-zero incarnation composite key", "[rpc][core][rawdb][util]") {
 }
 
 TEST_CASE("non-zero hash composite key", "[rpc][core][rawdb][util]") {
-    const auto hash = 0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6_bytes32;
+    const evmc::bytes32 hash = 0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6_bytes32;
     const auto key{composite_storage_key(kZeroAddress, 0, hash.bytes)};
     CHECK(key == from_hex("0000000000000000000000000000000000000000"
                           "0000000000000000"
@@ -71,8 +71,8 @@ TEST_CASE("non-zero hash composite key", "[rpc][core][rawdb][util]") {
 }
 
 TEST_CASE("non-zero composite key", "[rpc][core][rawdb][util]") {
-    const auto address = 0x79a4d418f7887dd4d5123a41b6c8c186686ae8cb_address;
-    const auto hash = 0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6_bytes32;
+    const evmc::address address = 0x79a4d418f7887dd4d5123a41b6c8c186686ae8cb_address;
+    const evmc::bytes32 hash = 0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6_bytes32;
     const auto key{composite_storage_key(address, 37, hash.bytes)};
     CHECK(key == from_hex("79a4d418f7887dd4d5123a41b6c8c186686ae8cb"
                           "0000000000000025"

--- a/silkworm/execution/grpc/client/endpoint/checkers_test.cpp
+++ b/silkworm/execution/grpc/client/endpoint/checkers_test.cpp
@@ -53,10 +53,10 @@ TEST_CASE("block_number_from_response", "[node][execution][grpc]") {
     }
 }
 
-static constexpr auto kHeadHash{0x0000000000000000000000000000000000000000000000000000000000000001_bytes32};
-static constexpr auto kFinalizedHash{0x0000000000000000000000000000000000000000000000000000000000000002_bytes32};
-static constexpr auto kSafeHash{0x0000000000000000000000000000000000000000000000000000000000000003_bytes32};
-static constexpr auto kTimeout{100u};
+static constexpr evmc::bytes32 kHeadHash{0x0000000000000000000000000000000000000000000000000000000000000001_bytes32};
+static constexpr evmc::bytes32 kFinalizedHash{0x0000000000000000000000000000000000000000000000000000000000000002_bytes32};
+static constexpr evmc::bytes32 kSafeHash{0x0000000000000000000000000000000000000000000000000000000000000003_bytes32};
+static constexpr uint64_t kTimeout{100u};
 
 static proto::ForkChoice sample_proto_fork_choice() {
     proto::ForkChoice fork_choice;

--- a/silkworm/execution/grpc/server/endpoint/checkers_test.cpp
+++ b/silkworm/execution/grpc/server/endpoint/checkers_test.cpp
@@ -58,10 +58,10 @@ TEST_CASE("response_from_block_number", "[node][execution][grpc]") {
     }
 }
 
-static constexpr auto kHeadHash{0x0000000000000000000000000000000000000000000000000000000000000001_bytes32};
-static constexpr auto kFinalizedHash{0x0000000000000000000000000000000000000000000000000000000000000002_bytes32};
-static constexpr auto kSafeHash{0x0000000000000000000000000000000000000000000000000000000000000003_bytes32};
-static constexpr auto kTimeout{100u};
+static constexpr evmc::bytes32 kHeadHash{0x0000000000000000000000000000000000000000000000000000000000000001_bytes32};
+static constexpr evmc::bytes32 kFinalizedHash{0x0000000000000000000000000000000000000000000000000000000000000002_bytes32};
+static constexpr evmc::bytes32 kSafeHash{0x0000000000000000000000000000000000000000000000000000000000000003_bytes32};
+static constexpr uint64_t kTimeout{100u};
 
 static proto::ForkChoice sample_proto_fork_choice() {
     proto::ForkChoice fork_choice;

--- a/silkworm/infra/grpc/common/conversion_test.cpp
+++ b/silkworm/infra/grpc/common/conversion_test.cpp
@@ -114,7 +114,8 @@ TEST_CASE("span_from_h512", "[rpc][conversion]") {
     }
 }
 
-static auto kSampleBytes32{0x000000000000007f0000000000000007000000000000006f0000000000000006_bytes32};
+static constexpr evmc::bytes32 kSampleBytes32 = 0x000000000000007f0000000000000007000000000000006f0000000000000006_bytes32;
+
 static std::unique_ptr<types::H256> sample_h256() {
     auto hi = new types::H128();
     auto lo = new types::H128();
@@ -170,7 +171,8 @@ TEST_CASE("address_from_h160", "[rpc][conversion]") {
     }
 }
 
-static auto kSampleBytes16{*from_hex("0x000000000000007f0000000000000007")};
+static const Bytes kSampleBytes16 = *from_hex("0x000000000000007f0000000000000007");
+
 static std::unique_ptr<types::H128> sample_h128() {
     auto h128_ptr = std::make_unique<::types::H128>();
     h128_ptr->set_lo(0x07);

--- a/silkworm/node/stagedsync/execution_engine_test.cpp
+++ b/silkworm/node/stagedsync/execution_engine_test.cpp
@@ -768,7 +768,7 @@ TEST_CASE("ExecutionEngine Integration Test", "[node][execution][execution_engin
 
     // TODO: temoporarily disabled, to be fixed (JG)
     // SECTION("updates storage") {
-    //     static constexpr auto kSender{0xb685342b8c54347aad148e1f22eff3eb3eb29391_address};
+    //     static constexpr evmc::address kSender{0xb685342b8c54347aad148e1f22eff3eb3eb29391_address};
     //     auto block1 = generate_sample_child_blocks(current_head);
 
     //     // This contract initially sets its 0th storage to 0x2a and its 1st storage to 0x01c9.

--- a/silkworm/node/stagedsync/stages/stage_history_index_test.cpp
+++ b/silkworm/node/stagedsync/stages/stage_history_index_test.cpp
@@ -40,7 +40,7 @@ using silkworm::test_util::SetLogVerbosityGuard;
 stagedsync::HistoryIndex make_stage_history_index(
     stagedsync::SyncContext* sync_context,
     const TempChainData& chain_data) {
-    constexpr auto kBatchSize{512_Mebi};
+    static constexpr size_t kBatchSize = 512_Mebi;
     return stagedsync::HistoryIndex{
         sync_context,
         kBatchSize,
@@ -451,8 +451,8 @@ TEST_CASE("HistoryIndex + Account access_layer") {
 
     Buffer buffer{txn};
 
-    const auto miner_a{0x00000000000000000000000000000000000000aa_address};
-    const auto miner_b{0x00000000000000000000000000000000000000bb_address};
+    const evmc::address miner_a{0x00000000000000000000000000000000000000aa_address};
+    const evmc::address miner_b{0x00000000000000000000000000000000000000bb_address};
 
     Block block1;
     block1.header.number = 1;

--- a/silkworm/node/stagedsync/stages/stage_interhashes/_test.cpp
+++ b/silkworm/node/stagedsync/stages/stage_interhashes/_test.cpp
@@ -385,13 +385,13 @@ TEST_CASE("Account and storage trie") {
 
     HashBuilder hb;
 
-    const auto key1{0xB000000000000000000000000000000000000000000000000000000000000000_bytes32};
+    const evmc::bytes32 key1{0xB000000000000000000000000000000000000000000000000000000000000000_bytes32};
     const Account a1{0, 3 * kEther};
     hashed_accounts.upsert(to_slice(key1), to_slice(a1.encode_for_storage()));
     hb.add_leaf(unpack_nibbles(key1.bytes), a1.rlp(/*storage_root=*/kEmptyRoot));
 
     // Some address whose hash starts with 0xB040
-    const auto address2{0x7db3e81b72d2695e19764583f6d219dbee0f35ca_address};
+    const evmc::address address2{0x7db3e81b72d2695e19764583f6d219dbee0f35ca_address};
     const auto key2{keccak256(address2)};
     REQUIRE((key2.bytes[0] == 0xB0 && key2.bytes[1] == 0x40));
     const Account a2{0, 1 * kEther};
@@ -399,10 +399,10 @@ TEST_CASE("Account and storage trie") {
     hb.add_leaf(unpack_nibbles(key2.bytes), a2.rlp(/*storage_root=*/kEmptyRoot));
 
     // Some address whose hash starts with 0xB041
-    const auto address3{0x16b07afd1c635f77172e842a000ead9a2a222459_address};
+    const evmc::address address3{0x16b07afd1c635f77172e842a000ead9a2a222459_address};
     const auto key3{keccak256(address3)};
     REQUIRE((key3.bytes[0] == 0xB0 && key3.bytes[1] == 0x41));
-    const auto code_hash{0x5be74cad16203c4905c068b012a2e9fb6d19d036c410f16fd177f337541440dd_bytes32};
+    const evmc::bytes32 code_hash{0x5be74cad16203c4905c068b012a2e9fb6d19d036c410f16fd177f337541440dd_bytes32};
     const Account a3{0, 2 * kEther, code_hash, kDefaultIncarnation};
     hashed_accounts.upsert(to_slice(key3.bytes), to_slice(a3.encode_for_storage()));
 
@@ -411,17 +411,17 @@ TEST_CASE("Account and storage trie") {
 
     hb.add_leaf(unpack_nibbles(key3.bytes), a3.rlp(storage_root));
 
-    const auto key4a{0xB1A0000000000000000000000000000000000000000000000000000000000000_bytes32};
+    const evmc::bytes32 key4a{0xB1A0000000000000000000000000000000000000000000000000000000000000_bytes32};
     const Account a4a{0, 4 * kEther};
     hashed_accounts.upsert(to_slice(key4a), to_slice(a4a.encode_for_storage()));
     hb.add_leaf(unpack_nibbles(key4a.bytes), a4a.rlp(/*storage_root=*/kEmptyRoot));
 
-    const auto key5{0xB310000000000000000000000000000000000000000000000000000000000000_bytes32};
+    const evmc::bytes32 key5{0xB310000000000000000000000000000000000000000000000000000000000000_bytes32};
     const Account a5{0, 8 * kEther};
     hashed_accounts.upsert(to_slice(key5), to_slice(a5.encode_for_storage()));
     hb.add_leaf(unpack_nibbles(key5.bytes), a5.rlp(/*storage_root=*/kEmptyRoot));
 
-    const auto key6{0xB340000000000000000000000000000000000000000000000000000000000000_bytes32};
+    const evmc::bytes32 key6{0xB340000000000000000000000000000000000000000000000000000000000000_bytes32};
     const Account a6{0, 1 * kEther};
     hashed_accounts.upsert(to_slice(key6), to_slice(a6.encode_for_storage()));
     hb.add_leaf(unpack_nibbles(key6.bytes), a6.rlp(/*storage_root=*/kEmptyRoot));
@@ -486,7 +486,7 @@ TEST_CASE("Account and storage trie") {
     // ----------------------------------------------------------------
 
     // Some address whose hash starts with 0xB1
-    const auto address4b{0x4f61f2d5ebd991b85aa1677db97307caf5215c91_address};
+    const evmc::address address4b{0x4f61f2d5ebd991b85aa1677db97307caf5215c91_address};
     const auto key4b{keccak256(address4b)};
     REQUIRE(key4b.bytes[0] == key4a.bytes[0]);
 
@@ -779,8 +779,8 @@ TEST_CASE("Trie Storage : incremental vs regeneration") {
         incarnation2,                                                                // incarnation
     };
 
-    const auto address1{0x1000000000000000000000000000000000000000_address};
-    const auto address2{0x2000000000000000000000000000000000000000_address};
+    const evmc::address address1{0x1000000000000000000000000000000000000000_address};
+    const evmc::address address2{0x2000000000000000000000000000000000000000_address};
 
     const auto hashed_address1{keccak256(address1)};
     const auto hashed_address2{keccak256(address2)};

--- a/silkworm/node/stagedsync/stages_test.cpp
+++ b/silkworm/node/stagedsync/stages_test.cpp
@@ -259,7 +259,7 @@ TEST_CASE("Sync Stages") {
 
         REQUIRE_NOTHROW(txn.commit_and_renew());
 
-        constexpr auto kExpectedSender{0xc15eb501c014515ad0ecb4ecbf75cc597110b060_address};
+        constexpr evmc::address kExpectedSender{0xc15eb501c014515ad0ecb4ecbf75cc597110b060_address};
         {
             auto senders_map{txn->open_map(table::kSenders.name)};
             REQUIRE(txn->get_map_stat(senders_map).ms_entries == 2);
@@ -316,7 +316,7 @@ TEST_CASE("Sync Stages") {
         // ---------------------------------------
 
         uint64_t block_number{1};
-        const auto miner{0x5a0b54d5dc17e0aadc383d2db43b0a0d3e029c4c_address};
+        const evmc::address miner{0x5a0b54d5dc17e0aadc383d2db43b0a0d3e029c4c_address};
 
         Block block{};
         block.header.number = block_number;
@@ -614,9 +614,9 @@ TEST_CASE("Sync Stages") {
         using StageResult = stagedsync::Stage::Result;
 
         // Prepare block 1
-        const auto miner{0x5a0b54d5dc17e0aadc383d2db43b0a0d3e029c4c_address};
-        const auto sender{0x9b9e32061f64f6c3f570a63b97a178d84e961db1_address};
-        const auto receiver{miner};
+        const evmc::address miner{0x5a0b54d5dc17e0aadc383d2db43b0a0d3e029c4c_address};
+        const evmc::address sender{0x9b9e32061f64f6c3f570a63b97a178d84e961db1_address};
+        const evmc::address receiver{miner};
 
         Block block{};
         block.header.number = 1;

--- a/silkworm/rpc/commands/eth_api_test.cpp
+++ b/silkworm/rpc/commands/eth_api_test.cpp
@@ -25,7 +25,7 @@ namespace silkworm::rpc::commands {
 
 #ifndef SILKWORM_SANITIZE
 TEST_CASE_METHOD(test_util::RpcApiE2ETest, "unit: eth_blockNumber succeeds if request well-formed", "[rpc][api]") {
-    const auto request = R"({"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]})"_json;
+    const nlohmann::json request = R"({"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]})"_json;
     std::string reply;
     run<&test_util::RequestHandlerForTest::request_and_create_reply>(request, reply);
     CHECK(nlohmann::json::parse(reply) == R"({
@@ -36,7 +36,7 @@ TEST_CASE_METHOD(test_util::RpcApiE2ETest, "unit: eth_blockNumber succeeds if re
 }
 
 TEST_CASE_METHOD(test_util::RpcApiE2ETest, "unit: eth_blockNumber fails if request empty", "[rpc][api]") {
-    const auto request = R"({})"_json;
+    const nlohmann::json request = R"({})"_json;
     std::string reply;
     run<&test_util::RequestHandlerForTest::request_and_create_reply>(request, reply);
     CHECK(nlohmann::json::parse(reply) == R"({
@@ -47,7 +47,7 @@ TEST_CASE_METHOD(test_util::RpcApiE2ETest, "unit: eth_blockNumber fails if reque
 }
 
 TEST_CASE_METHOD(test_util::RpcApiE2ETest, "unit: eth_sendRawTransaction fails rlp parsing", "[rpc][api]") {
-    const auto request = R"({
+    const nlohmann::json request = R"({
         "jsonrpc": "2.0",
         "id": 1,
         "method": "eth_sendRawTransaction",
@@ -63,7 +63,7 @@ TEST_CASE_METHOD(test_util::RpcApiE2ETest, "unit: eth_sendRawTransaction fails r
 }
 
 TEST_CASE_METHOD(test_util::RpcApiE2ETest, "unit: eth_sendRawTransaction fails length", "[rpc][api]") {
-    const auto request = R"({
+    const nlohmann::json request = R"({
         "jsonrpc": "2.0",
         "id": 1,
         "method": "eth_sendRawTransaction",
@@ -79,7 +79,7 @@ TEST_CASE_METHOD(test_util::RpcApiE2ETest, "unit: eth_sendRawTransaction fails l
 }
 
 TEST_CASE_METHOD(test_util::RpcApiE2ETest, "unit: eth_sendRawTransaction fails to send", "[rpc][api]") {
-    const auto request = R"({
+    const nlohmann::json request = R"({
         "jsonrpc": "2.0",
         "id": 1,
         "method": "eth_sendRawTransaction",
@@ -95,7 +95,7 @@ TEST_CASE_METHOD(test_util::RpcApiE2ETest, "unit: eth_sendRawTransaction fails t
 }
 
 TEST_CASE_METHOD(test_util::RpcApiE2ETest, "unit: eth_feeHistory succeeds if request well-formed", "[rpc][api]") {
-    const auto request = R"({"jsonrpc":"2.0","id":1,"method":"eth_feeHistory","params":["0x1","0x867A80",[25,75]]})"_json;
+    const nlohmann::json request = R"({"jsonrpc":"2.0","id":1,"method":"eth_feeHistory","params":["0x1","0x867A80",[25,75]]})"_json;
     std::string reply;
     run<&test_util::RequestHandlerForTest::request_and_create_reply>(request, reply);
     CHECK(nlohmann::json::parse(reply) == R"({
@@ -106,7 +106,7 @@ TEST_CASE_METHOD(test_util::RpcApiE2ETest, "unit: eth_feeHistory succeeds if req
 }
 
 TEST_CASE_METHOD(test_util::RpcApiE2ETest, "eth_call without params on gas", "[rpc][api]") {
-    const auto request = R"({"jsonrpc":"2.0","id":1,"method":"eth_call","params":[{}, "latest"]})"_json;
+    const nlohmann::json request = R"({"jsonrpc":"2.0","id":1,"method":"eth_call","params":[{}, "latest"]})"_json;
     std::string reply;
     run<&test_util::RequestHandlerForTest::request_and_create_reply>(request, reply);
     CHECK(nlohmann::json::parse(reply) == R"({
@@ -117,7 +117,7 @@ TEST_CASE_METHOD(test_util::RpcApiE2ETest, "eth_call without params on gas", "[r
 }
 
 TEST_CASE_METHOD(test_util::RpcApiE2ETest, "fuzzy: eth_feeHistory sigsegv invalid input", "[rpc][api]") {
-    const auto request = R"({"jsonrpc":"2.0","id":1,"method":"eth_feeHistory","params":["5x1","0x2",[95,99]]})"_json;
+    const nlohmann::json request = R"({"jsonrpc":"2.0","id":1,"method":"eth_feeHistory","params":["5x1","0x2",[95,99]]})"_json;
     std::string reply;
     run<&test_util::RequestHandlerForTest::request_and_create_reply>(request, reply);
     CHECK(nlohmann::json::parse(reply) == R"({
@@ -128,7 +128,7 @@ TEST_CASE_METHOD(test_util::RpcApiE2ETest, "fuzzy: eth_feeHistory sigsegv invali
 }
 
 TEST_CASE_METHOD(test_util::RpcApiE2ETest, "fuzzy: eth_feeHistory sigsegv valid input", "[rpc][api]") {
-    const auto request = R"({"jsonrpc":"2.0","id":1,"method":"eth_feeHistory","params":["0x5","0x2",[95,99]]})"_json;
+    const nlohmann::json request = R"({"jsonrpc":"2.0","id":1,"method":"eth_feeHistory","params":["0x5","0x2",[95,99]]})"_json;
     std::string reply;
     run<&test_util::RequestHandlerForTest::request_and_create_reply>(request, reply);
     CHECK(nlohmann::json::parse(reply) == R"({

--- a/silkworm/rpc/commands/parity_api_test.cpp
+++ b/silkworm/rpc/commands/parity_api_test.cpp
@@ -23,7 +23,7 @@ namespace silkworm::rpc::commands {
 
 #ifndef SILKWORM_SANITIZE
 TEST_CASE_METHOD(test_util::RpcApiE2ETest, "parity_getBlockReceipts: misnamed 'params' field", "[rpc][api]") {
-    const auto request = R"({"jsonrpc":"2.0","id":1,"method":"parity_getBlockReceipts","pirams":["0x0"]})";
+    const nlohmann::json request = R"({"jsonrpc":"2.0","id":1,"method":"parity_getBlockReceipts","pirams":["0x0"]})";
     std::string reply;
     run<&test_util::RequestHandlerForTest::handle_request>(request, reply);
     CHECK(nlohmann::json::parse(reply) == R"({

--- a/silkworm/rpc/core/evm_debug_test.cpp
+++ b/silkworm/rpc/core/evm_debug_test.cpp
@@ -281,7 +281,7 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 1") {
                 co_return Bytes{};
             }));
 
-        const auto block_number = 5'405'095;  // 0x5279A7
+        const BlockNum block_number = 5'405'095;  // 0x5279A7
         Call call;
         call.from = 0xe0a2Bd4258D2768837BAa26A28fE71Dc079f84c7_address;
         call.gas = 50'000;
@@ -339,7 +339,7 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 1") {
                 co_return Bytes{};
             }));
 
-        const auto block_number = 5'405'095;  // 0x5279A7
+        const BlockNum block_number = 5'405'095;  // 0x5279A7
         Call call;
         call.from = 0xe0a2Bd4258D2768837BAa26A28fE71Dc079f84c7_address;
         call.gas = 118'936;
@@ -445,7 +445,7 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 1") {
                 co_return Bytes{};
             }));
 
-        const auto block_number = 5'405'095;  // 0x5279A7
+        const BlockNum block_number = 5'405'095;  // 0x5279A7
         Call call;
         call.from = 0xe0a2Bd4258D2768837BAa26A28fE71Dc079f84c7_address;
         call.gas = 118'936;
@@ -543,7 +543,7 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 1") {
                 co_return Bytes{};
             }));
 
-        const auto block_number = 5'405'095;  // 0x5279A7
+        const BlockNum block_number = 5'405'095;  // 0x5279A7
         Call call;
         call.from = 0xe0a2Bd4258D2768837BAa26A28fE71Dc079f84c7_address;
         call.gas = 118'936;
@@ -646,7 +646,7 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 1") {
                 co_return Bytes{};
             }));
 
-        const auto block_number = 5'405'095;  // 0x5279A7
+        const BlockNum block_number = 5'405'095;  // 0x5279A7
         Call call;
         call.from = 0xe0a2Bd4258D2768837BAa26A28fE71Dc079f84c7_address;
         call.gas = 118'936;
@@ -750,7 +750,7 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 1") {
                 co_return Bytes{};
             }));
 
-        const auto block_number = 5'405'095;  // 0x5279A7
+        const BlockNum block_number = 5'405'095;  // 0x5279A7
         Call call;
         call.from = 0xe0a2Bd4258D2768837BAa26A28fE71Dc079f84c7_address;
         call.gas = 118'936;
@@ -841,7 +841,7 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 1") {
                 co_return Bytes{};
             }));
 
-        const auto block_number = 5'405'095;  // 0x5279A7
+        const BlockNum block_number = 5'405'095;  // 0x5279A7
         Call call;
         call.from = 0xe0a2Bd4258D2768837BAa26A28fE71Dc079f84c7_address;
         call.gas = 118'936;
@@ -1042,7 +1042,7 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 2") {
                     co_return kAccountChangeSetValue3;
                 }));
 
-        const auto block_number = 4'417'196;  // 0x4366AC
+        const BlockNum block_number = 4'417'196;  // 0x4366AC
         Call call;
         call.from = 0x8ced5ad0d8da4ec211c17355ed3dbfec4cf0e5b9_address;
         call.to = 0x5e1f0c9ddbe3cb57b80c933fab5151627d7966fa_address;

--- a/silkworm/rpc/core/evm_trace_test.cpp
+++ b/silkworm/rpc/core/evm_trace_test.cpp
@@ -286,7 +286,7 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_call 1") {
                 co_return Bytes{};
             }));
 
-        const auto block_number = 5'405'095;  // 0x5279A7
+        const BlockNum block_number = 5'405'095;  // 0x5279A7
         Call call;
         call.from = 0xe0a2Bd4258D2768837BAa26A28fE71Dc079f84c7_address;
         call.gas = 50'000;
@@ -338,7 +338,7 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_call 1") {
                 co_return Bytes{};
             }));
 
-        const auto block_number = 5'405'095;  // 0x5279A7
+        const BlockNum block_number = 5'405'095;  // 0x5279A7
         Call call;
         call.from = 0xe0a2Bd4258D2768837BAa26A28fE71Dc079f84c7_address;
         call.gas = 118'936;
@@ -514,7 +514,7 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_call 1") {
                 co_return Bytes{};
             }));
 
-        const auto block_number = 5'405'095;  // 0x5279A7
+        const BlockNum block_number = 5'405'095;  // 0x5279A7
         Call call;
         call.from = 0xe0a2Bd4258D2768837BAa26A28fE71Dc079f84c7_address;
         call.gas = 118'936;
@@ -627,7 +627,7 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_call 1") {
                 co_return Bytes{};
             }));
 
-        const auto block_number = 5'405'095;  // 0x5279A7
+        const BlockNum block_number = 5'405'095;  // 0x5279A7
         Call call;
         call.from = 0xe0a2Bd4258D2768837BAa26A28fE71Dc079f84c7_address;
         call.gas = 118'936;
@@ -786,7 +786,7 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_call 1") {
                 co_return Bytes{};
             }));
 
-        const auto block_number = 5'405'095;  // 0x5279A7
+        const BlockNum block_number = 5'405'095;  // 0x5279A7
         Call call;
         call.from = 0xe0a2Bd4258D2768837BAa26A28fE71Dc079f84c7_address;
         call.gas = 118'936;
@@ -923,7 +923,7 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_call 1") {
                 co_return Bytes{};
             }));
 
-        const auto block_number = 5'405'095;  // 0x5279A7
+        const BlockNum block_number = 5'405'095;  // 0x5279A7
         Call call;
         call.from = 0xe0a2Bd4258D2768837BAa26A28fE71Dc079f84c7_address;
         call.gas = 118'936;
@@ -1115,7 +1115,7 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_call 2") {
                 co_return Bytes{};
             }));
 
-        const auto block_number = 4'417'196;  // 0x4366AC
+        const BlockNum block_number = 4'417'196;  // 0x4366AC
         Call call;
         call.from = 0x8ced5ad0d8da4ec211c17355ed3dbfec4cf0e5b9_address;
         call.to = 0x5e1f0c9ddbe3cb57b80c933fab5151627d7966fa_address;
@@ -1576,7 +1576,7 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_calls") {
                 co_return Bytes{};
             }));
 
-        const auto block_number = 5'405'095;  // 0x5279A7
+        const BlockNum block_number = 5'405'095;  // 0x5279A7
 
         TraceCall trace_call;
         trace_call.call.from = 0xe0a2Bd4258D2768837BAa26A28fE71Dc079f84c7_address;
@@ -1632,7 +1632,7 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_calls") {
                 co_return Bytes{};
             }));
 
-        const auto block_number = 5'405'095;  // 0x5279A7
+        const BlockNum block_number = 5'405'095;  // 0x5279A7
         TraceCall trace_call;
         trace_call.call.from = 0xe0a2Bd4258D2768837BAa26A28fE71Dc079f84c7_address;
         trace_call.call.gas = 118'936;

--- a/silkworm/rpc/core/receipts_test.cpp
+++ b/silkworm/rpc/core/receipts_test.cpp
@@ -336,7 +336,7 @@ TEST_CASE("get_receipts") {
     }
 
     SECTION("many receipts") {  // https://goerli.etherscan.io/block/469011
-        const auto block_hash{0x608e7102f689c99c027c9f49860212348000eb2e13bff37aa4453605a0a2b9e7_bytes32};
+        const evmc::bytes32 block_hash{0x608e7102f689c99c027c9f49860212348000eb2e13bff37aa4453605a0a2b9e7_bytes32};
         EXPECT_CALL(transaction, get_one(table::kHeaderNumbersName, _)).WillOnce(InvokeWithoutArgs([]() -> Task<silkworm::Bytes> { co_return kNumber; }));
         EXPECT_CALL(transaction, get_one(table::kHeadersName, _)).WillOnce(InvokeWithoutArgs([]() -> Task<silkworm::Bytes> { co_return kHeader; }));
         EXPECT_CALL(transaction, get_one(table::kBlockBodiesName, _)).WillOnce(InvokeWithoutArgs([]() -> Task<silkworm::Bytes> { co_return kBody; }));

--- a/silkworm/rpc/ethbackend/remote_backend_test.cpp
+++ b/silkworm/rpc/ethbackend/remote_backend_test.cpp
@@ -311,7 +311,7 @@ TEST_CASE_METHOD(EthBackendTest, "BackEnd::node_info", "[silkworm][rpc][ethbacke
         p->set_block_number(0x1);
         p->set_gas_limit(0x1c9c380);
         p->set_timestamp(0x5);
-        const auto tx_bytes{*from_hex("0xf92ebdeab45d368f6354e8c5a8ac586c")};
+        const Bytes tx_bytes{*from_hex("0xf92ebdeab45d368f6354e8c5a8ac586c")};
         p->add_transactions(tx_bytes.data(), tx_bytes.size());
         const auto hi_hi_hi_logsbloom{make_h256(0x1000000000000000, 0x0, 0x0, 0x0)};
         const auto hi_hi_logsbloom{new ::types::H512()};
@@ -364,7 +364,7 @@ TEST_CASE_METHOD(EthBackendTest, "BackEnd::engine_new_payload", "[silkworm][rpc]
     silkworm::Bloom bloom;
     bloom.fill(0);
     bloom[0] = 0x12;
-    const auto transaction{*from_hex("0xf92ebdeab45d368f6354e8c5a8ac586c")};
+    const Bytes transaction{*from_hex("0xf92ebdeab45d368f6354e8c5a8ac586c")};
     const NewPayloadRequest request_v1{
         .execution_payload = ExecutionPayload{
             .version = ExecutionPayload::kV1,

--- a/silkworm/rpc/ethdb/cbor_test.cpp
+++ b/silkworm/rpc/ethdb/cbor_test.cpp
@@ -29,9 +29,9 @@
 
 namespace {
 #ifdef _WIN32
-const auto kInvalidArgumentMessage = "invalid argument";
+const char* kInvalidArgumentMessage = "invalid argument";
 #else
-const auto kInvalidArgumentMessage = "Invalid argument";
+const char* kInvalidArgumentMessage = "Invalid argument";
 #endif
 }  // namespace
 
@@ -116,9 +116,9 @@ TEST_CASE("decode logs from CBOR 4", "[rpc][ethdb][cbor]") {
 TEST_CASE("decode logs from incorrect bytes", "[rpc][ethdb][cbor]") {
     test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
     Logs logs{};
-    const auto b1 = *silkworm::from_hex("81");
+    const Bytes b1 = *silkworm::from_hex("81");
     CHECK(!cbor_decode(b1, logs));
-    const auto b2 = *silkworm::from_hex("83808040");
+    const Bytes b2 = *silkworm::from_hex("83808040");
     CHECK_THROWS_MATCHES(cbor_decode(b2, logs), std::invalid_argument, Message("Log CBOR: unexpected format(on_array wrong number of fields)"));
 }
 
@@ -180,9 +180,9 @@ TEST_CASE("decode receipts from CBOR 3", "[rpc][ethdb][cbor]") {
 TEST_CASE("decode receipts from incorrect bytes", "[rpc][ethdb][cbor]") {
     test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
     Receipts receipts{};
-    const auto b1 = *silkworm::from_hex("81");
+    const Bytes b1 = *silkworm::from_hex("81");
     CHECK_THROWS(cbor_decode(b1, receipts));
-    const auto b2 = *silkworm::from_hex("83808040");
+    const Bytes b2 = *silkworm::from_hex("83808040");
     CHECK_THROWS_MATCHES(cbor_decode(b2, receipts), std::system_error, Message("Receipt CBOR: missing entries: "s + kInvalidArgumentMessage));
 }
 

--- a/silkworm/rpc/http/connection_test.cpp
+++ b/silkworm/rpc/http/connection_test.cpp
@@ -60,10 +60,10 @@ TEST_CASE("connection creation", "[rpc][http][connection]") {
     }
 }
 
-static constexpr auto kSampleJWTKey{
+static constexpr std::string_view kSampleJWTKey{
     "NTNv7j0TuYARvmNMmWXo6fKvM4o6nv/aUi9ryX38ZH+L1bkrnD1ObOQ8JAUmHCBq7Iy7otZcyAagBLHVKvvYaIpmMuxmARQ97jUVG16Jkpkp1wXO"
     "PsrF9zwew6TpczyHkHgX5EuLg2MeBuiT/qJACs1J0apruOOJCg/gOtkjB4c="sv};
-static constexpr auto kSampleJWTBearer{
+static constexpr std::string_view kSampleJWTBearer{
     "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUs"
     "ImlhdCI6MTcxMzUxNDQ3MCwiZXhwIjoxNzEzNTE4MDcwfQ.IBKIdE8Bcto9cwGSkr6mqylBLvfcPZZyDOyZMWYtEaQ"sv};
 

--- a/silkworm/rpc/json/execution_payload_test.cpp
+++ b/silkworm/rpc/json/execution_payload_test.cpp
@@ -217,7 +217,7 @@ TEST_CASE("deserialize ExecutionPayloadV2", "[silkworm][rpc][json]") {
                                      });
     }
     SECTION("invalid hex transaction") {
-        const auto json = R"({
+        const nlohmann::json json = R"({
             "parentHash":"0x3b8fb240d288781d4aac94d3fd16809ee413bc99294a085798a589dae51ddd4a",
             "feeRecipient":"0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
             "stateRoot":"0xca3149fa9e37db08d1cd49c9061db1002ef1cd58db2210f2115c8c989b2bdf45",
@@ -431,7 +431,7 @@ TEST_CASE("deserialize ExecutionPayloadV3", "[silkworm][rpc][json]") {
         CHECK(payload.excess_blob_gas == 0x0100);
     }
     SECTION("missing excess_blob_gas") {
-        const auto json = R"({
+        const nlohmann::json json = R"({
             "parentHash":"0x3b8fb240d288781d4aac94d3fd16809ee413bc99294a085798a589dae51ddd4a",
             "feeRecipient":"0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
             "stateRoot":"0xca3149fa9e37db08d1cd49c9061db1002ef1cd58db2210f2115c8c989b2bdf45",
@@ -453,7 +453,7 @@ TEST_CASE("deserialize ExecutionPayloadV3", "[silkworm][rpc][json]") {
         CHECK_THROWS_AS(from_json(json, payload), std::system_error);
     }
     SECTION("missing blob_gas_used") {
-        const auto json = R"({
+        const nlohmann::json json = R"({
             "parentHash":"0x3b8fb240d288781d4aac94d3fd16809ee413bc99294a085798a589dae51ddd4a",
             "feeRecipient":"0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
             "stateRoot":"0xca3149fa9e37db08d1cd49c9061db1002ef1cd58db2210f2115c8c989b2bdf45",
@@ -475,7 +475,7 @@ TEST_CASE("deserialize ExecutionPayloadV3", "[silkworm][rpc][json]") {
         CHECK_THROWS_AS(from_json(json, payload), std::system_error);
     }
     SECTION("invalid missing withdrawals") {
-        const auto json = R"({
+        const nlohmann::json json = R"({
             "parentHash":"0x3b8fb240d288781d4aac94d3fd16809ee413bc99294a085798a589dae51ddd4a",
             "feeRecipient":"0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
             "stateRoot":"0xca3149fa9e37db08d1cd49c9061db1002ef1cd58db2210f2115c8c989b2bdf45",

--- a/silkworm/rpc/json/log_test.cpp
+++ b/silkworm/rpc/json/log_test.cpp
@@ -29,9 +29,9 @@
 
 namespace {
 #ifdef _WIN32
-const auto kInvalidArgumentMessage = "invalid argument";
+const char* kInvalidArgumentMessage = "invalid argument";
 #else
-const auto kInvalidArgumentMessage = "Invalid argument";
+const char* kInvalidArgumentMessage = "Invalid argument";
 #endif
 }  // namespace
 
@@ -114,7 +114,7 @@ TEST_CASE("deserialize empty log", "[rpc][from_json]") {
 }
 
 TEST_CASE("deserialize array log", "[rpc][from_json]") {
-    const auto bytes = silkworm::from_hex("8354ea674fdde714fd979de3edf0f56aa9716b898ec88043010043").value();
+    const Bytes bytes = silkworm::from_hex("8354ea674fdde714fd979de3edf0f56aa9716b898ec88043010043").value();
     const auto j = nlohmann::json::from_cbor(bytes);
     const auto log = j.get<Log>();
     CHECK(log.address == 0xea674fdde714fd979de3edf0f56aa9716b898ec8_address);

--- a/silkworm/rpc/json/receipt_test.cpp
+++ b/silkworm/rpc/json/receipt_test.cpp
@@ -22,12 +22,12 @@
 namespace silkworm::rpc {
 
 TEST_CASE("deserialize wrong receipt", "[rpc][from_json]") {
-    const auto j = R"({})"_json;
+    const nlohmann::json j = R"({})"_json;
     CHECK_THROWS(j.get<Receipt>());
 }
 
 TEST_CASE("deserialize empty receipt", "[rpc][from_json]") {
-    const auto j = R"({"success":false,"cumulative_gas_used":0})"_json;
+    const nlohmann::json j = R"({"success":false,"cumulative_gas_used":0})"_json;
     const auto r = j.get<Receipt>();
     CHECK(r.success == false);
     CHECK(r.cumulative_gas_used == 0);
@@ -58,7 +58,7 @@ TEST_CASE("deserialize wrong object receipt", "[rpc][from_json]") {
 }
 
 TEST_CASE("deserialize empty array receipt", "[rpc][from_json]") {
-    const auto j1 = R"([0,null,0,0])"_json;
+    const nlohmann::json j1 = R"([0,null,0,0])"_json;
     const auto r1 = j1.get<Receipt>();
     CHECK(*r1.type == 0);
     CHECK(r1.success == false);
@@ -71,7 +71,7 @@ TEST_CASE("deserialize empty array receipt", "[rpc][from_json]") {
 }
 
 TEST_CASE("deserialize array receipt", "[rpc][from_json]") {
-    const auto j = R"([1,null,1,123456])"_json;
+    const nlohmann::json j = R"([1,null,1,123456])"_json;
     const auto r = j.get<Receipt>();
     CHECK(*r.type == 1);
     CHECK(r.success == true);

--- a/silkworm/rpc/json/types_test.cpp
+++ b/silkworm/rpc/json/types_test.cpp
@@ -739,7 +739,7 @@ TEST_CASE("serialize PayloadStatusV1", "[silkworm::json][to_json]") {
 }
 
 TEST_CASE("make empty json content", "[silkworm::json][make_json_content]") {
-    const auto request = R"({
+    const nlohmann::json request = R"({
         "id":0
     })"_json;
     const auto j = make_json_content(request, {});
@@ -751,7 +751,7 @@ TEST_CASE("make empty json content", "[silkworm::json][make_json_content]") {
 }
 
 TEST_CASE("make json content", "[silkworm::json][make_json_content]") {
-    const auto request = R"({
+    const nlohmann::json request = R"({
         "id":123
     })"_json;
     nlohmann::json json_result = {{"currency", "ETH"}, {"value", 4.2}};
@@ -764,7 +764,7 @@ TEST_CASE("make json content", "[silkworm::json][make_json_content]") {
 }
 
 TEST_CASE("make empty json error", "[silkworm::json][make_json_error]") {
-    const auto request = R"({
+    const nlohmann::json request = R"({
         "id":0
     })"_json;
     const auto j = make_json_error(request, 0, "");
@@ -776,7 +776,7 @@ TEST_CASE("make empty json error", "[silkworm::json][make_json_error]") {
 }
 
 TEST_CASE("make empty json revert error", "[silkworm::json][make_json_error]") {
-    const auto request = R"({
+    const nlohmann::json request = R"({
         "id":0
     })"_json;
     const auto j = make_json_error(request, {{0, ""}, silkworm::Bytes{}});
@@ -788,7 +788,7 @@ TEST_CASE("make empty json revert error", "[silkworm::json][make_json_error]") {
 }
 
 TEST_CASE("make json error", "[silkworm::json][make_json_error]") {
-    const auto request = R"({
+    const nlohmann::json request = R"({
         "id":123
     })"_json;
 
@@ -801,7 +801,7 @@ TEST_CASE("make json error", "[silkworm::json][make_json_error]") {
 }
 
 TEST_CASE("make json revert error", "[silkworm::json][make_json_error]") {
-    const auto request = R"({
+    const nlohmann::json request = R"({
         "id":123
     })"_json;
 

--- a/silkworm/rpc/json_rpc/request_handler_test.cpp
+++ b/silkworm/rpc/json_rpc/request_handler_test.cpp
@@ -24,7 +24,7 @@ namespace silkworm::rpc::json_rpc {
 
 #ifndef SILKWORM_SANITIZE
 TEST_CASE_METHOD(test_util::RpcApiE2ETest, "check handle_request no method", "[rpc][handle]") {
-    const auto request = R"({"jsonrpc":"2.0","id":1})"_json;
+    const nlohmann::json request = R"({"jsonrpc":"2.0","id":1})"_json;
     std::string reply;
     run<&test_util::RequestHandlerForTest::request_and_create_reply>(request, reply);
     CHECK(nlohmann::json::parse(reply) == R"({
@@ -38,7 +38,7 @@ TEST_CASE_METHOD(test_util::RpcApiE2ETest, "check handle_request no method", "[r
 }
 
 TEST_CASE_METHOD(test_util::RpcApiE2ETest, "check handle_request invalid method", "[rpc][handle_request]") {
-    const auto request = R"({"jsonrpc":"2.0","id":1, "method":"eth_AAA"})"_json;
+    const nlohmann::json request = R"({"jsonrpc":"2.0","id":1, "method":"eth_AAA"})"_json;
     std::string reply;
     run<&test_util::RequestHandlerForTest::request_and_create_reply>(request, reply);
     CHECK(nlohmann::json::parse(reply) == R"({
@@ -52,7 +52,7 @@ TEST_CASE_METHOD(test_util::RpcApiE2ETest, "check handle_request invalid method"
 }
 
 TEST_CASE_METHOD(test_util::RpcApiE2ETest, "check handle_request method return failed", "[rpc][handle_request]") {
-    const auto request = R"({"jsonrpc":"2.0","id":3,"method":"eth_getBlockByNumber","params":[]})"_json;
+    const nlohmann::json request = R"({"jsonrpc":"2.0","id":3,"method":"eth_getBlockByNumber","params":[]})"_json;
     std::string reply;
     run<&test_util::RequestHandlerForTest::request_and_create_reply>(request, reply);
     CHECK(nlohmann::json::parse(reply) == R"({

--- a/silkworm/rpc/txpool/transaction_pool_test.cpp
+++ b/silkworm/rpc/txpool/transaction_pool_test.cpp
@@ -118,7 +118,7 @@ TEST_CASE_METHOD(TransactionPoolTest, "TransactionPool::add_transaction", "[rpc]
 TEST_CASE_METHOD(TransactionPoolTest, "TransactionPool::get_transaction", "[rpc][txpool][transaction_pool]") {
     test::StrictMockAsyncResponseReader<::txpool::TransactionsReply> reader;
     EXPECT_CALL(*stub_, AsyncTransactionsRaw).WillOnce(testing::Return(&reader));
-    const auto tx_hash{0x3763e4f6e4198413383534c763f3f5dac5c5e939f0a81724e3beb96d6e2ad0d5_bytes32};
+    const evmc::bytes32 tx_hash{0x3763e4f6e4198413383534c763f3f5dac5c5e939f0a81724e3beb96d6e2ad0d5_bytes32};
 
     SECTION("call get_transaction and check success") {
         ::txpool::TransactionsReply response;
@@ -155,7 +155,7 @@ TEST_CASE_METHOD(TransactionPoolTest, "TransactionPool::get_transaction", "[rpc]
 TEST_CASE_METHOD(TransactionPoolTest, "TransactionPool::nonce", "[rpc][txpool][transaction_pool]") {
     test::StrictMockAsyncResponseReader<::txpool::NonceReply> reader;
     EXPECT_CALL(*stub_, AsyncNonceRaw).WillOnce(testing::Return(&reader));
-    const auto account{0x99f9b87991262f6ba471f09758cde1c0fc1de734_address};
+    const evmc::address account{0x99f9b87991262f6ba471f09758cde1c0fc1de734_address};
 
     SECTION("call nonce and check success") {
         ::txpool::NonceReply response;

--- a/silkworm/rpc/types/dump_account_test.cpp
+++ b/silkworm/rpc/types/dump_account_test.cpp
@@ -26,9 +26,9 @@
 
 namespace silkworm::rpc {
 
-const auto kZeroAddress = evmc::address{};
-const auto kEmptyHash = evmc::bytes32{};
-const auto kZeroBalance = intx::uint256{0};
+static constexpr evmc::address kZeroAddress;
+static constexpr evmc::bytes32 kEmptyHash;
+static constexpr intx::uint256 kZeroBalance = intx::uint256{0};
 
 using evmc::literals::operator""_address;
 using evmc::literals::operator""_bytes32;


### PR DESCRIPTION
Add explicit types for constants defined by literals in accordance with:
https://github.com/erigontech/silkworm/blob/master/docs/code_style.md#p17-auto-for-constants

Note: this addressed only `auto` keyword and typing, proper init syntax and proper const keywords will be fixed in separate future PRs.
