### PR TITLE
rpcdaemon: page_token management in Data API Range ops

### DIFF
--- a/silkworm/db/kv/api/endpoint/paginated_sequence.hpp
+++ b/silkworm/db/kv/api/endpoint/paginated_sequence.hpp
@@ -50,7 +50,7 @@ class PaginatedSequence {
         Page values;
         std::string next_page_token;
     };
-    using Paginator = std::function<Task<PageResult>(const std::string& page_token)>;
+    using Paginator = std::function<Task<PageResult>(std::string page_token)>;
 
     class Iterator {
       public:

--- a/silkworm/db/kv/api/endpoint/paginated_sequence.hpp
+++ b/silkworm/db/kv/api/endpoint/paginated_sequence.hpp
@@ -61,7 +61,7 @@ class PaginatedSequence {
         Task<std::optional<T>> next() {
             if (it_ == current_.values.cend()) {
                 if (!current_.next_page_token.empty()) {
-                    current_ = co_await next_page_provider_(current_.next_page_token);
+                    current_ = co_await next_page_provider_(std::move(current_.next_page_token));
                     it_ = current_.values.cbegin();
                 }
             }
@@ -138,7 +138,7 @@ class PaginatedSequencePair {
             if (key_it_ == current_.keys.cend()) {
                 SILKWORM_ASSERT(value_it_ == current_.values.cend());
                 if (!current_.next_page_token.empty()) {
-                    current_ = co_await next_page_provider_(current_.next_page_token);
+                    current_ = co_await next_page_provider_(std::move(current_.next_page_token));
                     key_it_ = current_.keys.cbegin();
                     value_it_ = current_.values.cbegin();
                 }

--- a/silkworm/db/kv/api/endpoint/paginated_sequence.hpp
+++ b/silkworm/db/kv/api/endpoint/paginated_sequence.hpp
@@ -50,7 +50,8 @@ class PaginatedSequence {
         Page values;
         std::string next_page_token;
     };
-    using Paginator = std::function<Task<PageResult>(std::string page_token)>;
+    using PageToken = std::string;
+    using Paginator = std::function<Task<PageResult>(PageToken)>;
 
     class Iterator {
       public:
@@ -121,7 +122,8 @@ class PaginatedSequencePair {
         VPage values;
         std::string next_page_token;
     };
-    using Paginator = std::function<Task<PageResult>(const std::string& page_token)>;
+    using PageToken = std::string;
+    using Paginator = std::function<Task<PageResult>(PageToken)>;
 
     class Iterator {
       public:

--- a/silkworm/db/kv/api/endpoint/paginated_sequence.hpp
+++ b/silkworm/db/kv/api/endpoint/paginated_sequence.hpp
@@ -121,7 +121,7 @@ class PaginatedSequencePair {
         VPage values;
         std::string next_page_token;
     };
-    using Paginator = std::function<Task<PageResult>(const std::string &page_token)>;
+    using Paginator = std::function<Task<PageResult>(const std::string& page_token)>;
 
     class Iterator {
       public:

--- a/silkworm/db/kv/api/endpoint/paginated_sequence_benchmark.cpp
+++ b/silkworm/db/kv/api/endpoint/paginated_sequence_benchmark.cpp
@@ -31,7 +31,7 @@ template <typename TSequence>
 TSequence make_paginated_sequence(const size_t page_size, const size_t n) {
     const size_t num_pages = n / page_size + (n % page_size ? 1 : 0);
     const size_t last_page_size = n % page_size ? n % page_size : page_size;
-    typename TSequence::Paginator paginator = [=](const std::string&) -> Task<typename TSequence::PageResult> {
+    typename TSequence::Paginator paginator = [=](std::string) -> Task<typename TSequence::PageResult> {
         static size_t count{0};
         const bool has_more = ++count < num_pages;
         const std::string token = has_more ? "next" : "";

--- a/silkworm/db/kv/api/endpoint/paginated_sequence_benchmark.cpp
+++ b/silkworm/db/kv/api/endpoint/paginated_sequence_benchmark.cpp
@@ -88,7 +88,7 @@ class PaginatedSequence2 {
         Page values;
         std::string next_page_token;
     };
-    using Paginator = std::function<Task<PageResult>(const std::string& page_token)>;
+    using Paginator = std::function<Task<PageResult>(std::string page_token)>;
 
     class Iterator {
       public:

--- a/silkworm/db/kv/api/endpoint/paginated_sequence_benchmark.cpp
+++ b/silkworm/db/kv/api/endpoint/paginated_sequence_benchmark.cpp
@@ -88,7 +88,8 @@ class PaginatedSequence2 {
         Page values;
         std::string next_page_token;
     };
-    using Paginator = std::function<Task<PageResult>(std::string page_token)>;
+    using PageToken = std::string;
+    using Paginator = std::function<Task<PageResult>(PageToken)>;
 
     class Iterator {
       public:
@@ -108,7 +109,7 @@ class PaginatedSequence2 {
         }
 
         Task<void> next_page() {
-            current_ = co_await next_page_provider_(current_.next_page_token);
+            current_ = co_await next_page_provider_(std::move(current_.next_page_token));
             it_ = current_.values.cbegin();
         }
 

--- a/silkworm/db/kv/api/endpoint/paginated_sequence_benchmark.cpp
+++ b/silkworm/db/kv/api/endpoint/paginated_sequence_benchmark.cpp
@@ -31,7 +31,7 @@ template <typename TSequence>
 TSequence make_paginated_sequence(const size_t page_size, const size_t n) {
     const size_t num_pages = n / page_size + (n % page_size ? 1 : 0);
     const size_t last_page_size = n % page_size ? n % page_size : page_size;
-    typename TSequence::Paginator paginator = [=](std::string) -> Task<typename TSequence::PageResult> {
+    typename TSequence::Paginator paginator = [=](typename TSequence::PageToken) -> Task<typename TSequence::PageResult> {
         static size_t count{0};
         const bool has_more = ++count < num_pages;
         const std::string token = has_more ? "next" : "";

--- a/silkworm/db/kv/api/endpoint/paginated_sequence_test.cpp
+++ b/silkworm/db/kv/api/endpoint/paginated_sequence_test.cpp
@@ -149,7 +149,7 @@ TEST_CASE_METHOD(PaginatedSequenceTest, "paginated_kv_sequence: non-empty sequen
             case 2:
                 co_return PageResultKV{PageK{kKey3, kKey4}, PageV{kValue3, kValue4}, "next"};
             case 3:
-                co_return PageResultKV{PageK{kKey5, kKey6}, PageV{kValue5, kValue6}, "next"};
+                co_return PageResultKV{PageK{kKey5, kKey6}, PageV{kValue5, kValue6}, ""};
             default:
                 throw std::logic_error{"unexpected call to paginator"};
         }

--- a/silkworm/db/kv/api/endpoint/paginated_sequence_test.cpp
+++ b/silkworm/db/kv/api/endpoint/paginated_sequence_test.cpp
@@ -67,7 +67,7 @@ struct TestPaginatorUint64 {
 TEST_CASE_METHOD(PaginatedSequenceTest, "paginated_uint64_sequence: empty sequence", "[db][kv][api][paginated_sequence]") {
     PageUint64List empty;
     TestPaginatorUint64 paginator{empty};
-    auto lambda = [&](const std::string&) mutable -> Task<PageResultUint64> {
+    auto lambda = [&](std::string) mutable -> Task<PageResultUint64> {
         co_return co_await paginator();
     };
 
@@ -103,7 +103,7 @@ TEST_CASE_METHOD(PaginatedSequenceTest, "paginated_uint64_sequence: non-empty se
 }
 
 TEST_CASE_METHOD(PaginatedSequenceTest, "paginated_uint64_sequence: error", "[db][kv][api][paginated_sequence]") {
-    PaginatorUint64 paginator = [](const std::string&) -> Task<PageResultUint64> {
+    PaginatorUint64 paginator = [](std::string) -> Task<PageResultUint64> {
         static int count{0};
         switch (++count) {
             case 1:
@@ -121,7 +121,7 @@ TEST_CASE_METHOD(PaginatedSequenceTest, "paginated_uint64_sequence: error", "[db
 }
 
 TEST_CASE_METHOD(PaginatedSequenceTest, "paginated_kv_sequence: empty sequence", "[db][kv][api][paginated_sequence]") {
-    PaginatorKV paginator = [](const std::string&) -> Task<PageResultKV> {
+    PaginatorKV paginator = [](std::string) -> Task<PageResultKV> {
         co_return PageResultKV{};  // has_more=false as default
     };
     PaginatedKV paginated{paginator};
@@ -141,7 +141,7 @@ static const Bytes kValue1{*from_hex("FF11")}, kValue2{*from_hex("FF22")}, kValu
 static const Bytes kValue4{*from_hex("FF44")}, kValue5{*from_hex("FF55")}, kValue6{*from_hex("FF66")};
 
 TEST_CASE_METHOD(PaginatedSequenceTest, "paginated_kv_sequence: non-empty sequence", "[db][kv][api][paginated_sequence]") {
-    PaginatorKV paginator = [](const std::string&) -> Task<PageResultKV> {
+    PaginatorKV paginator = [](std::string) -> Task<PageResultKV> {
         static int count{0};
         switch (++count) {
             case 1:
@@ -160,7 +160,7 @@ TEST_CASE_METHOD(PaginatedSequenceTest, "paginated_kv_sequence: non-empty sequen
 }
 
 TEST_CASE_METHOD(PaginatedSequenceTest, "paginated_kv_sequence: error", "[db][kv][api][paginated_sequence]") {
-    PaginatorKV paginator = [](const std::string&) -> Task<PageResultKV> {
+    PaginatorKV paginator = [](std::string) -> Task<PageResultKV> {
         static int count{0};
         switch (++count) {
             case 1:
@@ -190,10 +190,10 @@ TEST_CASE_METHOD(PaginatedSequenceTest, "set_intersection", "[db][kv][api][pagin
         SECTION("test vector: " + std::to_string(++i)) {
             const auto& [v1, v2] = v1_v2_pair;
             TestPaginatorUint64 paginator1{v1}, paginator2{v2};
-            auto lambda1 = [&](const std::string&) mutable -> Task<PageResultUint64> {
+            auto lambda1 = [&](std::string) mutable -> Task<PageResultUint64> {
                 co_return co_await paginator1();
             };
-            auto lambda2 = [&](const std::string&) mutable -> Task<PageResultUint64> {
+            auto lambda2 = [&](std::string) mutable -> Task<PageResultUint64> {
                 co_return co_await paginator2();
             };
 
@@ -221,10 +221,10 @@ TEST_CASE_METHOD(PaginatedSequenceTest, "set_union", "[db][kv][api][paginated_se
         SECTION("test vector: " + std::to_string(++i)) {
             const auto& [v1, v2] = v1_v2_pair;
             TestPaginatorUint64 paginator1{v1}, paginator2{v2};
-            auto lambda1 = [&](const std::string&) mutable -> Task<PageResultUint64> {
+            auto lambda1 = [&](std::string) mutable -> Task<PageResultUint64> {
                 co_return co_await paginator1();
             };
-            auto lambda2 = [&](const std::string&) mutable -> Task<PageResultUint64> {
+            auto lambda2 = [&](std::string) mutable -> Task<PageResultUint64> {
                 co_return co_await paginator2();
             };
 

--- a/silkworm/db/kv/api/local_transaction.cpp
+++ b/silkworm/db/kv/api/local_transaction.cpp
@@ -89,7 +89,7 @@ Task<HistoryPointResult> LocalTransaction::history_seek(HistoryPointQuery&& /*qu
 // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
 Task<PaginatedTimestamps> LocalTransaction::index_range(IndexRangeQuery&& /*query*/) {
     // TODO(canepat) implement using E3-like aggregator abstraction [tx_id_ must be changed]
-    auto paginator = [](std::string) mutable -> Task<api::PaginatedTimestamps::PageResult> {
+    auto paginator = [](api::PaginatedTimestamps::PageToken) mutable -> Task<api::PaginatedTimestamps::PageResult> {
         co_return api::PaginatedTimestamps::PageResult{};
     };
     co_return api::PaginatedTimestamps{std::move(paginator)};
@@ -98,7 +98,7 @@ Task<PaginatedTimestamps> LocalTransaction::index_range(IndexRangeQuery&& /*quer
 // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
 Task<PaginatedKeysValues> LocalTransaction::history_range(HistoryRangeQuery&& /*query*/) {
     // TODO(canepat) implement using E3-like aggregator abstraction [tx_id_ must be changed]
-    auto paginator = [](std::string) mutable -> Task<api::PaginatedKeysValues::PageResult> {
+    auto paginator = [](api::PaginatedKeysValues::PageToken) mutable -> Task<api::PaginatedKeysValues::PageResult> {
         co_return api::PaginatedKeysValues::PageResult{};
     };
     co_return api::PaginatedKeysValues{std::move(paginator)};
@@ -107,7 +107,7 @@ Task<PaginatedKeysValues> LocalTransaction::history_range(HistoryRangeQuery&& /*
 // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
 Task<PaginatedKeysValues> LocalTransaction::domain_range(DomainRangeQuery&& /*query*/) {
     // TODO(canepat) implement using E3-like aggregator abstraction [tx_id_ must be changed]
-    auto paginator = [](std::string) mutable -> Task<api::PaginatedKeysValues::PageResult> {
+    auto paginator = [](api::PaginatedKeysValues::PageToken) mutable -> Task<api::PaginatedKeysValues::PageResult> {
         co_return api::PaginatedKeysValues::PageResult{};
     };
     co_return api::PaginatedKeysValues{std::move(paginator)};

--- a/silkworm/db/kv/api/local_transaction.cpp
+++ b/silkworm/db/kv/api/local_transaction.cpp
@@ -89,7 +89,7 @@ Task<HistoryPointResult> LocalTransaction::history_seek(HistoryPointQuery&& /*qu
 // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
 Task<PaginatedTimestamps> LocalTransaction::index_range(IndexRangeQuery&& /*query*/) {
     // TODO(canepat) implement using E3-like aggregator abstraction [tx_id_ must be changed]
-    auto paginator = []() mutable -> Task<api::PaginatedTimestamps::PageResult> {
+    auto paginator = [](const std::string&) mutable -> Task<api::PaginatedTimestamps::PageResult> {
         co_return api::PaginatedTimestamps::PageResult{};
     };
     co_return api::PaginatedTimestamps{std::move(paginator)};
@@ -98,7 +98,7 @@ Task<PaginatedTimestamps> LocalTransaction::index_range(IndexRangeQuery&& /*quer
 // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
 Task<PaginatedKeysValues> LocalTransaction::history_range(HistoryRangeQuery&& /*query*/) {
     // TODO(canepat) implement using E3-like aggregator abstraction [tx_id_ must be changed]
-    auto paginator = []() mutable -> Task<api::PaginatedKeysValues::PageResult> {
+    auto paginator = [](const std::string&) mutable -> Task<api::PaginatedKeysValues::PageResult> {
         co_return api::PaginatedKeysValues::PageResult{};
     };
     co_return api::PaginatedKeysValues{std::move(paginator)};
@@ -107,7 +107,7 @@ Task<PaginatedKeysValues> LocalTransaction::history_range(HistoryRangeQuery&& /*
 // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
 Task<PaginatedKeysValues> LocalTransaction::domain_range(DomainRangeQuery&& /*query*/) {
     // TODO(canepat) implement using E3-like aggregator abstraction [tx_id_ must be changed]
-    auto paginator = []() mutable -> Task<api::PaginatedKeysValues::PageResult> {
+    auto paginator = [](const std::string&) mutable -> Task<api::PaginatedKeysValues::PageResult> {
         co_return api::PaginatedKeysValues::PageResult{};
     };
     co_return api::PaginatedKeysValues{std::move(paginator)};

--- a/silkworm/db/kv/api/local_transaction.cpp
+++ b/silkworm/db/kv/api/local_transaction.cpp
@@ -89,7 +89,7 @@ Task<HistoryPointResult> LocalTransaction::history_seek(HistoryPointQuery&& /*qu
 // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
 Task<PaginatedTimestamps> LocalTransaction::index_range(IndexRangeQuery&& /*query*/) {
     // TODO(canepat) implement using E3-like aggregator abstraction [tx_id_ must be changed]
-    auto paginator = [](const std::string&) mutable -> Task<api::PaginatedTimestamps::PageResult> {
+    auto paginator = [](std::string) mutable -> Task<api::PaginatedTimestamps::PageResult> {
         co_return api::PaginatedTimestamps::PageResult{};
     };
     co_return api::PaginatedTimestamps{std::move(paginator)};
@@ -98,7 +98,7 @@ Task<PaginatedTimestamps> LocalTransaction::index_range(IndexRangeQuery&& /*quer
 // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
 Task<PaginatedKeysValues> LocalTransaction::history_range(HistoryRangeQuery&& /*query*/) {
     // TODO(canepat) implement using E3-like aggregator abstraction [tx_id_ must be changed]
-    auto paginator = [](const std::string&) mutable -> Task<api::PaginatedKeysValues::PageResult> {
+    auto paginator = [](std::string) mutable -> Task<api::PaginatedKeysValues::PageResult> {
         co_return api::PaginatedKeysValues::PageResult{};
     };
     co_return api::PaginatedKeysValues{std::move(paginator)};
@@ -107,7 +107,7 @@ Task<PaginatedKeysValues> LocalTransaction::history_range(HistoryRangeQuery&& /*
 // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
 Task<PaginatedKeysValues> LocalTransaction::domain_range(DomainRangeQuery&& /*query*/) {
     // TODO(canepat) implement using E3-like aggregator abstraction [tx_id_ must be changed]
-    auto paginator = [](const std::string&) mutable -> Task<api::PaginatedKeysValues::PageResult> {
+    auto paginator = [](std::string) mutable -> Task<api::PaginatedKeysValues::PageResult> {
         co_return api::PaginatedKeysValues::PageResult{};
     };
     co_return api::PaginatedKeysValues{std::move(paginator)};

--- a/silkworm/db/kv/grpc/client/remote_transaction.cpp
+++ b/silkworm/db/kv/grpc/client/remote_transaction.cpp
@@ -149,7 +149,7 @@ Task<api::HistoryPointResult> RemoteTransaction::history_seek(api::HistoryPointQ
 }
 
 Task<api::PaginatedTimestamps> RemoteTransaction::index_range(api::IndexRangeQuery&& query) {
-    auto paginator = [&, query = std::move(query)](const std::string& page_token) mutable -> Task<api::PaginatedTimestamps::PageResult> {
+    auto paginator = [&, query = std::move(query)](std::string page_token) mutable -> Task<api::PaginatedTimestamps::PageResult> {
         query.tx_id = tx_id_;
         query.page_token = page_token;
         auto request = index_range_request_from_query(query);
@@ -167,7 +167,7 @@ Task<api::PaginatedTimestamps> RemoteTransaction::index_range(api::IndexRangeQue
 }
 
 Task<api::PaginatedKeysValues> RemoteTransaction::history_range(api::HistoryRangeQuery&& query) {
-    auto paginator = [&, query = std::move(query)](const std::string& page_token) mutable -> Task<api::PaginatedKeysValues::PageResult> {
+    auto paginator = [&, query = std::move(query)](std::string page_token) mutable -> Task<api::PaginatedKeysValues::PageResult> {
         query.tx_id = tx_id_;
         query.page_token = page_token;
         auto request = history_range_request_from_query(query);
@@ -185,7 +185,7 @@ Task<api::PaginatedKeysValues> RemoteTransaction::history_range(api::HistoryRang
 }
 
 Task<api::PaginatedKeysValues> RemoteTransaction::domain_range(api::DomainRangeQuery&& query) {
-    auto paginator = [&, query = std::move(query)](const std::string& page_token) mutable -> Task<api::PaginatedKeysValues::PageResult> {
+    auto paginator = [&, query = std::move(query)](std::string page_token) mutable -> Task<api::PaginatedKeysValues::PageResult> {
         query.tx_id = tx_id_;
         query.page_token = page_token;
         auto request = domain_range_request_from_query(query);

--- a/silkworm/db/kv/grpc/client/remote_transaction.cpp
+++ b/silkworm/db/kv/grpc/client/remote_transaction.cpp
@@ -149,7 +149,7 @@ Task<api::HistoryPointResult> RemoteTransaction::history_seek(api::HistoryPointQ
 }
 
 Task<api::PaginatedTimestamps> RemoteTransaction::index_range(api::IndexRangeQuery&& query) {
-    auto paginator = [&, query = std::move(query)](std::string page_token) mutable -> Task<api::PaginatedTimestamps::PageResult> {
+    auto paginator = [&, query = std::move(query)](api::PaginatedTimestamps::PageToken page_token) mutable -> Task<api::PaginatedTimestamps::PageResult> {
         query.tx_id = tx_id_;
         query.page_token = std::move(page_token);
         auto request = index_range_request_from_query(query);
@@ -167,7 +167,7 @@ Task<api::PaginatedTimestamps> RemoteTransaction::index_range(api::IndexRangeQue
 }
 
 Task<api::PaginatedKeysValues> RemoteTransaction::history_range(api::HistoryRangeQuery&& query) {
-    auto paginator = [&, query = std::move(query)](std::string page_token) mutable -> Task<api::PaginatedKeysValues::PageResult> {
+    auto paginator = [&, query = std::move(query)](api::PaginatedKeysValues::PageToken page_token) mutable -> Task<api::PaginatedKeysValues::PageResult> {
         query.tx_id = tx_id_;
         query.page_token = std::move(page_token);
         auto request = history_range_request_from_query(query);
@@ -185,7 +185,7 @@ Task<api::PaginatedKeysValues> RemoteTransaction::history_range(api::HistoryRang
 }
 
 Task<api::PaginatedKeysValues> RemoteTransaction::domain_range(api::DomainRangeQuery&& query) {
-    auto paginator = [&, query = std::move(query)](std::string page_token) mutable -> Task<api::PaginatedKeysValues::PageResult> {
+    auto paginator = [&, query = std::move(query)](api::PaginatedKeysValues::PageToken page_token) mutable -> Task<api::PaginatedKeysValues::PageResult> {
         query.tx_id = tx_id_;
         query.page_token = std::move(page_token);
         auto request = domain_range_request_from_query(query);

--- a/silkworm/db/kv/grpc/client/remote_transaction.cpp
+++ b/silkworm/db/kv/grpc/client/remote_transaction.cpp
@@ -150,15 +150,14 @@ Task<api::HistoryPointResult> RemoteTransaction::history_seek(api::HistoryPointQ
 
 Task<api::PaginatedTimestamps> RemoteTransaction::index_range(api::IndexRangeQuery&& query) {
     auto paginator = [&, query = std::move(query)]() mutable -> Task<api::PaginatedTimestamps::PageResult> {
-        static std::string page_token{query.page_token};
         query.tx_id = tx_id_;
-        query.page_token = page_token;
+        query.page_token = page_token_;
         auto request = index_range_request_from_query(query);
         try {
             const auto reply = co_await rpc::unary_rpc(&Stub::AsyncIndexRange, stub_, std::move(request), grpc_context_);
             auto result = index_range_result_from_response(reply);
-            page_token = std::move(result.next_page_token);
-            co_return api::PaginatedTimestamps::PageResult{std::move(result.timestamps), !page_token.empty()};
+            page_token_ = std::move(result.next_page_token);
+            co_return api::PaginatedTimestamps::PageResult{std::move(result.timestamps), !page_token_.empty()};
         } catch (rpc::GrpcStatusError& gse) {
             SILK_WARN << "KV::IndexRange RPC failed status=" << gse.status();
             throw boost::system::system_error{rpc::to_system_code(gse.status().error_code())};
@@ -169,15 +168,14 @@ Task<api::PaginatedTimestamps> RemoteTransaction::index_range(api::IndexRangeQue
 
 Task<api::PaginatedKeysValues> RemoteTransaction::history_range(api::HistoryRangeQuery&& query) {
     auto paginator = [&, query = std::move(query)]() mutable -> Task<api::PaginatedKeysValues::PageResult> {
-        static std::string page_token{query.page_token};
         query.tx_id = tx_id_;
-        query.page_token = page_token;
+        query.page_token = page_token_;
         auto request = history_range_request_from_query(query);
         try {
             const auto reply = co_await rpc::unary_rpc(&Stub::AsyncHistoryRange, stub_, std::move(request), grpc_context_);
             auto result = history_range_result_from_response(reply);
-            page_token = std::move(result.next_page_token);
-            co_return api::PaginatedKeysValues::PageResult{std::move(result.keys), std::move(result.values), !page_token.empty()};
+            page_token_ = std::move(result.next_page_token);
+            co_return api::PaginatedKeysValues::PageResult{std::move(result.keys), std::move(result.values), !page_token_.empty()};
         } catch (rpc::GrpcStatusError& gse) {
             SILK_WARN << "KV::HistoryRange RPC failed status=" << gse.status();
             throw boost::system::system_error{rpc::to_system_code(gse.status().error_code())};
@@ -188,15 +186,14 @@ Task<api::PaginatedKeysValues> RemoteTransaction::history_range(api::HistoryRang
 
 Task<api::PaginatedKeysValues> RemoteTransaction::domain_range(api::DomainRangeQuery&& query) {
     auto paginator = [&, query = std::move(query)]() mutable -> Task<api::PaginatedKeysValues::PageResult> {
-        static std::string page_token{query.page_token};
         query.tx_id = tx_id_;
-        query.page_token = page_token;
+        query.page_token = page_token_;
         auto request = domain_range_request_from_query(query);
         try {
             const auto reply = co_await rpc::unary_rpc(&Stub::AsyncDomainRange, stub_, std::move(request), grpc_context_);
             auto result = history_range_result_from_response(reply);
-            page_token = std::move(result.next_page_token);
-            co_return api::PaginatedKeysValues::PageResult{std::move(result.keys), std::move(result.values), !page_token.empty()};
+            page_token_ = std::move(result.next_page_token);
+            co_return api::PaginatedKeysValues::PageResult{std::move(result.keys), std::move(result.values), !page_token_.empty()};
         } catch (rpc::GrpcStatusError& gse) {
             SILK_WARN << "KV::DomainRange RPC failed status=" << gse.status();
             throw boost::system::system_error{rpc::to_system_code(gse.status().error_code())};

--- a/silkworm/db/kv/grpc/client/remote_transaction.cpp
+++ b/silkworm/db/kv/grpc/client/remote_transaction.cpp
@@ -149,15 +149,15 @@ Task<api::HistoryPointResult> RemoteTransaction::history_seek(api::HistoryPointQ
 }
 
 Task<api::PaginatedTimestamps> RemoteTransaction::index_range(api::IndexRangeQuery&& query) {
-    auto paginator = [&, query = std::move(query)]() mutable -> Task<api::PaginatedTimestamps::PageResult> {
+    auto paginator = [&, query = std::move(query)](const std::string& page_token) mutable -> Task<api::PaginatedTimestamps::PageResult> {
         query.tx_id = tx_id_;
-        query.page_token = page_token_;
+        query.page_token = page_token;
         auto request = index_range_request_from_query(query);
         try {
             const auto reply = co_await rpc::unary_rpc(&Stub::AsyncIndexRange, stub_, std::move(request), grpc_context_);
             auto result = index_range_result_from_response(reply);
-            page_token_ = std::move(result.next_page_token);
-            co_return api::PaginatedTimestamps::PageResult{std::move(result.timestamps), !page_token_.empty()};
+
+            co_return api::PaginatedTimestamps::PageResult{std::move(result.timestamps), std::move(result.next_page_token)};
         } catch (rpc::GrpcStatusError& gse) {
             SILK_WARN << "KV::IndexRange RPC failed status=" << gse.status();
             throw boost::system::system_error{rpc::to_system_code(gse.status().error_code())};
@@ -167,15 +167,15 @@ Task<api::PaginatedTimestamps> RemoteTransaction::index_range(api::IndexRangeQue
 }
 
 Task<api::PaginatedKeysValues> RemoteTransaction::history_range(api::HistoryRangeQuery&& query) {
-    auto paginator = [&, query = std::move(query)]() mutable -> Task<api::PaginatedKeysValues::PageResult> {
+    auto paginator = [&, query = std::move(query)](const std::string& page_token) mutable -> Task<api::PaginatedKeysValues::PageResult> {
         query.tx_id = tx_id_;
-        query.page_token = page_token_;
+        query.page_token = page_token;
         auto request = history_range_request_from_query(query);
         try {
             const auto reply = co_await rpc::unary_rpc(&Stub::AsyncHistoryRange, stub_, std::move(request), grpc_context_);
             auto result = history_range_result_from_response(reply);
-            page_token_ = std::move(result.next_page_token);
-            co_return api::PaginatedKeysValues::PageResult{std::move(result.keys), std::move(result.values), !page_token_.empty()};
+
+            co_return api::PaginatedKeysValues::PageResult{std::move(result.keys), std::move(result.values), std::move(result.next_page_token)};
         } catch (rpc::GrpcStatusError& gse) {
             SILK_WARN << "KV::HistoryRange RPC failed status=" << gse.status();
             throw boost::system::system_error{rpc::to_system_code(gse.status().error_code())};
@@ -185,15 +185,15 @@ Task<api::PaginatedKeysValues> RemoteTransaction::history_range(api::HistoryRang
 }
 
 Task<api::PaginatedKeysValues> RemoteTransaction::domain_range(api::DomainRangeQuery&& query) {
-    auto paginator = [&, query = std::move(query)]() mutable -> Task<api::PaginatedKeysValues::PageResult> {
+    auto paginator = [&, query = std::move(query)](const std::string& page_token) mutable -> Task<api::PaginatedKeysValues::PageResult> {
         query.tx_id = tx_id_;
-        query.page_token = page_token_;
+        query.page_token = page_token;
         auto request = domain_range_request_from_query(query);
         try {
             const auto reply = co_await rpc::unary_rpc(&Stub::AsyncDomainRange, stub_, std::move(request), grpc_context_);
             auto result = history_range_result_from_response(reply);
-            page_token_ = std::move(result.next_page_token);
-            co_return api::PaginatedKeysValues::PageResult{std::move(result.keys), std::move(result.values), !page_token_.empty()};
+
+            co_return api::PaginatedKeysValues::PageResult{std::move(result.keys), std::move(result.values), std::move(result.next_page_token)};
         } catch (rpc::GrpcStatusError& gse) {
             SILK_WARN << "KV::DomainRange RPC failed status=" << gse.status();
             throw boost::system::system_error{rpc::to_system_code(gse.status().error_code())};

--- a/silkworm/db/kv/grpc/client/remote_transaction.cpp
+++ b/silkworm/db/kv/grpc/client/remote_transaction.cpp
@@ -151,7 +151,7 @@ Task<api::HistoryPointResult> RemoteTransaction::history_seek(api::HistoryPointQ
 Task<api::PaginatedTimestamps> RemoteTransaction::index_range(api::IndexRangeQuery&& query) {
     auto paginator = [&, query = std::move(query)](std::string page_token) mutable -> Task<api::PaginatedTimestamps::PageResult> {
         query.tx_id = tx_id_;
-        query.page_token = page_token;
+        query.page_token = std::move(page_token);
         auto request = index_range_request_from_query(query);
         try {
             const auto reply = co_await rpc::unary_rpc(&Stub::AsyncIndexRange, stub_, std::move(request), grpc_context_);
@@ -169,7 +169,7 @@ Task<api::PaginatedTimestamps> RemoteTransaction::index_range(api::IndexRangeQue
 Task<api::PaginatedKeysValues> RemoteTransaction::history_range(api::HistoryRangeQuery&& query) {
     auto paginator = [&, query = std::move(query)](std::string page_token) mutable -> Task<api::PaginatedKeysValues::PageResult> {
         query.tx_id = tx_id_;
-        query.page_token = page_token;
+        query.page_token = std::move(page_token);
         auto request = history_range_request_from_query(query);
         try {
             const auto reply = co_await rpc::unary_rpc(&Stub::AsyncHistoryRange, stub_, std::move(request), grpc_context_);
@@ -187,7 +187,7 @@ Task<api::PaginatedKeysValues> RemoteTransaction::history_range(api::HistoryRang
 Task<api::PaginatedKeysValues> RemoteTransaction::domain_range(api::DomainRangeQuery&& query) {
     auto paginator = [&, query = std::move(query)](std::string page_token) mutable -> Task<api::PaginatedKeysValues::PageResult> {
         query.tx_id = tx_id_;
-        query.page_token = page_token;
+        query.page_token = std::move(page_token);
         auto request = domain_range_request_from_query(query);
         try {
             const auto reply = co_await rpc::unary_rpc(&Stub::AsyncDomainRange, stub_, std::move(request), grpc_context_);

--- a/silkworm/db/kv/grpc/client/remote_transaction.hpp
+++ b/silkworm/db/kv/grpc/client/remote_transaction.hpp
@@ -90,7 +90,6 @@ class RemoteTransaction : public api::BaseTransaction {
     //! Flag indicating if agrpc::ClientRPC<>::start has been called on Tx RPC or not. This is necessary to avoid
     //! a crash in agrpc if you call agrpc::ClientRPC<>::finish before calling agrpc::ClientRPC<>::start
     bool start_called_{false};
-    std::string page_token_;
     uint64_t tx_id_{0};
     uint64_t view_id_{0};
 };

--- a/silkworm/db/kv/grpc/client/remote_transaction.hpp
+++ b/silkworm/db/kv/grpc/client/remote_transaction.hpp
@@ -90,6 +90,7 @@ class RemoteTransaction : public api::BaseTransaction {
     //! Flag indicating if agrpc::ClientRPC<>::start has been called on Tx RPC or not. This is necessary to avoid
     //! a crash in agrpc if you call agrpc::ClientRPC<>::finish before calling agrpc::ClientRPC<>::start
     bool start_called_{false};
+    std::string page_token_;
     uint64_t tx_id_{0};
     uint64_t view_id_{0};
 };

--- a/silkworm/rpc/test_util/dummy_transaction.hpp
+++ b/silkworm/rpc/test_util/dummy_transaction.hpp
@@ -33,7 +33,7 @@ namespace silkworm::rpc::test {
 
 template <typename Paginated>
 inline Paginated empty_paginated_sequence() {
-    auto paginator = [](std::string) -> Task<typename Paginated::PageResult> {
+    auto paginator = [](typename Paginated::PageToken) -> Task<typename Paginated::PageResult> {
         co_return typename Paginated::PageResult{};
     };
     return Paginated{paginator};

--- a/silkworm/rpc/test_util/dummy_transaction.hpp
+++ b/silkworm/rpc/test_util/dummy_transaction.hpp
@@ -33,7 +33,7 @@ namespace silkworm::rpc::test {
 
 template <typename Paginated>
 inline Paginated empty_paginated_sequence() {
-    auto paginator = []() -> Task<typename Paginated::PageResult> {
+    auto paginator = [](const std::string&) -> Task<typename Paginated::PageResult> {
         co_return typename Paginated::PageResult{};
     };
     return Paginated{paginator};

--- a/silkworm/rpc/test_util/dummy_transaction.hpp
+++ b/silkworm/rpc/test_util/dummy_transaction.hpp
@@ -33,7 +33,7 @@ namespace silkworm::rpc::test {
 
 template <typename Paginated>
 inline Paginated empty_paginated_sequence() {
-    auto paginator = [](const std::string&) -> Task<typename Paginated::PageResult> {
+    auto paginator = [](std::string) -> Task<typename Paginated::PageResult> {
         co_return typename Paginated::PageResult{};
     };
     return Paginated{paginator};


### PR DESCRIPTION
Fix `page_token` management in Range queries: add `page_token` parameter to `PaginatedSequence::Paginator` and `PaginatedSequence::PageResult`. 
