### PR TITLE
execution: fix stages lookup in sanitizer builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -455,8 +455,21 @@ workflows:
         equal: [ master, <<pipeline.git.branch>> ]
     jobs:
       - lint
-      - linux-gcc-thread-sanitizer
-      - linux-clang-address-sanitizer
+      - linux-clang-tidy-diff
+      - linux-release:
+          name: linux-gcc-12-release
+          compiler_id: gcc
+          compiler_version: 12
+          ethereum_tests: false
+          requires:
+            - lint
+      - linux-release:
+          name: linux-clang-<<pipeline.parameters.clang_version_min>>-release
+          compiler_id: clang
+          compiler_version: <<pipeline.parameters.clang_version_min>>
+          ethereum_tests: false
+          requires:
+            - lint
 
   integration:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -455,21 +455,8 @@ workflows:
         equal: [ master, <<pipeline.git.branch>> ]
     jobs:
       - lint
-      - linux-clang-tidy-diff
-      - linux-release:
-          name: linux-gcc-12-release
-          compiler_id: gcc
-          compiler_version: 12
-          ethereum_tests: false
-          requires:
-            - lint
-      - linux-release:
-          name: linux-clang-<<pipeline.parameters.clang_version_min>>-release
-          compiler_id: clang
-          compiler_version: <<pipeline.parameters.clang_version_min>>
-          ethereum_tests: false
-          requires:
-            - lint
+      - linux-gcc-thread-sanitizer
+      - linux-clang-address-sanitizer
 
   integration:
     when:

