### PR TITLE
integration: update rpc-tests to v1.12.0

### DIFF
--- a/.github/workflows/rpc-integration-tests.yml
+++ b/.github/workflows/rpc-integration-tests.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout RPC Tests Repository & Install Requirements
         run: |
           rm -rf ${{runner.workspace}}/rpc-tests
-          git -c advice.detachedHead=false clone --depth 1 --branch v1.11.0 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
+          git -c advice.detachedHead=false clone --depth 1 --branch v1.12.0 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
           cd ${{runner.workspace}}/rpc-tests
           pip3 install -r requirements.txt
 

--- a/.github/workflows/run_integration_tests.sh
+++ b/.github/workflows/run_integration_tests.sh
@@ -34,6 +34,12 @@ debug_traceBlockByHash/test_09,\
 debug_traceBlockByHash/test_10,\
 debug_traceBlockByHash/test_11,\
 debug_traceBlockByHash/test_12,\
+debug_traceBlockByNumber/test_05,\
+debug_traceBlockByNumber/test_08,\
+debug_traceBlockByNumber/test_09,\
+debug_traceBlockByNumber/test_10,\
+debug_traceBlockByNumber/test_11,\
+debug_traceBlockByNumber/test_12,\
 debug_traceCall/test_02.json,\
 debug_traceTransaction/test_25.json,\
 debug_traceTransaction/test_36.json,\


### PR DESCRIPTION
Moved to integration tests v1.12 skipping debug_traceBlockByNumber not working ones