### PR TITLE
db: provide SnapshotRepository to DataModel

### DIFF
--- a/cmd/capi/execute.cpp
+++ b/cmd/capi/execute.cpp
@@ -430,15 +430,11 @@ int main(int argc, char* argv[]) {
             return init_status_code;
         }
 
-        // Add snapshots to Silkworm API library
-        SnapshotSettings snapshot_settings{};
-        snapshot_settings.repository_dir = data_dir.snapshots().path();
-
         int status_code = -1;
         if (settings.execute_blocks_settings) {
             // Execute specified block range using Silkworm API library
             SnapshotRepository repository{
-                snapshot_settings,
+                data_dir.snapshots().path(),
                 std::make_unique<StepToBlockNumConverter>(),
                 std::make_unique<db::SnapshotBundleFactoryImpl>(),
             };

--- a/cmd/dev/scan_txs.cpp
+++ b/cmd/dev/scan_txs.cpp
@@ -88,7 +88,7 @@ int main(int argc, char* argv[]) {
                 break;
             }
 
-            db::Buffer buffer{txn};
+            db::Buffer buffer{txn, std::make_unique<db::BufferROTxDataModel>(txn)};
             buffer.set_historical_block(block_num);
 
             ExecutionProcessor processor{block, *rule_set, buffer, *chain_config};

--- a/silkworm/capi/rpcdaemon.cpp
+++ b/silkworm/capi/rpcdaemon.cpp
@@ -101,10 +101,13 @@ SILKWORM_EXPORT int silkworm_start_rpcdaemon(SilkwormHandle handle, MDBX_env* en
     }
 
     auto daemon_settings = make_daemon_settings(handle, *settings);
-    db::EnvUnmanaged unmanaged_env{env};
+    db::DataStoreRef data_store{
+        db::EnvUnmanaged{env},
+        *handle->snapshot_repository,
+    };
 
     // Create the one-and-only Silkrpc daemon
-    handle->rpcdaemon = std::make_unique<rpc::Daemon>(daemon_settings, std::make_optional<mdbx::env>(unmanaged_env));
+    handle->rpcdaemon = std::make_unique<rpc::Daemon>(daemon_settings, data_store);
 
     // Check protocol version compatibility with Core Services
     if (!daemon_settings.skip_protocol_check) {

--- a/silkworm/db/access_layer_test.cpp
+++ b/silkworm/db/access_layer_test.cpp
@@ -452,8 +452,6 @@ TEST_CASE("Difficulty", "[db][access_layer]") {
 
     write_total_difficulty(txn, block_num, hash, difficulty);
     CHECK(read_total_difficulty(txn, block_num, hash) == difficulty);
-    DataModel model{txn};
-    CHECK(model.read_total_difficulty(block_num, hash) == difficulty);
 }
 
 TEST_CASE("Headers and bodies", "[db][access_layer]") {

--- a/silkworm/db/blocks/bodies/body_queries.hpp
+++ b/silkworm/db/blocks/bodies/body_queries.hpp
@@ -17,11 +17,28 @@
 #pragma once
 
 #include <silkworm/db/datastore/snapshots/basic_queries.hpp>
+#include <silkworm/db/datastore/snapshots/snapshot_repository.hpp>
 
 #include "body_segment.hpp"
 
 namespace silkworm::snapshots {
 
 using BodyFindByBlockNumQuery = FindByIdQuery<BodySegmentReader>;
+
+class BodyFindByBlockNumMultiQuery {
+  public:
+    // TODO: use a sub-interface of SnapshotRepository
+    explicit BodyFindByBlockNumMultiQuery(SnapshotRepository& repository)
+        : repository_{repository} {}
+
+    std::optional<BlockBodyForStorage> exec(BlockNum block_num) {
+        const auto [segment_and_index, _] = repository_.find_segment(SnapshotType::bodies, block_num);
+        if (!segment_and_index) return std::nullopt;
+        return BodyFindByBlockNumQuery{*segment_and_index}.exec(block_num);
+    }
+
+  private:
+    SnapshotRepository& repository_;
+};
 
 }  // namespace silkworm::snapshots

--- a/silkworm/db/buffer.cpp
+++ b/silkworm/db/buffer.cpp
@@ -504,7 +504,7 @@ std::optional<BlockHeader> Buffer::read_header(uint64_t block_number, const evmc
     if (auto it{headers_.find(key)}; it != headers_.end()) {
         return it->second;
     }
-    return access_layer_.read_header(block_number, block_hash.bytes);
+    return data_model_->read_header(block_number, Hash{block_hash.bytes});
 }
 
 bool Buffer::read_body(uint64_t block_number, const evmc::bytes32& block_hash, BlockBody& out) const noexcept {
@@ -513,7 +513,7 @@ bool Buffer::read_body(uint64_t block_number, const evmc::bytes32& block_hash, B
         out = it->second;
         return true;
     }
-    return access_layer_.read_body(block_number, block_hash.bytes, /*read_senders=*/false, out);
+    return data_model_->read_body(block_number, block_hash.bytes, /*read_senders=*/false, out);
 }
 
 std::optional<Account> Buffer::read_account(const evmc::address& address) const noexcept {

--- a/silkworm/db/buffer_test.cpp
+++ b/silkworm/db/buffer_test.cpp
@@ -54,7 +54,7 @@ TEST_CASE("Buffer storage", "[silkworm][db][buffer]") {
     upsert_storage_value(*state, key, location_a.bytes, value_a1.bytes);
     upsert_storage_value(*state, key, location_b.bytes, value_b.bytes);
 
-    Buffer buffer{txn};
+    Buffer buffer{txn, std::make_unique<BufferROTxDataModel>(txn)};
 
     SECTION("Reads storage by address and location") {
         CHECK(buffer.read_storage(address, kDefaultIncarnation, location_a) == value_a1);
@@ -251,7 +251,7 @@ TEST_CASE("Buffer account", "[silkworm][db][buffer]") {
         Account current_account;
         current_account.balance = kEther;
 
-        Buffer buffer{txn};
+        Buffer buffer{txn, std::make_unique<BufferROTxDataModel>(txn)};
         buffer.begin_block(1, 1);
         buffer.update_account(address, /*initial=*/std::nullopt, current_account);
         REQUIRE(!buffer.account_changes().empty());
@@ -284,7 +284,7 @@ TEST_CASE("Buffer account", "[silkworm][db][buffer]") {
         current_account.nonce = 2;
         current_account.balance = kEther;
 
-        Buffer buffer{txn};
+        Buffer buffer{txn, std::make_unique<BufferROTxDataModel>(txn)};
         buffer.begin_block(1, 1);
         buffer.update_account(address, /*initial=*/initial_account, current_account);
         REQUIRE(!buffer.account_changes().empty());
@@ -316,7 +316,7 @@ TEST_CASE("Buffer account", "[silkworm][db][buffer]") {
         account.incarnation = kDefaultIncarnation;
         account.code_hash = to_bytes32(keccak256(address.bytes).bytes);  // Just a fake hash
 
-        Buffer buffer{txn};
+        Buffer buffer{txn, std::make_unique<BufferROTxDataModel>(txn)};
         buffer.begin_block(1, 1);
         buffer.update_account(address, /*initial=*/account, /*current=*/std::nullopt);
         REQUIRE(!buffer.account_changes().empty());
@@ -338,7 +338,7 @@ TEST_CASE("Buffer account", "[silkworm][db][buffer]") {
         account.code_hash = to_bytes32(keccak256(address.bytes).bytes);  // Just a fake hash
 
         // Block 1: create contract account
-        Buffer buffer{txn};
+        Buffer buffer{txn, std::make_unique<BufferROTxDataModel>(txn)};
         buffer.begin_block(1, 1);
         buffer.update_account(address, /*initial=*/std::nullopt, /*current=*/account);
         REQUIRE(!buffer.account_changes().empty());
@@ -369,7 +369,7 @@ TEST_CASE("Buffer account", "[silkworm][db][buffer]") {
         current_account.nonce = 2;
         current_account.balance = kEther;
 
-        Buffer buffer{txn};
+        Buffer buffer{txn, std::make_unique<BufferROTxDataModel>(txn)};
         buffer.begin_block(1, 1);
         buffer.update_account(address, /*initial=*/initial_account, current_account);
         REQUIRE(buffer.account_changes().empty());

--- a/silkworm/db/chain/local_chain_storage.cpp
+++ b/silkworm/db/chain/local_chain_storage.cpp
@@ -22,8 +22,6 @@
 
 namespace silkworm::db::chain {
 
-LocalChainStorage::LocalChainStorage(ROTxn& txn) : data_model_{txn} {}
-
 Task<ChainConfig> LocalChainStorage::read_chain_config() const {
     const auto chain_config{data_model_.read_chain_config()};
     if (!chain_config) {

--- a/silkworm/db/chain/local_chain_storage.hpp
+++ b/silkworm/db/chain/local_chain_storage.hpp
@@ -17,7 +17,6 @@
 #pragma once
 
 #include <silkworm/db/access_layer.hpp>
-#include <silkworm/db/datastore/mdbx/mdbx.hpp>
 
 #include "chain_storage.hpp"
 
@@ -27,7 +26,8 @@ namespace silkworm::db::chain {
 //! in local database (accessed via MDBX API) or local snapshot files (accessed via custom snapshot API)
 class LocalChainStorage : public ChainStorage {
   public:
-    explicit LocalChainStorage(db::ROTxn& txn);
+    explicit LocalChainStorage(db::DataModel data_model)
+        : data_model_{data_model} {}
     ~LocalChainStorage() override = default;
 
     Task<ChainConfig> read_chain_config() const override;

--- a/silkworm/db/data_store.hpp
+++ b/silkworm/db/data_store.hpp
@@ -16,11 +16,14 @@
 
 #pragma once
 
-#include "../datastore/snapshots/snapshot_repository.hpp"
+#include <silkworm/db/datastore/mdbx/mdbx.hpp>
+#include <silkworm/db/datastore/snapshots/snapshot_repository.hpp>
 
-namespace silkworm::db::test_util {
+namespace silkworm::db {
 
-snapshots::SnapshotRepository make_repository(std::filesystem::path dir_path);
-snapshots::SnapshotRepository make_repository();
+struct DataStoreRef {
+    mdbx::env chaindata_env;
+    snapshots::SnapshotRepository& repository;
+};
 
-}  // namespace silkworm::db::test_util
+}  // namespace silkworm::db

--- a/silkworm/db/datastore/snapshots/snapshot_repository.hpp
+++ b/silkworm/db/datastore/snapshots/snapshot_repository.hpp
@@ -33,7 +33,6 @@
 #include "segment_and_index.hpp"
 #include "snapshot_bundle.hpp"
 #include "snapshot_bundle_factory.hpp"
-#include "snapshot_settings.hpp"
 
 namespace silkworm::snapshots {
 
@@ -46,14 +45,13 @@ struct IndexBuilder;
 //! - segments have [from:to) semantic
 class SnapshotRepository {
   public:
-    explicit SnapshotRepository(
-        SnapshotSettings settings,
+    SnapshotRepository(
+        std::filesystem::path dir_path,
         std::unique_ptr<StepToTimestampConverter> step_converter,
         std::unique_ptr<SnapshotBundleFactory> bundle_factory);
     ~SnapshotRepository();
 
-    const SnapshotSettings& settings() const { return settings_; }
-    std::filesystem::path path() const { return settings_.repository_dir; }
+    const std::filesystem::path& path() const { return dir_path_; }
     const SnapshotBundleFactory& bundle_factory() const { return *bundle_factory_; }
 
     void reopen_folder();
@@ -125,8 +123,8 @@ class SnapshotRepository {
 
     SnapshotPathList stale_index_paths() const;
 
-    //! The configuration settings for snapshots
-    SnapshotSettings settings_;
+    //! Path to the snapshots directory
+    std::filesystem::path dir_path_;
 
     //! Converts timestamp units to steps
     std::unique_ptr<StepToTimestampConverter> step_converter_;

--- a/silkworm/db/kv/api/direct_service.cpp
+++ b/silkworm/db/kv/api/direct_service.cpp
@@ -23,8 +23,13 @@
 
 namespace silkworm::db::kv::api {
 
-DirectService::DirectService(ServiceRouter router, ::mdbx::env chaindata_env, StateCache* state_cache)
-    : router_{router}, chaindata_env_{std::move(chaindata_env)}, state_cache_{state_cache} {}
+DirectService::DirectService(
+    ServiceRouter router,
+    DataStoreRef data_store,
+    StateCache* state_cache)
+    : router_{router},
+      data_store_{std::move(data_store)},
+      state_cache_{state_cache} {}
 
 // rpc Version(google.protobuf.Empty) returns (types.VersionReply);
 Task<Version> DirectService::version() {
@@ -33,7 +38,7 @@ Task<Version> DirectService::version() {
 
 // rpc Tx(stream Cursor) returns (stream Pair);
 Task<std::unique_ptr<Transaction>> DirectService::begin_transaction() {
-    co_return std::make_unique<LocalTransaction>(chaindata_env_, state_cache_);
+    co_return std::make_unique<LocalTransaction>(data_store_, state_cache_);
 }
 
 // rpc StateChanges(StateChangeRequest) returns (stream StateChangeBatch);

--- a/silkworm/db/kv/api/direct_service.hpp
+++ b/silkworm/db/kv/api/direct_service.hpp
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <silkworm/db/datastore/mdbx/mdbx.hpp>
+#include <silkworm/db/data_store.hpp>
 
 #include "service.hpp"
 #include "service_router.hpp"
@@ -28,7 +28,10 @@ namespace silkworm::db::kv::api {
 //! This is used both client-side by 'direct' (i.e. no-gRPC) implementation and server-side by gRPC server.
 class DirectService : public Service {
   public:
-    explicit DirectService(ServiceRouter router, ::mdbx::env chaindata_env, StateCache* state_cache);
+    explicit DirectService(
+        ServiceRouter router,
+        DataStoreRef data_store,
+        StateCache* state_cache);
     ~DirectService() override = default;
 
     DirectService(const DirectService&) = delete;
@@ -50,8 +53,8 @@ class DirectService : public Service {
     //! The router to service endpoint implementation
     ServiceRouter router_;
 
-    //! The MDBX chain database
-    ::mdbx::env chaindata_env_;
+    //! The data store
+    DataStoreRef data_store_;
 
     //! The local state cache built upon incoming state changes
     StateCache* state_cache_;

--- a/silkworm/db/kv/api/direct_service_test.cpp
+++ b/silkworm/db/kv/api/direct_service_test.cpp
@@ -18,13 +18,16 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <silkworm/db/snapshot_bundle_factory_impl.hpp>
 #include <silkworm/db/test_util/kv_test_base.hpp>
+#include <silkworm/db/test_util/make_repository.hpp>
 #include <silkworm/db/test_util/test_database_context.hpp>
 #include <silkworm/infra/test_util/fixture.hpp>
 
 namespace silkworm::db::kv::api {
 
 using namespace silkworm::test_util;
+using test_util::make_repository;
 using test_util::TestDatabaseContext;
 
 struct DirectServiceTest : public test_util::KVTestBase, TestDatabaseContext {
@@ -32,11 +35,13 @@ struct DirectServiceTest : public test_util::KVTestBase, TestDatabaseContext {
         if (!change_set) co_return;
         change_set_vector.push_back(*change_set);
     }
+    DataStoreRef data_store() { return {mdbx_env(), repository}; }
 
     StateChangeChannelPtr channel{std::make_shared<StateChangeChannel>(io_context_.get_executor())};
     concurrency::Channel<StateChangesCall> state_changes_calls_channel{io_context_.get_executor()};
+    snapshots::SnapshotRepository repository{make_repository()};
     std::unique_ptr<StateCache> state_cache{std::make_unique<CoherentStateCache>()};
-    DirectService service{ServiceRouter{state_changes_calls_channel}, mdbx_env(), state_cache.get()};
+    DirectService service{ServiceRouter{state_changes_calls_channel}, data_store(), state_cache.get()};
     std::vector<StateChangeSet> change_set_vector;
 };
 

--- a/silkworm/db/kv/api/local_transaction.cpp
+++ b/silkworm/db/kv/api/local_transaction.cpp
@@ -61,11 +61,11 @@ Task<std::shared_ptr<CursorDupSort>> LocalTransaction::get_cursor(const std::str
 }
 
 std::shared_ptr<State> LocalTransaction::create_state(boost::asio::any_io_executor&, const chain::ChainStorage&, BlockNum block_number) {
-    return std::make_shared<state::LocalState>(block_number, chaindata_env_);
+    return std::make_shared<state::LocalState>(block_number, data_store_);
 }
 
 std::shared_ptr<chain::ChainStorage> LocalTransaction::create_storage() {
-    return std::make_shared<chain::LocalChainStorage>(txn_);
+    return std::make_shared<chain::LocalChainStorage>(DataModel{txn_, data_store_.repository});
 }
 
 // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)

--- a/silkworm/db/kv/api/local_transaction.hpp
+++ b/silkworm/db/kv/api/local_transaction.hpp
@@ -24,7 +24,7 @@
 
 #include <silkworm/infra/concurrency/task.hpp>
 
-#include <silkworm/db/datastore/mdbx/mdbx.hpp>
+#include <silkworm/db/data_store.hpp>
 
 #include "base_transaction.hpp"
 #include "cursor.hpp"
@@ -35,8 +35,12 @@ namespace silkworm::db::kv::api {
 
 class LocalTransaction : public BaseTransaction {
   public:
-    explicit LocalTransaction(mdbx::env chaindata_env, StateCache* state_cache)
-        : BaseTransaction(state_cache), chaindata_env_{std::move(chaindata_env)}, txn_{chaindata_env_} {}
+    explicit LocalTransaction(
+        DataStoreRef data_store,
+        StateCache* state_cache)
+        : BaseTransaction(state_cache),
+          data_store_{std::move(data_store)},
+          txn_{data_store_.chaindata_env} {}
 
     ~LocalTransaction() override = default;
 
@@ -78,7 +82,7 @@ class LocalTransaction : public BaseTransaction {
     std::map<std::string, std::shared_ptr<CursorDupSort>> cursors_;
     std::map<std::string, std::shared_ptr<CursorDupSort>> dup_cursors_;
 
-    mdbx::env chaindata_env_;
+    DataStoreRef data_store_;
     uint32_t last_cursor_id_{0};
     ROTxnManaged txn_;
     uint64_t tx_id_{++next_tx_id_};

--- a/silkworm/db/kv/state_changes_stream_test.cpp
+++ b/silkworm/db/kv/state_changes_stream_test.cpp
@@ -39,6 +39,8 @@
 #if !defined(__APPLE__) || defined(NDEBUG)
 #include <silkworm/infra/concurrency/signal_handler.hpp>
 #endif  // !defined(__APPLE__) || defined(NDEBUG)
+#include <silkworm/db/snapshot_bundle_factory_impl.hpp>
+#include <silkworm/db/test_util/make_repository.hpp>
 #include <silkworm/infra/grpc/test_util/grpc_actions.hpp>
 #include <silkworm/infra/grpc/test_util/interfaces/kv_mock_fix24351.grpc.pb.h>
 #include <silkworm/infra/grpc/test_util/test_runner.hpp>
@@ -49,6 +51,7 @@ namespace silkworm::db::kv {
 
 using namespace std::chrono_literals;  // NOLINT(build/namespaces)
 using grpc::client::RemoteClient;
+using test_util::make_repository;
 using testing::InvokeWithoutArgs;
 namespace test = rpc::test;
 
@@ -73,7 +76,9 @@ struct StateChangesStreamTest : public StateCacheTestBase {
 };
 
 struct DirectStateChangesStreamTest : public StateChangesStreamTest, test_util::TestDatabaseContext {
-    std::shared_ptr<api::DirectService> direct_service{std::make_shared<api::DirectService>(router, mdbx_env(), state_cache.get())};
+    DataStoreRef data_store() { return {mdbx_env(), repository}; }
+    snapshots::SnapshotRepository repository{make_repository()};
+    std::shared_ptr<api::DirectService> direct_service{std::make_shared<api::DirectService>(router, data_store(), state_cache.get())};
     api::DirectClient direct_client{direct_service};
     StateChangesStream stream{context_, direct_client};
 };

--- a/silkworm/db/snapshot_benchmark.cpp
+++ b/silkworm/db/snapshot_benchmark.cpp
@@ -72,8 +72,7 @@ BENCHMARK(open_snapshot);
 
 static void build_header_index(benchmark::State& state) {
     TemporaryDirectory tmp_dir;
-    SnapshotSettings settings{tmp_dir.path()};
-    auto repository = make_repository(settings);
+    auto repository = make_repository(tmp_dir.path());
 
     // These sample snapshot files just contain data for block range [1'500'012, 1'500'013], hence current snapshot
     // file name format is not sufficient to support them (see checks commented out below)
@@ -91,8 +90,7 @@ BENCHMARK(build_header_index);
 
 static void build_body_index(benchmark::State& state) {
     TemporaryDirectory tmp_dir;
-    SnapshotSettings settings{tmp_dir.path()};
-    auto repository = make_repository(settings);
+    auto repository = make_repository(tmp_dir.path());
 
     // These sample snapshot files just contain data for block range [1'500'012, 1'500'013], hence current snapshot
     // file name format is not sufficient to support them (see checks commented out below)
@@ -108,8 +106,7 @@ BENCHMARK(build_body_index);
 
 static void build_tx_index(benchmark::State& state) {
     TemporaryDirectory tmp_dir;
-    SnapshotSettings settings{tmp_dir.path()};
-    auto repository = make_repository(settings);
+    auto repository = make_repository(tmp_dir.path());
 
     // These sample snapshot files just contain data for block range [1'500'012, 1'500'013], hence current snapshot
     // file name format is not sufficient to support them (see checks commented out below)
@@ -134,8 +131,7 @@ BENCHMARK(build_tx_index);
 static void reopen_folder(benchmark::State& state) {
     SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryDirectory tmp_dir;
-    snapshots::SnapshotSettings settings{tmp_dir.path()};
-    auto repository = make_repository(settings);
+    auto repository = make_repository(tmp_dir.path());
 
     // These sample snapshot files just contain data for block range [1'500'012, 1'500'013], hence current snapshot
     // file name format is not sufficient to support them (see checks commented out below)

--- a/silkworm/db/snapshot_repository_test.cpp
+++ b/silkworm/db/snapshot_repository_test.cpp
@@ -44,7 +44,7 @@ using silkworm::test_util::SetLogVerbosityGuard;
 
 TEST_CASE("SnapshotRepository::SnapshotRepository", "[silkworm][node][snapshot]") {
     SetLogVerbosityGuard guard{log::Level::kNone};
-    CHECK_NOTHROW(make_repository(SnapshotSettings{}));
+    CHECK_NOTHROW(make_repository());
 }
 
 TEST_CASE("SnapshotRepository::reopen_folder.partial_bundle", "[silkworm][node][snapshot]") {
@@ -54,8 +54,7 @@ TEST_CASE("SnapshotRepository::reopen_folder.partial_bundle", "[silkworm][node][
     test::TemporarySnapshotFile tmp_snapshot_1{tmp_dir.path(), "v1-014500-015000-headers.seg"};
     test::TemporarySnapshotFile tmp_snapshot_2{tmp_dir.path(), "v1-011500-012000-bodies.seg"};
     test::TemporarySnapshotFile tmp_snapshot_3{tmp_dir.path(), "v1-015000-015500-transactions.seg"};
-    SnapshotSettings settings{tmp_dir.path()};
-    auto repository = make_repository(settings);
+    auto repository = make_repository(tmp_dir.path());
     repository.reopen_folder();
     CHECK(repository.bundles_count() == 0);
     CHECK(repository.max_block_available() == 0);
@@ -65,8 +64,7 @@ TEST_CASE("SnapshotRepository::view", "[silkworm][node][snapshot]") {
     SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryDirectory tmp_dir;
 
-    SnapshotSettings settings{tmp_dir.path()};
-    auto repository = make_repository(settings);
+    auto repository = make_repository(tmp_dir.path());
 
     SECTION("no snapshots") {
         repository.reopen_folder();
@@ -140,8 +138,7 @@ TEST_CASE("SnapshotRepository::view", "[silkworm][node][snapshot]") {
 TEST_CASE("SnapshotRepository::find_segment", "[silkworm][node][snapshot]") {
     SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryDirectory tmp_dir;
-    SnapshotSettings settings{tmp_dir.path()};
-    auto repository = make_repository(settings);
+    auto repository = make_repository(tmp_dir.path());
 
     // These sample snapshot files just contain data for block range [1'500'012, 1'500'013], hence current snapshot
     // file name format is not sufficient to support them (see checks commented out below)
@@ -207,8 +204,7 @@ TEST_CASE("SnapshotRepository::find_segment", "[silkworm][node][snapshot]") {
 TEST_CASE("SnapshotRepository::find_block_number", "[silkworm][node][snapshot]") {
     SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryDirectory tmp_dir;
-    SnapshotSettings settings{tmp_dir.path()};
-    auto repository = make_repository(settings);
+    auto repository = make_repository(tmp_dir.path());
 
     // These sample snapshot files just contain data for block range [1'500'012, 1'500'013], hence current snapshot
     // file name format is not sufficient to support them (see checks commented out below)
@@ -257,8 +253,7 @@ TEST_CASE("SnapshotRepository::remove_stale_indexes", "[silkworm][node][snapshot
 
     SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryDirectory tmp_dir;
-    SnapshotSettings settings{tmp_dir.path()};
-    auto repository = make_repository(settings);
+    auto repository = make_repository(tmp_dir.path());
 
     // create a snapshot file
     test::SampleHeaderSnapshotFile header_segment_file{tmp_dir.path()};

--- a/silkworm/db/snapshot_sync.hpp
+++ b/silkworm/db/snapshot_sync.hpp
@@ -32,6 +32,7 @@
 #include <silkworm/infra/concurrency/stoppable.hpp>
 
 #include "access_layer.hpp"
+#include "data_store.hpp"
 #include "datastore/mdbx/mdbx.hpp"
 #include "datastore/snapshot_merger.hpp"
 #include "datastore/snapshots/bittorrent/client.hpp"
@@ -50,7 +51,7 @@ class SnapshotSync {
     SnapshotSync(
         snapshots::SnapshotSettings settings,
         ChainId chain_id,
-        mdbx::env chaindata_env,
+        db::DataStoreRef data_store,
         std::filesystem::path tmp_dir_path,
         stagedsync::StageScheduler& stage_scheduler);
 
@@ -81,7 +82,7 @@ class SnapshotSync {
     const snapshots::Config snapshots_config_;
     mdbx::env chaindata_env_;
 
-    snapshots::SnapshotRepository repository_;
+    snapshots::SnapshotRepository& repository_;
 
     snapshots::bittorrent::BitTorrentClient client_;
 

--- a/silkworm/db/snapshot_sync_test.cpp
+++ b/silkworm/db/snapshot_sync_test.cpp
@@ -21,6 +21,7 @@
 #include <silkworm/core/chain/config.hpp>
 #include <silkworm/db/blocks/bodies/body_index.hpp>
 #include <silkworm/db/blocks/headers/header_index.hpp>
+#include <silkworm/db/test_util/make_repository.hpp>
 #include <silkworm/db/test_util/temp_chain_data.hpp>
 #include <silkworm/db/test_util/temp_snapshots.hpp>
 #include <silkworm/db/transactions/txn_index.hpp>
@@ -53,6 +54,7 @@ struct SnapshotSyncTest {
     SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryDirectory tmp_dir;
     db::test_util::TempChainData context;
+    SnapshotRepository repository{db::test_util::make_repository(tmp_dir.path())};
     TaskRunner runner;
     NoopStageSchedulerAdapter stage_scheduler;
 };
@@ -84,7 +86,7 @@ struct SnapshotSyncForTest : public SnapshotSync {
         : SnapshotSync{
               make_settings(test.tmp_dir.path(), overrides),
               kMainnetConfig.chain_id,
-              test.context.env(),
+              db::DataStoreRef{test.context.env(), test.repository},
               test.tmp_dir.path(),
               test.stage_scheduler} {}
 };

--- a/silkworm/db/state/local_state.hpp
+++ b/silkworm/db/state/local_state.hpp
@@ -29,12 +29,14 @@
 #include <silkworm/db/access_layer.hpp>
 #include <silkworm/db/datastore/mdbx/mdbx.hpp>
 
+#include "../data_store.hpp"
+
 namespace silkworm::db::state {
 
 class LocalState : public State {
   public:
-    explicit LocalState(BlockNum block_number, mdbx::env chaindata_env)
-        : block_number_{block_number}, txn_{std::move(chaindata_env)}, data_model_{txn_} {}
+    explicit LocalState(BlockNum block_number, DataStoreRef data_store)
+        : block_number_{block_number}, txn_{data_store.chaindata_env}, data_model_{txn_, data_store.repository} {}
 
     std::optional<Account> read_account(const evmc::address& address) const noexcept override;
 

--- a/silkworm/db/test_util/make_repository.cpp
+++ b/silkworm/db/test_util/make_repository.cpp
@@ -16,18 +16,24 @@
 
 #include "make_repository.hpp"
 
+#include "../datastore/snapshots/snapshot_settings.hpp"
 #include "../snapshot_bundle_factory_impl.hpp"
 
 namespace silkworm::db::test_util {
 
 using namespace silkworm::snapshots;
 
-SnapshotRepository make_repository(SnapshotSettings settings) {
+SnapshotRepository make_repository(std::filesystem::path dir_path) {
     return SnapshotRepository{
-        std::move(settings),
+        std::move(dir_path),
         std::make_unique<StepToBlockNumConverter>(),
         std::make_unique<SnapshotBundleFactoryImpl>(),
     };
+}
+
+SnapshotRepository make_repository() {
+    SnapshotSettings settings;
+    return make_repository(settings.repository_dir);
 }
 
 }  // namespace silkworm::db::test_util

--- a/silkworm/db/test_util/test_database_context.cpp
+++ b/silkworm/db/test_util/test_database_context.cpp
@@ -127,7 +127,7 @@ void populate_blocks(RWTxn& txn, const std::filesystem::path& tests_dir, InMemor
         // FIX 4b: populate receipts and logs table
         std::vector<silkworm::Receipt> receipts;
         ExecutionProcessor processor{block, *ruleSet, state_buffer, *chain_config};
-        Buffer db_buffer{txn};
+        Buffer db_buffer{txn, std::make_unique<BufferROTxDataModel>(txn)};
         for (auto& block_txn : block.transactions) {
             silkworm::Receipt receipt{};
             processor.execute_transaction(block_txn, receipt);

--- a/silkworm/node/stagedsync/execution_engine.cpp
+++ b/silkworm/node/stagedsync/execution_engine.cpp
@@ -32,8 +32,9 @@ using execution::api::VerificationResult;
 ExecutionEngine::ExecutionEngine(
     std::optional<boost::asio::any_io_executor> executor,
     NodeSettings& ns,
+    db::DataModelFactory data_model_factory,
     std::optional<TimerFactory> log_timer_factory,
-    BodiesStageFactory bodies_stage_factory,
+    StageContainerFactory stages_factory,
     db::RWAccess dba)
     : context_pool_{executor ? std::unique_ptr<concurrency::ContextPool<>>{} : std::make_unique<concurrency::ContextPool<>>(1)},
       executor_{executor ? std::move(*executor) : context_pool_->any_executor()},
@@ -41,8 +42,9 @@ ExecutionEngine::ExecutionEngine(
       main_chain_{
           executor_,
           ns,
+          std::move(data_model_factory),
           std::move(log_timer_factory),
-          std::move(bodies_stage_factory),
+          std::move(stages_factory),
           std::move(dba),
       },
       block_cache_{kDefaultCacheSize} {}
@@ -77,7 +79,7 @@ BlockId ExecutionEngine::last_safe_block() const {
 }
 
 BlockNum ExecutionEngine::highest_frozen_block_number() const {
-    return db::DataModel::highest_frozen_block_number();
+    return main_chain_.highest_frozen_block_number();
 }
 
 void ExecutionEngine::insert_blocks(const std::vector<std::shared_ptr<Block>>& blocks) {

--- a/silkworm/node/stagedsync/execution_engine.hpp
+++ b/silkworm/node/stagedsync/execution_engine.hpp
@@ -30,6 +30,7 @@
 
 #include <silkworm/core/common/lru_cache.hpp>
 #include <silkworm/core/types/block.hpp>
+#include <silkworm/db/access_layer.hpp>
 #include <silkworm/db/datastore/stage_scheduler.hpp>
 #include <silkworm/db/stage.hpp>
 #include <silkworm/execution/api/execution_engine.hpp>
@@ -38,7 +39,6 @@
 
 #include "forks/extending_fork.hpp"
 #include "forks/main_chain.hpp"
-#include "stages/stage_bodies_factory.hpp"
 #include "timer_factory.hpp"
 
 namespace silkworm::stagedsync {
@@ -60,8 +60,9 @@ class ExecutionEngine : public execution::api::ExecutionEngine, public Stoppable
     ExecutionEngine(
         std::optional<boost::asio::any_io_executor> executor,
         NodeSettings& ns,
+        db::DataModelFactory data_model_factory,
         std::optional<TimerFactory> log_timer_factory,
-        BodiesStageFactory bodies_stage_factory,
+        StageContainerFactory stages_factory,
         db::RWAccess dba);
     ~ExecutionEngine() override = default;
 

--- a/silkworm/node/stagedsync/forks/canonical_chain.hpp
+++ b/silkworm/node/stagedsync/forks/canonical_chain.hpp
@@ -35,8 +35,11 @@ class CanonicalChain {
   public:
     static constexpr size_t kNoCache = 0;
 
-    explicit CanonicalChain(db::RWTxn&, size_t cache_size = kDefaultCacheSize);
-    CanonicalChain(CanonicalChain&) = delete;           // tx is not copiable
+    explicit CanonicalChain(
+        db::RWTxn& tx,
+        db::DataModelFactory data_model_factory,
+        size_t cache_size = kDefaultCacheSize);
+    CanonicalChain(CanonicalChain&) = delete;           // tx is not copyable
     CanonicalChain(const CanonicalChain&, db::RWTxn&);  // we can copy a CanonicalChain giving a new tx
     CanonicalChain(CanonicalChain&&) noexcept;
 
@@ -46,7 +49,7 @@ class CanonicalChain {
     BlockId find_forking_point(const BlockHeader& header, Hash header_hash) const;
 
     void advance(BlockNum height, Hash header_hash);
-    void update_up_to(BlockNum height, Hash header_hash);
+    void update_up_to(BlockNum height, Hash hash);
     void delete_down_to(BlockNum unwind_point);
     void set_current_head(BlockId);
 
@@ -57,8 +60,10 @@ class CanonicalChain {
     bool has(Hash block_hash) const;
 
   private:
+    db::DataModel data_model() const { return data_model_factory_(tx_); }
+
     db::RWTxn& tx_;
-    db::DataModel data_model_;
+    db::DataModelFactory data_model_factory_;
 
     BlockId initial_head_{};
     BlockId current_head_{};

--- a/silkworm/node/stagedsync/forks/extending_fork.cpp
+++ b/silkworm/node/stagedsync/forks/extending_fork.cpp
@@ -70,9 +70,10 @@ void ExtendingFork::start_with(BlockId new_head, std::list<std::shared_ptr<Block
             fork_ = std::make_unique<Fork>(
                 forking_point_,
                 db::ROTxnManaged(main_chain_.tx().db()),
+                main_chain_.data_model_factory(),
                 main_chain_.log_timer_factory(),
-                main_chain_.bodies_stage_factory(),
-                main_chain_.node_settings());
+                main_chain_.stages_factory(),
+                main_chain_.node_settings().data_directory->forks().path());
             fork_->extend_with(blocks_);
             ensure(fork_->current_head() == new_head, "fork head mismatch");
         } catch (...) {

--- a/silkworm/node/stagedsync/stages/stage_bodies.cpp
+++ b/silkworm/node/stagedsync/stages/stage_bodies.cpp
@@ -27,12 +27,15 @@
 
 namespace silkworm::stagedsync {
 
-BodiesStage::BodyDataModel::BodyDataModel(db::RWTxn& tx, BlockNum bodies_stage_height, const ChainConfig& chain_config)
-    : tx_(tx),
-      data_model_(tx_),
+BodiesStage::BodyDataModel::BodyDataModel(
+    db::RWTxn& tx,
+    db::DataModel data_model,
+    BlockNum bodies_stage_height,
+    const ChainConfig& chain_config)
+    : data_model_(data_model),
       chain_config_{chain_config},
       rule_set_{protocol::rule_set_factory(chain_config)},
-      chain_state_{tx},
+      chain_state_{tx, std::make_unique<db::BufferFullDataModel>(data_model)},
       initial_height_{bodies_stage_height},
       highest_height_{bodies_stage_height} {
 }
@@ -97,9 +100,11 @@ bool BodiesStage::BodyDataModel::get_canonical_block(BlockNum height, Block& blo
 BodiesStage::BodiesStage(
     SyncContext* sync_context,
     const ChainConfig& chain_config,
+    db::DataModelFactory data_model_factory,
     std::function<BlockNum()> last_pre_validated_block)
     : Stage(sync_context, db::stages::kBlockBodiesKey),
       chain_config_(chain_config),
+      data_model_factory_(std::move(data_model_factory)),
       last_pre_validated_block_(std::move(last_pre_validated_block)) {}
 
 Stage::Result BodiesStage::forward(db::RWTxn& tx) {
@@ -132,8 +137,12 @@ Stage::Result BodiesStage::forward(db::RWTxn& tx) {
                        "to", std::to_string(target_height),
                        "span", std::to_string(target_height - current_height_)});
         }
-
-        BodyDataModel body_persistence(tx, current_height_, chain_config_);
+        BodyDataModel body_persistence{
+            tx,
+            data_model_factory_(tx),
+            current_height_,
+            chain_config_,
+        };
         body_persistence.set_preverified_height(last_pre_validated_block_());
 
         get_log_progress();  // this is a trick to set log progress initial value, please improve

--- a/silkworm/node/stagedsync/stages/stage_execution.hpp
+++ b/silkworm/node/stagedsync/stages/stage_execution.hpp
@@ -21,6 +21,7 @@
 #include <silkworm/core/chain/config.hpp>
 #include <silkworm/core/execution/evm.hpp>
 #include <silkworm/core/protocol/rule_set.hpp>
+#include <silkworm/db/access_layer.hpp>
 #include <silkworm/db/prune_mode.hpp>
 #include <silkworm/db/stage.hpp>
 
@@ -30,10 +31,12 @@ class Execution final : public Stage {
   public:
     Execution(
         SyncContext* sync_context,
+        db::DataModelFactory data_model_factory,
         const ChainConfig& chain_config,
         size_t batch_size,
         db::PruneMode prune_mode)
         : Stage(sync_context, db::stages::kExecutionKey),
+          data_model_factory_(std::move(data_model_factory)),
           chain_config_(chain_config),
           batch_size_(batch_size),
           prune_mode_(prune_mode),
@@ -49,6 +52,7 @@ class Execution final : public Stage {
   private:
     static constexpr size_t kMaxPrefetchedBlocks{10240};
 
+    db::DataModelFactory data_model_factory_;
     const ChainConfig& chain_config_;
     size_t batch_size_;
     db::PruneMode prune_mode_;

--- a/silkworm/node/stagedsync/stages/stage_headers.hpp
+++ b/silkworm/node/stagedsync/stages/stage_headers.hpp
@@ -61,7 +61,9 @@ namespace silkworm::stagedsync {
  */
 class HeadersStage : public Stage {
   public:
-    explicit HeadersStage(SyncContext*);
+    HeadersStage(
+        SyncContext* sync_context,
+        db::DataModelFactory data_model_factory);
     HeadersStage(const HeadersStage&) = delete;  // not copyable
     HeadersStage(HeadersStage&&) = delete;       // nor movable
 
@@ -71,14 +73,18 @@ class HeadersStage : public Stage {
 
   protected:
     std::vector<std::string> get_log_progress() override;  // thread safe
-    std::atomic<BlockNum> current_height_{0};
 
+    db::DataModelFactory data_model_factory_;
+    std::atomic<BlockNum> current_height_{0};
     std::optional<BlockNum> forced_target_block_;
 
     // HeaderDataModel has the responsibility to update headers related tables
     class HeaderDataModel {
       public:
-        explicit HeaderDataModel(db::RWTxn& tx, BlockNum headers_height);
+        HeaderDataModel(
+            db::RWTxn& tx,
+            db::DataModel data_model,
+            BlockNum headers_height);
 
         void update_tables(const BlockHeader&);  // update header related tables
 

--- a/silkworm/node/stagedsync/stages/stage_history_index_test.cpp
+++ b/silkworm/node/stagedsync/stages/stage_history_index_test.cpp
@@ -89,7 +89,7 @@ TEST_CASE("Stage History Index") {
         block.transactions[0].s = 1;  // dummy
         block.transactions[0].set_sender(sender);
 
-        Buffer buffer{txn};
+        Buffer buffer{txn, std::make_unique<BufferROTxDataModel>(txn)};
         Account sender_account{};
         sender_account.balance = kEther;
         buffer.update_account(sender, std::nullopt, sender_account);
@@ -449,7 +449,7 @@ TEST_CASE("HistoryIndex + Account access_layer") {
     TempChainData context;
     RWTxn& txn{context.rw_txn()};
 
-    Buffer buffer{txn};
+    Buffer buffer{txn, std::make_unique<BufferROTxDataModel>(txn)};
 
     const evmc::address miner_a{0x00000000000000000000000000000000000000aa_address};
     const evmc::address miner_b{0x00000000000000000000000000000000000000bb_address};

--- a/silkworm/node/stagedsync/stages/stage_interhashes.cpp
+++ b/silkworm/node/stagedsync/stages/stage_interhashes.cpp
@@ -42,7 +42,7 @@ Stage::Result InterHashes::forward(RWTxn& txn) {
 
     try {
         throw_if_stopping();
-        DataModel data_model{txn};
+        DataModel data_model = data_model_factory_(txn);
 
         // Check stage boundaries from previous execution and previous stage execution
         auto previous_progress{get_progress(txn)};
@@ -135,7 +135,7 @@ Stage::Result InterHashes::unwind(RWTxn& txn) {
 
     try {
         throw_if_stopping();
-        DataModel data_model{txn};
+        DataModel data_model = data_model_factory_(txn);
 
         BlockNum previous_progress{get_progress(txn)};
         if (to >= previous_progress) {

--- a/silkworm/node/stagedsync/stages/stage_interhashes.hpp
+++ b/silkworm/node/stagedsync/stages/stage_interhashes.hpp
@@ -18,6 +18,7 @@
 
 #include <silkworm/core/trie/hash_builder.hpp>
 #include <silkworm/core/trie/prefix_set.hpp>
+#include <silkworm/db/access_layer.hpp>
 #include <silkworm/db/datastore/etl/collector.hpp>
 #include <silkworm/db/datastore/etl/collector_settings.hpp>
 #include <silkworm/db/stage.hpp>
@@ -27,8 +28,12 @@ namespace silkworm::stagedsync {
 
 class InterHashes final : public Stage {
   public:
-    explicit InterHashes(SyncContext* sync_context, db::etl::CollectorSettings etl_settings)
+    InterHashes(
+        SyncContext* sync_context,
+        db::DataModelFactory data_model_factory,
+        db::etl::CollectorSettings etl_settings)
         : Stage(sync_context, db::stages::kIntermediateHashesKey),
+          data_model_factory_(std::move(data_model_factory)),
           etl_settings_(std::move(etl_settings)) {}
     ~InterHashes() override = default;
 
@@ -111,6 +116,8 @@ class InterHashes final : public Stage {
 
     // The loader which (re)builds the trees
     std::unique_ptr<trie::TrieLoader> trie_loader_;
+
+    db::DataModelFactory data_model_factory_;
 
     db::etl::CollectorSettings etl_settings_;
 

--- a/silkworm/node/stagedsync/stages/stage_senders.cpp
+++ b/silkworm/node/stagedsync/stages/stage_senders.cpp
@@ -36,11 +36,13 @@ using namespace silkworm::db;
 
 Senders::Senders(
     SyncContext* sync_context,
+    DataModelFactory data_model_factory,
     const ChainConfig& chain_config,
     size_t batch_size,
     etl::CollectorSettings etl_settings,
     BlockAmount prune_mode_senders)
     : Stage(sync_context, stages::kSendersKey),
+      data_model_factory_(std::move(data_model_factory)),
       chain_config_(chain_config),
       prune_mode_senders_(prune_mode_senders),
       max_batch_size_{batch_size / std::thread::hardware_concurrency() / sizeof(AddressRecovery)},
@@ -265,7 +267,7 @@ Stage::Result Senders::parallel_recover(RWTxn& txn) {
     results_.clear();
 
     try {
-        DataModel data_model{txn};
+        DataModel data_model = data_model_factory_(txn);
 
         // Check stage boundaries using previous execution of current stage and current execution of previous stage
         auto previous_progress{stages::read_stage_progress(txn, stages::kSendersKey)};

--- a/silkworm/node/stagedsync/stages/stage_senders.hpp
+++ b/silkworm/node/stagedsync/stages/stage_senders.hpp
@@ -28,6 +28,7 @@
 #include <silkworm/core/chain/config.hpp>
 #include <silkworm/core/common/base.hpp>
 #include <silkworm/core/common/bytes.hpp>
+#include <silkworm/db/access_layer.hpp>
 #include <silkworm/db/datastore/etl/collector.hpp>
 #include <silkworm/db/datastore/etl/collector_settings.hpp>
 #include <silkworm/db/prune_mode.hpp>
@@ -52,6 +53,7 @@ class Senders final : public Stage {
   public:
     Senders(
         SyncContext* sync_context,
+        db::DataModelFactory data_model_factory,
         const ChainConfig& chain_config,
         size_t batch_size,
         db::etl::CollectorSettings etl_settings,
@@ -77,6 +79,7 @@ class Senders final : public Stage {
     void increment_total_processed_blocks();
     void increment_total_collected_transactions(size_t delta);
 
+    db::DataModelFactory data_model_factory_;
     const ChainConfig& chain_config_;
     db::BlockAmount prune_mode_senders_;
 

--- a/silkworm/node/stagedsync/stages/stage_tx_lookup.cpp
+++ b/silkworm/node/stagedsync/stages/stage_tx_lookup.cpp
@@ -50,7 +50,8 @@ Stage::Result TxLookup::forward(RWTxn& txn) {
         }
 
         // Snapshots already have TxLookup index, so we must start after max frozen block here
-        const auto highest_frozen_block_number{DataModel::highest_frozen_block_number()};
+        DataModel data_model = data_model_factory_(txn);
+        const auto highest_frozen_block_number{data_model.highest_frozen_block_number()};
         if (highest_frozen_block_number > previous_progress) {
             previous_progress = std::min(highest_frozen_block_number, target_progress);
             // If pruning is enabled, make it start from max frozen block as well
@@ -124,7 +125,8 @@ Stage::Result TxLookup::unwind(RWTxn& txn) {
         }
 
         // Snapshots already have TxLookup index, so we must stop before max frozen block here
-        const auto highest_frozen_block_number{DataModel::highest_frozen_block_number()};
+        DataModel data_model = data_model_factory_(txn);
+        const auto highest_frozen_block_number{data_model.highest_frozen_block_number()};
         if (highest_frozen_block_number > to) {
             to = highest_frozen_block_number;
         }
@@ -338,7 +340,7 @@ void TxLookup::collect_transaction_hashes_from_canonical_bodies(RWTxn& txn,
     using namespace std::chrono_literals;
     auto log_time{std::chrono::steady_clock::now()};
 
-    DataModel data_model{txn};
+    DataModel data_model = data_model_factory_(txn);
 
     BlockNum target_block_num{std::max(from, to)};
     BlockNum start_block_num{std::min(from, to) + 1};

--- a/silkworm/node/stagedsync/stages/stage_tx_lookup.hpp
+++ b/silkworm/node/stagedsync/stages/stage_tx_lookup.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <silkworm/db/access_layer.hpp>
 #include <silkworm/db/datastore/etl/collector_settings.hpp>
 #include <silkworm/db/datastore/mdbx/bitmap.hpp>
 #include <silkworm/db/prune_mode.hpp>
@@ -27,9 +28,11 @@ class TxLookup : public Stage {
   public:
     TxLookup(
         SyncContext* sync_context,
+        db::DataModelFactory data_model_factory,
         db::etl::CollectorSettings etl_settings,
         db::BlockAmount prune_mode_tx_index)
         : Stage(sync_context, db::stages::kTxLookupKey),
+          data_model_factory_(std::move(data_model_factory)),
           etl_settings_(std::move(etl_settings)),
           prune_mode_tx_index_(prune_mode_tx_index) {}
     TxLookup(const TxLookup&) = delete;  // not copyable
@@ -42,6 +45,7 @@ class TxLookup : public Stage {
     std::vector<std::string> get_log_progress() final;
 
   private:
+    db::DataModelFactory data_model_factory_;
     db::etl::CollectorSettings etl_settings_;
     db::BlockAmount prune_mode_tx_index_;
 

--- a/silkworm/node/stagedsync/stages_factory_impl.cpp
+++ b/silkworm/node/stagedsync/stages_factory_impl.cpp
@@ -1,0 +1,63 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "stages_factory_impl.hpp"
+
+#include <silkworm/db/stages.hpp>
+#include <silkworm/node/stagedsync/stages/stage_blockhashes.hpp>
+#include <silkworm/node/stagedsync/stages/stage_bodies.hpp>
+#include <silkworm/node/stagedsync/stages/stage_call_trace_index.hpp>
+#include <silkworm/node/stagedsync/stages/stage_execution.hpp>
+#include <silkworm/node/stagedsync/stages/stage_finish.hpp>
+#include <silkworm/node/stagedsync/stages/stage_hashstate.hpp>
+#include <silkworm/node/stagedsync/stages/stage_headers.hpp>
+#include <silkworm/node/stagedsync/stages/stage_history_index.hpp>
+#include <silkworm/node/stagedsync/stages/stage_interhashes.hpp>
+#include <silkworm/node/stagedsync/stages/stage_log_index.hpp>
+#include <silkworm/node/stagedsync/stages/stage_senders.hpp>
+#include <silkworm/node/stagedsync/stages/stage_triggers.hpp>
+#include <silkworm/node/stagedsync/stages/stage_tx_lookup.hpp>
+
+namespace silkworm::stagedsync {
+
+using namespace db::stages;
+
+StageContainer StagesFactoryImpl::make(SyncContext& sync_context) const {
+    SyncContext* sync_context_ptr = &sync_context;
+    StageContainer stages;
+    stages.emplace(kHeadersKey, std::make_unique<HeadersStage>(sync_context_ptr, data_model_factory_));
+    stages.emplace(kBlockBodiesKey, bodies_stage_factory_(sync_context_ptr));
+    stages.emplace(kBlockHashesKey, std::make_unique<BlockHashes>(sync_context_ptr, settings_.etl()));
+    stages.emplace(kSendersKey, std::make_unique<Senders>(sync_context_ptr, data_model_factory_, *settings_.chain_config, settings_.batch_size, settings_.etl(), settings_.prune_mode.senders()));
+    stages.emplace(kExecutionKey, std::make_unique<Execution>(sync_context_ptr, data_model_factory_, *settings_.chain_config, settings_.batch_size, settings_.prune_mode));
+    stages.emplace(kHashStateKey, std::make_unique<HashState>(sync_context_ptr, settings_.etl()));
+    stages.emplace(kIntermediateHashesKey, std::make_unique<InterHashes>(sync_context_ptr, data_model_factory_, settings_.etl()));
+    stages.emplace(kHistoryIndexKey, std::make_unique<HistoryIndex>(sync_context_ptr, settings_.batch_size, settings_.etl(), settings_.prune_mode.history()));
+    stages.emplace(kLogIndexKey, std::make_unique<LogIndex>(sync_context_ptr, settings_.batch_size, settings_.etl(), settings_.prune_mode.history()));
+    stages.emplace(kCallTracesKey, std::make_unique<CallTraceIndex>(sync_context_ptr, settings_.batch_size, settings_.etl(), settings_.prune_mode.call_traces()));
+    stages.emplace(kTxLookupKey, std::make_unique<TxLookup>(sync_context_ptr, data_model_factory_, settings_.etl(), settings_.prune_mode.tx_index()));
+    stages.emplace(kTriggersStageKey, std::make_unique<TriggersStage>(sync_context_ptr));
+    stages.emplace(kFinishKey, std::make_unique<Finish>(sync_context_ptr, settings_.build_info.build_description));
+    return stages;
+}
+
+StageContainerFactory StagesFactoryImpl::to_factory(StagesFactoryImpl instance) {
+    return [instance = std::move(instance)](SyncContext& sync_context) -> StageContainer {
+        return instance.make(sync_context);
+    };
+}
+
+}  // namespace silkworm::stagedsync

--- a/silkworm/node/stagedsync/stages_factory_impl.hpp
+++ b/silkworm/node/stagedsync/stages_factory_impl.hpp
@@ -1,0 +1,47 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <silkworm/db/access_layer.hpp>
+#include <silkworm/node/common/node_settings.hpp>
+
+#include "execution_pipeline.hpp"
+#include "stages/stage_bodies_factory.hpp"
+
+namespace silkworm::stagedsync {
+
+class StagesFactoryImpl {
+  public:
+    StagesFactoryImpl(
+        const NodeSettings& settings,
+        db::DataModelFactory data_model_factory,
+        BodiesStageFactory bodies_stage_factory)
+        : settings_{settings},
+          data_model_factory_{std::move(data_model_factory)},
+          bodies_stage_factory_{std::move(bodies_stage_factory)} {}
+
+    static StageContainerFactory to_factory(StagesFactoryImpl instance);
+
+  private:
+    StageContainer make(SyncContext& sync_context) const;
+
+    const NodeSettings& settings_;
+    db::DataModelFactory data_model_factory_;
+    BodiesStageFactory bodies_stage_factory_;
+};
+
+}  // namespace silkworm::stagedsync

--- a/silkworm/node/test_util/make_stages_factory.cpp
+++ b/silkworm/node/test_util/make_stages_factory.cpp
@@ -1,0 +1,43 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "make_stages_factory.hpp"
+
+#include "../stagedsync/stages/stage_bodies.hpp"
+#include "../stagedsync/stages_factory_impl.hpp"
+
+namespace silkworm::stagedsync::test_util {
+
+BodiesStageFactory make_bodies_stage_factory(const ChainConfig& chain_config, db::DataModelFactory data_model_factory) {
+    return [chain_config, data_model_factory = std::move(data_model_factory)](SyncContext* sync_context) {
+        return std::make_unique<BodiesStage>(
+            sync_context,
+            chain_config,
+            data_model_factory,
+            [] { return 0; });
+    };
+};
+
+StageContainerFactory make_stages_factory(const NodeSettings& node_settings, db::DataModelFactory data_model_factory) {
+    auto bodies_stage_factory = make_bodies_stage_factory(*node_settings.chain_config, data_model_factory);
+    return StagesFactoryImpl::to_factory({
+        node_settings,
+        std::move(data_model_factory),
+        std::move(bodies_stage_factory),
+    });
+}
+
+}  // namespace silkworm::stagedsync::test_util

--- a/silkworm/node/test_util/make_stages_factory.hpp
+++ b/silkworm/node/test_util/make_stages_factory.hpp
@@ -16,11 +16,16 @@
 
 #pragma once
 
-#include "../datastore/snapshots/snapshot_repository.hpp"
+#include <silkworm/core/chain/config.hpp>
+#include <silkworm/db/access_layer.hpp>
 
-namespace silkworm::db::test_util {
+#include "../common/node_settings.hpp"
+#include "../stagedsync/execution_pipeline.hpp"
+#include "../stagedsync/stages/stage_bodies_factory.hpp"
 
-snapshots::SnapshotRepository make_repository(std::filesystem::path dir_path);
-snapshots::SnapshotRepository make_repository();
+namespace silkworm::stagedsync::test_util {
 
-}  // namespace silkworm::db::test_util
+BodiesStageFactory make_bodies_stage_factory(const ChainConfig& chain_config, db::DataModelFactory data_model_factory);
+StageContainerFactory make_stages_factory(const NodeSettings& node_settings, db::DataModelFactory data_model_factory);
+
+}  // namespace silkworm::stagedsync::test_util

--- a/silkworm/node/test_util/mock_execution_engine.hpp
+++ b/silkworm/node/test_util/mock_execution_engine.hpp
@@ -22,26 +22,41 @@
 #include <gmock/gmock.h>
 
 #include <silkworm/core/chain/config.hpp>
+#include <silkworm/core/common/assert.hpp>
 #include <silkworm/core/common/base.hpp>
 #include <silkworm/core/types/block.hpp>
 #include <silkworm/core/types/hash.hpp>
 #include <silkworm/db/datastore/mdbx/mdbx.hpp>
 #include <silkworm/node/stagedsync/execution_engine.hpp>
-#include <silkworm/node/stagedsync/stages/stage_bodies.hpp>
+#include <silkworm/node/stagedsync/execution_pipeline.hpp>
 
 namespace silkworm::execution::api {
 
 //! \brief gMock mock class for stagedsync::ExecutionEngine
 class MockExecutionEngine : public stagedsync::ExecutionEngine {
   public:
-    static stagedsync::BodiesStageFactory empty_bodies_stage_factory() {
-        return [](stagedsync::SyncContext*) {
-            return std::unique_ptr<stagedsync::BodiesStage>{};
+    static db::DataModelFactory null_data_model_factory() {
+        return [](db::ROTxn&) -> db::DataModel {
+            SILKWORM_ASSERT(false);
+            std::abort();
+        };
+    };
+
+    static stagedsync::StageContainerFactory empty_stages_factory() {
+        return [](stagedsync::SyncContext&) {
+            return stagedsync::StageContainer{};
         };
     };
 
     MockExecutionEngine(boost::asio::any_io_executor executor, NodeSettings& ns, db::RWAccess dba)
-        : ExecutionEngine(std::move(executor), ns, /* log_timer_factory = */ std::nullopt, empty_bodies_stage_factory(), std::move(dba)) {}
+        : ExecutionEngine{
+              std::move(executor),
+              ns,
+              null_data_model_factory(),
+              /* log_timer_factory = */ std::nullopt,
+              empty_stages_factory(),
+              std::move(dba),
+          } {}
     ~MockExecutionEngine() override = default;
 
     MOCK_METHOD((void), open, (), (override));

--- a/silkworm/rpc/daemon.hpp
+++ b/silkworm/rpc/daemon.hpp
@@ -21,6 +21,7 @@
 #include <string>
 #include <vector>
 
+#include <silkworm/db/data_store.hpp>
 #include <silkworm/db/datastore/mdbx/mdbx.hpp>
 #include <silkworm/db/datastore/snapshots/snapshot_repository.hpp>
 #include <silkworm/db/kv/api/client.hpp>
@@ -46,7 +47,9 @@ class Daemon {
   public:
     static int run(const DaemonSettings& settings);
 
-    explicit Daemon(DaemonSettings settings, std::optional<mdbx::env> chaindata_env = {});
+    explicit Daemon(
+        DaemonSettings settings,
+        std::optional<db::DataStoreRef> data_store);
 
     Daemon(const Daemon&) = delete;
     Daemon& operator=(const Daemon&) = delete;
@@ -82,8 +85,8 @@ class Daemon {
     //! The pool of workers for long-running tasks.
     WorkerPool worker_pool_;
 
-    //! The chaindata MDBX environment or \code std::nullopt if working remotely
-    std::optional<mdbx::env> chaindata_env_;
+    //! The data store or std::nullopt if working remotely
+    std::optional<db::DataStoreRef> data_store_;
 
     //! The JSON RPC API services.
     std::vector<std::unique_ptr<http::Server>> rpc_services_;

--- a/silkworm/rpc/ethdb/file/local_database.cpp
+++ b/silkworm/rpc/ethdb/file/local_database.cpp
@@ -23,8 +23,11 @@
 
 namespace silkworm::rpc::ethdb::file {
 
-LocalDatabase::LocalDatabase(StateCache* state_cache, mdbx::env chaindata_env)
-    : state_cache_{state_cache}, chaindata_env_{std::move(chaindata_env)} {
+LocalDatabase::LocalDatabase(
+    db::DataStoreRef data_store,
+    StateCache* state_cache)
+    : data_store_{std::move(data_store)},
+      state_cache_{state_cache} {
     SILK_TRACE << "LocalDatabase::ctor " << this;
 }
 
@@ -34,7 +37,7 @@ LocalDatabase::~LocalDatabase() {
 
 Task<std::unique_ptr<db::kv::api::Transaction>> LocalDatabase::begin() {
     SILK_TRACE << "LocalDatabase::begin " << this << " start";
-    auto txn = std::make_unique<db::kv::api::LocalTransaction>(chaindata_env_, state_cache_);
+    auto txn = std::make_unique<db::kv::api::LocalTransaction>(data_store_, state_cache_);
     co_await txn->open();
     SILK_TRACE << "LocalDatabase::begin " << this << " txn: " << txn.get() << " end";
     co_return txn;

--- a/silkworm/rpc/ethdb/file/local_database.hpp
+++ b/silkworm/rpc/ethdb/file/local_database.hpp
@@ -20,6 +20,7 @@
 #include <string>
 #include <utility>
 
+#include <silkworm/db/data_store.hpp>
 #include <silkworm/db/datastore/mdbx/mdbx.hpp>
 #include <silkworm/db/kv/api/state_cache.hpp>
 #include <silkworm/db/kv/api/transaction.hpp>
@@ -31,7 +32,9 @@ using db::kv::api::StateCache;
 
 class LocalDatabase : public Database {
   public:
-    explicit LocalDatabase(StateCache* state_cache, mdbx::env chaindata_env);
+    explicit LocalDatabase(
+        db::DataStoreRef data_store,
+        StateCache* state_cache);
 
     ~LocalDatabase() override;
 
@@ -41,8 +44,8 @@ class LocalDatabase : public Database {
     Task<std::unique_ptr<db::kv::api::Transaction>> begin() override;
 
   private:
+    db::DataStoreRef data_store_;
     StateCache* state_cache_;
-    mdbx::env chaindata_env_;
 };
 
 }  // namespace silkworm::rpc::ethdb::file

--- a/silkworm/sentry/eth/status_data_provider.cpp
+++ b/silkworm/sentry/eth/status_data_provider.cpp
@@ -67,7 +67,7 @@ StatusDataProvider::StatusData StatusDataProvider::make_status_data(
     return status_data;
 }
 
-StatusDataProvider::StatusData StatusDataProvider::get_status_data(uint8_t eth_version) {
+StatusDataProvider::StatusData StatusDataProvider::get_status_data(uint8_t eth_version) const {
     if (eth_version != silkworm::sentry::eth::Protocol::kVersion) {
         throw std::runtime_error("StatusDataProvider::get_status_data: unsupported eth version " + std::to_string(eth_version));
     }
@@ -79,7 +79,7 @@ StatusDataProvider::StatusData StatusDataProvider::get_status_data(uint8_t eth_v
 }
 
 StatusDataProvider::StatusDataProviderFactory StatusDataProvider::to_factory_function(StatusDataProvider provider) {
-    return [provider = std::move(provider)](uint8_t eth_version) mutable -> Task<StatusData> {
+    return [provider = std::move(provider)](uint8_t eth_version) -> Task<StatusData> {
         co_return provider.get_status_data(eth_version);
     };
 }

--- a/silkworm/sentry/eth/status_data_provider.hpp
+++ b/silkworm/sentry/eth/status_data_provider.hpp
@@ -36,7 +36,7 @@ class StatusDataProvider {
           chain_config_(chain_config) {}
 
     using StatusData = silkworm::sentry::eth::StatusData;
-    StatusData get_status_data(uint8_t eth_version);
+    StatusData get_status_data(uint8_t eth_version) const;
 
     using StatusDataProviderFactory = std::function<Task<StatusData>(uint8_t eth_version)>;
     static StatusDataProviderFactory to_factory_function(StatusDataProvider provider);

--- a/silkworm/sync/block_exchange.hpp
+++ b/silkworm/sync/block_exchange.hpp
@@ -17,14 +17,13 @@
 #pragma once
 
 #include <memory>
-#include <variant>
 
 #include <silkworm/core/common/base.hpp>
 #include <silkworm/core/types/block.hpp>
 #include <silkworm/db/access_layer.hpp>
+#include <silkworm/db/data_store.hpp>
 #include <silkworm/infra/concurrency/active_component.hpp>
 #include <silkworm/infra/concurrency/containers.hpp>
-#include <silkworm/sentry/api/common/message_from_peer.hpp>
 #include <silkworm/sync/internals/body_sequence.hpp>
 #include <silkworm/sync/internals/header_chain.hpp>
 #include <silkworm/sync/messages/inbound_message.hpp>
@@ -37,8 +36,8 @@ class SentryClient;
 class BlockExchange : public ActiveComponent {
   public:
     BlockExchange(
+        db::DataStoreRef data_store,
         SentryClient& sentry,
-        db::ROAccess dba,
         const ChainConfig& chain_config,
         bool use_preverified_hashes);
     ~BlockExchange() override;
@@ -83,7 +82,8 @@ class BlockExchange : public ActiveComponent {
     void collect_bodies();
     void log_status();
 
-    db::ROAccess db_access_;  // only to reply remote peer's requests
+    // only to reply remote peer's requests
+    db::DataStoreRef data_store_;
     SentryClient& sentry_;
     const ChainConfig& chain_config_;
     HeaderChain header_chain_;

--- a/silkworm/sync/internals/body_retrieval.cpp
+++ b/silkworm/sync/internals/body_retrieval.cpp
@@ -20,8 +20,6 @@
 
 namespace silkworm {
 
-BodyRetrieval::BodyRetrieval(db::ROAccess db_access) : db_tx_{db_access.start_ro_tx()} {}
-
 std::vector<BlockBody> BodyRetrieval::recover(std::vector<Hash> request) {
     std::vector<BlockBody> response;
     size_t bytes = 0;

--- a/silkworm/sync/internals/body_retrieval.hpp
+++ b/silkworm/sync/internals/body_retrieval.hpp
@@ -27,12 +27,13 @@ class BodyRetrieval {
     static const int kSoftResponseLimit = 2 * 1024 * 1024;  // Target maximum size of returned blocks
     static const int kMaxBodiesServe = 1024;                // Amount of block bodies to be fetched per retrieval request
 
-    explicit BodyRetrieval(db::ROAccess db_access);
+    explicit BodyRetrieval(db::ROTxn& db_tx)
+        : db_tx_{db_tx} {}
 
     std::vector<BlockBody> recover(std::vector<Hash>);
 
   protected:
-    db::ROTxnManaged db_tx_;
+    db::ROTxn& db_tx_;
 };
 
 }  // namespace silkworm

--- a/silkworm/sync/internals/header_retrieval.cpp
+++ b/silkworm/sync/internals/header_retrieval.cpp
@@ -22,8 +22,6 @@
 
 namespace silkworm {
 
-HeaderRetrieval::HeaderRetrieval(db::ROAccess db_access) : db_tx_{db_access.start_ro_tx()}, data_model_{db_tx_} {}
-
 std::vector<BlockHeader> HeaderRetrieval::recover_by_hash(Hash origin, uint64_t amount, uint64_t skip, bool reverse) {
     using std::optional;
     uint64_t max_non_canonical = 100;
@@ -127,9 +125,9 @@ std::tuple<Hash, BlockNum> HeaderRetrieval::get_ancestor(Hash hash, BlockNum blo
     }
 
     while (ancestor_delta != 0) {
-        auto h = db::read_canonical_header_hash(db_tx_, block_num);
+        auto h = data_model_.read_canonical_header_hash(block_num);
         if (h == hash) {
-            auto ancestorHash = db::read_canonical_header_hash(db_tx_, block_num - ancestor_delta);
+            auto ancestorHash = data_model_.read_canonical_header_hash(block_num - ancestor_delta);
             if (!ancestorHash) {
                 return {Hash{}, 0};
             }

--- a/silkworm/sync/internals/header_retrieval.hpp
+++ b/silkworm/sync/internals/header_retrieval.hpp
@@ -31,7 +31,8 @@ class HeaderRetrieval {
     static const int kEstHeaderRlpSize = 500;               // Approximate size of an RLP encoded block header
     static const int kMaxHeadersServe = 1024;               // Amount of block headers to be fetched per retrieval request
 
-    explicit HeaderRetrieval(db::ROAccess);
+    explicit HeaderRetrieval(db::DataModel data_model)
+        : data_model_{data_model} {}
 
     // Headers
     std::vector<BlockHeader> recover_by_hash(Hash origin, uint64_t amount, uint64_t skip, bool reverse);
@@ -42,7 +43,6 @@ class HeaderRetrieval {
                                             uint64_t& max_non_canonical);
 
   protected:
-    db::ROTxnManaged db_tx_;
     db::DataModel data_model_;
 };
 

--- a/silkworm/sync/internals/header_retrieval_test.cpp
+++ b/silkworm/sync/internals/header_retrieval_test.cpp
@@ -18,6 +18,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <silkworm/db/test_util/make_repository.hpp>
 #include <silkworm/db/test_util/temp_chain_data.hpp>
 
 namespace silkworm {
@@ -26,7 +27,13 @@ TEST_CASE("HeaderRetrieval") {
     db::test_util::TempChainData context;
     context.add_genesis_data();
     context.commit_txn();
-    HeaderRetrieval header_retrieval{db::ROAccess{context.env()}};
+
+    snapshots::SnapshotRepository repository = db::test_util::make_repository();
+
+    db::ROTxnManaged tx = db::ROAccess{context.env()}.start_ro_tx();
+    db::DataModel data_model{tx, repository};
+
+    HeaderRetrieval header_retrieval{data_model};
 
     SECTION("recover_by_hash") {
         const auto headers{header_retrieval.recover_by_hash({}, 1, 0, false)};

--- a/silkworm/sync/messages/inbound_block_bodies.cpp
+++ b/silkworm/sync/messages/inbound_block_bodies.cpp
@@ -29,7 +29,7 @@ InboundBlockBodies::InboundBlockBodies(ByteView data, PeerId peer_id)
     SILK_TRACE << "Received message " << *this;
 }
 
-void InboundBlockBodies::execute(db::ROAccess, HeaderChain&, BodySequence& bs, SentryClient& sentry) {
+void InboundBlockBodies::execute(db::DataStoreRef, HeaderChain&, BodySequence& bs, SentryClient& sentry) {
     SILK_TRACE << "Processing message " << *this;
 
     Penalty penalty = bs.accept_requested_bodies(packet_, peer_id_);

--- a/silkworm/sync/messages/inbound_block_bodies.hpp
+++ b/silkworm/sync/messages/inbound_block_bodies.hpp
@@ -31,7 +31,7 @@ class InboundBlockBodies : public InboundMessage {
     std::string content() const override;
     uint64_t req_id() const override;
 
-    void execute(db::ROAccess db, HeaderChain&, BodySequence&, SentryClient&) override;
+    void execute(db::DataStoreRef db, HeaderChain&, BodySequence&, SentryClient&) override;
 
   private:
     PeerId peer_id_;

--- a/silkworm/sync/messages/inbound_block_headers.cpp
+++ b/silkworm/sync/messages/inbound_block_headers.cpp
@@ -29,7 +29,7 @@ InboundBlockHeaders::InboundBlockHeaders(ByteView data, PeerId peer_id)
     SILK_TRACE << "Received message " << *this;
 }
 
-void InboundBlockHeaders::execute(db::ROAccess, HeaderChain& hc, BodySequence&, SentryClient& sentry) {
+void InboundBlockHeaders::execute(db::DataStoreRef, HeaderChain& hc, BodySequence&, SentryClient& sentry) {
     using namespace std;
 
     SILK_TRACE << "Processing message " << *this;

--- a/silkworm/sync/messages/inbound_block_headers.hpp
+++ b/silkworm/sync/messages/inbound_block_headers.hpp
@@ -31,7 +31,7 @@ class InboundBlockHeaders : public InboundMessage {
     std::string content() const override;
     uint64_t req_id() const override;
 
-    void execute(db::ROAccess, HeaderChain&, BodySequence&, SentryClient&) override;
+    void execute(db::DataStoreRef, HeaderChain&, BodySequence&, SentryClient&) override;
 
   private:
     PeerId peer_id_;

--- a/silkworm/sync/messages/inbound_get_block_bodies.cpp
+++ b/silkworm/sync/messages/inbound_get_block_bodies.cpp
@@ -32,7 +32,7 @@ InboundGetBlockBodies::InboundGetBlockBodies(ByteView data, PeerId peer_id)
     SILK_TRACE << "Received message " << *this;
 }
 
-void InboundGetBlockBodies::execute(db::ROAccess db, HeaderChain&, BodySequence& bs, SentryClient& sentry) {
+void InboundGetBlockBodies::execute(db::DataStoreRef db, HeaderChain&, BodySequence& bs, SentryClient& sentry) {
     using namespace std;
 
     SILK_TRACE << "Processing message " << *this;
@@ -40,7 +40,8 @@ void InboundGetBlockBodies::execute(db::ROAccess db, HeaderChain&, BodySequence&
     if (bs.highest_block_in_output() == 0)
         return;
 
-    BodyRetrieval body_retrieval(db);
+    db::ROTxnManaged tx = db::ROAccess{db.chaindata_env}.start_ro_tx();
+    BodyRetrieval body_retrieval{tx};
 
     BlockBodiesPacket66 reply;
     reply.request_id = packet_.request_id;

--- a/silkworm/sync/messages/inbound_get_block_bodies.hpp
+++ b/silkworm/sync/messages/inbound_get_block_bodies.hpp
@@ -31,7 +31,7 @@ class InboundGetBlockBodies : public InboundMessage {
     std::string content() const override;
     uint64_t req_id() const override;
 
-    void execute(db::ROAccess, HeaderChain&, BodySequence&, SentryClient&) override;
+    void execute(db::DataStoreRef, HeaderChain&, BodySequence&, SentryClient&) override;
 
   private:
     PeerId peer_id_;

--- a/silkworm/sync/messages/inbound_get_block_headers.hpp
+++ b/silkworm/sync/messages/inbound_get_block_headers.hpp
@@ -31,7 +31,7 @@ class InboundGetBlockHeaders : public InboundMessage {
     std::string content() const override;
     uint64_t req_id() const override;
 
-    void execute(db::ROAccess, HeaderChain&, BodySequence&, SentryClient&) override;
+    void execute(db::DataStoreRef, HeaderChain&, BodySequence&, SentryClient&) override;
 
   private:
     PeerId peer_id_;

--- a/silkworm/sync/messages/inbound_new_block.cpp
+++ b/silkworm/sync/messages/inbound_new_block.cpp
@@ -32,7 +32,7 @@ InboundNewBlock::InboundNewBlock(ByteView data, PeerId peer_id)
     SILK_TRACE << "Received message " << *this;
 }
 
-void InboundNewBlock::execute(db::ROAccess, HeaderChain&, BodySequence& bs, SentryClient&) {
+void InboundNewBlock::execute(db::DataStoreRef, HeaderChain&, BodySequence& bs, SentryClient&) {
     SILK_TRACE << "Processing message " << *this;
 
     // todo: complete implementation

--- a/silkworm/sync/messages/inbound_new_block.hpp
+++ b/silkworm/sync/messages/inbound_new_block.hpp
@@ -31,7 +31,7 @@ class InboundNewBlock : public InboundMessage {
     std::string content() const override;
     uint64_t req_id() const override;
 
-    void execute(db::ROAccess, HeaderChain&, BodySequence&, SentryClient&) override;
+    void execute(db::DataStoreRef, HeaderChain&, BodySequence&, SentryClient&) override;
 
   private:
     PeerId peer_id_;

--- a/silkworm/sync/messages/inbound_new_block_hashes.cpp
+++ b/silkworm/sync/messages/inbound_new_block_hashes.cpp
@@ -38,7 +38,7 @@ InboundNewBlockHashes::InboundNewBlockHashes(ByteView data, PeerId peer_id)
     SILK_TRACE << "Received message " << *this;
 }
 
-void InboundNewBlockHashes::execute(db::ROAccess, HeaderChain& hc, BodySequence&, SentryClient& sentry) {
+void InboundNewBlockHashes::execute(db::DataStoreRef, HeaderChain& hc, BodySequence&, SentryClient& sentry) {
     using namespace std;
 
     SILK_TRACE << "Processing message " << *this;

--- a/silkworm/sync/messages/inbound_new_block_hashes.hpp
+++ b/silkworm/sync/messages/inbound_new_block_hashes.hpp
@@ -31,7 +31,7 @@ class InboundNewBlockHashes : public InboundMessage {
     std::string content() const override;
     uint64_t req_id() const override;
 
-    void execute(db::ROAccess, HeaderChain&, BodySequence&, SentryClient&) override;
+    void execute(db::DataStoreRef, HeaderChain&, BodySequence&, SentryClient&) override;
 
   private:
     PeerId peer_id_;

--- a/silkworm/sync/messages/internal_message.hpp
+++ b/silkworm/sync/messages/internal_message.hpp
@@ -34,7 +34,7 @@ class InternalMessage : public Message {
 
     std::string name() const override { return "InternalMessage"; }
 
-    void execute(db::ROAccess, HeaderChain&, BodySequence&, SentryClient&) override;
+    void execute(db::DataStoreRef, HeaderChain&, BodySequence&, SentryClient&) override;
 
     std::future<R>& result() { return result_out_; }
 
@@ -50,13 +50,13 @@ template <class R>
 InternalMessage<R>::InternalMessage(ExecutionFunc exec) : execution_impl_{std::move(exec)} {}
 
 template <class R>
-void InternalMessage<R>::execute(db::ROAccess, HeaderChain& hc, BodySequence& bs, SentryClient&) {
+void InternalMessage<R>::execute(db::DataStoreRef, HeaderChain& hc, BodySequence& bs, SentryClient&) {
     R local_result = execution_impl_(hc, bs);
     result_in_.set_value(local_result);
 }
 
 template <>
-inline void InternalMessage<void>::execute(db::ROAccess, HeaderChain& hc, BodySequence& bs, SentryClient&) {
+inline void InternalMessage<void>::execute(db::DataStoreRef, HeaderChain& hc, BodySequence& bs, SentryClient&) {
     execution_impl_(hc, bs);
     result_in_.set_value();
 }

--- a/silkworm/sync/messages/internal_message_test.cpp
+++ b/silkworm/sync/messages/internal_message_test.cpp
@@ -18,6 +18,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <silkworm/db/test_util/make_repository.hpp>
 #include <silkworm/db/test_util/temp_chain_data.hpp>
 #include <silkworm/sync/internals/body_sequence.hpp>
 
@@ -27,7 +28,9 @@ namespace silkworm {
 [[clang::no_sanitize("null")]] TEST_CASE("internal message") {
     db::test_util::TempChainData context;
     // not used in the test execution
-    db::ROAccess dba(context.env());
+    snapshots::SnapshotRepository repository = db::test_util::make_repository();
+    // not used in the test execution
+    db::DataStoreRef data_store{context.env(), repository};
     // not used in the test execution
     HeaderChain hc(kMainnetConfig, /* use_preverified_hashes = */ false);
     // not used in the test execution
@@ -43,7 +46,7 @@ namespace silkworm {
 
     REQUIRE(!command->completed_and_read());
 
-    command->execute(dba, hc, bs, *sc);
+    command->execute(data_store, hc, bs, *sc);
 
     REQUIRE(!command->completed_and_read());
 

--- a/silkworm/sync/messages/message.hpp
+++ b/silkworm/sync/messages/message.hpp
@@ -18,7 +18,7 @@
 
 #include <string>
 
-#include <silkworm/db/access_layer.hpp>
+#include <silkworm/db/data_store.hpp>
 
 namespace silkworm {
 
@@ -31,7 +31,7 @@ class Message {
     virtual std::string name() const = 0;
 
     // execute: inbound message send a reply, outbound message send a request
-    virtual void execute(db::ROAccess, HeaderChain&, BodySequence&, SentryClient&) = 0;
+    virtual void execute(db::DataStoreRef, HeaderChain&, BodySequence&, SentryClient&) = 0;
 
     virtual ~Message() = default;
 };

--- a/silkworm/sync/messages/outbound_block_bodies.cpp
+++ b/silkworm/sync/messages/outbound_block_bodies.cpp
@@ -22,7 +22,7 @@
 
 namespace silkworm {
 
-void OutboundBlockBodies::execute(db::ROAccess, HeaderChain&, BodySequence&, SentryClient&) {
+void OutboundBlockBodies::execute(db::DataStoreRef, HeaderChain&, BodySequence&, SentryClient&) {
 }
 
 Bytes OutboundBlockBodies::message_data() const {

--- a/silkworm/sync/messages/outbound_block_bodies.hpp
+++ b/silkworm/sync/messages/outbound_block_bodies.hpp
@@ -29,7 +29,7 @@ class OutboundBlockBodies : public OutboundMessage {
     std::string name() const override { return "OutboundBlockBodies"; }
     std::string content() const override;
 
-    void execute(db::ROAccess, HeaderChain&, BodySequence&, SentryClient&) override;
+    void execute(db::DataStoreRef, HeaderChain&, BodySequence&, SentryClient&) override;
 
     silkworm::sentry::eth::MessageId eth_message_id() const override {
         return silkworm::sentry::eth::MessageId::kBlockBodies;

--- a/silkworm/sync/messages/outbound_block_headers.cpp
+++ b/silkworm/sync/messages/outbound_block_headers.cpp
@@ -22,7 +22,7 @@
 
 namespace silkworm {
 
-void OutboundBlockHeaders::execute(db::ROAccess, HeaderChain&, BodySequence&, SentryClient&) {
+void OutboundBlockHeaders::execute(db::DataStoreRef, HeaderChain&, BodySequence&, SentryClient&) {
 }
 
 Bytes OutboundBlockHeaders::message_data() const {

--- a/silkworm/sync/messages/outbound_block_headers.hpp
+++ b/silkworm/sync/messages/outbound_block_headers.hpp
@@ -29,7 +29,7 @@ class OutboundBlockHeaders : public OutboundMessage {
     std::string name() const override { return "OutboundBlockHeaders"; }
     std::string content() const override;
 
-    void execute(db::ROAccess, HeaderChain&, BodySequence&, SentryClient&) override;
+    void execute(db::DataStoreRef, HeaderChain&, BodySequence&, SentryClient&) override;
 
     silkworm::sentry::eth::MessageId eth_message_id() const override {
         return silkworm::sentry::eth::MessageId::kBlockHeaders;

--- a/silkworm/sync/messages/outbound_get_block_bodies.cpp
+++ b/silkworm/sync/messages/outbound_get_block_bodies.cpp
@@ -30,7 +30,7 @@ std::vector<PeerPenalization>& OutboundGetBlockBodies::penalties() { return pena
 BlockNum& OutboundGetBlockBodies::min_block() { return min_block_; }
 bool OutboundGetBlockBodies::packet_present() const { return !packet_.request.empty(); }
 
-void OutboundGetBlockBodies::execute(db::ROAccess, HeaderChain&, BodySequence& bs, SentryClient& sentry) {
+void OutboundGetBlockBodies::execute(db::DataStoreRef, HeaderChain&, BodySequence& bs, SentryClient& sentry) {
     if (packet_present()) {
         try {
             auto send_outcome = send_packet(sentry);

--- a/silkworm/sync/messages/outbound_get_block_bodies.hpp
+++ b/silkworm/sync/messages/outbound_get_block_bodies.hpp
@@ -31,7 +31,7 @@ class OutboundGetBlockBodies : public OutboundMessage {
     std::string name() const override { return "OutboundGetBlockBodies"; }
     std::string content() const override;
 
-    void execute(db::ROAccess, HeaderChain&, BodySequence&, SentryClient&) override;
+    void execute(db::DataStoreRef, HeaderChain&, BodySequence&, SentryClient&) override;
 
     silkworm::sentry::eth::MessageId eth_message_id() const override {
         return silkworm::sentry::eth::MessageId::kGetBlockBodies;

--- a/silkworm/sync/messages/outbound_get_block_headers.cpp
+++ b/silkworm/sync/messages/outbound_get_block_headers.cpp
@@ -29,7 +29,7 @@ GetBlockHeadersPacket66& OutboundGetBlockHeaders::packet() { return packet_; }
 std::vector<PeerPenalization>& OutboundGetBlockHeaders::penalties() { return penalizations_; }
 bool OutboundGetBlockHeaders::packet_present() const { return (packet_.request.amount != 0); }
 
-void OutboundGetBlockHeaders::execute(db::ROAccess, HeaderChain& hc, BodySequence&, SentryClient& sentry) {
+void OutboundGetBlockHeaders::execute(db::DataStoreRef, HeaderChain& hc, BodySequence&, SentryClient& sentry) {
     if (packet_present()) {
         try {
             auto send_outcome = send_packet(sentry);

--- a/silkworm/sync/messages/outbound_get_block_headers.hpp
+++ b/silkworm/sync/messages/outbound_get_block_headers.hpp
@@ -32,7 +32,7 @@ class OutboundGetBlockHeaders : public OutboundMessage {
     std::string name() const override { return "OutboundGetBlockHeaders"; }
     std::string content() const override;
 
-    void execute(db::ROAccess, HeaderChain&, BodySequence&, SentryClient&) override;
+    void execute(db::DataStoreRef, HeaderChain&, BodySequence&, SentryClient&) override;
 
     silkworm::sentry::eth::MessageId eth_message_id() const override {
         return silkworm::sentry::eth::MessageId::kGetBlockHeaders;

--- a/silkworm/sync/messages/outbound_message.hpp
+++ b/silkworm/sync/messages/outbound_message.hpp
@@ -27,7 +27,7 @@ namespace silkworm {
 
 class OutboundMessage : public Message {
   public:
-    void execute(db::ROAccess, HeaderChain&, BodySequence&, SentryClient&) override = 0;
+    void execute(db::DataStoreRef, HeaderChain&, BodySequence&, SentryClient&) override = 0;
 
     size_t sent_requests() const;
     size_t nack_requests() const;

--- a/silkworm/sync/messages/outbound_new_block.cpp
+++ b/silkworm/sync/messages/outbound_new_block.cpp
@@ -26,7 +26,7 @@ namespace silkworm {
 OutboundNewBlock::OutboundNewBlock(Blocks b, bool is_first_sync)
     : blocks_to_announce_{std::move(b)}, is_first_sync_{is_first_sync} {}
 
-void OutboundNewBlock::execute(db::ROAccess, HeaderChain&, BodySequence&, SentryClient& sentry) {
+void OutboundNewBlock::execute(db::DataStoreRef, HeaderChain&, BodySequence&, SentryClient& sentry) {
     if (is_first_sync_) return;  // Don't announce blocks during first sync
 
     for (auto& block_ptr : blocks_to_announce_) {

--- a/silkworm/sync/messages/outbound_new_block.hpp
+++ b/silkworm/sync/messages/outbound_new_block.hpp
@@ -33,7 +33,7 @@ class OutboundNewBlock : public OutboundMessage {
     std::string name() const override { return "OutboundNewBlock"; }
     std::string content() const override;
 
-    void execute(db::ROAccess, HeaderChain&, BodySequence&, SentryClient&) override;
+    void execute(db::DataStoreRef, HeaderChain&, BodySequence&, SentryClient&) override;
 
     silkworm::sentry::eth::MessageId eth_message_id() const override {
         return silkworm::sentry::eth::MessageId::kNewBlock;

--- a/silkworm/sync/messages/outbound_new_block_hashes.cpp
+++ b/silkworm/sync/messages/outbound_new_block_hashes.cpp
@@ -26,7 +26,7 @@ namespace silkworm {
 
 OutboundNewBlockHashes::OutboundNewBlockHashes(bool is_first_sync) : is_first_sync_{is_first_sync} {}
 
-void OutboundNewBlockHashes::execute(db::ROAccess, HeaderChain& hc, BodySequence&, SentryClient& sentry) {
+void OutboundNewBlockHashes::execute(db::DataStoreRef, HeaderChain& hc, BodySequence&, SentryClient& sentry) {
     auto& announces_to_do = hc.announces_to_do();
 
     if (is_first_sync_) {

--- a/silkworm/sync/messages/outbound_new_block_hashes.hpp
+++ b/silkworm/sync/messages/outbound_new_block_hashes.hpp
@@ -29,7 +29,7 @@ class OutboundNewBlockHashes : public OutboundMessage {
     std::string name() const override { return "OutboundNewBlockHashes"; }
     std::string content() const override;
 
-    void execute(db::ROAccess, HeaderChain&, BodySequence&, SentryClient&) override;
+    void execute(db::DataStoreRef, HeaderChain&, BodySequence&, SentryClient&) override;
 
     silkworm::sentry::eth::MessageId eth_message_id() const override {
         return silkworm::sentry::eth::MessageId::kNewBlockHashes;

--- a/silkworm/sync/sync.hpp
+++ b/silkworm/sync/sync.hpp
@@ -25,11 +25,8 @@
 
 #include <silkworm/core/chain/config.hpp>
 #include <silkworm/core/common/base.hpp>
-#include <silkworm/db/datastore/mdbx/mdbx.hpp>
+#include <silkworm/db/data_store.hpp>
 #include <silkworm/execution/api/client.hpp>
-#include <silkworm/infra/common/log.hpp>
-#include <silkworm/infra/grpc/client/client_context_pool.hpp>
-#include <silkworm/rpc/common/interface_log.hpp>
 #include <silkworm/rpc/daemon.hpp>
 #include <silkworm/sentry/api/common/sentry_client.hpp>
 
@@ -43,9 +40,9 @@ namespace silkworm::chainsync {
 class Sync {
   public:
     Sync(const boost::asio::any_io_executor& executor,
-         mdbx::env chaindata_env,
+         db::DataStoreRef data_store,
          execution::api::Client& execution,
-         const std::shared_ptr<silkworm::sentry::api::SentryClient>& sentry_client,
+         const std::shared_ptr<sentry::api::SentryClient>& sentry_client,
          const ChainConfig& config,
          bool use_preverified_hashes,
          const EngineRpcSettings& rpc_settings = {});

--- a/silkworm/sync/test_util/mock_block_exchange.hpp
+++ b/silkworm/sync/test_util/mock_block_exchange.hpp
@@ -25,7 +25,6 @@
 #include <silkworm/core/common/base.hpp>
 #include <silkworm/core/types/block.hpp>
 #include <silkworm/core/types/hash.hpp>
-#include <silkworm/db/datastore/mdbx/mdbx.hpp>
 #include <silkworm/sync/block_exchange.hpp>
 #include <silkworm/sync/messages/message.hpp>
 #include <silkworm/sync/sentry_client.hpp>
@@ -35,8 +34,8 @@ namespace silkworm::chainsync::test_util {
 //! \brief MockBlockExchange is the gMock mock class for BlockExchange.
 class MockBlockExchange : public BlockExchange {
   public:
-    MockBlockExchange(SentryClient& client, const db::ROAccess& dba, const ChainConfig& config)
-        : BlockExchange(client, dba, config, /* use_preverified_hashes = */ false) {}
+    MockBlockExchange(db::DataStoreRef data_store, SentryClient& client, const ChainConfig& config)
+        : BlockExchange{std::move(data_store), client, config, /* use_preverified_hashes = */ false} {}
 
     MOCK_METHOD((void), initial_state, (std::vector<BlockHeader>));
 


### PR DESCRIPTION
* no more DataModel::set_snapshot_repository singleton
* BodyFindByBlockNumMultiQuery: useful without RoTx
* DataStoreRef: source of creating DataModel queries for kv::api, sync and daemon
* db::Buffer works with BufferDataModel (useful to decouple tests from snapshots)
* ExecutionPipeline accepts StageContainerFactory
* stages and forks use DataModelFactory
* SnapshotRepository: init with path instead of settings