--- a/silkworm/node/stagedsync/execution_pipeline.cpp
+++ b/silkworm/node/stagedsync/execution_pipeline.cpp
@@ -39,8 +39,39 @@ ExecutionPipeline::ExecutionPipeline(
     : data_model_factory_{std::move(data_model_factory)},
       log_timer_factory_{std::move(log_timer_factory)},
       sync_context_{std::make_unique<SyncContext>()},
-      stages_{stages_factory(*sync_context_)} {
-    load_stages();
+      stages_{stages_factory(*sync_context_)},
+      current_stage_{stages_.end()} {
+    stages_forward_order_ = StageNames{
+        kHeadersKey,
+        kBlockHashesKey,
+        kBlockBodiesKey,
+        kSendersKey,
+        kExecutionKey,
+        kHashStateKey,
+        kIntermediateHashesKey,
+        kHistoryIndexKey,
+        kLogIndexKey,
+        kCallTracesKey,
+        kTxLookupKey,
+        kTriggersStageKey,
+        kFinishKey,
+    };
+
+    stages_unwind_order_ = StageNames{
+        kFinishKey,
+        kTriggersStageKey,
+        kTxLookupKey,
+        kCallTracesKey,
+        kLogIndexKey,
+        kHistoryIndexKey,
+        kHashStateKey,
+        kIntermediateHashesKey,  // Needs to happen after unwinding HashState
+        kExecutionKey,
+        kSendersKey,
+        kBlockBodiesKey,
+        kBlockHashesKey,  // De-canonify block hashes
+        kHeadersKey,
+    };
 }
 
 BlockNum ExecutionPipeline::head_header_number() const {
@@ -57,58 +88,6 @@ std::optional<BlockNum> ExecutionPipeline::unwind_point() {
 
 std::optional<Hash> ExecutionPipeline::bad_block() {
     return sync_context_->bad_block_hash;
-}
-
-/*
- * Stages from Erigon -> Silkworm
- *  1 StageHeaders ->  stagedsync::HeadersStage
- *  2 StageBodies -> stagedsync::BodiesStage
- *  3 StageBlockHashes -> stagedsync::BlockHashes
- *  4 StageSenders -> stagedsync::Senders
- *  5 StageExecution -> stagedsync::Execution
- *  6 StageHashState -> stagedsync::HashState
- *  7 StageInterHashes -> stagedsync::InterHashes
- *  8 StageIndexes -> stagedsync::HistoryIndex
- *  9 StageLogIndex -> stagedsync::LogIndex
- * 10 StageCallTraces -> stagedsync::CallTraceIndex
- * 11 StageTxLookup -> stagedsync::TxLookup
- * 12 StageFinish -> stagedsync::Finish
- */
-
-void ExecutionPipeline::load_stages() {
-    current_stage_ = stages_.begin();
-
-    stages_forward_order_.insert(stages_forward_order_.begin(),
-                                 {
-                                     kHeadersKey,
-                                     kBlockHashesKey,
-                                     kBlockBodiesKey,
-                                     kSendersKey,
-                                     kExecutionKey,
-                                     kHashStateKey,
-                                     kIntermediateHashesKey,
-                                     kHistoryIndexKey,
-                                     kLogIndexKey,
-                                     kCallTracesKey,
-                                     kTxLookupKey,
-                                     kFinishKey,
-                                 });
-
-    stages_unwind_order_.insert(stages_unwind_order_.begin(),
-                                {
-                                    kFinishKey,
-                                    kTxLookupKey,
-                                    kCallTracesKey,
-                                    kLogIndexKey,
-                                    kHistoryIndexKey,
-                                    kHashStateKey,
-                                    kIntermediateHashesKey,  // Needs to happen after unwinding HashState
-                                    kExecutionKey,
-                                    kSendersKey,
-                                    kBlockBodiesKey,
-                                    kBlockHashesKey,  // De-canonify block hashes
-                                    kHeadersKey,
-                                });
 }
 
 bool ExecutionPipeline::stop() {
@@ -150,7 +129,8 @@ Stage::Result ExecutionPipeline::forward(db::RWTxn& cycle_txn, BlockNum target_h
                 throw std::runtime_error("Stage " + std::string(stage_id) + " requested but not implemented");
             }
             ++current_stage_number_;
-            current_stage_->second->set_log_prefix(get_log_prefix());
+            const auto& current_stage_name = current_stage_->first;
+            current_stage_->second->set_log_prefix(get_log_prefix(current_stage_name));
 
             // Check if we have to start at specific stage due to environment variable
             if (start_stage_name) {
@@ -179,12 +159,12 @@ Stage::Result ExecutionPipeline::forward(db::RWTxn& cycle_txn, BlockNum target_h
 
             if (stage_result != Stage::Result::kSuccess) { /* clang-format off */
                 auto result_description = std::string(magic_enum::enum_name<Stage::Result>(stage_result));
-                log::Error(get_log_prefix(), {"op", "Forward", "returned", result_description});
+                log::Error(get_log_prefix(current_stage_name), {"op", "Forward", "returned", result_description});
                 log::Error("ExecPipeline") << "Forward interrupted due to stage " << current_stage_->first << " failure";
                 return stage_result;
             } /* clang-format on */
 
-            auto stage_head_number = read_stage_progress(cycle_txn, current_stage_->first);
+            auto stage_head_number = read_stage_progress(cycle_txn, current_stage_name.data());
             if (!stop_at_block && stage_head_number != target_height) {
                 throw std::logic_error("Sync pipeline: stage returned success with an height different from target=" +
                                        to_string(target_height) + " reached= " + to_string(stage_head_number));
@@ -192,7 +172,7 @@ Stage::Result ExecutionPipeline::forward(db::RWTxn& cycle_txn, BlockNum target_h
 
             auto [_, stage_duration] = stages_stop_watch.lap();
             if (stage_duration > kStageDurationThresholdForLog) {
-                log::Info(get_log_prefix(), {"op", "Forward", "done", StopWatch::format(stage_duration)});
+                log::Info(get_log_prefix(current_stage_name), {"op", "Forward", "done", StopWatch::format(stage_duration)});
             }
         }
 
@@ -215,8 +195,7 @@ Stage::Result ExecutionPipeline::forward(db::RWTxn& cycle_txn, BlockNum target_h
 
         return result;
     } catch (const std::exception& ex) {
-        log::Error(get_log_prefix(), {"exception", std::string(ex.what())});
-        log::Error("ExecutionPipeline") << "Forward aborted due to exception: " << ex.what();
+        SILK_ERROR_M("ExecutionPipeline") << get_log_prefix("unknown") << " Forward exception " << ex.what();
         return Stage::Result::kUnexpectedError;
     }
 }
@@ -239,7 +218,8 @@ Stage::Result ExecutionPipeline::unwind(db::RWTxn& cycle_txn, BlockNum unwind_po
                 throw std::runtime_error("Stage " + std::string(stage_id) + " requested but not implemented");
             }
             ++current_stage_number_;
-            current_stage_->second->set_log_prefix(get_log_prefix());
+            const auto& current_stage_name = current_stage_->first;
+            current_stage_->second->set_log_prefix(get_log_prefix(current_stage_name));
 
             if (log_timer) {
                 log_timer->reset();  // Resets the interval for next log line from now
@@ -249,7 +229,7 @@ Stage::Result ExecutionPipeline::unwind(db::RWTxn& cycle_txn, BlockNum unwind_po
             const auto stage_result = current_stage_->second->unwind(cycle_txn);
             if (stage_result != Stage::Result::kSuccess) {
                 auto result_description = std::string(magic_enum::enum_name<Stage::Result>(stage_result));
-                log::Error(get_log_prefix(), {"op", "Unwind", "returned", result_description});
+                log::Error(get_log_prefix(current_stage_name), {"op", "Unwind", "returned", result_description});
                 log::Error("ExecPipeline") << "Unwind interrupted due to stage " << current_stage_->first << " failure";
                 return stage_result;
             }
@@ -257,7 +237,7 @@ Stage::Result ExecutionPipeline::unwind(db::RWTxn& cycle_txn, BlockNum unwind_po
             // Log performances
             auto [_, stage_duration] = stages_stop_watch.lap();
             if (stage_duration > kStageDurationThresholdForLog) {
-                log::Info(get_log_prefix(), {"op", "Unwind", "done", StopWatch::format(stage_duration)});
+                log::Info(get_log_prefix(current_stage_name), {"op", "Unwind", "done", StopWatch::format(stage_duration)});
             }
         }
 
@@ -280,8 +260,7 @@ Stage::Result ExecutionPipeline::unwind(db::RWTxn& cycle_txn, BlockNum unwind_po
         return is_stopping() ? Stage::Result::kAborted : Stage::Result::kSuccess;
 
     } catch (const std::exception& ex) {
-        log::Error("ExecPipeline") << "Unwind aborted due to exception: " << ex.what();
-        log::Error(get_log_prefix(), {"exception", std::string(ex.what())});
+        SILK_ERROR_M("ExecutionPipeline") << get_log_prefix("unknown") << " Unwind exception " << ex.what();
         return Stage::Result::kUnexpectedError;
     }
 }
@@ -301,7 +280,8 @@ Stage::Result ExecutionPipeline::prune(db::RWTxn& cycle_txn) {
                 throw std::runtime_error("Stage " + std::string(stage_id) + " requested but not implemented");
             }
             ++current_stage_number_;
-            current_stage_->second->set_log_prefix(get_log_prefix());
+            const auto& current_stage_name = current_stage_->first;
+            current_stage_->second->set_log_prefix(get_log_prefix(current_stage_name));
 
             if (log_timer) {
                 log_timer->reset();  // Resets the interval for next log line from now
@@ -309,15 +289,15 @@ Stage::Result ExecutionPipeline::prune(db::RWTxn& cycle_txn) {
 
             const auto stage_result{current_stage_->second->prune(cycle_txn)};
             if (stage_result != Stage::Result::kSuccess) {
-                log::Error(get_log_prefix(), {"op", "Prune", "returned",
-                                              std::string(magic_enum::enum_name<Stage::Result>(stage_result))});
+                log::Error(get_log_prefix(current_stage_name), {"op", "Prune", "returned",
+                                                                std::string(magic_enum::enum_name<Stage::Result>(stage_result))});
                 log::Error("ExecPipeline") << "Prune interrupted due to stage " << current_stage_->first << " failure";
                 return stage_result;
             }
 
             auto [_, stage_duration] = stages_stop_watch.lap();
             if (stage_duration > kStageDurationThresholdForLog) {
-                log::Info(get_log_prefix(), {"op", "Prune", "done", StopWatch::format(stage_duration)});
+                log::Info(get_log_prefix(current_stage_name), {"op", "Prune", "done", StopWatch::format(stage_duration)});
             }
         }
 
@@ -331,16 +311,16 @@ Stage::Result ExecutionPipeline::prune(db::RWTxn& cycle_txn) {
         return is_stopping() ? Stage::Result::kAborted : Stage::Result::kSuccess;
 
     } catch (const std::exception& ex) {
-        log::Error(get_log_prefix(), {"exception", std::string(ex.what())});
+        SILK_ERROR_M("ExecutionPipeline") << get_log_prefix("unknown") << " Prune exception " << ex.what();
         return Stage::Result::kUnexpectedError;
     }
 }
 
-std::string ExecutionPipeline::get_log_prefix() const {
+std::string ExecutionPipeline::get_log_prefix(const std::string_view& stage_name) const {
     return absl::StrFormat("[%u/%u %s]",
                            current_stage_number_,
                            current_stages_count_,
-                           current_stage_->first);
+                           stage_name);
 }
 
 std::shared_ptr<Timer> ExecutionPipeline::make_log_timer() {
@@ -351,11 +331,15 @@ std::shared_ptr<Timer> ExecutionPipeline::make_log_timer() {
 }
 
 bool ExecutionPipeline::log_timer_expired() {
+    const auto current_stage_name =
+        (current_stage_ != stages_.end())
+            ? current_stage_->first
+            : "unknown";
     if (is_stopping()) {
-        log::Info(get_log_prefix()) << "stopping ...";
+        log::Info(get_log_prefix(current_stage_name)) << "stopping ...";
         return false;
     }
-    log::Info(get_log_prefix(), current_stage_->second->get_log_progress());
+    log::Info(get_log_prefix(current_stage_name), current_stage_->second->get_log_progress());
     return true;
 }
 

--- a/silkworm/node/stagedsync/execution_pipeline.hpp
+++ b/silkworm/node/stagedsync/execution_pipeline.hpp
@@ -21,6 +21,8 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <string>
+#include <string_view>
 #include <vector>
 
 #include <boost/asio/any_io_executor.hpp>
@@ -36,7 +38,7 @@
 
 namespace silkworm::stagedsync {
 
-using StageContainer = std::map<const char*, std::unique_ptr<Stage>>;
+using StageContainer = std::map<std::string_view, std::unique_ptr<Stage>>;
 using StageContainerFactory = std::function<StageContainer(SyncContext&)>;
 
 class ExecutionPipeline : public Stoppable {
@@ -68,7 +70,7 @@ class ExecutionPipeline : public Stoppable {
     StageContainer stages_;
     StageContainer::iterator current_stage_;
 
-    using StageNames = std::vector<const char*>;
+    using StageNames = std::vector<std::string_view>;
     StageNames stages_forward_order_;
     StageNames stages_unwind_order_;
     std::atomic<size_t> current_stages_count_{0};
@@ -77,9 +79,8 @@ class ExecutionPipeline : public Stoppable {
     BlockNum head_header_number_{0};
     Hash head_header_hash_;
 
-    void load_stages();  // Fills the vector with stages
-
-    std::string get_log_prefix() const;  // Returns the current log lines prefix on behalf of current stage
+    // Returns the current log lines prefix on behalf of current stage
+    std::string get_log_prefix(const std::string_view& stage_name) const;
 
     std::shared_ptr<Timer> make_log_timer();
     bool log_timer_expired();


### PR DESCRIPTION
* use string_view for keys to avoid stage not found if the name char* pointers are unstable across .cpp files
* avoid double logging of exceptions
* pass current_stage_name explicitly to avoid a crash when current_stage_ = end
* add missing kTriggersStageKey to the order lists