### PR TITLE
db: always pass TemporaryDirectory to TestDatabaseContext

### DIFF
--- a/silkworm/capi/silkworm_test.cpp
+++ b/silkworm/capi/silkworm_test.cpp
@@ -42,11 +42,13 @@ namespace silkworm {
 namespace snapshot_test = snapshots::test_util;
 using namespace silkworm::db;
 
-struct CApiTest : public db::test_util::TestDatabaseContext {
+struct CApiTest {
     TemporaryDirectory tmp_dir;
+    db::test_util::TestDatabaseContext database{tmp_dir};
+
     SilkwormSettings settings{.log_verbosity = SilkwormLogLevel::SILKWORM_LOG_NONE};
-    mdbx::env env{*chaindata_rw()};
-    const std::filesystem::path& env_path() { return chaindata_dir_path(); }
+    mdbx::env env{*database.chaindata_rw()};
+    const std::filesystem::path& env_path() { return database.chaindata_dir_path(); }
 };
 
 //! Utility to copy `src` C-string to `dst` fixed-size char array

--- a/silkworm/db/kv/api/local_cursor_test.cpp
+++ b/silkworm/db/kv/api/local_cursor_test.cpp
@@ -32,8 +32,12 @@ using namespace silkworm::test_util;
 using silkworm::test_util::ContextTestBase;
 using test_util::TestDatabaseContext;
 
-struct LocalCursorTest : public ContextTestBase, TestDatabaseContext {
+struct LocalCursorTest : public ContextTestBase {
+    TemporaryDirectory tmp_dir;
+    TestDatabaseContext database{tmp_dir};
     static inline uint32_t last_cursor_id{0};
+
+    db::ROAccess chaindata() const { return database.chaindata(); }
 };
 
 // In all following tests we need to create the MDBX transaction using the io_context scheduler thread, so we simply

--- a/silkworm/db/test_util/test_database_context.cpp
+++ b/silkworm/db/test_util/test_database_context.cpp
@@ -185,10 +185,6 @@ namespace {
 
 }  // namespace
 
-TestDatabaseContext::TestDatabaseContext()
-    : chaindata_dir_path_{TemporaryDirectory::get_unique_temporary_path()},
-      env_{std::make_unique<mdbx::env_managed>(initialize_test_database(chaindata_dir_path_))} {}
-
 TestDatabaseContext::TestDatabaseContext(const TemporaryDirectory& tmp_dir)
     : chaindata_dir_path_{DataDirectory{tmp_dir.path()}.chaindata().path()},
       env_{std::make_unique<mdbx::env_managed>(initialize_test_database(chaindata_dir_path_))} {}

--- a/silkworm/db/test_util/test_database_context.hpp
+++ b/silkworm/db/test_util/test_database_context.hpp
@@ -35,15 +35,8 @@ void populate_blocks(db::RWTxn& txn, const std::filesystem::path& tests_dir, InM
 
 class TestDatabaseContext {
   public:
-    TestDatabaseContext();
     explicit TestDatabaseContext(const TemporaryDirectory& tmp_dir);
-
-    virtual ~TestDatabaseContext() {
-        if (env_) {
-            env_->close();
-            std::filesystem::remove_all(chaindata_dir_path_);
-        }
-    }
+    virtual ~TestDatabaseContext() = default;
 
     virtual db::ROAccess chaindata() const {
         return db::ROAccess{*env_};
@@ -75,11 +68,7 @@ class TestDataStore : public TestDatabaseContext {
               blocks::make_blocks_repository(
                   DataDirectory{tmp_dir.path(), true}.snapshots().path()),
           } {}
-
-    ~TestDataStore() override {
-        data_store_.close();
-        std::filesystem::remove_all(chaindata_dir_path_);
-    }
+    ~TestDataStore() override = default;
 
     db::DataStore& operator*() { return data_store_; }
     db::DataStore* operator->() { return &data_store_; }

--- a/silkworm/node/stagedsync/stages_test.cpp
+++ b/silkworm/node/stagedsync/stages_test.cpp
@@ -70,9 +70,9 @@ static stagedsync::CallTraceIndex make_call_traces_stage(
 }
 
 TEST_CASE("Sync Stages") {
-    TemporaryDirectory temp_dir{};
+    TemporaryDirectory tmp_dir;
     NodeSettings node_settings{};
-    node_settings.data_directory = std::make_unique<DataDirectory>(temp_dir.path());
+    node_settings.data_directory = std::make_unique<DataDirectory>(tmp_dir.path());
     node_settings.data_directory->deploy();
     node_settings.chaindata_env_config.path = node_settings.data_directory->chaindata().path().string();
     node_settings.chaindata_env_config.max_size = 1_Gibi;      // Small enough to fit in memory

--- a/silkworm/rpc/commands/rpc_api_test.cpp
+++ b/silkworm/rpc/commands/rpc_api_test.cpp
@@ -20,6 +20,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include <silkworm/infra/common/directories.hpp>
 #include <silkworm/rpc/test_util/api_test_database.hpp>
 
 namespace silkworm::rpc::commands {
@@ -105,7 +106,8 @@ TEST_CASE("rpc_api io (all files)", "[rpc][rpc_api]") {
             }
 
             SECTION("RPC IO test " + group_name + " | " + test_name) {  // NOLINT(*-inefficient-string-concatenation)
-                auto context = db::test_util::TestDatabaseContext();
+                TemporaryDirectory tmp_dir;
+                auto context = db::test_util::TestDatabaseContext(tmp_dir);
                 RpcApiTestBase<RequestHandlerForTest> test_base{context.mdbx_env()};
 
                 std::string line_out;
@@ -138,7 +140,8 @@ TEST_CASE("rpc_api io (all files)", "[rpc][rpc_api]") {
 
 TEST_CASE("rpc_api io (individual)", "[rpc][rpc_api][ignore]") {
     SetLogVerbosityGuard log_guard{log::Level::kNone};
-    auto context = db::test_util::TestDatabaseContext();
+    TemporaryDirectory tmp_dir;
+    auto context = db::test_util::TestDatabaseContext(tmp_dir);
     RpcApiTestBase<RequestHandlerForTest> test_base{context.mdbx_env()};
 
     SECTION("sample test") {


### PR DESCRIPTION
This is a consistency refactoring so that each test manages its own TemporaryDirectory. TemporaryDirectory manages its cleanup.