### PR TITLE
rpcdaemon: ots_getTransactionBySenderAndNonce for e3

### DIFF
--- a/.github/workflows/run_integration_tests.sh
+++ b/.github/workflows/run_integration_tests.sh
@@ -19,8 +19,9 @@ rm -rf ./mainnet/results/
 # erigon_getBalanceChangesInBlock: new algo using TKV
 # erigon_getLatestLogs: new algo using TKV
 # eth_getLogs: new algo using TKV
-# ots_getTransactionBySenderAndNonce: new algo using TKV
 # ots_getContractCreator: new algo using TKV
+# ots_getTransactionBySenderAndNonce/test_04.json: erigon3 bug in limit and page_size management in IndexRangeQuery query
+# ots_getTransactionBySenderAndNonce/test_07.json: erigon3 bug in limit and page_size management in IndexRangeQuery query
 # ots_hasCode: new algo using TKV
 # ots_searchTransactionsAfter: new algo using TKV
 # ots_searchTransactionsBefore: new algo using TKV
@@ -28,7 +29,7 @@ rm -rf ./mainnet/results/
 # trace_rawTransaction: different implementation
 # trace_replayTransaction/trace_replyBlockTransaction: silkworm has different response with erigon3 but could be erigon3 problem (to be analyzed)
 
-python3 ./run_tests.py --continue --blockchain mainnet --jwt "$2" --display-only-fail --json-diff --port 51515 -x \
+python3 ./run_tests.py --continue --blockchain mainnet --jwt "$2" --display-only-fail --json-diff --port 51515 --transport_type http,websocket -x \
 debug_accountRange,\
 debug_getModifiedAccounts,\
 debug_storageRangeAt,\
@@ -57,7 +58,7 @@ ots_hasCode/test_09.json,\
 ots_searchTransactionsAfter,\
 ots_searchTransactionsBefore,\
 parity_listStorageKeys/test_12.json,\
-trace_rawTransaction --transport_type http,websocket
+trace_rawTransaction
 
 failed_test=$?
 

--- a/.github/workflows/run_integration_tests.sh
+++ b/.github/workflows/run_integration_tests.sh
@@ -50,7 +50,8 @@ erigon_getLatestLogs,\
 eth_estimateGas,\
 eth_getBlockReceipts/test_07.json,\
 eth_getLogs,\
-ots_getTransactionBySenderAndNonce,\
+ots_getTransactionBySenderAndNonce/test_04.json,\
+ots_getTransactionBySenderAndNonce/test_07.json,\
 ots_getContractCreator,\
 ots_hasCode/test_09.json,\
 ots_searchTransactionsAfter,\

