### PR TITLE
db: set operations on paginated Data API iterators

### DIFF
--- a/cmd/dev/grpc_toolbox.cpp
+++ b/cmd/dev/grpc_toolbox.cpp
@@ -889,10 +889,9 @@ Task<void> kv_index_range_query(const std::shared_ptr<Service>& kv_service,
         std::cout << "KV IndexRange <- #timestamps: ";
         int count{0};
         ListOfTimestamp timestamps;
-        while (it != paginated_result.end()) {
-            timestamps.emplace_back(*it);
+        while (const auto value = co_await it.next()) {
+            timestamps.emplace_back(*value);
             ++count;
-            co_await ++it;
         }
         std::cout << count << "\n";
         if (verbose) {
@@ -917,10 +916,9 @@ Task<void> kv_history_range_query(const std::shared_ptr<Service>& kv_service,
         std::cout << "KV HistoryRange <- #keys and #values: ";
         int count{0};
         std::vector<KeyValue> keys_and_values;
-        while (it != paginated_result.end()) {
-            keys_and_values.emplace_back(*it);
+        while (const auto key_value = co_await it.next()) {
+            keys_and_values.emplace_back(*key_value);
             ++count;
-            co_await ++it;
         }
         std::cout << count << "\n";
         if (verbose) {
@@ -945,10 +943,9 @@ Task<void> kv_domain_range_query(const std::shared_ptr<Service>& kv_service,
         std::cout << "KV DomainRange <- #keys and #values: ";
         int count{0};
         std::vector<KeyValue> keys_and_values;
-        while (it != paginated_result.end()) {
-            keys_and_values.emplace_back(*it);
+        while (const auto key_value = co_await it.next()) {
+            keys_and_values.emplace_back(*key_value);
             ++count;
-            co_await ++it;
         }
         std::cout << count << "\n";
         if (verbose) {

--- a/silkworm/db/kv/api/endpoint/paginated_sequence.hpp
+++ b/silkworm/db/kv/api/endpoint/paginated_sequence.hpp
@@ -16,18 +16,30 @@
 
 #pragma once
 
+#include <concepts>
 #include <functional>
+#include <iterator>
 #include <optional>
 #include <tuple>
 #include <vector>
 
 #include <silkworm/infra/concurrency/task.hpp>
 
+#include <silkworm/core/common/assert.hpp>
 #include <silkworm/infra/common/ensure.hpp>
 
 #include "key_value.hpp"
 
 namespace silkworm::db::kv::api {
+
+//! Definition of asynchronous paginated iterator (a.k.a. stream)
+template <class I>
+concept PaginatedIterator =
+    requires(I i) {
+        typename I::value_type;
+        { i.has_next() } -> std::same_as<bool>;
+        { i.next() } -> std::same_as<Task<std::optional<typename std::iter_value_t<I>>>>;
+    };
 
 //! Sequence of values produced by pagination using some asynchronous page provider function.
 template <typename T>
@@ -42,40 +54,35 @@ class PaginatedSequence {
 
     class Iterator {
       public:
-        T operator*() {
-            return std::move(*it_);
-        }
+        using value_type = T;
 
-        Task<void> operator++() {
-            ++it_;
+        bool has_next() const { return it_ != current_.values.cend(); }
+
+        Task<std::optional<T>> next() {
             if (it_ == current_.values.cend()) {
                 if (current_.has_more) {
                     current_ = co_await next_page_provider_();
                     it_ = current_.values.cbegin();
-                } else {
-                    it_ = typename Page::const_iterator();  // empty i.e. sentinel value
                 }
             }
-        }
-
-        bool operator==(const Iterator& other) const noexcept {
-            return it_ == other.it_;
-        }
-
-        bool operator!=(const Iterator& other) const noexcept {
-            return !(*this == other);
+            if (it_ == current_.values.cend()) {
+                co_return std::nullopt;
+            }
+            const auto value = *it_;
+            ++it_;
+            co_return value;
         }
 
         Iterator(Paginator& next_page_provider, PageResult current) noexcept
             : next_page_provider_(next_page_provider), current_(std::move(current)), it_{current_.values.cbegin()} {}
-        explicit Iterator(Paginator& next_page_provider) noexcept
-            : next_page_provider_(next_page_provider) {}
 
       private:
         Paginator& next_page_provider_;
         PageResult current_;
-        typename Page::const_iterator it_;  // empty i.e. sentinel value
+        typename Page::const_iterator it_;
     };
+
+    static_assert(PaginatedIterator<Iterator>);
 
     explicit PaginatedSequence(Paginator next_page_provider) noexcept
         : next_page_provider_(std::move(next_page_provider)) {}
@@ -85,23 +92,22 @@ class PaginatedSequence {
         co_return Iterator{next_page_provider_, std::move(current)};
     }
 
-    Iterator end() noexcept {
-        return Iterator{next_page_provider_};
-    }
-
   private:
     Paginator next_page_provider_;
 };
 
-template <typename T>
-Task<std::vector<T>> paginated_to_vector(PaginatedSequence<T>& paginated) {
-    std::vector<T> all_values;
-    auto it = co_await paginated.begin();
-    while (it != paginated.end()) {
-        all_values.emplace_back(*it);
-        co_await ++it;
+template <PaginatedIterator I>
+Task<std::vector<typename I::value_type>> paginated_iterator_to_vector(I it) {
+    std::vector<typename I::value_type> all_values;
+    while (const auto value = co_await it.next()) {
+        all_values.emplace_back(*value);
     }
     co_return all_values;
+}
+
+template <typename T>
+Task<std::vector<T>> paginated_to_vector(PaginatedSequence<T>& paginated) {
+    co_return co_await paginated_iterator_to_vector(co_await paginated.begin());
 }
 
 //! Sequence of keys and values produced by pagination using some asynchronous page provider function.
@@ -119,32 +125,31 @@ class PaginatedSequencePair {
 
     class Iterator {
       public:
-        std::pair<K, V> operator*() {
-            return {std::move(*key_it_), std::move(*value_it_)};
+        using value_type = std::pair<K, V>;
+
+        bool has_next() const {
+            const bool has_next_key = key_it_ != current_.keys.cend();
+            const bool has_next_value = value_it_ != current_.values.cend();
+            SILKWORM_ASSERT(has_next_key == has_next_value);
+            return has_next_key;
         }
 
-        Task<void> operator++() {
-            ++key_it_;
-            ++value_it_;
+        Task<std::optional<value_type>> next() {
             if (key_it_ == current_.keys.cend()) {
                 SILKWORM_ASSERT(value_it_ == current_.values.cend());
                 if (current_.has_more) {
                     current_ = co_await next_page_provider_();
                     key_it_ = current_.keys.cbegin();
                     value_it_ = current_.values.cbegin();
-                } else {
-                    key_it_ = typename KPage::const_iterator();    // empty i.e. sentinel value
-                    value_it_ = typename VPage::const_iterator();  // empty i.e. sentinel value
                 }
             }
-        }
-
-        bool operator==(const Iterator& other) const noexcept {
-            return key_it_ == other.key_it_ && value_it_ == other.value_it_;
-        }
-
-        bool operator!=(const Iterator& other) const noexcept {
-            return !(*this == other);
+            if (key_it_ == current_.keys.cend()) {
+                SILKWORM_ASSERT(value_it_ == current_.values.cend());
+                co_return std::nullopt;
+            }
+            const std::pair<K, V> key_value{std::move(*key_it_), std::move(*value_it_)};
+            ++key_it_, ++value_it_;
+            co_return key_value;
         }
 
         Iterator(Paginator& next_page_provider, PageResult current) noexcept
@@ -152,15 +157,15 @@ class PaginatedSequencePair {
               current_(std::move(current)),
               key_it_{current_.keys.cbegin()},
               value_it_{current_.values.cbegin()} {}
-        explicit Iterator(Paginator& next_page_provider) noexcept
-            : next_page_provider_(next_page_provider) {}
 
       private:
         Paginator& next_page_provider_;
         PageResult current_;
-        typename KPage::const_iterator key_it_;    // empty i.e. sentinel value
-        typename VPage::const_iterator value_it_;  // empty i.e. sentinel value
+        typename KPage::const_iterator key_it_;
+        typename VPage::const_iterator value_it_;
     };
+
+    static_assert(PaginatedIterator<Iterator>);
 
     explicit PaginatedSequencePair(Paginator next_page_provider) noexcept
         : next_page_provider_(std::move(next_page_provider)) {}
@@ -171,23 +176,133 @@ class PaginatedSequencePair {
         co_return Iterator{next_page_provider_, std::move(current)};
     }
 
-    Iterator end() noexcept {
-        return Iterator{next_page_provider_};
-    }
-
   private:
     Paginator next_page_provider_;
 };
 
 template <typename K, typename V>
 Task<std::vector<KeyValue>> paginated_to_vector(PaginatedSequencePair<K, V>& paginated) {
-    std::vector<KeyValue> all_keys_and_values;
+    std::vector<KeyValue> all_values;
     auto it = co_await paginated.begin();
-    while (it != paginated.end()) {
-        all_keys_and_values.emplace_back(*it);
-        co_await ++it;
+    while (const auto value = co_await it.next()) {
+        all_values.emplace_back(*value);
     }
-    co_return all_keys_and_values;
+    co_return all_values;
+    // co_return co_await paginated_iterator_to_vector(co_await paginated.begin());
+}
+
+//! Paginated iterator implementing 'intersection' set operation between 2 paginated iterators
+template <PaginatedIterator I>
+class IntersectionIterator {
+  public:
+    using value_type = typename I::value_type;
+
+    IntersectionIterator(I it1, I it2, size_t limit)
+        : it1_(std::move(it1)), it2_(std::move(it2)), limit_(limit) {}
+
+    bool has_next() const { return false; }  // TODO(canepat) implement
+
+    Task<std::optional<value_type>> next() {
+        if (limit_ == 0) {
+            co_return std::nullopt;
+        }
+        --limit_;
+        auto v1 = co_await it1_.next(), v2 = co_await it2_.next();
+        if (!v1 || !v2) {
+            co_return std::nullopt;
+        }
+        while (v1.has_value() && v2.has_value()) {
+            if (*v1 < *v2) {
+                v1 = co_await it1_.next();
+                continue;
+            }
+            if (*v1 == *v2) {
+                co_return v1;  // *v1 and *v2 are equivalent
+            } else {
+                v2 = co_await it2_.next();
+                continue;
+            }
+        }
+        co_return std::nullopt;
+    }
+
+  private:
+    I it1_;
+    I it2_;
+    size_t limit_;
+};
+
+static_assert(PaginatedIterator<IntersectionIterator<PaginatedSequence<uint64_t>::Iterator>>);
+
+template <PaginatedIterator I>
+IntersectionIterator<I> set_intersection(I it1, I it2, size_t limit = std::numeric_limits<size_t>::max()) {
+    return IntersectionIterator<I>{std::move(it1), std::move(it2), limit};
+}
+
+//! Paginated iterator implementing 'union' set operation between 2 paginated iterators
+template <PaginatedIterator I>
+class UnionIterator {
+  public:
+    using value_type = typename I::value_type;
+
+    UnionIterator(I it1, I it2, bool ascending, size_t limit)
+        : it1_(std::move(it1)), it2_(std::move(it2)), ascending_(ascending), limit_(limit) {}
+
+    bool has_next() const { return limit_ != 0 && (it1_.has_next() || it2_.has_next() || next_v1_ || next_v2_); }
+
+    Task<std::optional<value_type>> next() {
+        if (limit_ == 0) {
+            co_return std::nullopt;
+        }
+        --limit_;
+        if (!next_v1_ && it1_.has_next()) {
+            next_v1_ = co_await it1_.next();
+        }
+        if (!next_v2_ && it2_.has_next()) {
+            next_v2_ = co_await it2_.next();
+        }
+        if (!next_v1_ && !next_v2_) {
+            co_return std::nullopt;
+        }
+        if (next_v1_ && next_v2_) {
+            if ((ascending_ && *next_v1_ < *next_v2_) || (!ascending_ && *next_v1_ > *next_v2_)) {
+                const auto v1 = *next_v1_;
+                next_v1_ = co_await it1_.next();
+                co_return v1;
+            } else if (*next_v1_ == *next_v2_) {
+                const auto v1 = *next_v1_;
+                next_v1_ = co_await it1_.next();
+                next_v2_ = co_await it2_.next();
+                co_return v1;  // *v1 and *v2 are equivalent
+            }
+            const auto v2 = *next_v2_;
+            next_v2_ = co_await it2_.next();
+            co_return v2;
+        }
+        if (next_v1_) {
+            const auto v1 = *next_v1_;
+            next_v1_ = co_await it1_.next();
+            co_return v1;
+        }
+        const auto v2 = *next_v2_;
+        next_v2_ = co_await it2_.next();
+        co_return v2;
+    }
+
+  private:
+    I it1_;
+    I it2_;
+    std::optional<value_type> next_v1_;
+    std::optional<value_type> next_v2_;
+    bool ascending_;
+    size_t limit_;
+};
+
+static_assert(PaginatedIterator<UnionIterator<PaginatedSequence<uint64_t>::Iterator>>);
+
+template <PaginatedIterator I>
+UnionIterator<I> set_union(I it1, I it2, bool ascending = true, size_t limit = std::numeric_limits<size_t>::max()) {
+    return UnionIterator<I>{std::move(it1), std::move(it2), ascending, limit};
 }
 
 }  // namespace silkworm::db::kv::api

--- a/silkworm/db/kv/api/endpoint/paginated_sequence_benchmark.cpp
+++ b/silkworm/db/kv/api/endpoint/paginated_sequence_benchmark.cpp
@@ -43,9 +43,8 @@ TSequence make_paginated_sequence(const size_t page_size, const size_t n) {
 Task<size_t> paginated_sequence_iteration(PaginatedUint64& paginated) {
     size_t accumulator{0};
     auto it = co_await paginated.begin();
-    while (it != paginated.end()) {
-        accumulator += *it;
-        co_await ++it;
+    while (const auto value = co_await it.next()) {
+        accumulator += *value;
     }
     co_return accumulator;
 }
@@ -78,8 +77,8 @@ BENCHMARK(benchmark_paginated_sequence_iteration)->Args({100'000, 100'001});
 BENCHMARK(benchmark_paginated_sequence_iteration)->Args({100'000, 1'000'001});
 
 // Modified version of PaginatedSequence to check performance tradeoffs w/ different impl
-// - PaginatedSequence: async operator++ (more convenient at call site)
-// - PaginatedSequence2: sync operator++ plus async next_page
+// - PaginatedSequence::Iterator async next() method (more convenient at call site)
+// - PaginatedSequence2::Iterator sync operator++ plus async next_page
 template <typename T>
 class PaginatedSequence2 {
   public:

--- a/silkworm/db/kv/api/endpoint/paginated_sequence_test.cpp
+++ b/silkworm/db/kv/api/endpoint/paginated_sequence_test.cpp
@@ -168,6 +168,7 @@ TEST_CASE_METHOD(PaginatedSetTest, "set_intersection", "[db][kv][api][paginated_
         {{/*v1=*/{{1, 2, 3}, {4, 5, 6}, {7, 8}}, /*v2=*/{}}, /*v1_and_v2=*/{}},  // one empty => empty
         {{/*v1=*/{{1, 2, 3}, {4, 5, 6}, {7, 8}}, /*v2=*/{{10, 11, 12}, {13}}}, /*v1_and_v2=*/{}},  // disjoint => empty
         {{/*v1=*/{{1, 2, 3}, {4, 5, 6}, {7, 8}}, /*v2=*/{{7, 8, 9}, {10, 11, 12}, {13}}}, /*v1_and_v2=*/{7, 8}},
+        {{/*v1=*/{{1, 2, 3}, {4, 5, 6}, {7, 8}}, /*v2=*/{{1, 2, 3}, {4, 5, 6}, {7, 8}}}, /*v1_and_v2=*/{1, 2, 3, 4, 5, 6, 7, 8}},
     };
     int i = 0;
     for (const auto& [v1_v2_pair, expected_intersection_set] : fixtures) {
@@ -184,39 +185,27 @@ TEST_CASE_METHOD(PaginatedSetTest, "set_intersection", "[db][kv][api][paginated_
     }
 }
 
-TEST_CASE_METHOD(PaginatedSetTest, "set_union: non-empty uint64 sequence", "[db][kv][api][paginated_sequence]") {
-    PaginatedUint64::Paginator paginator1 = []() -> Task<PaginatedUint64::PageResult> {
-        static int count{0};
-        switch (++count) {
-            case 1:
-                co_return PaginatedUint64::PageResult{PaginatedUint64::Page{1, 2, 3}, /*has_more=*/true};
-            case 2:
-                co_return PaginatedUint64::PageResult{PaginatedUint64::Page{4, 5, 6}, /*has_more=*/true};
-            case 3:
-                co_return PaginatedUint64::PageResult{PaginatedUint64::Page{7, 8}, /*has_more=*/false};
-            default:
-                throw std::logic_error{"unexpected call to paginator"};
+TEST_CASE_METHOD(PaginatedSetTest, "set_union", "[db][kv][api][paginated_sequence]") {
+    const Fixtures<std::pair<PageUint64Vector, PageUint64Vector>, std::vector<uint64_t>> fixtures{
+        {{/*v1=*/{}, /*v2=*/{}}, /*v1_or_v2=*/{}},  // both empty => empty
+        {{/*v1=*/{{1, 2, 3}, {4, 5, 6}, {7, 8}}, /*v2=*/{}}, /*v1_or_v2=*/{1, 2, 3, 4, 5, 6, 7, 8}},  // one empty => other
+        {{/*v1=*/{{1, 2, 3}, {4, 5, 6}, {7, 8}}, /*v2=*/{{10, 11, 12}, {13}}}, /*v1_or_v2=*/{1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 13}},
+        {{/*v1=*/{{1, 2, 3}, {4, 5, 6}, {7, 8}}, /*v2=*/{{7, 8, 9}, {10, 11, 12}, {13}}}, /*v1_or_v2=*/{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13}},
+        {{/*v1=*/{{1, 2, 3}, {4, 5, 6}, {7, 8}}, /*v2=*/{{1, 2, 3}, {4, 5, 6}, {7, 8}}}, /*v1_and_v2=*/{1, 2, 3, 4, 5, 6, 7, 8}},
+    };
+    int i = 0;
+    for (const auto& [v1_v2_pair, expected_union_set] : fixtures) {
+        SECTION("test vector: " + std::to_string(++i)) {
+            const auto& [v1, v2] = v1_v2_pair;
+            TestPaginatorUint64 paginator1{v1}, paginator2{v2};
+            PaginatedUint64 paginated1{paginator1}, paginated2{paginator2};
+            const auto async_union = [](PaginatedUint64& ps1, PaginatedUint64& ps2) -> Task<std::vector<uint64_t>> {
+                UnionIterator<PaginatedUint64::Iterator> it = set_union(co_await ps1.begin(), co_await ps2.begin());
+                co_return co_await paginated_iterator_to_vector(std::move(it));
+            };
+            CHECK(spawn_and_wait(async_union(paginated1, paginated2)) == expected_union_set);
         }
-    };
-    PaginatedUint64::Paginator paginator2 = []() -> Task<PaginatedUint64::PageResult> {
-        static int count{0};
-        switch (++count) {
-            case 1:
-                co_return PaginatedUint64::PageResult{PaginatedUint64::Page{7, 8, 9}, /*has_more=*/true};
-            case 2:
-                co_return PaginatedUint64::PageResult{PaginatedUint64::Page{10, 11, 12}, /*has_more=*/true};
-            case 3:
-                co_return PaginatedUint64::PageResult{PaginatedUint64::Page{13}, /*has_more=*/false};
-            default:
-                throw std::logic_error{"unexpected call to paginator"};
-        }
-    };
-    PaginatedUint64 paginated1{paginator1}, paginated2{paginator2};
-    const auto async_intersection = [](PaginatedUint64& ps1, PaginatedUint64& ps2) -> Task<std::vector<uint64_t>> {
-        UnionIterator<PaginatedUint64::Iterator> it = set_union(co_await ps1.begin(), co_await ps2.begin());
-        co_return co_await paginated_iterator_to_vector(std::move(it));
-    };
-    CHECK(spawn_and_wait(async_intersection(paginated1, paginated2)) == std::vector<uint64_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13});
+    }
 }
 
 }  // namespace silkworm::db::kv::api

--- a/silkworm/db/kv/api/endpoint/paginated_sequence_test.cpp
+++ b/silkworm/db/kv/api/endpoint/paginated_sequence_test.cpp
@@ -164,8 +164,8 @@ struct TestPaginatorUint64 {
 
 TEST_CASE_METHOD(PaginatedSetTest, "set_intersection", "[db][kv][api][paginated_sequence]") {
     const Fixtures<std::pair<PageUint64Vector, PageUint64Vector>, std::vector<uint64_t>> fixtures{
-        {{/*v1=*/{}, /*v2=*/{}}, /*v1_and_v2=*/{}},  // both empty => empty
-        {{/*v1=*/{{1, 2, 3}, {4, 5, 6}, {7, 8}}, /*v2=*/{}}, /*v1_and_v2=*/{}},  // one empty => empty
+        {{/*v1=*/{}, /*v2=*/{}}, /*v1_and_v2=*/{}},                                                // both empty => empty
+        {{/*v1=*/{{1, 2, 3}, {4, 5, 6}, {7, 8}}, /*v2=*/{}}, /*v1_and_v2=*/{}},                    // one empty => empty
         {{/*v1=*/{{1, 2, 3}, {4, 5, 6}, {7, 8}}, /*v2=*/{{10, 11, 12}, {13}}}, /*v1_and_v2=*/{}},  // disjoint => empty
         {{/*v1=*/{{1, 2, 3}, {4, 5, 6}, {7, 8}}, /*v2=*/{{7, 8, 9}, {10, 11, 12}, {13}}}, /*v1_and_v2=*/{7, 8}},
         {{/*v1=*/{{1, 2, 3}, {4, 5, 6}, {7, 8}}, /*v2=*/{{1, 2, 3}, {4, 5, 6}, {7, 8}}}, /*v1_and_v2=*/{1, 2, 3, 4, 5, 6, 7, 8}},
@@ -187,7 +187,7 @@ TEST_CASE_METHOD(PaginatedSetTest, "set_intersection", "[db][kv][api][paginated_
 
 TEST_CASE_METHOD(PaginatedSetTest, "set_union", "[db][kv][api][paginated_sequence]") {
     const Fixtures<std::pair<PageUint64Vector, PageUint64Vector>, std::vector<uint64_t>> fixtures{
-        {{/*v1=*/{}, /*v2=*/{}}, /*v1_or_v2=*/{}},  // both empty => empty
+        {{/*v1=*/{}, /*v2=*/{}}, /*v1_or_v2=*/{}},                                                    // both empty => empty
         {{/*v1=*/{{1, 2, 3}, {4, 5, 6}, {7, 8}}, /*v2=*/{}}, /*v1_or_v2=*/{1, 2, 3, 4, 5, 6, 7, 8}},  // one empty => other
         {{/*v1=*/{{1, 2, 3}, {4, 5, 6}, {7, 8}}, /*v2=*/{{10, 11, 12}, {13}}}, /*v1_or_v2=*/{1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 13}},
         {{/*v1=*/{{1, 2, 3}, {4, 5, 6}, {7, 8}}, /*v2=*/{{7, 8, 9}, {10, 11, 12}, {13}}}, /*v1_or_v2=*/{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13}},

--- a/silkworm/db/kv/api/endpoint/paginated_sequence_test.cpp
+++ b/silkworm/db/kv/api/endpoint/paginated_sequence_test.cpp
@@ -18,33 +18,43 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <silkworm/core/common/util.hpp>
 #include <silkworm/infra/test_util/context_test_base.hpp>
 
 namespace silkworm::db::kv::api {
 
 using PaginatedUint64 = PaginatedSequence<uint64_t>;
+using PaginatorUint64 = PaginatedUint64::Paginator;
+using PageUint64 = PaginatedUint64::Page;
+using PageResultUint64 = PaginatedUint64::PageResult;
+
+using PaginatedKV = PaginatedSequencePair<Bytes, Bytes>;
+using PaginatorKV = PaginatedKV::Paginator;
+using PageK = PaginatedKV::KPage;
+using PageV = PaginatedKV::VPage;
+using PageResultKV = PaginatedKV::PageResult;
 
 struct PaginatedSequenceTest : public test_util::ContextTestBase {
 };
 
-TEST_CASE_METHOD(PaginatedSequenceTest, "paginated_sequence: empty uint64 sequence", "[db][kv][api][paginated_sequence]") {
-    PaginatedUint64::Paginator paginator = []() -> Task<PaginatedUint64::PageResult> {
-        co_return PaginatedUint64::PageResult{};  // has_more=false as default
+TEST_CASE_METHOD(PaginatedSequenceTest, "paginated_uint64_sequence: empty sequence", "[db][kv][api][paginated_sequence]") {
+    PaginatorUint64 paginator = []() -> Task<PageResultUint64> {
+        co_return PageResultUint64{};  // has_more=false as default
     };
     PaginatedUint64 paginated{paginator};
     CHECK(spawn_and_wait(paginated_to_vector(paginated)).empty());
 }
 
-TEST_CASE_METHOD(PaginatedSequenceTest, "paginated_sequence: non-empty uint64 sequence", "[db][kv][api][paginated_sequence]") {
-    PaginatedUint64::Paginator paginator = []() -> Task<PaginatedUint64::PageResult> {
+TEST_CASE_METHOD(PaginatedSequenceTest, "paginated_uint64_sequence: non-empty sequence", "[db][kv][api][paginated_sequence]") {
+    PaginatorUint64 paginator = []() -> Task<PageResultUint64> {
         static int count{0};
         switch (++count) {
             case 1:
-                co_return PaginatedUint64::PageResult{PaginatedUint64::Page{1, 2, 3}, /*has_more=*/true};
+                co_return PageResultUint64{PageUint64{1, 2, 3}, /*has_more=*/true};
             case 2:
-                co_return PaginatedUint64::PageResult{PaginatedUint64::Page{4, 5, 6}, /*has_more=*/true};
+                co_return PageResultUint64{PageUint64{4, 5, 6}, /*has_more=*/true};
             case 3:
-                co_return PaginatedUint64::PageResult{PaginatedUint64::Page{7}, /*has_more=*/false};
+                co_return PageResultUint64{PageUint64{7}, /*has_more=*/false};
             default:
                 throw std::logic_error{"unexpected call to paginator"};
         }
@@ -53,14 +63,14 @@ TEST_CASE_METHOD(PaginatedSequenceTest, "paginated_sequence: non-empty uint64 se
     CHECK(spawn_and_wait(paginated_to_vector(paginated)) == std::vector<uint64_t>{1, 2, 3, 4, 5, 6, 7});
 }
 
-TEST_CASE_METHOD(PaginatedSequenceTest, "paginated_sequence: error", "[db][kv][api][paginated_sequence]") {
-    PaginatedUint64::Paginator paginator = []() -> Task<PaginatedUint64::PageResult> {
+TEST_CASE_METHOD(PaginatedSequenceTest, "paginated_uint64_sequence: error", "[db][kv][api][paginated_sequence]") {
+    PaginatorUint64 paginator = []() -> Task<PageResultUint64> {
         static int count{0};
         switch (++count) {
             case 1:
-                co_return PaginatedUint64::PageResult{PaginatedUint64::Page{1, 2, 3}, /*has_more=*/true};
+                co_return PageResultUint64{PageUint64{1, 2, 3}, /*has_more=*/true};
             case 2:
-                co_return PaginatedUint64::PageResult{PaginatedUint64::Page{4, 5, 6}, /*has_more=*/true};
+                co_return PageResultUint64{PageUint64{4, 5, 6}, /*has_more=*/true};
             case 3:
                 throw std::runtime_error{"error during pagination"};
             default:
@@ -69,6 +79,130 @@ TEST_CASE_METHOD(PaginatedSequenceTest, "paginated_sequence: error", "[db][kv][a
     };
     PaginatedUint64 paginated{paginator};
     CHECK_THROWS_AS(spawn_and_wait(paginated_to_vector(paginated)), std::runtime_error);
+}
+
+TEST_CASE_METHOD(PaginatedSequenceTest, "paginated_kv_sequence: empty sequence", "[db][kv][api][paginated_sequence]") {
+    PaginatorKV paginator = []() -> Task<PageResultKV> {
+        co_return PageResultKV{};  // has_more=false as default
+    };
+    PaginatedKV paginated{paginator};
+    CHECK(spawn_and_wait(paginated_to_vector(paginated)).empty());
+}
+
+const Bytes kKey1{*from_hex("0011")}, kKey2{*from_hex("0022")}, kKey3{*from_hex("0033")};
+const Bytes kKey4{*from_hex("0044")}, kKey5{*from_hex("0055")}, kKey6{*from_hex("0066")};
+
+const Bytes kValue1{*from_hex("FF11")}, kValue2{*from_hex("FF22")}, kValue3{*from_hex("FF33")};
+const Bytes kValue4{*from_hex("FF44")}, kValue5{*from_hex("FF55")}, kValue6{*from_hex("FF66")};
+
+TEST_CASE_METHOD(PaginatedSequenceTest, "paginated_kv_sequence: non-empty sequence", "[db][kv][api][paginated_sequence]") {
+    PaginatorKV paginator = []() -> Task<PageResultKV> {
+        static int count{0};
+        switch (++count) {
+            case 1:
+                co_return PageResultKV{PageK{kKey1, kKey2}, PageV{kValue1, kValue2}, /*has_more=*/true};
+            case 2:
+                co_return PageResultKV{PageK{kKey3, kKey4}, PageV{kValue3, kValue4}, /*has_more=*/true};
+            case 3:
+                co_return PageResultKV{PageK{kKey5, kKey6}, PageV{kValue5, kValue6}, /*has_more=*/false};
+            default:
+                throw std::logic_error{"unexpected call to paginator"};
+        }
+    };
+    PaginatedKV paginated{paginator};
+    CHECK(spawn_and_wait(paginated_to_vector(paginated)) == std::vector<KeyValue>{
+                                                                {kKey1, kValue1}, {kKey2, kValue2}, {kKey3, kValue3}, {kKey4, kValue4}, {kKey5, kValue5}, {kKey6, kValue6}});
+}
+
+TEST_CASE_METHOD(PaginatedSequenceTest, "paginated_kv_sequence: error", "[db][kv][api][paginated_sequence]") {
+    PaginatorKV paginator = []() -> Task<PageResultKV> {
+        static int count{0};
+        switch (++count) {
+            case 1:
+                co_return PageResultKV{PageK{kKey1, kKey2}, PageV{kValue1, kValue2}, /*has_more=*/true};
+            case 2:
+                co_return PageResultKV{PageK{kKey3, kKey4}, PageV{kValue3, kValue4}, /*has_more=*/true};
+            case 3:
+                throw std::runtime_error{"error during pagination"};
+            default:
+                throw std::logic_error{"unexpected call to paginator"};
+        }
+    };
+    PaginatedKV paginated{paginator};
+    CHECK_THROWS_AS(spawn_and_wait(paginated_to_vector(paginated)), std::runtime_error);
+}
+
+struct PaginatedSetTest : public test_util::ContextTestBase {
+};
+
+TEST_CASE_METHOD(PaginatedSetTest, "set_intersection: non-empty uint64 sequence", "[db][kv][api][paginated_sequence]") {
+    PaginatedUint64::Paginator paginator1 = []() -> Task<PaginatedUint64::PageResult> {
+        static int count{0};
+        switch (++count) {
+            case 1:
+                co_return PaginatedUint64::PageResult{PaginatedUint64::Page{1, 2, 3}, /*has_more=*/true};
+            case 2:
+                co_return PaginatedUint64::PageResult{PaginatedUint64::Page{4, 5, 6}, /*has_more=*/true};
+            case 3:
+                co_return PaginatedUint64::PageResult{PaginatedUint64::Page{7, 8}, /*has_more=*/false};
+            default:
+                throw std::logic_error{"unexpected call to paginator"};
+        }
+    };
+    PaginatedUint64::Paginator paginator2 = []() -> Task<PaginatedUint64::PageResult> {
+        static int count{0};
+        switch (++count) {
+            case 1:
+                co_return PaginatedUint64::PageResult{PaginatedUint64::Page{7, 8, 9}, /*has_more=*/true};
+            case 2:
+                co_return PaginatedUint64::PageResult{PaginatedUint64::Page{10, 11, 12}, /*has_more=*/true};
+            case 3:
+                co_return PaginatedUint64::PageResult{PaginatedUint64::Page{13}, /*has_more=*/false};
+            default:
+                throw std::logic_error{"unexpected call to paginator"};
+        }
+    };
+    PaginatedUint64 paginated1{paginator1}, paginated2{paginator2};
+    const auto async_intersection = [](PaginatedUint64& ps1, PaginatedUint64& ps2) -> Task<std::vector<uint64_t>> {
+        IntersectionIterator it = set_intersection(co_await ps1.begin(), co_await ps2.begin());
+        co_return co_await paginated_iterator_to_vector(std::move(it));
+    };
+    CHECK(spawn_and_wait(async_intersection(paginated1, paginated2)) == std::vector<uint64_t>{7, 8});
+}
+
+TEST_CASE_METHOD(PaginatedSetTest, "set_union: non-empty uint64 sequence", "[db][kv][api][paginated_sequence]") {
+    PaginatedUint64::Paginator paginator1 = []() -> Task<PaginatedUint64::PageResult> {
+        static int count{0};
+        switch (++count) {
+            case 1:
+                co_return PaginatedUint64::PageResult{PaginatedUint64::Page{1, 2, 3}, /*has_more=*/true};
+            case 2:
+                co_return PaginatedUint64::PageResult{PaginatedUint64::Page{4, 5, 6}, /*has_more=*/true};
+            case 3:
+                co_return PaginatedUint64::PageResult{PaginatedUint64::Page{7, 8}, /*has_more=*/false};
+            default:
+                throw std::logic_error{"unexpected call to paginator"};
+        }
+    };
+    PaginatedUint64::Paginator paginator2 = []() -> Task<PaginatedUint64::PageResult> {
+        static int count{0};
+        switch (++count) {
+            case 1:
+                co_return PaginatedUint64::PageResult{PaginatedUint64::Page{7, 8, 9}, /*has_more=*/true};
+            case 2:
+                co_return PaginatedUint64::PageResult{PaginatedUint64::Page{10, 11, 12}, /*has_more=*/true};
+            case 3:
+                co_return PaginatedUint64::PageResult{PaginatedUint64::Page{13}, /*has_more=*/false};
+            default:
+                throw std::logic_error{"unexpected call to paginator"};
+        }
+    };
+    PaginatedUint64 paginated1{paginator1}, paginated2{paginator2};
+    const auto async_intersection = [](PaginatedUint64& ps1, PaginatedUint64& ps2) -> Task<std::vector<uint64_t>> {
+        UnionIterator<PaginatedUint64::Iterator> it = set_union(co_await ps1.begin(), co_await ps2.begin());
+        co_return co_await paginated_iterator_to_vector(std::move(it));
+    };
+    CHECK(spawn_and_wait(async_intersection(paginated1, paginated2)) == std::vector<uint64_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13});
 }
 
 }  // namespace silkworm::db::kv::api

--- a/silkworm/db/kv/grpc/client/remote_transaction_test.cpp
+++ b/silkworm/db/kv/grpc/client/remote_transaction_test.cpp
@@ -574,8 +574,6 @@ TEST_CASE_METHOD(RemoteTransactionTest, "RemoteTransaction::index_range", "[db][
         expect_request_async_tx(/*ok=*/true);
         // 2. AsyncReaderWriter<remote::Cursor, remote::Pair>::Read calls succeed w/ specified transaction and cursor IDs
         remote::Pair tx_id_pair{make_fake_tx_created_pair()};
-        remote::Pair cursor_id_pair;
-        cursor_id_pair.set_cursor_id(0x23);
         EXPECT_CALL(reader_writer_, Read)
             .WillOnce(test::read_success_with(grpc_context_, tx_id_pair));
         // 3. AsyncReaderWriter<remote::Cursor, remote::Pair>::WritesDone call succeeds
@@ -670,8 +668,6 @@ TEST_CASE_METHOD(RemoteTransactionTest, "RemoteTransaction::history_range", "[db
         expect_request_async_tx(/*ok=*/true);
         // 2. AsyncReaderWriter<remote::Cursor, remote::Pair>::Read calls succeed w/ specified transaction and cursor IDs
         remote::Pair tx_id_pair{make_fake_tx_created_pair()};
-        remote::Pair cursor_id_pair;
-        cursor_id_pair.set_cursor_id(0x23);
         EXPECT_CALL(reader_writer_, Read)
             .WillOnce(test::read_success_with(grpc_context_, tx_id_pair));
         // 3. AsyncReaderWriter<remote::Cursor, remote::Pair>::WritesDone call succeeds
@@ -756,8 +752,6 @@ TEST_CASE_METHOD(RemoteTransactionTest, "RemoteTransaction::domain_range", "[db]
         expect_request_async_tx(/*ok=*/true);
         // 2. AsyncReaderWriter<remote::Cursor, remote::Pair>::Read calls succeed w/ specified transaction and cursor IDs
         remote::Pair tx_id_pair{make_fake_tx_created_pair()};
-        remote::Pair cursor_id_pair;
-        cursor_id_pair.set_cursor_id(0x23);
         EXPECT_CALL(reader_writer_, Read)
             .WillOnce(test::read_success_with(grpc_context_, tx_id_pair));
         // 3. AsyncReaderWriter<remote::Cursor, remote::Pair>::WritesDone call succeeds


### PR DESCRIPTION
Add support for intersection/union set operations on E3 Data API paginated iterators and change the paginated iterator API exposing `has_next`/`next` stream-like methods, notably:

```c++
PaginatedUint64& paginated = ...;
auto it = co_await paginated.begin();
while (const auto value = co_await it.next()) {
    // use *value;
}
```

Furthermore, conceptualise and improve `PaginatedIterator` abstraction and increase test coverage.

*Extra*
- cleanup `RemoteTransactionTest`