### PR TITLE
tests: remove leftovers from the previous runs in conan cache

### DIFF
--- a/.github/actions/fuzzer-common-steps/action.yml
+++ b/.github/actions/fuzzer-common-steps/action.yml
@@ -21,6 +21,10 @@ runs:
       shell: bash
       run: cmake -E make_directory ${{runner.workspace}}/silkworm/build
 
+    - name: Temporary step - conan cache cleanup - to be executed only once per runner
+      shell: bash
+      run: conan remove "*" --force
+
     - name: Preinstall Conan packages
       shell: bash
       working-directory: ${{runner.workspace}}/silkworm

--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -15,7 +15,6 @@
 ]]
 
 include(${CMAKE_CURRENT_LIST_DIR}/compiler_settings_sanitize.cmake)
-include(CheckCXXCompilerFlag)
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 
@@ -88,11 +87,6 @@ elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES ".*Clang$")
     endif()
     link_libraries(c++)
     link_libraries(c++abi)
-  endif()
-
-  check_cxx_compiler_flag("-fuse-ld=lld" HAS_LLD)
-  if(HAS_LLD)
-    add_link_options(-fuse-ld=lld)
   endif()
 
 else()


### PR DESCRIPTION
This applies to the Erigon 2 runner only - Erigon 3 runner has already been cleaned up