--- a/silkworm/db/tables.hpp
+++ b/silkworm/db/tables.hpp
@@ -62,6 +62,12 @@ inline constexpr MapConfig kAccountChangeSet{kAccountChangeSetName, mdbx::key_mo
 inline constexpr const char* kAccountHistoryName{"AccountHistory"};
 inline constexpr MapConfig kAccountHistory{kAccountHistoryName};
 
+inline constexpr const char* kAccountsHistoryName{"AccountsHistory"};
+inline constexpr MapConfig kAccountsHistory{kAccountsHistoryName, mdbx::key_mode::usual, mdbx::value_mode::multi};
+
+inline constexpr const char* kAccountsHistoryIdxName{"AccountsHistoryIdx"};
+inline constexpr MapConfig kAccountsHistoryIdx{kAccountsHistoryIdxName, mdbx::key_mode::usual, mdbx::value_mode::multi};
+
 //! \details Holds block body data
 //! \struct
 //! \verbatim
@@ -376,6 +382,8 @@ inline constexpr MapConfig kMaxTxNum{kMaxTxNumName};
 inline constexpr MapConfig kChainDataTables[]{
     kAccountChangeSet,
     kAccountHistory,
+    kAccountsHistory,
+    kAccountsHistoryIdx,
     kBlockBodies,
     kBlockReceipts,
     kCallFromIndex,

--- a/silkworm/db/tables.hpp
+++ b/silkworm/db/tables.hpp
@@ -62,12 +62,6 @@ inline constexpr MapConfig kAccountChangeSet{kAccountChangeSetName, mdbx::key_mo
 inline constexpr const char* kAccountHistoryName{"AccountHistory"};
 inline constexpr MapConfig kAccountHistory{kAccountHistoryName};
 
-inline constexpr const char* kAccountsHistoryName{"AccountsHistory"};
-inline constexpr MapConfig kAccountsHistory{kAccountsHistoryName, mdbx::key_mode::usual, mdbx::value_mode::multi};
-
-inline constexpr const char* kAccountsHistoryIdxName{"AccountsHistoryIdx"};
-inline constexpr MapConfig kAccountsHistoryIdx{kAccountsHistoryIdxName, mdbx::key_mode::usual, mdbx::value_mode::multi};
-
 //! \details Holds block body data
 //! \struct
 //! \verbatim
@@ -382,8 +376,6 @@ inline constexpr MapConfig kMaxTxNum{kMaxTxNumName};
 inline constexpr MapConfig kChainDataTables[]{
     kAccountChangeSet,
     kAccountHistory,
-    kAccountsHistory,
-    kAccountsHistoryIdx,
     kBlockBodies,
     kBlockReceipts,
     kCallFromIndex,
@@ -437,5 +429,11 @@ inline constexpr const char* kStorageDomain{"storage"};
 
 //! \details Domain storing the account code information
 inline constexpr const char* kCodeDomain{"code"};
+
+//! \details History storing the account common information
+inline constexpr const char* kAccountsHistory{"AccountsHistory"};
+
+//! \details Inverted Index storing the account common information
+inline constexpr const char* kAccountsHistoryIdx{"AccountsHistoryIdx"};
 
 }  // namespace silkworm::db::table

--- a/silkworm/rpc/commands/eth_api.cpp
+++ b/silkworm/rpc/commands/eth_api.cpp
@@ -2063,7 +2063,7 @@ Task<void> EthereumRpcApi::handle_fee_history(const nlohmann::json& request, nlo
 
 Task<void> EthereumRpcApi::handle_base_fee(const nlohmann::json& request, nlohmann::json& reply) {
     const auto& params = request["params"];
-    if (params.size() != 0) {
+    if (!params.empty()) {
         const auto error_msg = "invalid eth_baseFee params: " + params.dump();
         SILK_ERROR << error_msg;
         reply = make_json_error(request, 100, error_msg);
@@ -2106,7 +2106,7 @@ Task<void> EthereumRpcApi::handle_base_fee(const nlohmann::json& request, nlohma
 
 Task<void> EthereumRpcApi::handle_blob_base_fee(const nlohmann::json& request, nlohmann::json& reply) {
     const auto& params = request["params"];
-    if (params.size() != 0) {
+    if (!params.empty()) {
         const auto error_msg = "invalid eth_blobBaseFee params: " + params.dump();
         SILK_ERROR << error_msg;
         reply = make_json_error(request, 100, error_msg);

--- a/silkworm/rpc/commands/ots_api.cpp
+++ b/silkworm/rpc/commands/ots_api.cpp
@@ -297,7 +297,7 @@ Task<void> OtsRpcApi::handle_ots_get_transaction_by_sender_and_nonce(const nlohm
                 continue;
             }
             SILK_DEBUG << "count: " << count << ", txnId: " << txn_id;
-            db::kv::api::HistoryPointQuery hpq {
+            db::kv::api::HistoryPointQuery hpq{
                 .table = db::table::kAccountsHistoryName,
                 .key = key,
                 .timestamp = *value};
@@ -332,11 +332,10 @@ Task<void> OtsRpcApi::handle_ots_get_transaction_by_sender_and_nonce(const nlohm
             auto txn_id = i + prev_txn_id;
 
             SILK_DEBUG << "searching for txnId: " << txn_id << ", i: " << i;
-            db::kv::api::HistoryPointQuery hpq {
+            db::kv::api::HistoryPointQuery hpq{
                 .table = db::table::kAccountsHistoryName,
                 .key = key,
-                .timestamp = static_cast<db::kv::api::Timestamp>(txn_id)
-            };
+                .timestamp = static_cast<db::kv::api::Timestamp>(txn_id)};
             auto result = co_await tx->history_seek(std::move(hpq));
             if (!result.success) {
                 co_return false;

--- a/silkworm/rpc/commands/ots_api.cpp
+++ b/silkworm/rpc/commands/ots_api.cpp
@@ -278,7 +278,7 @@ Task<void> OtsRpcApi::handle_ots_get_transaction_by_sender_and_nonce(const nlohm
         auto key = db::code_domain_key(sender);
 
         db::kv::api::IndexRangeQuery query{
-            .table = "AccountsHistoryIdx",  // TODO insert in tables.hpp
+            .table = db::table::kAccountsHistoryIdxName,
             .key = key,
             .from_timestamp = -1,
             .to_timestamp = -1,
@@ -297,8 +297,8 @@ Task<void> OtsRpcApi::handle_ots_get_transaction_by_sender_and_nonce(const nlohm
                 continue;
             }
             SILK_DEBUG << "count: " << count << ", txnId: " << txn_id;
-            db::kv::api::HistoryPointQuery hpq{
-                .table = "AccountsHistory",  // TODO insert in tables.hpp
+            db::kv::api::HistoryPointQuery hpq {
+                .table = db::table::kAccountsHistoryName,
                 .key = key,
                 .timestamp = *value};
             auto result = co_await tx->history_seek(std::move(hpq));
@@ -323,7 +323,6 @@ Task<void> OtsRpcApi::handle_ots_get_transaction_by_sender_and_nonce(const nlohm
         }
         SILK_DEBUG << "range -> prev_txn_id: " << prev_txn_id << ", next_txn_id: " << next_txn_id;
 
-        reply = make_json_content(request, nlohmann::detail::value_t::null);
         if (next_txn_id == 0) {
             next_txn_id = prev_txn_id + 1;
         }
@@ -333,10 +332,11 @@ Task<void> OtsRpcApi::handle_ots_get_transaction_by_sender_and_nonce(const nlohm
             auto txn_id = i + prev_txn_id;
 
             SILK_DEBUG << "searching for txnId: " << txn_id << ", i: " << i;
-            db::kv::api::HistoryPointQuery hpq{
-                .table = "AccountsHistory",  // TODO insert in tables.hpp
+            db::kv::api::HistoryPointQuery hpq {
+                .table = db::table::kAccountsHistoryName,
                 .key = key,
-                .timestamp = static_cast<db::kv::api::Timestamp>(txn_id)};
+                .timestamp = static_cast<db::kv::api::Timestamp>(txn_id)
+            };
             auto result = co_await tx->history_seek(std::move(hpq));
             if (!result.success) {
                 co_return false;

--- a/silkworm/rpc/commands/ots_api.cpp
+++ b/silkworm/rpc/commands/ots_api.cpp
@@ -278,11 +278,11 @@ Task<void> OtsRpcApi::handle_ots_get_transaction_by_sender_and_nonce(const nlohm
         auto key = db::code_domain_key(sender);
 
         db::kv::api::IndexRangeQuery query{
-                .table = "AccountsHistoryIdx", // TODO insert in tables.hpp
-                .key = key,
-                .from_timestamp = -1,
-                .to_timestamp = -1,
-                .ascending_order = true};
+            .table = "AccountsHistoryIdx",  // TODO insert in tables.hpp
+            .key = key,
+            .from_timestamp = -1,
+            .to_timestamp = -1,
+            .ascending_order = true};
         auto paginated_result = co_await tx->index_range(std::move(query));
         auto it = co_await paginated_result.begin();
 
@@ -297,11 +297,10 @@ Task<void> OtsRpcApi::handle_ots_get_transaction_by_sender_and_nonce(const nlohm
                 continue;
             }
             SILK_DEBUG << "count: " << count << ", txnId: " << txn_id;
-            db::kv::api::HistoryPointQuery hpq {
-                .table = "AccountsHistory", // TODO insert in tables.hpp
+            db::kv::api::HistoryPointQuery hpq{
+                .table = "AccountsHistory",  // TODO insert in tables.hpp
                 .key = key,
-                .timestamp = *value
-            };
+                .timestamp = *value};
             auto result = co_await tx->history_seek(std::move(hpq));
             if (!result.success) {
                 reply = make_json_content(request, nlohmann::detail::value_t::null);
@@ -315,7 +314,7 @@ Task<void> OtsRpcApi::handle_ots_get_transaction_by_sender_and_nonce(const nlohm
                 prev_txn_id = txn_id;
                 continue;
             }
-            const auto account {Account::from_encoded_storage_v3(result.value)};
+            const auto account{Account::from_encoded_storage_v3(result.value)};
             SILK_DEBUG << "Account: " << *account;
             if (account->nonce > nonce) {
                 break;
@@ -334,11 +333,10 @@ Task<void> OtsRpcApi::handle_ots_get_transaction_by_sender_and_nonce(const nlohm
             auto txn_id = i + prev_txn_id;
 
             SILK_DEBUG << "searching for txnId: " << txn_id << ", i: " << i;
-            db::kv::api::HistoryPointQuery hpq {
-                    .table = "AccountsHistory", // TODO insert in tables.hpp
-                    .key = key,
-                    .timestamp = static_cast<db::kv::api::Timestamp>(txn_id)
-            };
+            db::kv::api::HistoryPointQuery hpq{
+                .table = "AccountsHistory",  // TODO insert in tables.hpp
+                .key = key,
+                .timestamp = static_cast<db::kv::api::Timestamp>(txn_id)};
             auto result = co_await tx->history_seek(std::move(hpq));
             if (!result.success) {
                 co_return false;
@@ -347,7 +345,7 @@ Task<void> OtsRpcApi::handle_ots_get_transaction_by_sender_and_nonce(const nlohm
                 creation_txn_id = static_cast<uint64_t>(txn_id);
                 co_return false;
             }
-            const auto account {Account::from_encoded_storage_v3(result.value)};
+            const auto account{Account::from_encoded_storage_v3(result.value)};
             SILK_DEBUG << "account.nonce: " << account->nonce << ", nonce: " << nonce;
             if (account->nonce <= nonce) {
                 creation_txn_id = std::max(creation_txn_id, static_cast<uint64_t>(txn_id));

--- a/silkworm/rpc/commands/ots_api.cpp
+++ b/silkworm/rpc/commands/ots_api.cpp
@@ -278,7 +278,7 @@ Task<void> OtsRpcApi::handle_ots_get_transaction_by_sender_and_nonce(const nlohm
         auto key = db::code_domain_key(sender);
 
         db::kv::api::IndexRangeQuery query{
-            .table = db::table::kAccountsHistoryIdxName,
+            .table = db::table::kAccountsHistoryIdx,
             .key = key,
             .from_timestamp = -1,
             .to_timestamp = -1,
@@ -298,7 +298,7 @@ Task<void> OtsRpcApi::handle_ots_get_transaction_by_sender_and_nonce(const nlohm
             }
             SILK_DEBUG << "count: " << count << ", txnId: " << txn_id;
             db::kv::api::HistoryPointQuery hpq{
-                .table = db::table::kAccountsHistoryName,
+                .table = db::table::kAccountsHistory,
                 .key = key,
                 .timestamp = *value};
             auto result = co_await tx->history_seek(std::move(hpq));
@@ -333,7 +333,7 @@ Task<void> OtsRpcApi::handle_ots_get_transaction_by_sender_and_nonce(const nlohm
 
             SILK_DEBUG << "searching for txnId: " << txn_id << ", i: " << i;
             db::kv::api::HistoryPointQuery hpq{
-                .table = db::table::kAccountsHistoryName,
+                .table = db::table::kAccountsHistory,
                 .key = key,
                 .timestamp = static_cast<db::kv::api::Timestamp>(txn_id)};
             auto result = co_await tx->history_seek(std::move(hpq));


### PR DESCRIPTION
Moved ots_getTransactionBySenderAndNonce  on new KV APIs

*Extras*
fix clang tidy after #2465 