### PR TITLE
sync: remove singleton from core

### DIFF
--- a/silkworm/sync/block_exchange.cpp
+++ b/silkworm/sync/block_exchange.cpp
@@ -22,9 +22,9 @@
 #include <boost/signals2.hpp>
 
 #include <silkworm/core/common/random_number.hpp>
-#include <silkworm/core/common/singleton.hpp>
 #include <silkworm/infra/common/decoding_exception.hpp>
 #include <silkworm/infra/common/log.hpp>
+#include <silkworm/sync/internals/random_number.hpp>
 #include <silkworm/sync/messages/inbound_message.hpp>
 #include <silkworm/sync/messages/internal_message.hpp>
 #include <silkworm/sync/sentry_client.hpp>
@@ -117,8 +117,8 @@ void BlockExchange::execution_loop() {
             size_t room_for_new_requests = peers_capacity > outstanding_requests ? peers_capacity - outstanding_requests : 0;
 
             auto body_requests = room_for_new_requests == 1
-                                     ? Singleton<RandomNumber>::instance().generate_one() % 2  // 50% chance to request a body
-                                     : room_for_new_requests / 2;                              // a slight bias towards headers
+                                     ? chainsync::random_number.generate_one() % 2  // 50% chance to request a body
+                                     : room_for_new_requests / 2;                   // a slight bias towards headers
 
             room_for_new_requests -= request_bodies(now, body_requests);           // do the computed nr. of body requests
             room_for_new_requests -= request_headers(now, room_for_new_requests);  // do the remaining nr. of header requests

--- a/silkworm/sync/internals/body_sequence.cpp
+++ b/silkworm/sync/internals/body_sequence.cpp
@@ -17,9 +17,9 @@
 #include "body_sequence.hpp"
 
 #include <silkworm/core/common/random_number.hpp>
-#include <silkworm/core/common/singleton.hpp>
 #include <silkworm/core/protocol/validation.hpp>
 #include <silkworm/infra/common/log.hpp>
+#include <silkworm/sync/internals/random_number.hpp>
 #include <silkworm/sync/sentry_client.hpp>
 
 namespace silkworm {
@@ -144,7 +144,7 @@ std::shared_ptr<OutboundMessage> BodySequence::request_bodies(time_point_t tp) {
 
     auto body_request = std::make_shared<OutboundGetBlockBodies>();
     auto& packet = body_request->packet();
-    packet.request_id = Singleton<RandomNumber>::instance().generate_one();
+    packet.request_id = chainsync::random_number.generate_one();
 
     auto penalizations = renew_stale_requests(packet, min_block, tp, timeout);
 

--- a/silkworm/sync/internals/header_chain.cpp
+++ b/silkworm/sync/internals/header_chain.cpp
@@ -21,12 +21,12 @@
 #include <gsl/util>
 
 #include <silkworm/core/common/random_number.hpp>
-#include <silkworm/core/common/singleton.hpp>
 #include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/core/types/hash.hpp>
 #include <silkworm/db/db_utils.hpp>
 #include <silkworm/infra/common/environment.hpp>
 #include <silkworm/infra/common/log.hpp>
+#include <silkworm/sync/internals/random_number.hpp>
 #include <silkworm/sync/sentry_client.hpp>
 
 #include "algorithm.hpp"
@@ -539,7 +539,7 @@ std::optional<GetBlockHeadersPacket66> HeaderChain::save_external_announce(Hash 
     if (has_link(hash)) return std::nullopt;  // we already have this link, no need to request it
 
     GetBlockHeadersPacket66 request;
-    request.request_id = Singleton<RandomNumber>::instance().generate_one();
+    request.request_id = chainsync::random_number.generate_one();
     request.request.origin = {hash};
     request.request.amount = 1;
     request.request.skip = 0;

--- a/silkworm/sync/internals/random_number.hpp
+++ b/silkworm/sync/internals/random_number.hpp
@@ -1,5 +1,5 @@
 /*
-   Copyright 2022 The Silkworm Authors
+   Copyright 2024 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -16,16 +16,10 @@
 
 #pragma once
 
-#include <concepts>
+#include <silkworm/core/common/random_number.hpp>
 
-namespace silkworm {
+namespace silkworm::chainsync {
 
-template <std::default_initializable T>
-class Singleton {
-    static inline T instance_;
+inline RandomNumber random_number;
 
-  public:
-    static T& instance() { return instance_; }
-};
-
-}  // namespace silkworm
+}  // namespace silkworm::chainsync

--- a/silkworm/sync/messages/inbound_new_block.cpp
+++ b/silkworm/sync/messages/inbound_new_block.cpp
@@ -17,16 +17,16 @@
 #include "inbound_new_block.hpp"
 
 #include <silkworm/core/common/random_number.hpp>
-#include <silkworm/core/common/singleton.hpp>
 #include <silkworm/infra/common/decoding_exception.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/sync/internals/body_sequence.hpp>
+#include <silkworm/sync/internals/random_number.hpp>
 
 namespace silkworm {
 
 InboundNewBlock::InboundNewBlock(ByteView data, PeerId peer_id)
     : peer_id_(std::move(peer_id)),
-      req_id_(Singleton<RandomNumber>::instance().generate_one())  // for trace purposes
+      req_id_(chainsync::random_number.generate_one())  // for trace purposes
 {
     success_or_throw(rlp::decode(data, packet_));
     SILK_TRACE << "Received message " << *this;

--- a/silkworm/sync/messages/inbound_new_block_hashes.cpp
+++ b/silkworm/sync/messages/inbound_new_block_hashes.cpp
@@ -19,11 +19,11 @@
 #include <algorithm>
 
 #include <silkworm/core/common/random_number.hpp>
-#include <silkworm/core/common/singleton.hpp>
 #include <silkworm/core/rlp/decode_vector.hpp>
 #include <silkworm/infra/common/decoding_exception.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/sync/internals/header_chain.hpp>
+#include <silkworm/sync/internals/random_number.hpp>
 #include <silkworm/sync/sentry_client.hpp>
 
 #include "outbound_get_block_headers.hpp"
@@ -32,7 +32,7 @@ namespace silkworm {
 
 InboundNewBlockHashes::InboundNewBlockHashes(ByteView data, PeerId peer_id)
     : peer_id_(std::move(peer_id)),
-      req_id_(Singleton<RandomNumber>::instance().generate_one())  // for trace purposes
+      req_id_(chainsync::random_number.generate_one())  // for trace purposes
 {
     success_or_throw(rlp::decode(data, packet_));
     SILK_TRACE << "Received message " << *this;


### PR DESCRIPTION
We discourage the use of singletons and global variables in general.

For now use a global variable within sync.