### PR TITLE
snapshots: timestamp-based repository

### DIFF
--- a/cmd/capi/execute.cpp
+++ b/cmd/capi/execute.cpp
@@ -437,7 +437,11 @@ int main(int argc, char* argv[]) {
         int status_code = -1;
         if (settings.execute_blocks_settings) {
             // Execute specified block range using Silkworm API library
-            SnapshotRepository repository{snapshot_settings, std::make_unique<db::SnapshotBundleFactoryImpl>()};
+            SnapshotRepository repository{
+                snapshot_settings,
+                std::make_unique<StepToBlockNumConverter>(),
+                std::make_unique<db::SnapshotBundleFactoryImpl>(),
+            };
             repository.reopen_folder();
             status_code = execute_blocks(handle, *settings.execute_blocks_settings, repository, data_dir);
         } else if (settings.build_indexes_settings) {

--- a/cmd/dev/check_changes.cpp
+++ b/cmd/dev/check_changes.cpp
@@ -110,8 +110,11 @@ int main(int argc, char* argv[]) {
             throw std::runtime_error("Unable to retrieve chain config");
         }
 
-        auto snapshot_bundle_factory = std::make_unique<db::SnapshotBundleFactoryImpl>();
-        snapshots::SnapshotRepository repository{snapshots::SnapshotSettings{}, std::move(snapshot_bundle_factory)};
+        snapshots::SnapshotRepository repository{
+            snapshots::SnapshotSettings{},
+            std::make_unique<snapshots::StepToBlockNumConverter>(),
+            std::make_unique<db::SnapshotBundleFactoryImpl>(),
+        };
         repository.reopen_folder();
         db::DataModel::set_snapshot_repository(&repository);
         db::DataModel access_layer{txn};

--- a/cmd/dev/db_toolbox.cpp
+++ b/cmd/dev/db_toolbox.cpp
@@ -2240,8 +2240,11 @@ void do_freeze(EnvConfig& config, const DataDirectory& data_dir, bool keep_block
     snapshots::SnapshotSettings settings;
     settings.repository_dir = data_dir.snapshots().path();
     settings.no_downloader = true;
-    std::unique_ptr<snapshots::SnapshotBundleFactory> bundle_factory = std::make_unique<SnapshotBundleFactoryImpl>();
-    snapshots::SnapshotRepository repository{std::move(settings), std::move(bundle_factory)};
+    snapshots::SnapshotRepository repository{
+        std::move(settings),
+        std::make_unique<snapshots::StepToBlockNumConverter>(),
+        std::make_unique<SnapshotBundleFactoryImpl>(),
+    };
     repository.reopen_folder();
     DataModel::set_snapshot_repository(&repository);
 

--- a/silkworm/db/datastore/snapshot_merger.cpp
+++ b/silkworm/db/datastore/snapshot_merger.cpp
@@ -61,17 +61,21 @@ std::unique_ptr<DataMigrationCommand> SnapshotMerger::next_command() {
 
     for (auto& bundle_ptr : snapshots_.view_bundles()) {
         auto& bundle = *bundle_ptr;
-        if (bundle.block_count() >= kMaxSnapshotSize) {
+
+        auto bundle_block_range = bundle.step_range().to_block_num_range();
+        size_t bundle_block_count = bundle_block_range.size();
+
+        if (bundle_block_count >= kMaxSnapshotSize) {
             continue;
         }
-        if (bundle.block_count() != block_count) {
-            first_block_num = bundle.block_range().start;
-            block_count = bundle.block_count();
+        if (bundle_block_count != block_count) {
+            first_block_num = bundle_block_range.start;
+            block_count = bundle_block_count;
             batch_size = 0;
         }
         ++batch_size;
         if (batch_size == kBatchSize) {
-            return std::make_unique<SnapshotMergerCommand>(BlockNumRange{first_block_num, bundle.block_range().end});
+            return std::make_unique<SnapshotMergerCommand>(BlockNumRange{first_block_num, bundle_block_range.end});
         }
     }
 
@@ -89,14 +93,15 @@ struct RawDecoder : public Decoder {
 std::shared_ptr<DataMigrationResult> SnapshotMerger::migrate(std::unique_ptr<DataMigrationCommand> command) {
     auto& merger_command = dynamic_cast<SnapshotMergerCommand&>(*command);
     auto range = merger_command.range;
+    auto step_range = StepRange::from_block_num_range(range);
 
-    auto new_bundle = snapshots_.bundle_factory().make(tmp_dir_path_, range);
+    auto new_bundle = snapshots_.bundle_factory().make(tmp_dir_path_, step_range);
     for (auto& segment_ref : new_bundle.segments()) {
         auto path = segment_ref.get().path();
         log::Debug("SnapshotMerger") << "merging " << path.type_string() << " range " << range.to_string();
         seg::Compressor compressor{path.path(), tmp_dir_path_};
 
-        for (auto& bundle_ptr : snapshots_.bundles_in_range(range)) {
+        for (auto& bundle_ptr : snapshots_.bundles_in_range(StepRange::from_block_num_range(range))) {
             auto& bundle = *bundle_ptr;
             SegmentReader<RawDecoder> reader{bundle.segment(path.type())};
             std::copy(reader.begin(), reader.end(), compressor.add_word_iterator());
@@ -125,21 +130,21 @@ static void schedule_bundle_cleanup(SnapshotBundle& bundle) {
 void SnapshotMerger::commit(std::shared_ptr<DataMigrationResult> result) {
     auto& freezer_result = dynamic_cast<SnapshotMergerResult&>(*result);
     auto& bundle = freezer_result.bundle;
-    auto merged_bundles = snapshots_.bundles_in_range(bundle.block_range());
+    auto merged_bundles = snapshots_.bundles_in_range(bundle.step_range());
 
     move_files(bundle.files(), snapshots_.path());
 
-    auto final_bundle = snapshots_.bundle_factory().make(snapshots_.path(), bundle.block_range());
+    auto final_bundle = snapshots_.bundle_factory().make(snapshots_.path(), bundle.step_range());
     snapshots_.replace_snapshot_bundles(std::move(final_bundle));
 
     for (auto& merged_bundle : merged_bundles) {
         schedule_bundle_cleanup(*merged_bundle);
     }
 
-    on_snapshot_merged_signal_(bundle.block_range());
+    on_snapshot_merged_signal_(bundle.step_range());
 }
 
-boost::signals2::scoped_connection SnapshotMerger::on_snapshot_merged(const std::function<void(BlockNumRange)>& callback) {
+boost::signals2::scoped_connection SnapshotMerger::on_snapshot_merged(const std::function<void(snapshots::StepRange)>& callback) {
     return on_snapshot_merged_signal_.connect(callback);
 }
 

--- a/silkworm/db/datastore/snapshot_merger.hpp
+++ b/silkworm/db/datastore/snapshot_merger.hpp
@@ -16,13 +16,13 @@
 
 #pragma once
 
+#include <filesystem>
 #include <functional>
 
 #include <boost/signals2.hpp>
 
-#include <silkworm/core/common/base.hpp>
-
 #include "data_migration.hpp"
+#include "snapshots/common/step.hpp"
 #include "snapshots/snapshot_repository.hpp"
 #include "snapshots/snapshot_size.hpp"
 
@@ -36,7 +36,7 @@ class SnapshotMerger : public DataMigration {
         : snapshots_(snapshots),
           tmp_dir_path_(std::move(tmp_dir_path)) {}
 
-    boost::signals2::scoped_connection on_snapshot_merged(const std::function<void(BlockNumRange)>& callback);
+    boost::signals2::scoped_connection on_snapshot_merged(const std::function<void(snapshots::StepRange)>& callback);
 
   private:
     static constexpr size_t kBatchSize = 10;
@@ -51,7 +51,7 @@ class SnapshotMerger : public DataMigration {
 
     snapshots::SnapshotRepository& snapshots_;
     std::filesystem::path tmp_dir_path_;
-    boost::signals2::signal<void(BlockNumRange)> on_snapshot_merged_signal_;
+    boost::signals2::signal<void(snapshots::StepRange)> on_snapshot_merged_signal_;
 };
 
 }  // namespace silkworm::db

--- a/silkworm/db/datastore/snapshots/common/timestamp.hpp
+++ b/silkworm/db/datastore/snapshots/common/timestamp.hpp
@@ -1,0 +1,37 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace silkworm::snapshots {
+
+using Timestamp = uint64_t;
+
+struct TimestampRange {
+    Timestamp start;
+    Timestamp end;
+    TimestampRange(Timestamp start1, Timestamp end1) : start(start1), end(end1) {}
+    friend bool operator==(const TimestampRange&, const TimestampRange&) = default;
+    bool contains(Timestamp value) const { return (start <= value) && (value < end); }
+    bool contains_range(TimestampRange range) const { return (start <= range.start) && (range.end <= end); }
+    Timestamp size() const { return end - start; }
+    std::string to_string() const { return std::string("[") + std::to_string(start) + ", " + std::to_string(end) + ")"; }
+};
+
+}  // namespace silkworm::snapshots

--- a/silkworm/db/datastore/snapshots/snapshot_bundle.hpp
+++ b/silkworm/db/datastore/snapshots/snapshot_bundle.hpp
@@ -22,7 +22,6 @@
 #include <vector>
 
 #include <silkworm/core/common/assert.hpp>
-#include <silkworm/core/common/base.hpp>
 
 #include "common/snapshot_path.hpp"
 #include "rec_split_index/index.hpp"
@@ -51,7 +50,9 @@ struct SnapshotBundleData {
 };
 
 struct SnapshotBundle : public SnapshotBundleData {
-    explicit SnapshotBundle(SnapshotBundleData bundle) : SnapshotBundleData(std::move(bundle)) {}
+    explicit SnapshotBundle(StepRange step_range, SnapshotBundleData bundle)
+        : SnapshotBundleData{std::move(bundle)},
+          step_range_{step_range} {}
     virtual ~SnapshotBundle();
 
     SnapshotBundle(SnapshotBundle&&) = default;
@@ -124,9 +125,7 @@ struct SnapshotBundle : public SnapshotBundleData {
         return {segment(type), index(type)};
     }
 
-    // assume that all snapshots have the same block range, and use one of them
-    BlockNumRange block_range() const { return header_segment.path().step_range().to_block_num_range(); }
-    size_t block_count() const { return block_range().size(); }
+    StepRange step_range() const { return step_range_; }
 
     std::vector<std::filesystem::path> files();
     std::vector<SnapshotPath> snapshot_paths();
@@ -139,6 +138,7 @@ struct SnapshotBundle : public SnapshotBundleData {
     }
 
   private:
+    StepRange step_range_;
     std::function<void(SnapshotBundle&)> on_close_callback_;
 };
 

--- a/silkworm/db/datastore/snapshots/snapshot_bundle_factory.hpp
+++ b/silkworm/db/datastore/snapshots/snapshot_bundle_factory.hpp
@@ -21,8 +21,6 @@
 #include <memory>
 #include <vector>
 
-#include <silkworm/core/common/base.hpp>
-
 #include "common/snapshot_path.hpp"
 #include "index_builder.hpp"
 #include "snapshot_bundle.hpp"
@@ -34,7 +32,7 @@ struct SnapshotBundleFactory {
 
     using PathByTypeProvider = std::function<SnapshotPath(SnapshotType)>;
     virtual SnapshotBundle make(PathByTypeProvider snapshot_path, PathByTypeProvider index_path) const = 0;
-    virtual SnapshotBundle make(const std::filesystem::path& dir_path, BlockNumRange range) const = 0;
+    virtual SnapshotBundle make(const std::filesystem::path& dir_path, StepRange range) const = 0;
 
     virtual std::vector<std::shared_ptr<IndexBuilder>> index_builders(const SnapshotPath& segment_path) const = 0;
     virtual std::vector<std::shared_ptr<IndexBuilder>> index_builders(const SnapshotPathList& segment_paths) const = 0;

--- a/silkworm/db/datastore/snapshots/snapshot_repository.cpp
+++ b/silkworm/db/datastore/snapshots/snapshot_repository.cpp
@@ -29,8 +29,10 @@ namespace fs = std::filesystem;
 
 SnapshotRepository::SnapshotRepository(
     SnapshotSettings settings,
+    std::unique_ptr<StepToTimestampConverter> step_converter,
     std::unique_ptr<SnapshotBundleFactory> bundle_factory)
     : settings_(std::move(settings)),
+      step_converter_(std::move(step_converter)),
       bundle_factory_(std::move(bundle_factory)),
       bundles_(std::make_shared<Bundles>()) {}
 
@@ -51,11 +53,11 @@ void SnapshotRepository::replace_snapshot_bundles(SnapshotBundle bundle) {
 
     std::erase_if(*bundles, [&](const auto& entry) {
         const SnapshotBundle& it = *entry.second;
-        return bundle.block_range().contains_range(it.block_range());
+        return bundle.step_range().contains_range(it.step_range());
     });
 
-    BlockNum block_from = bundle.block_range().start;
-    bundles->insert_or_assign(block_from, std::make_shared<SnapshotBundle>(std::move(bundle)));
+    Step key = bundle.step_range().start;
+    bundles->insert_or_assign(key, std::make_shared<SnapshotBundle>(std::move(bundle)));
 
     bundles_ = bundles;
 }
@@ -72,18 +74,29 @@ void SnapshotRepository::close() {
 }
 
 BlockNum SnapshotRepository::max_block_available() const {
+    Step end_step = max_end_step();
+    if (end_step.value == 0) return 0;
+    return end_step.to_block_num() - 1;
+}
+
+Timestamp SnapshotRepository::max_timestamp_available() const {
+    Step end_step = max_end_step();
+    if (end_step.value == 0) return 0;
+    return step_converter_->timestamp_from_step(end_step) - 1;
+}
+
+Step SnapshotRepository::max_end_step() const {
     std::scoped_lock lock(bundles_mutex_);
     if (bundles_->empty())
-        return 0;
+        return Step{0};
 
     // a bundle with the max block range is last in the sorted bundles map
     auto& bundle = *bundles_->rbegin()->second;
-    BlockNumRange block_num_range = bundle.block_range();
-    return (block_num_range.size() > 0) ? block_num_range.end - 1 : block_num_range.start;
+    return bundle.step_range().end;
 }
 
-std::pair<std::optional<SegmentAndIndex>, std::shared_ptr<SnapshotBundle>> SnapshotRepository::find_segment(SnapshotType type, BlockNum number) const {
-    auto bundle = find_bundle(number);
+std::pair<std::optional<SegmentAndIndex>, std::shared_ptr<SnapshotBundle>> SnapshotRepository::find_segment(SnapshotType type, Timestamp t) const {
+    auto bundle = find_bundle(step_converter_->step_from_timestamp(t));
     if (bundle) {
         return {bundle->segment_and_index(type), bundle};
     }
@@ -105,21 +118,21 @@ void SnapshotRepository::reopen_folder() {
     SnapshotPathList all_snapshot_paths = get_segment_files();
     SnapshotPathList all_index_paths = get_idx_files();
 
-    std::map<BlockNum, std::map<bool, std::map<SnapshotType, size_t>>> groups;
+    std::map<Step, std::map<bool, std::map<SnapshotType, size_t>>> groups;
 
     for (size_t i = 0; i < all_snapshot_paths.size(); ++i) {
         auto& path = all_snapshot_paths[i];
-        auto& group = groups[path.step_range().to_block_num_range().start][false];
+        auto& group = groups[path.step_range().start][false];
         group[path.type()] = i;
     }
 
     for (size_t i = 0; i < all_index_paths.size(); ++i) {
         auto& path = all_index_paths[i];
-        auto& group = groups[path.step_range().to_block_num_range().start][true];
+        auto& group = groups[path.step_range().start][true];
         group[path.type()] = i;
     }
 
-    BlockNum num = 0;
+    Step num{0};
     if (!groups.empty()) {
         num = groups.begin()->first;
     }
@@ -146,8 +159,8 @@ void SnapshotRepository::reopen_folder() {
 
         auto& bundle = *bundles->at(num);
 
-        if (num < bundle.block_range().end) {
-            num = bundle.block_range().end;
+        if (num < bundle.step_range().end) {
+            num = bundle.step_range().end;
         } else {
             break;
         }
@@ -162,23 +175,22 @@ void SnapshotRepository::reopen_folder() {
               << " max block available: " << max_block_available();
 }
 
-std::shared_ptr<SnapshotBundle> SnapshotRepository::find_bundle(BlockNum number) const {
+std::shared_ptr<SnapshotBundle> SnapshotRepository::find_bundle(Step step) const {
     // Search for target segment in reverse order (from the newest segment to the oldest one)
     for (const auto& bundle_ptr : this->view_bundles_reverse()) {
         auto& bundle = *bundle_ptr;
-        // We're looking for the segment containing the target block number in its block range
-        if (bundle.block_range().contains(number) ||
-            ((bundle.block_range().start == number) && (bundle.block_range().size() == 0))) {
+        if (bundle.step_range().contains(step) ||
+            ((bundle.step_range().start == step) && (bundle.step_range().size() == 0))) {
             return bundle_ptr;
         }
     }
     return {};
 }
 
-std::vector<std::shared_ptr<SnapshotBundle>> SnapshotRepository::bundles_in_range(BlockNumRange range) const {
+std::vector<std::shared_ptr<SnapshotBundle>> SnapshotRepository::bundles_in_range(StepRange range) const {
     std::vector<std::shared_ptr<SnapshotBundle>> bundles;
     for (const auto& bundle : view_bundles()) {
-        if (range.contains_range(bundle->block_range())) {
+        if (range.contains_range(bundle->step_range())) {
             bundles.push_back(bundle);
         }
     }

--- a/silkworm/db/datastore/snapshots/snapshot_repository.hpp
+++ b/silkworm/db/datastore/snapshots/snapshot_repository.hpp
@@ -27,8 +27,6 @@
 #include <utility>
 #include <vector>
 
-#include <silkworm/core/common/base.hpp>
-
 #include "common/snapshot_path.hpp"
 #include "common/util/iterator/map_values_view.hpp"
 #include "index_builder.hpp"
@@ -43,7 +41,6 @@ struct IndexBuilder;
 
 //! Read-only repository for all snapshot files.
 //! @details Some simplifications are currently in place:
-//! - it opens snapshots only on startup and they are immutable
 //! - all snapshots of given blocks range must exist (to make such range available)
 //! - gaps in blocks range are not allowed
 //! - segments have [from:to) semantic
@@ -51,6 +48,7 @@ class SnapshotRepository {
   public:
     explicit SnapshotRepository(
         SnapshotSettings settings,
+        std::unique_ptr<StepToTimestampConverter> step_converter,
         std::unique_ptr<SnapshotBundleFactory> bundle_factory);
     ~SnapshotRepository();
 
@@ -72,12 +70,13 @@ class SnapshotRepository {
 
     //! All types of .seg and .idx files are available up to this block number
     BlockNum max_block_available() const;
+    Timestamp max_timestamp_available() const;
 
     std::vector<std::shared_ptr<IndexBuilder>> missing_indexes() const;
     void remove_stale_indexes() const;
     void build_indexes(SnapshotBundle& bundle) const;
 
-    using Bundles = std::map<BlockNum, std::shared_ptr<SnapshotBundle>>;
+    using Bundles = std::map<Step, std::shared_ptr<SnapshotBundle>>;
 
     template <class TBaseView>
     class BundlesView : public std::ranges::view_interface<BundlesView<TBaseView>> {
@@ -106,12 +105,14 @@ class SnapshotRepository {
         return BundlesView{std::ranges::reverse_view(make_map_values_view(*bundles_)), bundles_};
     }
 
-    std::pair<std::optional<SegmentAndIndex>, std::shared_ptr<SnapshotBundle>> find_segment(SnapshotType type, BlockNum number) const;
-    std::shared_ptr<SnapshotBundle> find_bundle(BlockNum number) const;
+    std::pair<std::optional<SegmentAndIndex>, std::shared_ptr<SnapshotBundle>> find_segment(SnapshotType type, Timestamp t) const;
+    std::shared_ptr<SnapshotBundle> find_bundle(Step step) const;
 
-    std::vector<std::shared_ptr<SnapshotBundle>> bundles_in_range(BlockNumRange range) const;
+    std::vector<std::shared_ptr<SnapshotBundle>> bundles_in_range(StepRange range) const;
 
   private:
+    Step max_end_step() const;
+
     SnapshotPathList get_segment_files() const {
         return get_files(kSegmentExtension);
     }
@@ -126,6 +127,9 @@ class SnapshotRepository {
 
     //! The configuration settings for snapshots
     SnapshotSettings settings_;
+
+    //! Converts timestamp units to steps
+    std::unique_ptr<StepToTimestampConverter> step_converter_;
 
     //! SnapshotBundle factory
     std::unique_ptr<SnapshotBundleFactory> bundle_factory_;

--- a/silkworm/db/freezer.cpp
+++ b/silkworm/db/freezer.cpp
@@ -107,8 +107,9 @@ static const SegmentCollation& get_collation(SnapshotType type) {
 std::shared_ptr<DataMigrationResult> Freezer::migrate(std::unique_ptr<DataMigrationCommand> command) {
     auto& freezer_command = dynamic_cast<SegmentCollationCommand&>(*command);
     auto range = freezer_command.range;
+    auto step_range = StepRange::from_block_num_range(range);
 
-    auto bundle = snapshots_.bundle_factory().make(tmp_dir_path_, range);
+    auto bundle = snapshots_.bundle_factory().make(tmp_dir_path_, step_range);
     for (auto& segment_ref : bundle.segments()) {
         auto path = segment_ref.get().path();
         SegmentFileWriter file_writer{path, tmp_dir_path_};
@@ -134,7 +135,7 @@ void Freezer::commit(std::shared_ptr<DataMigrationResult> result) {
     auto& bundle = freezer_result.bundle;
     move_files(bundle.files(), snapshots_.path());
 
-    auto final_bundle = snapshots_.bundle_factory().make(snapshots_.path(), bundle.block_range());
+    auto final_bundle = snapshots_.bundle_factory().make(snapshots_.path(), bundle.step_range());
     snapshots_.add_snapshot_bundle(std::move(final_bundle));
 }
 

--- a/silkworm/db/snapshot_benchmark.cpp
+++ b/silkworm/db/snapshot_benchmark.cpp
@@ -21,7 +21,7 @@
 #include <silkworm/db/blocks/headers/header_index.hpp>
 #include <silkworm/db/datastore/snapshots/index_builder.hpp>
 #include <silkworm/db/datastore/snapshots/seg/decompressor.hpp>
-#include <silkworm/db/snapshot_bundle_factory_impl.hpp>
+#include <silkworm/db/test_util/make_repository.hpp>
 #include <silkworm/db/test_util/temp_snapshots.hpp>
 #include <silkworm/db/transactions/txn_index.hpp>
 #include <silkworm/db/transactions/txn_to_block_index.hpp>
@@ -32,6 +32,7 @@
 namespace silkworm::snapshots {
 
 namespace test = test_util;
+using db::test_util::make_repository;
 using silkworm::test_util::SetLogVerbosityGuard;
 using silkworm::test_util::TemporaryFile;
 
@@ -69,14 +70,10 @@ static void open_snapshot(benchmark::State& state) {
 }
 BENCHMARK(open_snapshot);
 
-static std::unique_ptr<SnapshotBundleFactory> bundle_factory() {
-    return std::make_unique<db::SnapshotBundleFactoryImpl>();
-}
-
 static void build_header_index(benchmark::State& state) {
     TemporaryDirectory tmp_dir;
-    snapshots::SnapshotSettings settings{tmp_dir.path()};
-    snapshots::SnapshotRepository repository{settings, bundle_factory()};
+    SnapshotSettings settings{tmp_dir.path()};
+    auto repository = make_repository(settings);
 
     // These sample snapshot files just contain data for block range [1'500'012, 1'500'013], hence current snapshot
     // file name format is not sufficient to support them (see checks commented out below)
@@ -94,8 +91,8 @@ BENCHMARK(build_header_index);
 
 static void build_body_index(benchmark::State& state) {
     TemporaryDirectory tmp_dir;
-    snapshots::SnapshotSettings settings{tmp_dir.path()};
-    snapshots::SnapshotRepository repository{settings, bundle_factory()};
+    SnapshotSettings settings{tmp_dir.path()};
+    auto repository = make_repository(settings);
 
     // These sample snapshot files just contain data for block range [1'500'012, 1'500'013], hence current snapshot
     // file name format is not sufficient to support them (see checks commented out below)
@@ -111,8 +108,8 @@ BENCHMARK(build_body_index);
 
 static void build_tx_index(benchmark::State& state) {
     TemporaryDirectory tmp_dir;
-    snapshots::SnapshotSettings settings{tmp_dir.path()};
-    snapshots::SnapshotRepository repository{settings, bundle_factory()};
+    SnapshotSettings settings{tmp_dir.path()};
+    auto repository = make_repository(settings);
 
     // These sample snapshot files just contain data for block range [1'500'012, 1'500'013], hence current snapshot
     // file name format is not sufficient to support them (see checks commented out below)
@@ -138,7 +135,7 @@ static void reopen_folder(benchmark::State& state) {
     SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryDirectory tmp_dir;
     snapshots::SnapshotSettings settings{tmp_dir.path()};
-    snapshots::SnapshotRepository repository{settings, bundle_factory()};
+    auto repository = make_repository(settings);
 
     // These sample snapshot files just contain data for block range [1'500'012, 1'500'013], hence current snapshot
     // file name format is not sufficient to support them (see checks commented out below)

--- a/silkworm/db/snapshot_bundle_factory_impl.cpp
+++ b/silkworm/db/snapshot_bundle_factory_impl.cpp
@@ -28,26 +28,28 @@ namespace silkworm::db {
 using namespace snapshots;
 
 SnapshotBundle SnapshotBundleFactoryImpl::make(PathByTypeProvider snapshot_path, PathByTypeProvider index_path) const {
-    return SnapshotBundle{{
-        .header_segment = SegmentFileReader(snapshot_path(SnapshotType::headers)),
-        .idx_header_hash = Index(index_path(SnapshotType::headers)),
+    return SnapshotBundle{
+        snapshot_path(SnapshotType::headers).step_range(),
+        {
+            .header_segment = SegmentFileReader(snapshot_path(SnapshotType::headers)),
+            .idx_header_hash = Index(index_path(SnapshotType::headers)),
 
-        .body_segment = SegmentFileReader(snapshot_path(SnapshotType::bodies)),
-        .idx_body_number = Index(index_path(SnapshotType::bodies)),
+            .body_segment = SegmentFileReader(snapshot_path(SnapshotType::bodies)),
+            .idx_body_number = Index(index_path(SnapshotType::bodies)),
 
-        .txn_segment = SegmentFileReader(snapshot_path(SnapshotType::transactions)),
-        .idx_txn_hash = Index(index_path(SnapshotType::transactions)),
-        .idx_txn_hash_2_block = Index(index_path(SnapshotType::transactions_to_block)),
-    }};
+            .txn_segment = SegmentFileReader(snapshot_path(SnapshotType::transactions)),
+            .idx_txn_hash = Index(index_path(SnapshotType::transactions)),
+            .idx_txn_hash_2_block = Index(index_path(SnapshotType::transactions_to_block)),
+        },
+    };
 }
 
-SnapshotBundle SnapshotBundleFactoryImpl::make(const std::filesystem::path& dir_path, BlockNumRange range) const {
-    StepRange step_range = StepRange::from_block_num_range(range);
+SnapshotBundle SnapshotBundleFactoryImpl::make(const std::filesystem::path& dir_path, snapshots::StepRange range) const {
     PathByTypeProvider snapshot_path = [&](silkworm::snapshots::SnapshotType type) {
-        return SnapshotPath::make(dir_path, kSnapshotV1, step_range, type);
+        return SnapshotPath::make(dir_path, kSnapshotV1, range, type);
     };
     PathByTypeProvider index_path = [&](silkworm::snapshots::SnapshotType type) {
-        return SnapshotPath::make(dir_path, kSnapshotV1, step_range, type, kIdxExtension);
+        return SnapshotPath::make(dir_path, kSnapshotV1, range, type, kIdxExtension);
     };
     return make(std::move(snapshot_path), std::move(index_path));
 }

--- a/silkworm/db/snapshot_bundle_factory_impl.hpp
+++ b/silkworm/db/snapshot_bundle_factory_impl.hpp
@@ -24,7 +24,7 @@ struct SnapshotBundleFactoryImpl : public snapshots::SnapshotBundleFactory {
     ~SnapshotBundleFactoryImpl() override = default;
 
     snapshots::SnapshotBundle make(PathByTypeProvider snapshot_path, PathByTypeProvider index_path) const override;
-    snapshots::SnapshotBundle make(const std::filesystem::path& dir_path, BlockNumRange range) const override;
+    snapshots::SnapshotBundle make(const std::filesystem::path& dir_path, snapshots::StepRange range) const override;
     std::vector<std::shared_ptr<snapshots::IndexBuilder>> index_builders(const snapshots::SnapshotPath& segment_path) const override;
     std::vector<std::shared_ptr<snapshots::IndexBuilder>> index_builders(const snapshots::SnapshotPathList& segment_paths) const override;
 };

--- a/silkworm/db/snapshot_repository_test.cpp
+++ b/silkworm/db/snapshot_repository_test.cpp
@@ -24,6 +24,7 @@
 #include <silkworm/db/datastore/snapshots/index_builder.hpp>
 #include <silkworm/db/datastore/snapshots/snapshot_repository.hpp>
 #include <silkworm/db/snapshot_bundle_factory_impl.hpp>
+#include <silkworm/db/test_util/make_repository.hpp>
 #include <silkworm/db/test_util/temp_snapshots.hpp>
 #include <silkworm/db/transactions/txn_index.hpp>
 #include <silkworm/db/transactions/txn_queries.hpp>
@@ -35,18 +36,15 @@
 namespace silkworm::snapshots {
 
 namespace test = test_util;
+using db::test_util::make_repository;
 using silkworm::test_util::SetLogVerbosityGuard;
-
-static std::unique_ptr<SnapshotBundleFactory> bundle_factory() {
-    return std::make_unique<db::SnapshotBundleFactoryImpl>();
-}
 
 #define CHECK_FIRST(x) CHECK((x).first)
 #define CHECK_FALSE_FIRST(x) CHECK_FALSE((x).first)
 
 TEST_CASE("SnapshotRepository::SnapshotRepository", "[silkworm][node][snapshot]") {
     SetLogVerbosityGuard guard{log::Level::kNone};
-    CHECK_NOTHROW(SnapshotRepository{SnapshotSettings{}, bundle_factory()});
+    CHECK_NOTHROW(make_repository(SnapshotSettings{}));
 }
 
 TEST_CASE("SnapshotRepository::reopen_folder.partial_bundle", "[silkworm][node][snapshot]") {
@@ -57,7 +55,7 @@ TEST_CASE("SnapshotRepository::reopen_folder.partial_bundle", "[silkworm][node][
     test::TemporarySnapshotFile tmp_snapshot_2{tmp_dir.path(), "v1-011500-012000-bodies.seg"};
     test::TemporarySnapshotFile tmp_snapshot_3{tmp_dir.path(), "v1-015000-015500-transactions.seg"};
     SnapshotSettings settings{tmp_dir.path()};
-    SnapshotRepository repository{settings, bundle_factory()};
+    auto repository = make_repository(settings);
     repository.reopen_folder();
     CHECK(repository.bundles_count() == 0);
     CHECK(repository.max_block_available() == 0);
@@ -68,7 +66,7 @@ TEST_CASE("SnapshotRepository::view", "[silkworm][node][snapshot]") {
     TemporaryDirectory tmp_dir;
 
     SnapshotSettings settings{tmp_dir.path()};
-    SnapshotRepository repository{settings, bundle_factory()};
+    auto repository = make_repository(settings);
 
     SECTION("no snapshots") {
         repository.reopen_folder();
@@ -143,7 +141,7 @@ TEST_CASE("SnapshotRepository::find_segment", "[silkworm][node][snapshot]") {
     SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryDirectory tmp_dir;
     SnapshotSettings settings{tmp_dir.path()};
-    SnapshotRepository repository{settings, bundle_factory()};
+    auto repository = make_repository(settings);
 
     // These sample snapshot files just contain data for block range [1'500'012, 1'500'013], hence current snapshot
     // file name format is not sufficient to support them (see checks commented out below)
@@ -210,7 +208,7 @@ TEST_CASE("SnapshotRepository::find_block_number", "[silkworm][node][snapshot]")
     SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryDirectory tmp_dir;
     SnapshotSettings settings{tmp_dir.path()};
-    SnapshotRepository repository{settings, bundle_factory()};
+    auto repository = make_repository(settings);
 
     // These sample snapshot files just contain data for block range [1'500'012, 1'500'013], hence current snapshot
     // file name format is not sufficient to support them (see checks commented out below)
@@ -260,7 +258,7 @@ TEST_CASE("SnapshotRepository::remove_stale_indexes", "[silkworm][node][snapshot
     SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryDirectory tmp_dir;
     SnapshotSettings settings{tmp_dir.path()};
-    SnapshotRepository repository{settings, bundle_factory()};
+    auto repository = make_repository(settings);
 
     // create a snapshot file
     test::SampleHeaderSnapshotFile header_segment_file{tmp_dir.path()};

--- a/silkworm/db/snapshot_sync.hpp
+++ b/silkworm/db/snapshot_sync.hpp
@@ -66,7 +66,7 @@ class SnapshotSync {
     Task<void> build_missing_indexes();
 
     void seed_frozen_local_snapshots();
-    void seed_frozen_bundle(BlockNumRange range);
+    void seed_frozen_bundle(snapshots::StepRange range);
     void seed_bundle(snapshots::SnapshotBundle& bundle);
     void seed_snapshot(const snapshots::SnapshotPath& path);
 

--- a/silkworm/db/snapshot_sync_test.cpp
+++ b/silkworm/db/snapshot_sync_test.cpp
@@ -141,17 +141,20 @@ TEST_CASE("SnapshotSync::update_block_headers", "[db][snapshot][sync]") {
     Index idx_txn_hash_2_block{txn_segment_path.related_path(SnapshotType::transactions_to_block, kIdxExtension)};
 
     // Add a sample Snapshot bundle to the repository
-    SnapshotBundle bundle{{
-        .header_segment = std::move(header_segment),
-        .idx_header_hash = std::move(idx_header_hash),
+    SnapshotBundle bundle{
+        header_segment_path.step_range(),
+        {
+            .header_segment = std::move(header_segment),
+            .idx_header_hash = std::move(idx_header_hash),
 
-        .body_segment = std::move(body_segment),
-        .idx_body_number = std::move(idx_body_number),
+            .body_segment = std::move(body_segment),
+            .idx_body_number = std::move(idx_body_number),
 
-        .txn_segment = std::move(txn_segment),
-        .idx_txn_hash = std::move(idx_txn_hash),
-        .idx_txn_hash_2_block = std::move(idx_txn_hash_2_block),
-    }};
+            .txn_segment = std::move(txn_segment),
+            .idx_txn_hash = std::move(idx_txn_hash),
+            .idx_txn_hash_2_block = std::move(idx_txn_hash_2_block),
+        },
+    };
     auto& repository = snapshot_sync.repository();
     repository.add_snapshot_bundle(std::move(bundle));
 

--- a/silkworm/db/test_util/make_repository.cpp
+++ b/silkworm/db/test_util/make_repository.cpp
@@ -1,0 +1,33 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "make_repository.hpp"
+
+#include "../snapshot_bundle_factory_impl.hpp"
+
+namespace silkworm::db::test_util {
+
+using namespace silkworm::snapshots;
+
+SnapshotRepository make_repository(SnapshotSettings settings) {
+    return SnapshotRepository{
+        std::move(settings),
+        std::make_unique<StepToBlockNumConverter>(),
+        std::make_unique<SnapshotBundleFactoryImpl>(),
+    };
+}
+
+}  // namespace silkworm::db::test_util

--- a/silkworm/db/test_util/make_repository.hpp
+++ b/silkworm/db/test_util/make_repository.hpp
@@ -1,0 +1,26 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include "../datastore/snapshots/snapshot_repository.hpp"
+#include "../datastore/snapshots/snapshot_settings.hpp"
+
+namespace silkworm::db::test_util {
+
+snapshots::SnapshotRepository make_repository(snapshots::SnapshotSettings settings);
+
+}  // namespace silkworm::db::test_util

--- a/silkworm/rpc/daemon.cpp
+++ b/silkworm/rpc/daemon.cpp
@@ -141,8 +141,10 @@ int Daemon::run(const DaemonSettings& settings) {
             snapshots::SnapshotSettings snapshot_settings{
                 .repository_dir = data_folder.snapshots().path(),
             };
-            auto snapshot_bundle_factory = std::make_unique<db::SnapshotBundleFactoryImpl>();
-            snapshot_repository = std::make_unique<snapshots::SnapshotRepository>(std::move(snapshot_settings), std::move(snapshot_bundle_factory));
+            snapshot_repository = std::make_unique<snapshots::SnapshotRepository>(
+                std::move(snapshot_settings),
+                std::make_unique<snapshots::StepToBlockNumConverter>(),
+                std::make_unique<db::SnapshotBundleFactoryImpl>());
             snapshot_repository->reopen_folder();
 
             db::DataModel::set_snapshot_repository(snapshot_repository.get());


### PR DESCRIPTION
* define a Timestamp type and conversions to/from Step-s (currently it is a separate type in snapshots/common, later on we can consider migrating kv/api to this type)
* Repository can be created with either BlockNum converter or TxnId converter (it will be used later for state snapshots repository). Repository now uses steps internally, and uses a timestamp converter to implement find_segment and max_timestamp_available
* SnapshotBundle requires an explicit step range on construction. Bundle factory is modified to use steps
* SnapshotBundle.block_range() is removed. freezer, merger currently still do conversions to block numbers themselves, in the future they should be also refactored to work with steps
