### PR TITLE
db, rpcdaemon: fix canonical_hash_provider for state reader

### DIFF
--- a/silkworm/core/execution/processor.hpp
+++ b/silkworm/core/execution/processor.hpp
@@ -55,7 +55,9 @@ class ExecutionProcessor {
 
     EVM& evm() noexcept { return evm_; }
     const EVM& evm() const noexcept { return evm_; }
-    IntraBlockState& get_ibs_state() { return state_; }
+    IntraBlockState& intra_block_state() { return state_; }
+    const IntraBlockState& intra_block_state() const { return state_; }
+
     void reset();
 
   private:

--- a/silkworm/db/kv/api/local_transaction.cpp
+++ b/silkworm/db/kv/api/local_transaction.cpp
@@ -61,11 +61,17 @@ Task<std::shared_ptr<CursorDupSort>> LocalTransaction::get_cursor(const std::str
 }
 
 std::shared_ptr<State> LocalTransaction::create_state(boost::asio::any_io_executor&, const chain::ChainStorage&, BlockNum block_number) {
+    // The calling thread *must* be *different* from the one which created this LocalTransaction instance
     return std::make_shared<state::LocalState>(block_number, chaindata_env_);
 }
 
 std::shared_ptr<chain::ChainStorage> LocalTransaction::create_storage() {
+    // The calling thread *must* be the *same* which created this LocalTransaction instance
     return std::make_shared<chain::LocalChainStorage>(txn_);
+}
+
+Task<TxnId> LocalTransaction::first_txn_num_in_block(BlockNum /*block_num*/) {
+    throw std::logic_error{"not yet implemented"};
 }
 
 // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)

--- a/silkworm/db/kv/api/local_transaction.hpp
+++ b/silkworm/db/kv/api/local_transaction.hpp
@@ -53,6 +53,8 @@ class LocalTransaction : public BaseTransaction {
 
     std::shared_ptr<chain::ChainStorage> create_storage() override;
 
+    Task<TxnId> first_txn_num_in_block(BlockNum block_num) override;
+
     Task<void> close() override;
 
     // rpc DomainGet(DomainGetReq) returns (DomainGetReply);

--- a/silkworm/db/kv/api/transaction.hpp
+++ b/silkworm/db/kv/api/transaction.hpp
@@ -21,6 +21,7 @@
 
 #include <silkworm/infra/concurrency/task.hpp>
 
+#include <silkworm/core/common/base.hpp>
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/core/state/state.hpp>
 #include <silkworm/db/chain/chain_storage.hpp>
@@ -65,6 +66,9 @@ class Transaction {
     virtual Task<Bytes> get_one(const std::string& table, ByteView key) = 0;
 
     virtual Task<std::optional<Bytes>> get_both_range(const std::string& table, ByteView key, ByteView subkey) = 0;
+
+    // Temporarily here waiting for a better place
+    virtual Task<TxnId> first_txn_num_in_block(BlockNum block_num) = 0;
 
     /** Temporal Point Queries **/
 

--- a/silkworm/db/kv/grpc/client/remote_transaction.cpp
+++ b/silkworm/db/kv/grpc/client/remote_transaction.cpp
@@ -17,6 +17,7 @@
 #include "remote_transaction.hpp"
 
 #include <silkworm/db/chain/remote_chain_storage.hpp>
+#include <silkworm/db/kv/txn_num.hpp>
 #include <silkworm/db/state/remote_state.hpp>
 #include <silkworm/infra/grpc/client/call.hpp>
 #include <silkworm/infra/grpc/common/errors.hpp>
@@ -109,11 +110,16 @@ Task<std::shared_ptr<api::CursorDupSort>> RemoteTransaction::get_cursor(const st
 }
 
 std::shared_ptr<silkworm::State> RemoteTransaction::create_state(boost::asio::any_io_executor& executor, const chain::ChainStorage& storage, BlockNum block_number) {
-    return std::make_shared<db::state::RemoteState>(executor, *this, storage, block_number, providers_);
+    return std::make_shared<db::state::RemoteState>(executor, *this, storage, block_number);
 }
 
 std::shared_ptr<chain::ChainStorage> RemoteTransaction::create_storage() {
     return std::make_shared<chain::RemoteChainStorage>(*this, providers_);
+}
+
+Task<TxnId> RemoteTransaction::first_txn_num_in_block(BlockNum block_num) {
+    const auto min_txn_num = co_await txn::min_tx_num(*this, block_num, providers_.canonical_body_for_storage);
+    co_return min_txn_num + /*txn_index*/ 0;
 }
 
 Task<api::DomainPointResult> RemoteTransaction::domain_get(api::DomainPointQuery&& query) {  // NOLINT(*-rvalue-reference-param-not-moved)

--- a/silkworm/db/kv/grpc/client/remote_transaction.hpp
+++ b/silkworm/db/kv/grpc/client/remote_transaction.hpp
@@ -58,6 +58,8 @@ class RemoteTransaction : public api::BaseTransaction {
 
     std::shared_ptr<chain::ChainStorage> create_storage() override;
 
+    Task<TxnId> first_txn_num_in_block(BlockNum block_num) override;
+
     Task<void> close() override;
 
     // rpc DomainGet(DomainGetReq) returns (DomainGetReply);

--- a/silkworm/db/kv/txn_num.cpp
+++ b/silkworm/db/kv/txn_num.cpp
@@ -30,15 +30,17 @@ namespace silkworm::db::txn {
 using kv::api::KeyValue;
 using kv::api::Transaction;
 
-static Task<TxNum> last_tx_num_for_block(Transaction& tx, BlockNum block_number, chain::CanonicalBodyForStorageProvider canonical_body_for_storage_provider) {
-    auto max_tx_num_cursor = co_await tx.cursor(table::kMaxTxNumName);
+static Task<TxNum> last_tx_num_for_block(Transaction& tx,
+                                         BlockNum block_number,
+                                         chain::CanonicalBodyForStorageProvider canonical_body_for_storage_provider) {
+    const auto max_tx_num_cursor = co_await tx.cursor(table::kMaxTxNumName);
     const auto block_number_key = block_key(block_number);
-    auto key_value = co_await max_tx_num_cursor->seek_exact(block_number_key);
+    const auto key_value = co_await max_tx_num_cursor->seek_exact(block_number_key);
     if (key_value.value.empty()) {
         SILKWORM_ASSERT(canonical_body_for_storage_provider);
         Bytes block_body_data = co_await canonical_body_for_storage_provider(block_number);
         ByteView block_body_data_view{block_body_data};
-        const auto stored_body{unwrap_or_throw(decode_stored_block_body(block_body_data_view))};
+        const auto stored_body = unwrap_or_throw(decode_stored_block_body(block_body_data_view));
         co_return stored_body.base_txn_id + stored_body.txn_count - 1;
     }
     if (key_value.value.size() != sizeof(TxNum)) {
@@ -60,15 +62,15 @@ static std::pair<BlockNum, TxNum> kv_to_block_num_and_tx_num(const KeyValue& key
     return std::make_pair(endian::load_big_u64(key_value.key.data()), endian::load_big_u64(key_value.value.data()));
 }
 
-Task<TxNum> max_tx_num(Transaction& tx, BlockNum block_number, chain::CanonicalBodyForStorageProvider canonical_body_for_storage_provider) {
-    co_return co_await last_tx_num_for_block(tx, block_number, canonical_body_for_storage_provider);
+Task<TxNum> max_tx_num(Transaction& tx, BlockNum block_number, chain::CanonicalBodyForStorageProvider provider) {
+    co_return co_await last_tx_num_for_block(tx, block_number, provider);
 }
 
-Task<TxNum> min_tx_num(Transaction& tx, BlockNum block_number, chain::CanonicalBodyForStorageProvider canonical_body_for_storage_provider) {
+Task<TxNum> min_tx_num(Transaction& tx, BlockNum block_number, chain::CanonicalBodyForStorageProvider provider) {
     if (block_number == 0) {
         co_return 0;
     }
-    co_return (co_await last_tx_num_for_block(tx, (block_number - 1), canonical_body_for_storage_provider) + 1);
+    co_return (co_await last_tx_num_for_block(tx, (block_number - 1), provider) + 1);
 }
 
 Task<BlockNumAndTxnNumber> first_tx_num(Transaction& tx) {

--- a/silkworm/db/kv/txn_num.hpp
+++ b/silkworm/db/kv/txn_num.hpp
@@ -34,10 +34,10 @@ namespace silkworm::db::txn {
 using TxNum = TxnId;
 
 //! Return the maximum TxNum in specified \code block_number
-Task<TxNum> max_tx_num(kv::api::Transaction& tx, BlockNum block_number, chain::CanonicalBodyForStorageProvider canonical_body_for_storage_provider);
+Task<TxNum> max_tx_num(kv::api::Transaction& tx, BlockNum block_number, chain::CanonicalBodyForStorageProvider provider);
 
 //! Return the minimum TxNum in specified \code block_number
-Task<TxNum> min_tx_num(kv::api::Transaction& tx, BlockNum block_number, chain::CanonicalBodyForStorageProvider canonical_body_for_storage_provider);
+Task<TxNum> min_tx_num(kv::api::Transaction& tx, BlockNum block_number, chain::CanonicalBodyForStorageProvider provider);
 
 using BlockNumAndTxnNumber = std::pair<BlockNum, TxNum>;
 

--- a/silkworm/db/state/remote_state.hpp
+++ b/silkworm/db/state/remote_state.hpp
@@ -36,8 +36,8 @@ namespace silkworm::db::state {
 
 class AsyncRemoteState {
   public:
-    explicit AsyncRemoteState(kv::api::Transaction& tx, const chain::ChainStorage& storage, BlockNum block_number, chain::Providers providers)
-        : storage_(storage), state_reader_(tx, block_number + 1, std::move(providers.canonical_body_for_storage)) {}
+    explicit AsyncRemoteState(kv::api::Transaction& tx, const chain::ChainStorage& storage, BlockNum block_number)
+        : storage_(storage), state_reader_(tx, block_number + 1) {}
 
     Task<std::optional<Account>> read_account(const evmc::address& address) const noexcept;
 
@@ -68,8 +68,8 @@ class AsyncRemoteState {
 
 class RemoteState : public State {
   public:
-    explicit RemoteState(boost::asio::any_io_executor& executor, kv::api::Transaction& tx, const chain::ChainStorage& storage, BlockNum block_number, chain::Providers providers)
-        : executor_(executor), async_state_{tx, storage, block_number, providers}, providers_{std::move(providers)} {}
+    explicit RemoteState(boost::asio::any_io_executor& executor, kv::api::Transaction& tx, const chain::ChainStorage& storage, BlockNum block_number)
+        : executor_(executor), async_state_{tx, storage, block_number} {}
 
     std::optional<Account> read_account(const evmc::address& address) const noexcept override;
 
@@ -126,7 +126,6 @@ class RemoteState : public State {
   private:
     boost::asio::any_io_executor executor_;
     AsyncRemoteState async_state_;
-    chain::Providers providers_;
 };
 
 std::ostream& operator<<(std::ostream& out, const RemoteState& s);

--- a/silkworm/db/state/state_reader.hpp
+++ b/silkworm/db/state/state_reader.hpp
@@ -22,11 +22,11 @@
 
 #include <evmc/evmc.hpp>
 
+#include <silkworm/core/common/base.hpp>
 #include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/types/account.hpp>
 #include <silkworm/db/chain/providers.hpp>
 #include <silkworm/db/kv/api/transaction.hpp>
-#include <silkworm/db/kv/txn_num.hpp>
 
 #include "version.hpp"
 
@@ -34,7 +34,7 @@ namespace silkworm::db::state {
 
 class StateReader {
   public:
-    StateReader(kv::api::Transaction& tx, BlockNum block_number, chain::CanonicalBodyForStorageProvider canonical_body_for_storage_provider);
+    StateReader(kv::api::Transaction& tx, BlockNum block_number);
 
     StateReader(const StateReader&) = delete;
     StateReader& operator=(const StateReader&) = delete;
@@ -48,11 +48,9 @@ class StateReader {
     Task<std::optional<Bytes>> read_code(const evmc::address& address, const evmc::bytes32& code_hash) const;
 
   private:
-    Task<txn::TxNum> first_txn_num_in_block() const;
     kv::api::Transaction& tx_;
     BlockNum block_number_;
-    mutable std::optional<txn::TxNum> txn_number_;
-    chain::CanonicalBodyForStorageProvider canonical_body_for_storage_provider_;
+    mutable std::optional<TxnId> txn_number_;
 };
 
 }  // namespace silkworm::db::state

--- a/silkworm/db/state/state_reader_test.cpp
+++ b/silkworm/db/state/state_reader_test.cpp
@@ -47,13 +47,15 @@ static const evmc::bytes32 kCodeHash{0xef722d9baf50b9983c2fce6329c5a43a15b8d5ba7
 class StateReaderTest : public silkworm::test_util::ContextTestBase {
   protected:
     db::test_util::MockTransaction transaction_;
-    StateReader state_reader_{transaction_, kEarliestBlockNumber, db::chain::CanonicalBodyForStorageProvider{}};
+    StateReader state_reader_{transaction_, kEarliestBlockNumber};
 };
 
 TEST_CASE_METHOD(StateReaderTest, "StateReader::read_account") {
+    EXPECT_CALL(transaction_, first_txn_num_in_block(0)).WillOnce(Invoke([]() -> Task<TxnId> {
+        co_return 0;
+    }));
+
     SECTION("no account for history empty and current state empty") {
-        // Set the call expectations:
-        // 1. DatabaseReader::get call on kAccountHistory returns empty key-value
         EXPECT_CALL(transaction_, domain_get(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = false,
@@ -68,8 +70,6 @@ TEST_CASE_METHOD(StateReaderTest, "StateReader::read_account") {
     }
 
     SECTION("account found in current state") {
-        // Set the call expectations:
-        // 1. DatabaseReader::get call on kAccountHistory returns empty key-value
         EXPECT_CALL(transaction_, domain_get(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
@@ -90,8 +90,6 @@ TEST_CASE_METHOD(StateReaderTest, "StateReader::read_account") {
     }
 
     SECTION("account found in history") {
-        // Set the call expectations:
-        // 1. DatabaseReader::get call on kAccountHistory returns the account bitmap
         EXPECT_CALL(transaction_, domain_get(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
@@ -113,9 +111,11 @@ TEST_CASE_METHOD(StateReaderTest, "StateReader::read_account") {
 }
 
 TEST_CASE_METHOD(StateReaderTest, "StateReader::read_storage") {
+    EXPECT_CALL(transaction_, first_txn_num_in_block(0)).WillOnce(Invoke([]() -> Task<TxnId> {
+        co_return 0;
+    }));
+
     SECTION("empty storage for history empty and current state empty") {
-        // Set the call expectations:
-        // 1. DatabaseReader::get call on kStorageHistory returns empty key-value
         EXPECT_CALL(transaction_, domain_get(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = false,
@@ -130,8 +130,6 @@ TEST_CASE_METHOD(StateReaderTest, "StateReader::read_storage") {
     }
 
     SECTION("storage found in current state") {
-        // Set the call expectations:
-        // 1. DatabaseReader::get call on kStorageHistory returns empty key-value
         EXPECT_CALL(transaction_, domain_get(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
@@ -145,8 +143,6 @@ TEST_CASE_METHOD(StateReaderTest, "StateReader::read_storage") {
     }
 
     SECTION("storage found in history") {
-        // Set the call expectations:
-        // 1. DatabaseReader::get call on kStorageHistory returns the storage bitmap
         EXPECT_CALL(transaction_, domain_get(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
@@ -170,8 +166,10 @@ TEST_CASE_METHOD(StateReaderTest, "StateReader::read_code") {
     }
 
     SECTION("empty code found for code hash") {
-        // Set the call expectations:
-        // 1. DatabaseReader::get_one call on kCode returns the binary code
+        EXPECT_CALL(transaction_, first_txn_num_in_block(0)).WillOnce(Invoke([]() -> Task<TxnId> {
+            co_return 0;
+        }));
+
         EXPECT_CALL(transaction_, domain_get(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
@@ -189,8 +187,10 @@ TEST_CASE_METHOD(StateReaderTest, "StateReader::read_code") {
     }
 
     SECTION("non-empty code found for code hash") {
-        // Set the call expectations:
-        // 1. DatabaseReader::get_one call on kCode returns the binary code
+        EXPECT_CALL(transaction_, first_txn_num_in_block(0)).WillOnce(Invoke([]() -> Task<TxnId> {
+            co_return 0;
+        }));
+
         EXPECT_CALL(transaction_, domain_get(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,

--- a/silkworm/db/test_util/mock_transaction.hpp
+++ b/silkworm/db/test_util/mock_transaction.hpp
@@ -41,6 +41,7 @@ class MockTransaction : public kv::api::Transaction {
     MOCK_METHOD((std::shared_ptr<State>), create_state,
                 (boost::asio::any_io_executor&, const chain::ChainStorage&, BlockNum), (override));
     MOCK_METHOD((std::shared_ptr<chain::ChainStorage>), create_storage, (), (override));
+    MOCK_METHOD((Task<TxnId>), first_txn_num_in_block, (BlockNum), (override));
     MOCK_METHOD((Task<void>), close, (), (override));
     MOCK_METHOD((Task<kv::api::KeyValue>), get, (const std::string&, ByteView), (override));
     MOCK_METHOD((Task<Bytes>), get_one, (const std::string&, ByteView), (override));

--- a/silkworm/rpc/commands/debug_api.cpp
+++ b/silkworm/rpc/commands/debug_api.cpp
@@ -327,7 +327,7 @@ Task<void> DebugRpcApi::handle_debug_account_at(const nlohmann::json& request, n
                 executor.call(block, txn);
             }
 
-            const auto& ibs = executor.get_ibs_state();
+            const auto& ibs = executor.intra_block_state();
 
             nlohmann::json json_result;
             if (ibs.exists(address)) {

--- a/silkworm/rpc/commands/debug_api_test.cpp
+++ b/silkworm/rpc/commands/debug_api_test.cpp
@@ -215,6 +215,10 @@ class DummyTransaction : public db::kv::api::BaseTransaction {
         return nullptr;
     }
 
+    Task<TxnId> first_txn_num_in_block(BlockNum /*block_num*/) override {
+        co_return 0;
+    }
+
     Task<void> close() override {
         co_return;
     }

--- a/silkworm/rpc/commands/engine_api_test.cpp
+++ b/silkworm/rpc/commands/engine_api_test.cpp
@@ -26,8 +26,6 @@
 
 #include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/common/bytes_to_string.hpp>
-#include <silkworm/db/chain/remote_chain_storage.hpp>
-#include <silkworm/db/kv/api/base_transaction.hpp>
 #include <silkworm/db/test_util/mock_cursor.hpp>
 #include <silkworm/infra/concurrency/private_service.hpp>
 #include <silkworm/infra/concurrency/shared_service.hpp>
@@ -41,8 +39,6 @@ namespace silkworm::rpc::commands {
 
 using db::kv::api::KeyValue;
 using rpc::test::DummyDatabase;
-
-static const evmc::bytes32 kZeroHeaderHash{0x0000000000000000000000000000000000000000000000000000000000000000_bytes32};
 
 class EngineRpcApiForTest : public EngineRpcApi {
   public:
@@ -76,6 +72,7 @@ struct EngineRpcApiTest : public test_util::JsonApiTestBase<EngineRpcApiForTest>
 };
 
 #ifndef SILKWORM_SANITIZE
+static const evmc::bytes32 kZeroHeaderHash{0x0000000000000000000000000000000000000000000000000000000000000000_bytes32};
 static const silkworm::Bytes kBlockHash(32, '\0');
 
 static const silkworm::ChainConfig kChainConfig{
@@ -508,9 +505,6 @@ TEST_CASE_METHOD(EngineRpcApiTest, "engine_forkchoiceUpdatedv1 KO: empty safe bl
 }
 
 TEST_CASE_METHOD(EngineRpcApiTest, "engine_transitionConfigurationV1 OK: EL config has the same CL config", "[silkworm][rpc][commands][engine_api]") {
-    const silkworm::Bytes block_number{*silkworm::from_hex("0000000000000000")};
-    const silkworm::ByteView block_key{block_number};
-
     const silkworm::Bytes genesis_block_hash{*silkworm::from_hex("0000000000000000000000000000000000000000000000000000000000000000")};
     const silkworm::ByteView genesis_block_key{genesis_block_hash};
     EXPECT_CALL(*mock_backend, get_block_hash_from_block_number(_))
@@ -548,8 +542,6 @@ TEST_CASE_METHOD(EngineRpcApiTest, "engine_transitionConfigurationV1 OK: EL conf
 }
 
 TEST_CASE_METHOD(EngineRpcApiTest, "engine_transitionConfigurationV1 OK: terminal block number zero if not sent", "[silkworm][rpc][commands][engine_api]") {
-    const silkworm::Bytes block_number{*silkworm::from_hex("0000000000000000")};
-    const silkworm::ByteView block_key{block_number};
     EXPECT_CALL(*mock_backend, get_block_hash_from_block_number(_))
         .WillOnce(InvokeWithoutArgs([]() -> Task<evmc::bytes32> {
             co_return kZeroHeaderHash;
@@ -587,8 +579,6 @@ TEST_CASE_METHOD(EngineRpcApiTest, "engine_transitionConfigurationV1 OK: termina
 }
 
 TEST_CASE_METHOD(EngineRpcApiTest, "engine_transitionConfigurationV1 KO: incorrect terminal total difficulty", "[silkworm][rpc][commands][engine_api]") {
-    const silkworm::Bytes block_number{*silkworm::from_hex("0000000000000000")};
-    const silkworm::ByteView block_key{block_number};
     EXPECT_CALL(*mock_backend, get_block_hash_from_block_number(_))
         .WillOnce(InvokeWithoutArgs([]() -> Task<evmc::bytes32> {
             co_return kZeroHeaderHash;
@@ -625,8 +615,6 @@ TEST_CASE_METHOD(EngineRpcApiTest, "engine_transitionConfigurationV1 KO: incorre
 }
 
 TEST_CASE_METHOD(EngineRpcApiTest, "engine_transitionConfigurationV1 KO: EL does not have TTD", "[silkworm][rpc][commands][engine_api]") {
-    const silkworm::Bytes block_number{*silkworm::from_hex("0000000000000000")};
-    const silkworm::ByteView block_key{block_number};
     EXPECT_CALL(*mock_backend, get_block_hash_from_block_number(_))
         .WillOnce(InvokeWithoutArgs([]() -> Task<evmc::bytes32> {
             co_return kZeroHeaderHash;
@@ -663,8 +651,6 @@ TEST_CASE_METHOD(EngineRpcApiTest, "engine_transitionConfigurationV1 KO: EL does
 }
 
 TEST_CASE_METHOD(EngineRpcApiTest, "engine_transitionConfigurationV1 KO: CL sends wrong TTD", "[silkworm][rpc][commands][engine_api]") {
-    const silkworm::Bytes block_number{*silkworm::from_hex("0000000000000000")};
-    const silkworm::ByteView block_key{block_number};
     EXPECT_CALL(*mock_backend, get_block_hash_from_block_number(_))
         .WillOnce(InvokeWithoutArgs([]() -> Task<evmc::bytes32> {
             co_return kZeroHeaderHash;
@@ -701,8 +687,6 @@ TEST_CASE_METHOD(EngineRpcApiTest, "engine_transitionConfigurationV1 KO: CL send
 }
 
 TEST_CASE_METHOD(EngineRpcApiTest, "engine_transitionConfigurationV1 KO: CL sends wrong terminal block hash", "[silkworm][rpc][commands][engine_api]") {
-    const silkworm::Bytes block_number{*silkworm::from_hex("0000000000000000")};
-    const silkworm::ByteView block_key{block_number};
     EXPECT_CALL(*mock_backend, get_block_hash_from_block_number(_))
         .WillOnce(InvokeWithoutArgs([]() -> Task<evmc::bytes32> {
             co_return kZeroHeaderHash;
@@ -739,8 +723,6 @@ TEST_CASE_METHOD(EngineRpcApiTest, "engine_transitionConfigurationV1 KO: CL send
 }
 
 TEST_CASE_METHOD(EngineRpcApiTest, "engine_transitionConfigurationV1 OK: no matching terminal block number", "[silkworm][rpc][commands][engine_api]") {
-    const silkworm::Bytes block_number{*silkworm::from_hex("0000000000000000")};
-    const silkworm::ByteView block_key{block_number};
     EXPECT_CALL(*mock_backend, get_block_hash_from_block_number(_))
         .WillOnce(InvokeWithoutArgs([]() -> Task<evmc::bytes32> {
             co_return kZeroHeaderHash;

--- a/silkworm/rpc/commands/eth_api.cpp
+++ b/silkworm/rpc/commands/eth_api.cpp
@@ -903,7 +903,7 @@ Task<void> EthereumRpcApi::handle_eth_estimate_gas(const nlohmann::json& request
         };
 
         rpc::AccountReader account_reader = [&tx](const evmc::address& address, BlockNum block_number) -> Task<std::optional<Account>> {
-            StateReader state_reader{*tx, block_number + 1, db::chain::CanonicalBodyForStorageProvider{}};
+            StateReader state_reader{*tx, block_number + 1};
             co_return co_await state_reader.read_account(address);
         };
 
@@ -951,7 +951,7 @@ Task<void> EthereumRpcApi::handle_eth_get_balance(const nlohmann::json& request,
         const auto [block_number, is_latest_block] = co_await core::get_block_number(bnoh, *tx);
         tx->set_state_cache_enabled(is_latest_block);
 
-        StateReader state_reader{*tx, block_number + 1, db::chain::CanonicalBodyForStorageProvider{}};
+        StateReader state_reader{*tx, block_number + 1};
         std::optional<silkworm::Account> account{co_await state_reader.read_account(address)};
 
         reply = make_json_content(request, "0x" + (account ? intx::hex(account->balance) : "0"));
@@ -985,7 +985,7 @@ Task<void> EthereumRpcApi::handle_eth_get_code(const nlohmann::json& request, nl
         const auto [block_number, is_latest_block] = co_await core::get_block_number(block_id, *tx, /*latest_required=*/true);
         tx->set_state_cache_enabled(is_latest_block);
 
-        StateReader state_reader{*tx, block_number + 1, db::chain::CanonicalBodyForStorageProvider{}};
+        StateReader state_reader{*tx, block_number + 1};
         std::optional<silkworm::Account> account{co_await state_reader.read_account(address)};
 
         if (account) {
@@ -1024,7 +1024,7 @@ Task<void> EthereumRpcApi::handle_eth_get_transaction_count(const nlohmann::json
         const auto [block_number, is_latest_block] = co_await core::get_block_number(block_id, *tx, /*latest_required=*/true);
         tx->set_state_cache_enabled(is_latest_block);
 
-        StateReader state_reader{*tx, block_number + 1, db::chain::CanonicalBodyForStorageProvider{}};
+        StateReader state_reader{*tx, block_number + 1};
         std::optional<silkworm::Account> account{co_await state_reader.read_account(address)};
 
         if (account) {
@@ -1070,7 +1070,7 @@ Task<void> EthereumRpcApi::handle_eth_get_storage_at(const nlohmann::json& reque
         const auto [block_number, is_latest_block] = co_await core::get_block_number(block_id, *tx, /*latest_required=*/true);
         tx->set_state_cache_enabled(is_latest_block);
 
-        StateReader state_reader{*tx, block_number + 1, db::chain::CanonicalBodyForStorageProvider{}};
+        StateReader state_reader{*tx, block_number + 1};
         std::optional<silkworm::Account> account{co_await state_reader.read_account(address)};
 
         if (account) {
@@ -1279,7 +1279,7 @@ Task<void> EthereumRpcApi::handle_eth_create_access_list(const nlohmann::json& r
         const bool is_latest_block = co_await core::get_latest_executed_block_number(*tx) == block_with_hash->block.header.number;
         tx->set_state_cache_enabled(/*cache_enabled=*/is_latest_block);
 
-        StateReader state_reader{*tx, block_with_hash->block.header.number + 1, db::chain::CanonicalBodyForStorageProvider{}};
+        StateReader state_reader{*tx, block_with_hash->block.header.number + 1};
 
         std::optional<uint64_t> nonce = std::nullopt;
         evmc::address to{};

--- a/silkworm/rpc/commands/ots_api.cpp
+++ b/silkworm/rpc/commands/ots_api.cpp
@@ -71,7 +71,7 @@ Task<void> OtsRpcApi::handle_ots_has_code(const nlohmann::json& request, nlohman
         tx->set_state_cache_enabled(is_latest_block);
 
         const auto block_number = co_await core::get_block_number(block_id, *tx);
-        StateReader state_reader{*tx, block_number + 1, db::chain::CanonicalBodyForStorageProvider{}};
+        StateReader state_reader{*tx, block_number + 1};
         std::optional<silkworm::Account> account{co_await state_reader.read_account(address)};
 
         if (account) {

--- a/silkworm/rpc/commands/parity_api.cpp
+++ b/silkworm/rpc/commands/parity_api.cpp
@@ -114,7 +114,7 @@ Task<void> ParityRpcApi::handle_parity_list_storage_keys(const nlohmann::json& r
     try {
         const auto block_number = co_await core::get_block_number(block_id, *tx);
         SILK_DEBUG << "read account with address: " << address << " block number: " << block_number;
-        StateReader state_reader{*tx, block_number, db::chain::CanonicalBodyForStorageProvider{}};
+        StateReader state_reader{*tx, block_number};
         std::optional<Account> account = co_await state_reader.read_account(address);
         if (!account) throw std::domain_error{"account not found"};
 

--- a/silkworm/rpc/core/account_dumper.cpp
+++ b/silkworm/rpc/core/account_dumper.cpp
@@ -87,7 +87,7 @@ Task<DumpAccounts> AccountDumper::dump_accounts(
 }
 
 Task<void> AccountDumper::load_accounts(BlockNum block_number, const std::vector<KeyValue>& collected_data, DumpAccounts& dump_accounts, bool exclude_code) {
-    StateReader state_reader{transaction_, block_number, db::chain::CanonicalBodyForStorageProvider{}};
+    StateReader state_reader{transaction_, block_number};
     for (const auto& kv : collected_data) {
         const auto address = bytes_to_address(kv.key);
 

--- a/silkworm/rpc/core/account_dumper_test.cpp
+++ b/silkworm/rpc/core/account_dumper_test.cpp
@@ -202,6 +202,10 @@ class DummyTransaction : public BaseTransaction {
         return nullptr;
     }
 
+    Task<TxnId> first_txn_num_in_block(BlockNum /*block_num*/) override {
+        co_return 0;
+    }
+
     Task<void> close() override {
         co_return;
     }

--- a/silkworm/rpc/core/account_walker_test.cpp
+++ b/silkworm/rpc/core/account_walker_test.cpp
@@ -203,6 +203,10 @@ class DummyTransaction : public BaseTransaction {
         return nullptr;
     }
 
+    Task<TxnId> first_txn_num_in_block(BlockNum /*block_num*/) override {
+        co_return 0;
+    }
+
     Task<void> close() override {
         co_return;
     }

--- a/silkworm/rpc/core/block_reader.cpp
+++ b/silkworm/rpc/core/block_reader.cpp
@@ -47,7 +47,7 @@ Task<void> BlockReader::read_balance_changes(BlockCache& cache, const BlockNumbe
 
     SILK_TRACE << "read_balance_changes: block_number: " << block_number;
 
-    StateReader state_reader{transaction_, block_number + 1, db::chain::CanonicalBodyForStorageProvider{}};
+    StateReader state_reader{transaction_, block_number + 1};
 
     co_await load_addresses(block_number, balance_changes);
     BalanceChanges::iterator it;

--- a/silkworm/rpc/core/evm_debug_test.cpp
+++ b/silkworm/rpc/core/evm_debug_test.cpp
@@ -93,7 +93,7 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute precompiled") {
     auto& tx = transaction;
     EXPECT_CALL(transaction, create_state(_, _, _))
         .WillOnce(Invoke([&tx](auto& ioc, const auto& storage, auto block_number) -> std::shared_ptr<State> {
-        return std::make_shared<RemoteState>(ioc, tx, storage, block_number);
+            return std::make_shared<RemoteState>(ioc, tx, storage, block_number);
         }));
 
     SECTION("precompiled contract failure") {

--- a/silkworm/rpc/core/evm_debug_test.cpp
+++ b/silkworm/rpc/core/evm_debug_test.cpp
@@ -29,7 +29,6 @@
 #include <silkworm/db/kv/api/transaction.hpp>
 #include <silkworm/db/state/remote_state.hpp>
 #include <silkworm/db/tables.hpp>
-#include <silkworm/db/test_util/mock_cursor.hpp>
 #include <silkworm/db/test_util/mock_transaction.hpp>
 #include <silkworm/rpc/ethdb/kv/backend_providers.hpp>
 #include <silkworm/rpc/test_util/mock_back_end.hpp>
@@ -92,11 +91,9 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute precompiled") {
     static Bytes kAccountHistoryValue1{*silkworm::from_hex("010203ed03e820f1885eda54b7a053318cd41e2093220dab15d65381b1157a3633a83bfd5c92390105")};
 
     auto& tx = transaction;
-    auto cursor = std::make_shared<silkworm::db::test_util::MockCursor>();
-
     EXPECT_CALL(transaction, create_state(_, _, _))
         .WillOnce(Invoke([&tx](auto& ioc, const auto& storage, auto block_number) -> std::shared_ptr<State> {
-            return std::make_shared<RemoteState>(ioc, tx, storage, block_number, db::chain::Providers{});
+        return std::make_shared<RemoteState>(ioc, tx, storage, block_number);
         }));
 
     SECTION("precompiled contract failure") {
@@ -123,11 +120,8 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute precompiled") {
             .WillOnce(InvokeWithoutArgs([]() -> Task<Bytes> {
                 co_return kConfigValue;
             }));
-        EXPECT_CALL(transaction, cursor(table::kMaxTxNumName)).WillOnce(Invoke([&cursor](Unused) -> Task<std::shared_ptr<kv::api::Cursor>> {
-            co_return cursor;
-        }));
-        EXPECT_CALL(*cursor, seek_exact(_)).WillOnce(Invoke([=](Unused) -> Task<kv::api::KeyValue> {
-            co_return KeyValue{*silkworm::from_hex("0000000000000000"), *silkworm::from_hex("0000ddff12345678")};
+        EXPECT_CALL(transaction, first_txn_num_in_block(10'336'007)).WillOnce(Invoke([]() -> Task<TxnId> {
+            co_return 244087591818873;
         }));
         EXPECT_CALL(transaction, domain_get(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult rsp1{
@@ -187,10 +181,9 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 1") {
     static Bytes kAccountHistoryValue3{*silkworm::from_hex("000944ed67f28fd50bb8e90000")};
 
     auto& tx = transaction;
-    auto cursor = std::make_shared<silkworm::db::test_util::MockCursor>();
     EXPECT_CALL(transaction, create_state(_, _, _))
         .WillOnce(Invoke([&tx](auto& ioc, const auto& storage, auto block_number) -> std::shared_ptr<State> {
-            return std::make_shared<RemoteState>(ioc, tx, storage, block_number, db::chain::Providers{});
+            return std::make_shared<RemoteState>(ioc, tx, storage, block_number);
         }));
 
     SECTION("Call: failed with intrinsic gas too low") {
@@ -252,11 +245,8 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 1") {
             .WillOnce(InvokeWithoutArgs([]() -> Task<Bytes> {
                 co_return kConfigValue;
             }));
-        EXPECT_CALL(transaction, cursor(table::kMaxTxNumName)).WillOnce(Invoke([&cursor](Unused) -> Task<std::shared_ptr<kv::api::Cursor>> {
-            co_return cursor;
-        }));
-        EXPECT_CALL(*cursor, seek_exact(_)).WillOnce(Invoke([=](Unused) -> Task<kv::api::KeyValue> {
-            co_return KeyValue{*silkworm::from_hex("0000000000000000"), *silkworm::from_hex("0000ddff12345678")};
+        EXPECT_CALL(transaction, first_txn_num_in_block(5'405'096)).WillOnce(Invoke([]() -> Task<TxnId> {
+            co_return 244087591818873;
         }));
         EXPECT_CALL(transaction, domain_get(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
@@ -373,11 +363,8 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 1") {
             .WillOnce(InvokeWithoutArgs([]() -> Task<Bytes> {
                 co_return kConfigValue;
             }));
-        EXPECT_CALL(transaction, cursor(table::kMaxTxNumName)).WillOnce(Invoke([&cursor](Unused) -> Task<std::shared_ptr<kv::api::Cursor>> {
-            co_return cursor;
-        }));
-        EXPECT_CALL(*cursor, seek_exact(_)).WillOnce(Invoke([=](Unused) -> Task<kv::api::KeyValue> {
-            co_return KeyValue{*silkworm::from_hex("0000000000000000"), *silkworm::from_hex("0000ddff12345678")};
+        EXPECT_CALL(transaction, first_txn_num_in_block(5'405'096)).WillOnce(Invoke([]() -> Task<TxnId> {
+            co_return 244087591818873;
         }));
         EXPECT_CALL(transaction, domain_get(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
@@ -486,11 +473,8 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 1") {
             .WillOnce(InvokeWithoutArgs([]() -> Task<Bytes> {
                 co_return kConfigValue;
             }));
-        EXPECT_CALL(transaction, cursor(table::kMaxTxNumName)).WillOnce(Invoke([&cursor](Unused) -> Task<std::shared_ptr<kv::api::Cursor>> {
-            co_return cursor;
-        }));
-        EXPECT_CALL(*cursor, seek_exact(_)).WillOnce(Invoke([=](Unused) -> Task<kv::api::KeyValue> {
-            co_return KeyValue{*silkworm::from_hex("0000000000000000"), *silkworm::from_hex("0000ddff12345678")};
+        EXPECT_CALL(transaction, first_txn_num_in_block(5'405'096)).WillOnce(Invoke([]() -> Task<TxnId> {
+            co_return 244087591818873;
         }));
         EXPECT_CALL(transaction, domain_get(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
@@ -604,11 +588,8 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 1") {
             .WillOnce(InvokeWithoutArgs([]() -> Task<Bytes> {
                 co_return kConfigValue;
             }));
-        EXPECT_CALL(transaction, cursor(table::kMaxTxNumName)).WillOnce(Invoke([&cursor](Unused) -> Task<std::shared_ptr<kv::api::Cursor>> {
-            co_return cursor;
-        }));
-        EXPECT_CALL(*cursor, seek_exact(_)).WillOnce(Invoke([=](Unused) -> Task<kv::api::KeyValue> {
-            co_return KeyValue{*silkworm::from_hex("0000000000000000"), *silkworm::from_hex("0000ddff12345678")};
+        EXPECT_CALL(transaction, first_txn_num_in_block(5'405'096)).WillOnce(Invoke([]() -> Task<TxnId> {
+            co_return 244087591818873;
         }));
         EXPECT_CALL(transaction, domain_get(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
@@ -723,11 +704,8 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 1") {
             .WillOnce(InvokeWithoutArgs([]() -> Task<Bytes> {
                 co_return kConfigValue;
             }));
-        EXPECT_CALL(transaction, cursor(table::kMaxTxNumName)).WillOnce(Invoke([&cursor](Unused) -> Task<std::shared_ptr<kv::api::Cursor>> {
-            co_return cursor;
-        }));
-        EXPECT_CALL(*cursor, seek_exact(_)).WillOnce(Invoke([=](Unused) -> Task<kv::api::KeyValue> {
-            co_return KeyValue{*silkworm::from_hex("0000000000000000"), *silkworm::from_hex("0000ddff12345678")};
+        EXPECT_CALL(transaction, first_txn_num_in_block(5'405'096)).WillOnce(Invoke([]() -> Task<TxnId> {
+            co_return 244087591818873;
         }));
         EXPECT_CALL(transaction, domain_get(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
@@ -829,11 +807,8 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 1") {
             .WillOnce(InvokeWithoutArgs([]() -> Task<Bytes> {
                 co_return kConfigValue;
             }));
-        EXPECT_CALL(transaction, cursor(table::kMaxTxNumName)).WillOnce(Invoke([&cursor](Unused) -> Task<std::shared_ptr<kv::api::Cursor>> {
-            co_return cursor;
-        }));
-        EXPECT_CALL(*cursor, seek_exact(_)).WillOnce(Invoke([=](Unused) -> Task<kv::api::KeyValue> {
-            co_return KeyValue{*silkworm::from_hex("0000000000000000"), *silkworm::from_hex("0000ddff12345678")};
+        EXPECT_CALL(transaction, first_txn_num_in_block(5'405'096)).WillOnce(Invoke([]() -> Task<TxnId> {
+            co_return 244087591818873;
         }));
         EXPECT_CALL(transaction, domain_get(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
@@ -923,10 +898,9 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 2") {
     static Bytes kAccountHistoryValue3{*silkworm::from_hex("00094165832d46fa1082db0000")};
 
     auto& tx = transaction;
-    auto cursor = std::make_shared<silkworm::db::test_util::MockCursor>();
     EXPECT_CALL(transaction, create_state(_, _, _))
         .WillOnce(Invoke([&tx](auto& ioc, const auto& storage, auto block_number) -> std::shared_ptr<State> {
-            return std::make_shared<RemoteState>(ioc, tx, storage, block_number, db::chain::Providers{});
+            return std::make_shared<RemoteState>(ioc, tx, storage, block_number);
         }));
 
     SECTION("Call: TO present") {
@@ -953,11 +927,8 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 2") {
             .WillOnce(InvokeWithoutArgs([]() -> Task<Bytes> {
                 co_return kConfigValue;
             }));
-        EXPECT_CALL(transaction, cursor(table::kMaxTxNumName)).WillOnce(Invoke([&cursor](Unused) -> Task<std::shared_ptr<kv::api::Cursor>> {
-            co_return cursor;
-        }));
-        EXPECT_CALL(*cursor, seek_exact(_)).WillOnce(Invoke([=](Unused) -> Task<kv::api::KeyValue> {
-            co_return KeyValue{*silkworm::from_hex("0000000000000000"), *silkworm::from_hex("0000ddff12345678")};
+        EXPECT_CALL(transaction, first_txn_num_in_block(4'417'197)).WillOnce(Invoke([]() -> Task<TxnId> {
+            co_return 244087591818873;
         }));
         EXPECT_CALL(transaction, domain_get(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
@@ -1018,10 +989,9 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call with error") {
     static Bytes kAccountHistoryValue3{*silkworm::from_hex("000944ed67f28fd50bb8e90000")};
 
     auto& tx = transaction;
-    auto cursor = std::make_shared<silkworm::db::test_util::MockCursor>();
     EXPECT_CALL(transaction, create_state(_, _, _))
         .WillOnce(Invoke([&tx](auto& ioc, const auto& storage, auto block_number) -> std::shared_ptr<State> {
-            return std::make_shared<RemoteState>(ioc, tx, storage, block_number, db::chain::Providers{});
+            return std::make_shared<RemoteState>(ioc, tx, storage, block_number);
         }));
 
     db::kv::api::DomainPointQuery query1{
@@ -1047,11 +1017,8 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call with error") {
         .WillOnce(InvokeWithoutArgs([]() -> Task<Bytes> {
             co_return kConfigValue;
         }));
-    EXPECT_CALL(transaction, cursor(table::kMaxTxNumName)).WillOnce(Invoke([&cursor](Unused) -> Task<std::shared_ptr<kv::api::Cursor>> {
-        co_return cursor;
-    }));
-    EXPECT_CALL(*cursor, seek_exact(_)).WillOnce(Invoke([=](Unused) -> Task<kv::api::KeyValue> {
-        co_return KeyValue{*silkworm::from_hex("0000000000000000"), *silkworm::from_hex("0000ddff12345678")};
+    EXPECT_CALL(transaction, first_txn_num_in_block(5'405'096)).WillOnce(Invoke([]() -> Task<TxnId> {
+        co_return 244087591818873;
     }));
     EXPECT_CALL(transaction, domain_get(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
         db::kv::api::DomainPointResult response{

--- a/silkworm/rpc/core/evm_debug_test.cpp
+++ b/silkworm/rpc/core/evm_debug_test.cpp
@@ -46,13 +46,6 @@ using testing::InvokeWithoutArgs;
 using testing::Unused;
 using namespace evmc::literals;
 
-static const Bytes kZeroKey{*silkworm::from_hex("0000000000000000")};
-static const Bytes kZeroHeader{*silkworm::from_hex("bf7e331f7f7c1dd2e05159666b3bf8bc7a8a3a9eb1d518969eab529dd9b88c1a")};
-static const evmc::bytes32 kZeroHeaderHash{0xbf7e331f7f7c1dd2e05159666b3bf8bc7a8a3a9eb1d518969eab529dd9b88c1a_bytes32};
-
-static const Bytes kConfigKey{kZeroHeader};
-static const Bytes kConfigValue{string_view_to_byte_view(kSepoliaConfig.to_json().dump())};  // NOLINT(cppcoreguidelines-interfaces-global-init)
-
 struct DebugExecutorTest : public test_util::ServiceContextTestBase {
     test::MockBlockCache cache;
     db::test_util::MockTransaction transaction;
@@ -83,6 +76,10 @@ class TestDebugExecutor : DebugExecutor {
 };
 
 #ifndef SILKWORM_SANITIZE
+static const evmc::bytes32 kZeroHeaderHash{0xbf7e331f7f7c1dd2e05159666b3bf8bc7a8a3a9eb1d518969eab529dd9b88c1a_bytes32};
+static const Bytes kConfigKey{kZeroHeaderHash.bytes};
+static const Bytes kConfigValue{string_view_to_byte_view(kSepoliaConfig.to_json().dump())};  // NOLINT(cppcoreguidelines-interfaces-global-init)
+
 TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute precompiled") {
     static Bytes kAccountHistoryKey1{*silkworm::from_hex("0a6bb546b9208cfab9e8fa2b9b2c042b18df7030")};
     static Bytes kAccountHistoryKey2{*silkworm::from_hex("0000000000000000000000000000000000000009")};

--- a/silkworm/rpc/core/evm_debug_test.cpp
+++ b/silkworm/rpc/core/evm_debug_test.cpp
@@ -77,7 +77,7 @@ class TestDebugExecutor : DebugExecutor {
 
 #ifndef SILKWORM_SANITIZE
 static const evmc::bytes32 kZeroHeaderHash{0xbf7e331f7f7c1dd2e05159666b3bf8bc7a8a3a9eb1d518969eab529dd9b88c1a_bytes32};
-static const Bytes kConfigKey{kZeroHeaderHash.bytes};
+static const Bytes kConfigKey{kZeroHeaderHash.bytes, kHashLength};
 static const Bytes kConfigValue{string_view_to_byte_view(kSepoliaConfig.to_json().dump())};  // NOLINT(cppcoreguidelines-interfaces-global-init)
 
 TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute precompiled") {

--- a/silkworm/rpc/core/evm_executor.cpp
+++ b/silkworm/rpc/core/evm_executor.cpp
@@ -246,7 +246,7 @@ ExecutionResult EVMExecutor::call(
         return convert_validated_precheck(result, block, txn, evm);
     }
 
-    const auto owned_funds = execution_processor_.get_ibs_state().get_balance(*txn.sender());
+    const auto owned_funds = execution_processor_.intra_block_state().get_balance(*txn.sender());
 
     if (const auto result = protocol::validate_call_funds(txn, evm, owned_funds, bailout);
         result != ValidationResult::kOk) {
@@ -274,7 +274,7 @@ ExecutionResult EVMExecutor::call_with_receipt(
 
     const auto exec_result = call(block, txn, tracers, refund, gas_bailout);
 
-    const auto& logs = execution_processor_.get_ibs_state().logs();
+    const auto& logs = execution_processor_.intra_block_state().logs();
 
     receipt.success = exec_result.success();
     receipt.bloom = logs_bloom(logs);

--- a/silkworm/rpc/core/evm_executor.hpp
+++ b/silkworm/rpc/core/evm_executor.hpp
@@ -135,7 +135,7 @@ class EVMExecutor {
 
     void call_first_n(const silkworm::Block& block, uint64_t n, const Tracers& tracers = {}, bool refund = true, bool gas_bailout = false);
 
-    const IntraBlockState& get_ibs_state() { return execution_processor_.get_ibs_state(); }
+    const IntraBlockState& intra_block_state() const { return execution_processor_.intra_block_state(); }
 
   private:
     struct PreCheckResult {

--- a/silkworm/rpc/core/evm_executor_test.cpp
+++ b/silkworm/rpc/core/evm_executor_test.cpp
@@ -29,7 +29,6 @@
 #include <silkworm/db/kv/api/endpoint/key_value.hpp>
 #include <silkworm/db/kv/api/transaction.hpp>
 #include <silkworm/db/state/remote_state.hpp>
-#include <silkworm/db/tables.hpp>
 #include <silkworm/db/test_util/mock_cursor.hpp>
 #include <silkworm/db/test_util/mock_transaction.hpp>
 #include <silkworm/infra/common/log.hpp>
@@ -63,7 +62,7 @@ struct EVMExecutorTest : public test_util::ServiceContextTestBase {
     const uint64_t chain_id{11155111};
     const ChainConfig* chain_config_ptr{lookup_chain_config(chain_id)};
     BlockNum block_number{6'000'000};
-    std::shared_ptr<State> state{std::make_shared<db::state::RemoteState>(io_executor, transaction, storage, block_number, db::chain::Providers{})};
+    std::shared_ptr<State> state{std::make_shared<db::state::RemoteState>(io_executor, transaction, storage, block_number)};
     silkworm::test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
 };
 
@@ -112,11 +111,8 @@ TEST_CASE_METHOD(EVMExecutorTest, "EVMExecutor") {
 
     SECTION("failed if transaction cost greater user amount") {
         auto cursor = std::make_shared<silkworm::db::test_util::MockCursor>();
-        EXPECT_CALL(transaction, cursor(db::table::kMaxTxNumName)).WillOnce(Invoke([&cursor](Unused) -> Task<std::shared_ptr<db::kv::api::Cursor>> {
-            co_return cursor;
-        }));
-        EXPECT_CALL(*cursor, seek_exact(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::KeyValue> {
-            co_return KeyValue{*silkworm::from_hex("0000000000000000"), *silkworm::from_hex("0000ddff12345678")};
+        EXPECT_CALL(transaction, first_txn_num_in_block(6'000'001)).WillOnce(Invoke([]() -> Task<TxnId> {
+            co_return 244087591818873;
         }));
         EXPECT_CALL(transaction, domain_get(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
@@ -141,11 +137,8 @@ TEST_CASE_METHOD(EVMExecutorTest, "EVMExecutor") {
 
     SECTION("doesn't fail if transaction cost greater user amount && gasBailout == true") {
         auto cursor = std::make_shared<silkworm::db::test_util::MockCursor>();
-        EXPECT_CALL(transaction, cursor(db::table::kMaxTxNumName)).WillOnce(Invoke([&cursor](Unused) -> Task<std::shared_ptr<db::kv::api::Cursor>> {
-            co_return cursor;
-        }));
-        EXPECT_CALL(*cursor, seek_exact(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::KeyValue> {
-            co_return KeyValue{*silkworm::from_hex("0000000000000000"), *silkworm::from_hex("0000ddff12345678")};
+        EXPECT_CALL(transaction, first_txn_num_in_block(6'000'001)).WillOnce(Invoke([]() -> Task<TxnId> {
+            co_return 244087591818873;
         }));
         EXPECT_CALL(transaction, domain_get(_)).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
@@ -179,11 +172,8 @@ TEST_CASE_METHOD(EVMExecutorTest, "EVMExecutor") {
 
     SECTION("call returns SUCCESS") {
         auto cursor = std::make_shared<silkworm::db::test_util::MockCursor>();
-        EXPECT_CALL(transaction, cursor(db::table::kMaxTxNumName)).WillOnce(Invoke([&cursor](Unused) -> Task<std::shared_ptr<db::kv::api::Cursor>> {
-            co_return cursor;
-        }));
-        EXPECT_CALL(*cursor, seek_exact(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::KeyValue> {
-            co_return KeyValue{*silkworm::from_hex("0000000000000000"), *silkworm::from_hex("0000ddff12345678")};
+        EXPECT_CALL(transaction, first_txn_num_in_block(6'000'001)).WillOnce(Invoke([]() -> Task<TxnId> {
+            co_return 244087591818873;
         }));
         EXPECT_CALL(transaction, domain_get(_)).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{

--- a/silkworm/rpc/core/evm_trace_test.cpp
+++ b/silkworm/rpc/core/evm_trace_test.cpp
@@ -50,11 +50,6 @@ using testing::Invoke;
 using testing::InvokeWithoutArgs;
 using testing::Unused;
 
-static const Bytes kZeroHeader{*silkworm::from_hex("bf7e331f7f7c1dd2e05159666b3bf8bc7a8a3a9eb1d518969eab529dd9b88c1a")};
-static const evmc::bytes32 kZeroHeaderHash{0xbf7e331f7f7c1dd2e05159666b3bf8bc7a8a3a9eb1d518969eab529dd9b88c1a_bytes32};
-static const Bytes kConfigKey{kZeroHeader};
-static const Bytes kConfigValue{string_view_to_byte_view(kSepoliaConfig.to_json().dump())};  // NOLINT(cppcoreguidelines-interfaces-global-init)
-
 struct TraceCallExecutorTest : public test_util::ServiceContextTestBase {
     db::test_util::MockTransaction transaction;
     WorkerPool workers{1};
@@ -66,6 +61,10 @@ struct TraceCallExecutorTest : public test_util::ServiceContextTestBase {
 };
 
 #ifndef SILKWORM_SANITIZE
+static const evmc::bytes32 kZeroHeaderHash{0xbf7e331f7f7c1dd2e05159666b3bf8bc7a8a3a9eb1d518969eab529dd9b88c1a_bytes32};
+static const Bytes kConfigKey{kZeroHeaderHash.bytes};
+static const Bytes kConfigValue{string_view_to_byte_view(kSepoliaConfig.to_json().dump())};  // NOLINT(cppcoreguidelines-interfaces-global-init)
+
 TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_call precompiled") {
     static Bytes kAccountHistoryKey1{*silkworm::from_hex("0a6bb546b9208cfab9e8fa2b9b2c042b18df7030")};
     static Bytes kAccountHistoryKey2{*silkworm::from_hex("0000000000000000000000000000000000000009")};

--- a/silkworm/rpc/core/evm_trace_test.cpp
+++ b/silkworm/rpc/core/evm_trace_test.cpp
@@ -62,7 +62,7 @@ struct TraceCallExecutorTest : public test_util::ServiceContextTestBase {
 
 #ifndef SILKWORM_SANITIZE
 static const evmc::bytes32 kZeroHeaderHash{0xbf7e331f7f7c1dd2e05159666b3bf8bc7a8a3a9eb1d518969eab529dd9b88c1a_bytes32};
-static const Bytes kConfigKey{kZeroHeaderHash.bytes};
+static const Bytes kConfigKey{kZeroHeaderHash.bytes, kHashLength};
 static const Bytes kConfigValue{string_view_to_byte_view(kSepoliaConfig.to_json().dump())};  // NOLINT(cppcoreguidelines-interfaces-global-init)
 
 TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_call precompiled") {

--- a/silkworm/rpc/core/storage_walker_test.cpp
+++ b/silkworm/rpc/core/storage_walker_test.cpp
@@ -202,6 +202,10 @@ class DummyTransaction : public BaseTransaction {
         return nullptr;
     }
 
+    Task<TxnId> first_txn_num_in_block(BlockNum /*block_num*/) override {
+        co_return 0;
+    }
+
     Task<void> close() override {
         co_return;
     }

--- a/silkworm/rpc/test_util/dummy_transaction.hpp
+++ b/silkworm/rpc/test_util/dummy_transaction.hpp
@@ -71,11 +71,15 @@ class DummyTransaction : public db::kv::api::BaseTransaction {
     }
 
     std::shared_ptr<silkworm::State> create_state(boost::asio::any_io_executor& executor, const db::chain::ChainStorage& storage, BlockNum block_number) override {
-        return std::make_shared<db::state::RemoteState>(executor, *this, storage, block_number, db::chain::Providers{});
+        return std::make_shared<db::state::RemoteState>(executor, *this, storage, block_number);
     }
 
     std::shared_ptr<db::chain::ChainStorage> create_storage() override {
         return std::make_shared<db::chain::RemoteChainStorage>(*this, ethdb::kv::make_backend_providers(backend_));
+    }
+
+    Task<TxnId> first_txn_num_in_block(BlockNum /*block_num*/) override {
+        co_return 0;
     }
 
     Task<void> close() override { co_return; }


### PR DESCRIPTION
Refactor state access abstractions after adding `first_txn_num_in_block` in `kv::api::Transaction` to avoid passing canonical hash provider in multiple call sites.

*Extras*
- rename `get_ibs_state` as `intra_block_state`
- fix unused const variable warnings introduced by #2426