### PR TITLE
infra: global log level for tests, improve make test

### DIFF
--- a/cmake/run_smoke_tests.cmake
+++ b/cmake/run_smoke_tests.cmake
@@ -26,17 +26,29 @@ endif()
 file(
   GLOB_RECURSE COMMANDS
   LIST_DIRECTORIES false
-  "${SILKWORM_BUILD_DIR}/*_test${CMAKE_EXECUTABLE_SUFFIX}"
-  "${SILKWORM_BUILD_DIR}/*db_toolbox${CMAKE_EXECUTABLE_SUFFIX}"
-  "${SILKWORM_BUILD_DIR}/*rpcdaemon${CMAKE_EXECUTABLE_SUFFIX}"
-  "${SILKWORM_BUILD_DIR}/*sentry${CMAKE_EXECUTABLE_SUFFIX}"
-  "${SILKWORM_BUILD_DIR}/*silkworm${CMAKE_EXECUTABLE_SUFFIX}"
+  "${SILKWORM_BUILD_DIR}/cmd/*${CMAKE_EXECUTABLE_SUFFIX}"
 )
-list(FILTER COMMANDS EXCLUDE REGEX "sentry_client_test${CMAKE_EXECUTABLE_SUFFIX}\$")
+if(NOT CMAKE_EXECUTABLE_SUFFIX)
+  list(FILTER COMMANDS EXCLUDE REGEX "\\.")
+endif()
+list(FILTER COMMANDS EXCLUDE REGEX "core_test") # this is a unit test
+
+# TODO: fix check_log_indices --help
+list(FILTER COMMANDS EXCLUDE REGEX "check_log_indices")
+# TODO: fix grpc_toolbox --help
+list(FILTER COMMANDS EXCLUDE REGEX "grpc_toolbox")
+# TODO: fix sentry_client_test --help
+list(FILTER COMMANDS EXCLUDE REGEX "sentry_client_test")
+
+message("")
+message("===================")
+message("Running smoke tests")
+message("===================")
+message("")
 
 foreach(COMMAND IN LISTS COMMANDS)
   file(RELATIVE_PATH COMMAND_REL_PATH "${SILKWORM_BUILD_DIR}" "${COMMAND}")
-  message("Running ${COMMAND_REL_PATH}...")
+  message("Running ${COMMAND_REL_PATH} --help ...")
 
-  execute_process(COMMAND "${COMMAND}" "--help" COMMAND_ERROR_IS_FATAL ANY)
+  execute_process(COMMAND "${COMMAND}" "--help" OUTPUT_QUIET COMMAND_ERROR_IS_FATAL ANY)
 endforeach()

--- a/cmake/run_smoke_tests.cmake
+++ b/cmake/run_smoke_tests.cmake
@@ -32,6 +32,7 @@ if(NOT CMAKE_EXECUTABLE_SUFFIX)
   list(FILTER COMMANDS EXCLUDE REGEX "\\.")
 endif()
 list(FILTER COMMANDS EXCLUDE REGEX "core_test") # this is a unit test
+list(FILTER COMMANDS EXCLUDE REGEX "Makefile")
 
 # TODO: fix check_log_indices --help
 list(FILTER COMMANDS EXCLUDE REGEX "check_log_indices")

--- a/cmake/run_unit_tests.cmake
+++ b/cmake/run_unit_tests.cmake
@@ -33,6 +33,16 @@ list(FILTER TEST_COMMANDS EXCLUDE REGEX "backend_kv_test${CMAKE_EXECUTABLE_SUFFI
 list(FILTER TEST_COMMANDS EXCLUDE REGEX "benchmark_test${CMAKE_EXECUTABLE_SUFFIX}\$")
 list(FILTER TEST_COMMANDS EXCLUDE REGEX "sentry_client_test${CMAKE_EXECUTABLE_SUFFIX}\$")
 
+message("")
+message("==================")
+message("Running unit tests")
+message("==================")
+message("")
+
+string(TIMESTAMP TIME "%s")
+message("For all tests --rng-seed=${TIME}")
+message("")
+
 foreach(TEST_COMMAND IN LISTS TEST_COMMANDS)
   file(RELATIVE_PATH TEST_COMMAND_REL_PATH "${SILKWORM_BUILD_DIR}" "${TEST_COMMAND}")
   message("Running ${TEST_COMMAND_REL_PATH}...")
@@ -42,5 +52,8 @@ foreach(TEST_COMMAND IN LISTS TEST_COMMANDS)
     set(ENV{LLVM_PROFILE_FILE} "${TEST_COMMAND_NAME}.profraw")
   endif()
 
-  execute_process(COMMAND "${TEST_COMMAND}" "~[ignore]" COMMAND_ERROR_IS_FATAL ANY)
+  execute_process(COMMAND "${TEST_COMMAND}" "--rng-seed=${TIME}" "--min-duration=2" RESULT_VARIABLE EXIT_CODE)
+  if(NOT (EXIT_CODE EQUAL 0))
+    message(FATAL_ERROR "${TEST_COMMAND_REL_PATH} has failed: ${EXIT_CODE}")
+  endif()
 endforeach()

--- a/cmake/run_unit_tests.sh
+++ b/cmake/run_unit_tests.sh
@@ -7,4 +7,5 @@ fi
 
 script_dir=`dirname "$0"`
 
-cmake "-DSILKWORM_BUILD_DIR=$1" "-DSILKWORM_CLANG_COVERAGE=$2" -P "$script_dir/run_unit_tests.cmake"
+cmake "-DSILKWORM_BUILD_DIR=$1" "-DSILKWORM_CLANG_COVERAGE=$2" -P "$script_dir/run_unit_tests.cmake" \
+	| grep -Ev '^(Randomness|RNG seed|============================)'

--- a/cmd/common/common.cpp
+++ b/cmd/common/common.cpp
@@ -54,10 +54,9 @@ void add_logging_options(CLI::App& cli, log::Settings& log_settings) {
     };
     auto& log_opts = *cli.add_option_group("Log", "Logging options");
     log_opts.add_option("--log.verbosity", log_settings.log_verbosity, "Sets log verbosity")
-        ->capture_default_str()
         ->check(CLI::Range(log::Level::kCritical, log::Level::kTrace))
         ->transform(CLI::Transformer(level_mapping, CLI::ignore_case))
-        ->default_val(log_settings.log_verbosity);
+        ->default_val(log::Level::kInfo);
     log_opts.add_flag("--log.stdout", log_settings.log_std_out, "Outputs to std::out instead of std::err");
     log_opts.add_flag("--log.nocolor", log_settings.log_nocolor, "Disable colors on log lines");
     log_opts.add_flag("--log.utc", log_settings.log_utc, "Prints log timings in UTC");

--- a/silkworm/capi/silkworm_test.cpp
+++ b/silkworm/capi/silkworm_test.cpp
@@ -1057,8 +1057,6 @@ static SilkwormForkValidatorSettings make_fork_validator_settings_for_test() {
 static const SilkwormForkValidatorSettings kValidForkValidatorSettings{make_fork_validator_settings_for_test()};
 
 TEST_CASE_METHOD(CApiTest, "CAPI silkworm_fork_validator", "[silkworm][capi]") {
-    silkworm::test_util::SetLogVerbosityGuard log_guard(log::Level::kNone);
-
     // Use Silkworm as a library with silkworm_init/silkworm_fini automated by RAII
     SilkwormLibrary silkworm_lib{env_path()};
 

--- a/silkworm/db/access_layer_test.cpp
+++ b/silkworm/db/access_layer_test.cpp
@@ -114,10 +114,7 @@ static BlockBody block_body_17035047() {
 
 namespace silkworm::db {
 
-using silkworm::test_util::SetLogVerbosityGuard;
-
 TEST_CASE("Methods cursor_for_each/cursor_for_count", "[db][access_layer]") {
-    SetLogVerbosityGuard log_guard{log::Level::kNone};
     test_util::TempChainData context;
     auto& txn{context.rw_txn()};
 
@@ -154,7 +151,6 @@ TEST_CASE("VersionBase primitives", "[db][access_layer]") {
 }
 
 TEST_CASE("Sequences", "[db][access_layer]") {
-    SetLogVerbosityGuard log_guard{log::Level::kNone};
     test_util::TempChainData context;
     auto& txn{context.rw_txn()};
 
@@ -201,7 +197,6 @@ TEST_CASE("Sequences", "[db][access_layer]") {
 }
 
 TEST_CASE("Schema Version", "[db][access_layer]") {
-    SetLogVerbosityGuard log_guard{log::Level::kNone};
     test_util::TempChainData context(/*with_create_tables=*/false);
 
     SECTION("Read/Write") {
@@ -239,7 +234,6 @@ TEST_CASE("Schema Version", "[db][access_layer]") {
 }
 
 TEST_CASE("Storage and Prune Modes", "[db][access_layer]") {
-    SetLogVerbosityGuard log_guard{log::Level::kNone};
     test_util::TempChainData context;
     auto& txn{context.txn()};
 
@@ -366,7 +360,6 @@ TEST_CASE("Storage and Prune Modes", "[db][access_layer]") {
 }
 
 TEST_CASE("Stages", "[db][access_layer]") {
-    SetLogVerbosityGuard log_guard{log::Level::kNone};
     test_util::TempChainData context;
     auto& txn{context.rw_txn()};
 
@@ -410,7 +403,6 @@ TEST_CASE("Difficulty", "[db][access_layer]") {
 }
 
 TEST_CASE("Headers and bodies", "[db][access_layer]") {
-    SetLogVerbosityGuard log_guard{log::Level::kNone};
     test_util::TempChainData context;
     auto& txn{context.rw_txn()};
 
@@ -528,7 +520,6 @@ TEST_CASE("Headers and bodies", "[db][access_layer]") {
 }
 
 TEST_CASE("Storage", "[db][access_layer]") {
-    SetLogVerbosityGuard log_guard{log::Level::kNone};
     test_util::TempChainData context;
     auto& txn{context.rw_txn()};
 
@@ -651,7 +642,6 @@ TEST_CASE("Account changes", "[db][access_layer]") {
 }
 
 TEST_CASE("Storage changes", "[db][access_layer]") {
-    SetLogVerbosityGuard log_guard{log::Level::kNone};
     test_util::TempChainData context;
     auto& txn{context.rw_txn()};
 
@@ -731,7 +721,6 @@ TEST_CASE("Storage changes", "[db][access_layer]") {
 }
 
 TEST_CASE("Chain config", "[db][access_layer]") {
-    SetLogVerbosityGuard log_guard{log::Level::kNone};
     test_util::TempChainData context;
     auto& txn{context.rw_txn()};
 
@@ -754,7 +743,6 @@ TEST_CASE("Chain config", "[db][access_layer]") {
 }
 
 TEST_CASE("Head header", "[db][access_layer]") {
-    SetLogVerbosityGuard log_guard{log::Level::kNone};
     test_util::TempChainData context;
     auto& txn{context.rw_txn()};
 
@@ -764,7 +752,6 @@ TEST_CASE("Head header", "[db][access_layer]") {
 }
 
 TEST_CASE("Last Fork Choice", "[db][access_layer]") {
-    SetLogVerbosityGuard log_guard{log::Level::kNone};
     test_util::TempChainData context;
     auto& txn{context.rw_txn()};
 
@@ -782,7 +769,6 @@ TEST_CASE("Last Fork Choice", "[db][access_layer]") {
 }
 
 TEST_CASE("read rlp encoded transactions", "[db][access_layer]") {
-    SetLogVerbosityGuard log_guard{log::Level::kNone};
     test_util::TempChainData context;
     auto& txn{context.rw_txn()};
 
@@ -813,7 +799,6 @@ TEST_CASE("read rlp encoded transactions", "[db][access_layer]") {
 }
 
 TEST_CASE("write and read body w/ withdrawals", "[db][access_layer]") {
-    SetLogVerbosityGuard log_guard{log::Level::kNone};
     test_util::TempChainData context;
     auto& txn{context.rw_txn()};
 
@@ -847,7 +832,6 @@ struct AccessLayerTest {
         expect_mock_ro_cursor(mock_ro_txn, mock_ro_cursor);
     }
 
-    SetLogVerbosityGuard log_guard{log::Level::kNone};
     test_util::MockROTxn mock_ro_txn;
     test_util::MockROCursor* mock_ro_cursor = new test_util::MockROCursor;
 };

--- a/silkworm/db/blocks/bodies/body_txs_amount_query_test.cpp
+++ b/silkworm/db/blocks/bodies/body_txs_amount_query_test.cpp
@@ -26,7 +26,6 @@
 namespace silkworm::snapshots {
 
 TEST_CASE("BodyTxsAmountQuery") {
-    silkworm::test_util::SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryDirectory tmp_dir;
     test_util::SampleBodySnapshotFile snapshot_file{tmp_dir.path()};
     SegmentFileReader snapshot{snapshot_file.path()};

--- a/silkworm/db/buffer_test.cpp
+++ b/silkworm/db/buffer_test.cpp
@@ -28,10 +28,7 @@
 
 namespace silkworm::db {
 
-using silkworm::test_util::SetLogVerbosityGuard;
-
 TEST_CASE("Buffer storage", "[silkworm][db][buffer]") {
-    SetLogVerbosityGuard log_guard{log::Level::kNone};
     db::test_util::TempChainData context;
     auto& txn{context.rw_txn()};
 
@@ -242,7 +239,6 @@ TEST_CASE("Buffer storage", "[silkworm][db][buffer]") {
 }
 
 TEST_CASE("Buffer account", "[silkworm][db][buffer]") {
-    SetLogVerbosityGuard log_guard{log::Level::kNone};
     db::test_util::TempChainData context;
     auto& txn{context.rw_txn()};
 

--- a/silkworm/db/datastore/mdbx/mdbx_test.cpp
+++ b/silkworm/db/datastore/mdbx/mdbx_test.cpp
@@ -24,7 +24,6 @@
 namespace silkworm::db {
 
 TEST_CASE("open_env") {
-    silkworm::test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
     // Empty dir
     std::string empty{};
     EnvConfig db_config{empty};

--- a/silkworm/db/datastore/snapshots/bittorrent/client_test.cpp
+++ b/silkworm/db/datastore/snapshots/bittorrent/client_test.cpp
@@ -147,8 +147,6 @@ TEST_CASE("BitTorrentClient::BitTorrentClient", "[silkworm][snapshot][bittorrent
 }
 
 TEST_CASE("BitTorrentClient::add_info_hash", "[silkworm][snapshot][bittorrent]") {
-    test_util::SetLogVerbosityGuard guard{log::Level::kNone};
-
     TemporaryDirectory tmp_dir;
     BitTorrentSettings settings;
     settings.repository_path = tmp_dir.path();
@@ -170,8 +168,6 @@ TEST_CASE("BitTorrentClient::add_info_hash", "[silkworm][snapshot][bittorrent]")
 }
 
 TEST_CASE("BitTorrentClient::execute_loop", "[silkworm][snapshot][bittorrent]") {
-    test_util::SetLogVerbosityGuard guard{log::Level::kNone};
-
     TemporaryDirectory tmp_dir;
     BitTorrentSettings settings;
     settings.repository_path = tmp_dir.path();
@@ -228,8 +224,6 @@ TEST_CASE("BitTorrentClient::process_alerts", "[silkworm][snapshot][bittorrent]"
 }
 
 TEST_CASE("BitTorrentClient::handle_alert", "[silkworm][snapshot][bittorrent]") {
-    test_util::SetLogVerbosityGuard guard{log::Level::kNone};
-
     TemporaryDirectory tmp_dir;
     BitTorrentSettings settings;
     settings.repository_path = tmp_dir.path();

--- a/silkworm/db/datastore/snapshots/bittorrent/torrent_file_test.cpp
+++ b/silkworm/db/datastore/snapshots/bittorrent/torrent_file_test.cpp
@@ -68,6 +68,7 @@ unsigned char v1_000000_000500_bodies_seg_torrent[] = {
     0xb6, 0x2a, 0x85, 0xd4, 0x79, 0x65, 0x65};
 unsigned int v1_000000_000500_bodies_seg_torrent_len = 487;
 
+#ifdef SILKWORM_TEST_SKIP
 TEST_CASE("TorrentFile") {
     SKIP("Needs a valid snapshot file at the kInputFilePath");
     static const std::filesystem::path kInputFilePath{"/erigon-data/snapshots/v1-000000-000500-bodies.seg"};
@@ -84,5 +85,6 @@ TEST_CASE("TorrentFile") {
 
     CHECK(actual.substr(actual_offset) == expected.substr(expected_offset));
 }
+#endif  // SILKWORM_TEST_SKIP
 
 }  // namespace silkworm::snapshots::bittorrent

--- a/silkworm/db/datastore/snapshots/common/encoding/sequence_test.cpp
+++ b/silkworm/db/datastore/snapshots/common/encoding/sequence_test.cpp
@@ -28,7 +28,6 @@
 namespace silkworm::snapshots::encoding {
 
 TEST_CASE("Uint64Sequence", "[silkworm][snapshots][recsplit][sequence]") {
-    test_util::SetLogVerbosityGuard guard{log::Level::kNone};
     Uint64Sequence output_sequence{0, 11, 21, 31, 41, 51, 61};
 
     std::stringstream ss;
@@ -41,8 +40,6 @@ TEST_CASE("Uint64Sequence", "[silkworm][snapshots][recsplit][sequence]") {
 }
 
 TEST_CASE("Uint64Sequence: size too big", "[silkworm][snapshots][recsplit][sequence]") {
-    test_util::SetLogVerbosityGuard guard{log::Level::kNone};
-
     std::stringstream ss;
     Bytes invalid_size_buffer(sizeof(uint64_t), '\0');
     endian::store_big_u64(invalid_size_buffer.data(), 49287623586282974);

--- a/silkworm/db/datastore/snapshots/elias_fano/elias_fano_test.cpp
+++ b/silkworm/db/datastore/snapshots/elias_fano/elias_fano_test.cpp
@@ -70,8 +70,6 @@ static std::vector<uint64_t> generate_contiguous_offsets(uint64_t count) {
 }
 
 TEST_CASE("EliasFanoList32", "[silkworm][recsplit][elias_fano]") {
-    test_util::SetLogVerbosityGuard guard{log::Level::kNone};
-
     std::vector<EliasFanoList32Test> ef_test_vector{
         // Test Pattern 1
         {
@@ -134,7 +132,6 @@ TEST_CASE("EliasFanoList32", "[silkworm][recsplit][elias_fano]") {
 }
 
 TEST_CASE("DoubleEliasFanoList16", "[silkworm][recsplit][elias_fano]") {
-    test_util::SetLogVerbosityGuard guard{log::Level::kNone};
     DoubleEliasFanoList16 double_ef_list;
     std::vector<uint64_t> cum_keys{1, 1, 2, 6, 7, 11, 13, 20};
     std::vector<uint64_t> position{1, 2, 5, 5, 6, 7, 9, 9};

--- a/silkworm/db/datastore/snapshots/rec_split/golomb_rice_test.cpp
+++ b/silkworm/db/datastore/snapshots/rec_split/golomb_rice_test.cpp
@@ -70,8 +70,6 @@ static void test_trees(GolombRiceVector& v, const Uint64Sequence& keys, uint64_t
 }
 
 TEST_CASE("GolombRiceVector", "[silkworm][recsplit][golomb_rice]") {
-    test_util::SetLogVerbosityGuard guard{log::Level::kNone};
-
     const std::vector<size_t> golomb_params{0, 1, 2, 3, 4, 5, 6};
     for (size_t i{0}; i < golomb_params.size(); ++i) {
         SECTION("trees " + std::to_string(i)) {

--- a/silkworm/db/datastore/snapshots/rec_split/rec_split_par_test.cpp
+++ b/silkworm/db/datastore/snapshots/rec_split/rec_split_par_test.cpp
@@ -28,7 +28,6 @@
 
 namespace silkworm::snapshots::rec_split {
 
-using silkworm::test_util::SetLogVerbosityGuard;
 using silkworm::test_util::TemporaryFile;
 using test_util::next_pseudo_random;
 
@@ -39,7 +38,6 @@ using test_util::next_pseudo_random;
 static constexpr int kTestSalt{1};
 
 TEST_CASE("RecSplit8-Par: key_count=0", "[silkworm][node][recsplit]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryFile index_file;
     ThreadPool thread_pool{2};
     RecSplitSettings settings{
@@ -53,7 +51,6 @@ TEST_CASE("RecSplit8-Par: key_count=0", "[silkworm][node][recsplit]") {
 }
 
 TEST_CASE("RecSplit8-Par: key_count=1", "[silkworm][node][recsplit]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryFile index_file;
     ThreadPool thread_pool{2};
     RecSplitSettings settings{
@@ -68,7 +65,6 @@ TEST_CASE("RecSplit8-Par: key_count=1", "[silkworm][node][recsplit]") {
 }
 
 TEST_CASE("RecSplit8-Par key_count=2", "[silkworm][node][recsplit]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryFile index_file;
     ThreadPool thread_pool{2};
     RecSplitSettings settings{
@@ -131,7 +127,6 @@ const std::array<uint32_t, kMaxBucketSize> RecSplit4::kMemo;
 auto par_build_strategy_4(ThreadPool& tp) { return std::make_unique<RecSplit4::ParallelBuildingStrategy>(tp); }
 
 TEST_CASE("RecSplit4-Par: keys=1000 buckets=128", "[silkworm][node][recsplit]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryFile index_file;
     ThreadPool thread_pool{2};
 
@@ -170,7 +165,6 @@ TEST_CASE("RecSplit4-Par: keys=1000 buckets=128", "[silkworm][node][recsplit]") 
 }
 
 TEST_CASE("RecSplit4-Par: multiple keys-buckets", "[silkworm][node][recsplit]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryFile index_file;
     ThreadPool thread_pool{2};
 
@@ -217,8 +211,8 @@ TEST_CASE("RecSplit4-Par: multiple keys-buckets", "[silkworm][node][recsplit]") 
     }
 }
 
-TEST_CASE("RecSplit8-Par: index lookup", "[silkworm][node][recsplit][ignore]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
+#ifdef SILKWORM_TEST_SKIP
+TEST_CASE("RecSplit8-Par: index lookup", "[silkworm][node][recsplit]") {
     TemporaryFile index_file;
     ThreadPool thread_pool{2};
     RecSplitSettings settings{
@@ -240,9 +234,10 @@ TEST_CASE("RecSplit8-Par: index lookup", "[silkworm][node][recsplit][ignore]") {
         CHECK(rs2.lookup(key) == RecSplit8::LookupResult{i * 17, true});
     }
 }
+#endif  // SILKWORM_TEST_SKIP
 
-TEST_CASE("RecSplit8-Par: double index lookup", "[silkworm][node][recsplit][ignore]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
+#ifdef SILKWORM_TEST_SKIP
+TEST_CASE("RecSplit8-Par: double index lookup", "[silkworm][node][recsplit]") {
     TemporaryFile index_file;
     ThreadPool thread_pool{2};
     RecSplitSettings settings{
@@ -265,6 +260,7 @@ TEST_CASE("RecSplit8-Par: double index lookup", "[silkworm][node][recsplit][igno
         CHECK(rs2.lookup_by_ordinal(enumeration_index) == i * 17);
     }
 }
+#endif
 
 #endif  // _WIN32
 

--- a/silkworm/db/datastore/snapshots/rec_split/rec_split_seq_test.cpp
+++ b/silkworm/db/datastore/snapshots/rec_split/rec_split_seq_test.cpp
@@ -30,7 +30,6 @@
 
 namespace silkworm::snapshots::rec_split {
 
-using silkworm::test_util::SetLogVerbosityGuard;
 using silkworm::test_util::TemporaryFile;
 using test_util::next_pseudo_random;
 
@@ -41,7 +40,6 @@ using test_util::next_pseudo_random;
 static constexpr int kTestSalt{1};
 
 TEST_CASE("RecSplit8: key_count=0", "[silkworm][snapshots][recsplit]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryFile index_file;
     RecSplitSettings settings{
         .keys_count = 0,
@@ -54,7 +52,6 @@ TEST_CASE("RecSplit8: key_count=0", "[silkworm][snapshots][recsplit]") {
 }
 
 TEST_CASE("RecSplit8: key_count=1", "[silkworm][snapshots][recsplit]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryFile index_file;
     RecSplitSettings settings{
         .keys_count = 1,
@@ -68,7 +65,6 @@ TEST_CASE("RecSplit8: key_count=1", "[silkworm][snapshots][recsplit]") {
 }
 
 TEST_CASE("RecSplit8: key_count=2", "[silkworm][snapshots][recsplit]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryFile index_file;
     RecSplitSettings settings{
         .keys_count = 2,
@@ -130,7 +126,6 @@ using RecSplit4 = RecSplit<kTestLeaf>;
 auto seq_build_strategy_4() { return std::make_unique<RecSplit4::SequentialBuildingStrategy>(db::etl::kOptimalBufferSize); }
 
 TEST_CASE("RecSplit4: keys=1000 buckets=128", "[silkworm][snapshots][recsplit]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryFile index_file;
 
     constexpr int kTestNumKeys{1'000};
@@ -168,7 +163,6 @@ TEST_CASE("RecSplit4: keys=1000 buckets=128", "[silkworm][snapshots][recsplit]")
 }
 
 TEST_CASE("RecSplit4: multiple keys-buckets", "[silkworm][snapshots][recsplit]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryFile index_file;
 
     struct RecSplitParams {
@@ -214,8 +208,8 @@ TEST_CASE("RecSplit4: multiple keys-buckets", "[silkworm][snapshots][recsplit]")
     }
 }
 
-TEST_CASE("RecSplit8: index lookup", "[silkworm][snapshots][recsplit][ignore]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
+#ifdef SILKWORM_TEST_SKIP
+TEST_CASE("RecSplit8: index lookup", "[silkworm][snapshots][recsplit]") {
     TemporaryFile index_file;
     RecSplitSettings settings{
         .keys_count = 100,
@@ -236,9 +230,10 @@ TEST_CASE("RecSplit8: index lookup", "[silkworm][snapshots][recsplit][ignore]") 
         CHECK((rs2.lookup(key) == RecSplit8::LookupResult{i * 17, true}));
     }
 }
+#endif  // SILKWORM_TEST_SKIP
 
-TEST_CASE("RecSplit8: double index lookup", "[silkworm][snapshots][recsplit][ignore]") {
-    SetLogVerbosityGuard guard{log::Level::kInfo};
+#ifdef SILKWORM_TEST_SKIP
+TEST_CASE("RecSplit8: double index lookup", "[silkworm][snapshots][recsplit]") {
     TemporaryFile index_file;
     RecSplitSettings settings{
         .keys_count = 100,
@@ -260,10 +255,10 @@ TEST_CASE("RecSplit8: double index lookup", "[silkworm][snapshots][recsplit][ign
         CHECK(rs2.lookup_by_ordinal(enumeration_index) == i * 17);
     }
 }
+#endif  // SILKWORM_TEST_SKIP
 
-TEST_CASE("RecSplit8: unsupported feature", "[silkworm][snapshots][recsplit][ignore]") {
-    SetLogVerbosityGuard guard{log::Level::kInfo};
-
+#ifdef SILKWORM_TEST_SKIP
+TEST_CASE("RecSplit8: unsupported feature", "[silkworm][snapshots][recsplit]") {
     // Generate valid RecSplit index
     TemporaryFile index_file;
     RecSplitSettings settings{
@@ -292,6 +287,7 @@ TEST_CASE("RecSplit8: unsupported feature", "[silkworm][snapshots][recsplit][ign
 
     CHECK_THROWS_AS(RecSplit8{index_file.path()}, std::runtime_error);
 }
+#endif  // SILKWORM_TEST_SKIP
 
 #endif  // _WIN32
 

--- a/silkworm/db/etl_collector_test.cpp
+++ b/silkworm/db/etl_collector_test.cpp
@@ -31,7 +31,6 @@
 namespace silkworm::db::etl {
 
 namespace fs = std::filesystem;
-using silkworm::test_util::SetLogVerbosityGuard;
 
 static std::vector<Entry> generate_entry_set(size_t size) {
     std::vector<Entry> pairs;
@@ -100,17 +99,14 @@ void run_collector_test(const etl_mdbx::LoadFunc& load_func, bool do_copy = true
 }
 
 TEST_CASE("collect_and_default_load") {
-    SetLogVerbosityGuard log_guard{log::Level::kNone};
     run_collector_test(nullptr);
 }
 
 TEST_CASE("collect_and_default_load_move") {
-    SetLogVerbosityGuard log_guard{log::Level::kNone};
     run_collector_test(nullptr, false);
 }
 
 TEST_CASE("collect_and_load") {
-    SetLogVerbosityGuard log_guard{log::Level::kNone};
     run_collector_test([](const Entry& entry, auto& table, MDBX_put_flags_t) {
         Bytes key{entry.key};
         key.at(0) = 1;

--- a/silkworm/db/etl_in_memory_collector_test.cpp
+++ b/silkworm/db/etl_in_memory_collector_test.cpp
@@ -68,7 +68,6 @@ class InMemoryCollector : public etl::InMemoryCollector<CollectorStorage> {
 using etl::Entry;
 using etl::MapStorage;
 using etl::VectorStorage;
-using silkworm::test_util::SetLogVerbosityGuard;
 
 static std::vector<Entry> generate_entry_set(size_t size) {
     std::vector<Entry> pairs;
@@ -159,34 +158,28 @@ void run_collector_test(const KVLoadFunc& load_func, bool do_copy = true) {
 }
 
 TEST_CASE("collect_and_default_load_in_memory_map") {
-    SetLogVerbosityGuard log_guard{log::Level::kNone};
     run_collector_test<InMemoryCollector<MapStorage>>(nullptr);
 }
 
 TEST_CASE("collect_and_default_load_in_memory_vector") {
-    SetLogVerbosityGuard log_guard{log::Level::kNone};
     run_collector_test<InMemoryCollector<VectorStorage>>(nullptr);
 }
 
 TEST_CASE("collect_and_default_load_move_in_memory_map") {
-    SetLogVerbosityGuard log_guard{log::Level::kNone};
     run_collector_test<InMemoryCollector<MapStorage>>(nullptr, false);
 }
 
 TEST_CASE("collect_and_default_load_move_in_memory_vector") {
-    SetLogVerbosityGuard log_guard{log::Level::kNone};
     run_collector_test<InMemoryCollector<VectorStorage>>(nullptr, false);
 }
 
 TEST_CASE("collect_and_load_in_memory_map") {
-    SetLogVerbosityGuard log_guard{log::Level::kNone};
     run_collector_test<InMemoryCollector<MapStorage>>([](const Bytes& ekey, const Bytes& evalue, auto& table, MDBX_put_flags_t) {
         table.upsert(to_slice(ekey), to_slice(evalue));
     });
 }
 
 TEST_CASE("collect_and_load_in_memory_vector") {
-    SetLogVerbosityGuard log_guard{log::Level::kNone};
     run_collector_test<InMemoryCollector<VectorStorage>>([](const Bytes& ekey, const Bytes& evalue, auto& table, MDBX_put_flags_t) {
         table.upsert(to_slice(ekey), to_slice(evalue));
     });

--- a/silkworm/db/kv/grpc/server/kv_server_test.cpp
+++ b/silkworm/db/kv/grpc/server/kv_server_test.cpp
@@ -207,8 +207,7 @@ class TestableStateChangeCollection : public StateChangeCollection {
 using KvServer = db::kv::grpc::server::KvServer;
 
 struct KvEnd2EndTest {
-    explicit KvEnd2EndTest(silkworm::log::Level log_verbosity = silkworm::log::Level::kNone)
-        : set_verbosity_log_guard{log_verbosity} {
+    explicit KvEnd2EndTest() {
         std::shared_ptr<grpc::Channel> channel =
             grpc::CreateChannel(kTestAddressUri, grpc::InsecureChannelCredentials());
         kv_stub = remote::KV::NewStub(channel);
@@ -262,7 +261,6 @@ struct KvEnd2EndTest {
         server->join();
     }
 
-    test_util::SetLogVerbosityGuard set_verbosity_log_guard;
     rpc::Grpc2SilkwormLogGuard grpc2silkworm_log_guard;
     std::unique_ptr<remote::KV::Stub> kv_stub;
     std::unique_ptr<KvClient> kv_client;
@@ -281,7 +279,6 @@ namespace silkworm::db::kv::grpc::server {
 // Exclude gRPC tests from sanitizer builds due to data race warnings inside gRPC library
 #ifndef SILKWORM_SANITIZE
 TEST_CASE("KvServer", "[silkworm][node][rpc]") {
-    test_util::SetLogVerbosityGuard guard{log::Level::kNone};
     rpc::Grpc2SilkwormLogGuard log_guard;
     rpc::ServerSettings srv_config;
     srv_config.address_uri = kTestAddressUri;
@@ -697,7 +694,7 @@ TEST_CASE_METHOD(KvEnd2EndTest, "KvServer E2E: KV", "[silkworm][node][rpc]") {
 TEST_CASE("KvServer E2E: trigger server-side write error", "[silkworm][node][rpc]") {
     {
         const uint32_t kNumTxs{1000};
-        KvEnd2EndTest test{silkworm::log::Level::kError};
+        KvEnd2EndTest test;
         test.fill_tables();
         auto kv_client = *test.kv_client;
 

--- a/silkworm/db/memory_mutation_cursor_test.cpp
+++ b/silkworm/db/memory_mutation_cursor_test.cpp
@@ -88,9 +88,6 @@ class MemoryMutationCursorTest {
     RWTxnManaged main_txn{main_env};
     MemoryOverlay overlay{tmp_dir.path(), &main_txn, table::get_map_config, table::kSequenceName};
     MemoryMutation mutation{overlay};
-
-  private:
-    silkworm::test_util::SetLogVerbosityGuard log_guard_{log::Level::kNone};
 };
 
 // Skip in TSAN build due to false positive lock-order-inversion: https://github.com/google/sanitizers/issues/814

--- a/silkworm/db/snapshot_benchmark.cpp
+++ b/silkworm/db/snapshot_benchmark.cpp
@@ -32,7 +32,6 @@
 namespace silkworm::snapshots {
 
 namespace test = test_util;
-using silkworm::test_util::SetLogVerbosityGuard;
 using silkworm::test_util::TemporaryFile;
 
 static const Bytes kLoremIpsumDict{*from_hex(
@@ -123,7 +122,6 @@ static void build_tx_index(benchmark::State& state) {
 BENCHMARK(build_tx_index);
 
 static void reopen_folder(benchmark::State& state) {
-    SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryDirectory tmp_dir;
 
     // These sample snapshot files just contain data for block range [1'500'012, 1'500'013], hence current snapshot

--- a/silkworm/db/snapshot_decompressor_test.cpp
+++ b/silkworm/db/snapshot_decompressor_test.cpp
@@ -40,7 +40,6 @@ namespace silkworm::snapshots {
 using Catch::Matchers::Message;
 namespace test = test_util;
 using silkworm::test_util::null_stream;
-using silkworm::test_util::SetLogVerbosityGuard;
 using silkworm::test_util::TemporaryFile;
 using namespace snapshots::seg;
 
@@ -230,7 +229,6 @@ TEST_CASE("Decompressor::Decompressor from path", "[silkworm][node][seg][decompr
 }
 
 TEST_CASE("Decompressor::Decompressor from memory", "[silkworm][node][seg][decompressor]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryDirectory tmp_dir;
     test::TemporarySnapshotFile tmp_snapshot = create_nonempty_snapshot_file(tmp_dir);
     MemoryMappedFile mmf{tmp_snapshot.fs_path()};
@@ -242,8 +240,6 @@ TEST_CASE("Decompressor::Decompressor from memory", "[silkworm][node][seg][decom
 }
 
 TEST_CASE("Decompressor::open invalid files", "[silkworm][node][seg][decompressor]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
-
     SECTION("empty file") {
         TemporaryFile tmp_file;
         Decompressor decoder{tmp_file.path()};
@@ -290,7 +286,6 @@ TEST_CASE("Decompressor::open invalid files", "[silkworm][node][seg][decompresso
 }
 
 TEST_CASE("Decompressor::open valid files", "[silkworm][node][seg][decompressor]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryDirectory tmp_dir;
 
     std::map<std::string, test::SnapshotHeader> header_tests{
@@ -347,7 +342,6 @@ TEST_CASE("Decompressor::open valid files", "[silkworm][node][seg][decompressor]
 }
 
 TEST_CASE("Decompressor::begin", "[silkworm][node][seg][decompressor]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryDirectory tmp_dir;
     test::TemporarySnapshotFile tmp_snapshot = create_nonempty_snapshot_file(tmp_dir);
     Decompressor decoder{tmp_snapshot.fs_path()};
@@ -360,7 +354,6 @@ TEST_CASE("Decompressor::begin", "[silkworm][node][seg][decompressor]") {
 }
 
 TEST_CASE("Decompressor::close", "[silkworm][node][seg][decompressor]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryDirectory tmp_dir;
     test::TemporarySnapshotFile tmp_snapshot = create_nonempty_snapshot_file(tmp_dir);
     Decompressor decoder{tmp_snapshot.fs_path()};
@@ -379,7 +372,6 @@ TEST_CASE("Decompressor::close", "[silkworm][node][seg][decompressor]") {
 }
 
 TEST_CASE("Iterator::Iterator empty data", "[silkworm][node][seg][decompressor]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryDirectory tmp_dir;
     test::TemporarySnapshotFile tmp_snapshot = create_empty_snapshot_file(tmp_dir);
     Decompressor decoder{tmp_snapshot.fs_path()};
@@ -440,7 +432,6 @@ static const Bytes kLoremIpsumDict{*from_hex(
     "73742036340d6c61626f72756d203635")};
 
 TEST_CASE("Decompressor: lorem ipsum next_uncompressed", "[silkworm][node][seg][decompressor]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryFile tmp_file{};
     tmp_file.write(kLoremIpsumDict);
     Decompressor decoder{tmp_file.path()};
@@ -467,7 +458,6 @@ TEST_CASE("Decompressor: lorem ipsum next_uncompressed", "[silkworm][node][seg][
 }
 
 TEST_CASE("Decompressor: lorem ipsum next", "[silkworm][node][seg][decompressor]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryFile tmp_file{};
     tmp_file.write(kLoremIpsumDict);
     Decompressor decoder{tmp_file.path()};
@@ -494,7 +484,6 @@ TEST_CASE("Decompressor: lorem ipsum next", "[silkworm][node][seg][decompressor]
 }
 
 TEST_CASE("Decompressor: lorem ipsum has_prefix", "[silkworm][node][seg][decompressor]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryFile tmp_file{};
     tmp_file.write(kLoremIpsumDict);
     Decompressor decoder{tmp_file.path()};

--- a/silkworm/db/snapshot_index_builder_test.cpp
+++ b/silkworm/db/snapshot_index_builder_test.cpp
@@ -30,11 +30,9 @@
 namespace silkworm::snapshots {
 
 namespace test = test_util;
-using silkworm::test_util::SetLogVerbosityGuard;
 using namespace Catch::Matchers;
 
 TEST_CASE("Index::Index", "[silkworm][snapshot][index]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryDirectory tmp_dir;
     test::TemporarySnapshotFile tmp_snapshot_file{tmp_dir.path(), "v1-014500-015000-headers.seg"};
     auto header_index = HeaderIndex::make(tmp_snapshot_file.path());
@@ -43,7 +41,6 @@ TEST_CASE("Index::Index", "[silkworm][snapshot][index]") {
 
 // This unit test fails on Windows with error: SIGSEGV - Segmentation violation signal
 TEST_CASE("BodyIndex::build OK", "[silkworm][snapshot][index]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryDirectory tmp_dir;
     test::SampleBodySnapshotFile body_segment_file{tmp_dir.path()};
     auto body_index = BodyIndex::make(body_segment_file.path());
@@ -52,7 +49,6 @@ TEST_CASE("BodyIndex::build OK", "[silkworm][snapshot][index]") {
 }
 
 TEST_CASE("TransactionIndex::build KO: empty snapshot", "[silkworm][snapshot][index]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryDirectory tmp_dir;
     constexpr const char* kBodiesSnapshotFileName{"v1-014500-015000-bodies.seg"};
     constexpr const char* kTransactionsSnapshotFileName{"v1-014500-015000-transactions.seg"};
@@ -70,7 +66,6 @@ TEST_CASE("TransactionIndex::build KO: empty snapshot", "[silkworm][snapshot][in
 }
 
 TEST_CASE("TransactionIndex::build KO: invalid snapshot", "[silkworm][snapshot][index]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryDirectory tmp_dir;
     constexpr const char* kTransactionsSnapshotFileName{"v1-015000-015500-transactions.seg"};
 
@@ -186,7 +181,6 @@ TEST_CASE("TransactionIndex::build KO: invalid snapshot", "[silkworm][snapshot][
 }
 
 TEST_CASE("TransactionIndex::build OK", "[silkworm][snapshot][index]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryDirectory tmp_dir;
     test::SampleBodySnapshotFile body_segment_file{tmp_dir.path()};
     auto& body_segment_path = body_segment_file.path();

--- a/silkworm/db/snapshot_repository_test.cpp
+++ b/silkworm/db/snapshot_repository_test.cpp
@@ -35,7 +35,6 @@
 namespace silkworm::snapshots {
 
 namespace test = test_util;
-using silkworm::test_util::SetLogVerbosityGuard;
 
 #define CHECK_FIRST(x) CHECK((x).first)
 #define CHECK_FALSE_FIRST(x) CHECK_FALSE((x).first)
@@ -53,13 +52,11 @@ struct SnapshotType {
 // NOLINTEND(readability-identifier-naming)
 
 TEST_CASE("SnapshotRepository::SnapshotRepository", "[silkworm][node][snapshot]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryDirectory tmp_dir;
     CHECK_NOTHROW(make_repository(tmp_dir.path()));
 }
 
 TEST_CASE("SnapshotRepository::reopen_folder.partial_bundle", "[silkworm][node][snapshot]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryDirectory tmp_dir;
 
     test::TemporarySnapshotFile tmp_snapshot_1{tmp_dir.path(), "v1-014500-015000-headers.seg"};
@@ -71,7 +68,6 @@ TEST_CASE("SnapshotRepository::reopen_folder.partial_bundle", "[silkworm][node][
 }
 
 TEST_CASE("SnapshotRepository::view", "[silkworm][node][snapshot]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryDirectory tmp_dir;
 
     SECTION("no snapshots") {
@@ -146,7 +142,6 @@ TEST_CASE("SnapshotRepository::view", "[silkworm][node][snapshot]") {
 }
 
 TEST_CASE("SnapshotRepository::find_segment", "[silkworm][node][snapshot]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryDirectory tmp_dir;
 
     // These sample snapshot files just contain data for block range [1'500'012, 1'500'013], hence current snapshot
@@ -213,7 +208,6 @@ TEST_CASE("SnapshotRepository::find_segment", "[silkworm][node][snapshot]") {
 }
 
 TEST_CASE("SnapshotRepository::find_block_number", "[silkworm][node][snapshot]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryDirectory tmp_dir;
 
     // These sample snapshot files just contain data for block range [1'500'012, 1'500'013], hence current snapshot
@@ -261,7 +255,6 @@ static auto move_last_write_time(const std::filesystem::path& p, const std::file
 TEST_CASE("SnapshotRepository::remove_stale_indexes", "[silkworm][node][snapshot][index]") {
     using namespace std::chrono_literals;
 
-    SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryDirectory tmp_dir;
     auto repository = make_repository(tmp_dir.path());
 

--- a/silkworm/db/snapshot_sync_test.cpp
+++ b/silkworm/db/snapshot_sync_test.cpp
@@ -50,7 +50,6 @@ class NoopStageSchedulerAdapter : public stagedsync::StageScheduler {
 };
 
 struct SnapshotSyncTest {
-    SetLogVerbosityGuard guard{log::Level::kNone};
     db::test_util::TempChainDataStore context;
     TaskRunner runner;
     NoopStageSchedulerAdapter stage_scheduler;

--- a/silkworm/db/snapshot_test.cpp
+++ b/silkworm/db/snapshot_test.cpp
@@ -38,7 +38,6 @@
 namespace silkworm::snapshots {
 
 namespace test = test_util;
-using silkworm::test_util::SetLogVerbosityGuard;
 
 static const SnapshotPath kValidHeadersSegmentPath{*SnapshotPath::parse("v1-014500-015000-headers.seg")};
 
@@ -84,7 +83,6 @@ TEST_CASE("Snapshot::Snapshot", "[silkworm][node][snapshot][snapshot]") {
 }
 
 TEST_CASE("Snapshot::reopen_segment", "[silkworm][node][snapshot][snapshot]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryDirectory tmp_dir;
     test::TemporarySnapshotFile tmp_snapshot_file{tmp_dir.path(), kValidHeadersSegmentPath.filename(), test::SnapshotHeader{}};
     SnapshotForTest snapshot{tmp_snapshot_file.path()};
@@ -92,7 +90,6 @@ TEST_CASE("Snapshot::reopen_segment", "[silkworm][node][snapshot][snapshot]") {
 }
 
 TEST_CASE("Snapshot::for_each_item", "[silkworm][node][snapshot][snapshot]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryDirectory tmp_dir;
     test::HelloWorldSnapshotFile hello_world_snapshot_file{tmp_dir.path(), kValidHeadersSegmentPath.filename()};
     SnapshotForTest tmp_snapshot{hello_world_snapshot_file.path()};
@@ -110,7 +107,6 @@ TEST_CASE("Snapshot::for_each_item", "[silkworm][node][snapshot][snapshot]") {
 }
 
 TEST_CASE("Snapshot::close", "[silkworm][node][snapshot][snapshot]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryDirectory tmp_dir;
     test::HelloWorldSnapshotFile hello_world_snapshot_file{tmp_dir.path(), kValidHeadersSegmentPath.filename()};
     seg::Decompressor decoder{hello_world_snapshot_file.fs_path()};
@@ -121,7 +117,6 @@ TEST_CASE("Snapshot::close", "[silkworm][node][snapshot][snapshot]") {
 
 // https://etherscan.io/block/1500013
 TEST_CASE("HeaderSnapshot::header_by_number OK", "[silkworm][node][snapshot][index]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryDirectory tmp_dir;
     test::SampleHeaderSnapshotFile header_segment_file{tmp_dir.path()};  // contains headers for [1'500'012, 1'500'013]
     auto& header_segment_path = header_segment_file.path();
@@ -164,7 +159,6 @@ TEST_CASE("HeaderSnapshot::header_by_number OK", "[silkworm][node][snapshot][ind
 
 // https://etherscan.io/block/1500013
 TEST_CASE("BodySnapshot::body_by_number OK", "[silkworm][node][snapshot][index]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryDirectory tmp_dir;
     test::SampleBodySnapshotFile body_segment_file{tmp_dir.path()};  // contains bodies for [1'500'012, 1'500'013]
     auto& body_segment_path = body_segment_file.path();
@@ -192,7 +186,6 @@ TEST_CASE("BodySnapshot::body_by_number OK", "[silkworm][node][snapshot][index]"
 
 // https://etherscan.io/block/1500013
 TEST_CASE("TransactionSnapshot::txn_by_id OK", "[silkworm][node][snapshot][index]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryDirectory tmp_dir;
     test::SampleBodySnapshotFile body_segment{tmp_dir.path()};
     auto& body_segment_path = body_segment.path();
@@ -219,7 +212,6 @@ TEST_CASE("TransactionSnapshot::txn_by_id OK", "[silkworm][node][snapshot][index
 
 // https://etherscan.io/block/1500012
 TEST_CASE("TransactionSnapshot::block_num_by_txn_hash OK", "[silkworm][node][snapshot][index]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryDirectory tmp_dir;
     test::SampleBodySnapshotFile body_segment{tmp_dir.path()};
     auto& body_segment_path = body_segment.path();
@@ -263,7 +255,6 @@ TEST_CASE("TransactionSnapshot::block_num_by_txn_hash OK", "[silkworm][node][sna
 
 // https://etherscan.io/block/1500012
 TEST_CASE("TransactionSnapshot::txn_range OK", "[silkworm][node][snapshot][index]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryDirectory tmp_dir;
     test::SampleBodySnapshotFile body_segment{tmp_dir.path()};
     auto& body_segment_path = body_segment.path();
@@ -295,7 +286,6 @@ TEST_CASE("TransactionSnapshot::txn_range OK", "[silkworm][node][snapshot][index
 }
 
 TEST_CASE("TransactionSnapshot::txn_rlp_range OK", "[silkworm][node][snapshot][index]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
     TemporaryDirectory tmp_dir;
     test::SampleBodySnapshotFile body_segment{tmp_dir.path()};
     auto& body_segment_path = body_segment.path();
@@ -327,7 +317,6 @@ TEST_CASE("TransactionSnapshot::txn_rlp_range OK", "[silkworm][node][snapshot][i
 }
 
 TEST_CASE("slice_tx_payload", "[silkworm][node][snapshot]") {
-    SetLogVerbosityGuard guard{log::Level::kNone};
     const std::vector<AccessListEntry> access_list{
         {0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae_address,
          {

--- a/silkworm/infra/common/log.hpp
+++ b/silkworm/infra/common/log.hpp
@@ -37,16 +37,26 @@ enum class Level {
 
 //! \brief Holds logging configuration
 struct Settings {
-    bool log_std_out{false};            // Whether console logging goes to std::cout or std::cerr (default)
-    bool log_utc{true};                 // Whether timestamps should be in UTC or imbue local timezone
-    bool log_timezone{true};            // Whether timestamps should include the timezone identifier
-    bool log_nocolor{false};            // Whether to disable colorized output
-    bool log_trim{false};               // Whether to trim log level
-    bool log_threads{false};            // Whether to print thread ids in log lines
-    Level log_verbosity{Level::kInfo};  // Log verbosity level
-    std::string log_file;               // Log to file
-    char log_thousands_sep{'\''};       // Thousands separator
-    bool log_grpc{true};                // Include GRPC library internal logs
+    //! Whether console logging goes to std::cout or std::cerr (default)
+    bool log_std_out{false};
+    //! Whether timestamps should be in UTC or imbue local timezone
+    bool log_utc{true};
+    //! Whether timestamps should include the timezone identifier
+    bool log_timezone{true};
+    //! Whether to disable colorized output
+    bool log_nocolor{false};
+    //! Whether to trim log level
+    bool log_trim{false};
+    //! Whether to print thread ids in log lines
+    bool log_threads{false};
+    //! Log verbosity level
+    Level log_verbosity{Level::kNone};
+    //! Log to file
+    std::string log_file;
+    //! Thousands separator
+    char log_thousands_sep{'\''};
+    //! Include GRPC library internal logs
+    bool log_grpc{true};
 };
 
 //! \brief Initializes logging facilities

--- a/silkworm/infra/concurrency/context_pool_test.cpp
+++ b/silkworm/infra/concurrency/context_pool_test.cpp
@@ -36,7 +36,6 @@ namespace silkworm::concurrency {
 // Exclude gRPC tests from sanitizer builds due to data race warnings inside gRPC library
 #ifndef SILKWORM_SANITIZE
 TEST_CASE("Context", "[silkworm][concurrency][server_context]") {
-    test_util::SetLogVerbosityGuard guard{log::Level::kNone};
     Context ctx{0};
 
     SECTION("ServerContext") {
@@ -75,8 +74,6 @@ TEST_CASE("Context", "[silkworm][concurrency][server_context]") {
 }
 
 TEST_CASE("ContextPool", "[silkworm][concurrency][Context]") {
-    test_util::SetLogVerbosityGuard guard{log::Level::kNone};
-
     SECTION("ContextPool OK") {
         ContextPool context_pool{2};
         CHECK(context_pool.size() == 2);

--- a/silkworm/infra/grpc/client/client_context_pool_test.cpp
+++ b/silkworm/infra/grpc/client/client_context_pool_test.cpp
@@ -78,8 +78,6 @@ TEST_CASE("ClientContext", "[silkworm][infra][grpc][client][client_context]") {
 }
 
 TEST_CASE("ClientContextPool: create context pool", "[silkworm][infra][grpc][client][client_context]") {
-    test_util::SetLogVerbosityGuard guard{log::Level::kNone};
-
     SECTION("reject size 0") {
         CHECK_THROWS_AS((ClientContextPool{0}), std::logic_error);
     }
@@ -120,8 +118,6 @@ TEST_CASE("ClientContextPool: create context pool", "[silkworm][infra][grpc][cli
 }
 
 TEST_CASE("ClientContextPool: start context pool", "[silkworm][infra][grpc][client][client_context]") {
-    test_util::SetLogVerbosityGuard guard{log::Level::kNone};
-
     SECTION("running 1 thread") {
         ClientContextPool cp{1};
         cp.start();
@@ -138,8 +134,6 @@ TEST_CASE("ClientContextPool: start context pool", "[silkworm][infra][grpc][clie
 }
 
 TEST_CASE("ClientContextPool: run context pool", "[silkworm][infra][grpc][client][client_context]") {
-    test_util::SetLogVerbosityGuard guard{log::Level::kNone};
-
     SECTION("running 1 thread") {
         ClientContextPool cp{1};
         auto context_pool_thread = std::thread([&]() { cp.run(); });
@@ -167,8 +161,6 @@ TEST_CASE("ClientContextPool: run context pool", "[silkworm][infra][grpc][client
 }
 
 TEST_CASE("ClientContextPool: stop context pool", "[silkworm][infra][grpc][client][client_context]") {
-    test_util::SetLogVerbosityGuard guard{log::Level::kNone};
-
     SECTION("not yet running") {
         ClientContextPool cp{3};
         CHECK_NOTHROW(cp.stop());
@@ -193,8 +185,6 @@ TEST_CASE("ClientContextPool: stop context pool", "[silkworm][infra][grpc][clien
 }
 
 TEST_CASE("ClientContextPool: cannot restart context pool", "[silkworm][infra][grpc][client][client_context]") {
-    test_util::SetLogVerbosityGuard guard{log::Level::kNone};
-
     SECTION("running 1 thread") {
         ClientContextPool cp{1};
         cp.start();
@@ -213,8 +203,6 @@ TEST_CASE("ClientContextPool: cannot restart context pool", "[silkworm][infra][g
 }
 
 TEST_CASE("ClientContextPool: handle loop exception", "[silkworm][infra][grpc][client][client_context]") {
-    test_util::SetLogVerbosityGuard guard{log::Level::kNone};
-
     ClientContextPool cp{3};
     std::exception_ptr run_exception;
     cp.set_exception_handler([&](std::exception_ptr eptr) {

--- a/silkworm/infra/grpc/common/util.hpp
+++ b/silkworm/infra/grpc/common/util.hpp
@@ -51,11 +51,11 @@ inline std::ostream& operator<<(std::ostream& out, const Status& status) {
 void gpr_default_log(gpr_log_func_args* args);
 
 //! Define an empty gRPC logging function
-static void gpr_no_log(gpr_log_func_args* /*args*/) {
+inline void gpr_no_log(gpr_log_func_args* /*args*/) {
 }
 
 //! Define a gRPC logging function delegating to Silkworm logging facility.
-static void gpr_silkworm_log(gpr_log_func_args* args) {
+inline void gpr_silkworm_log(gpr_log_func_args* args) {
     std::string log_message{"gRPC: "};
     log_message.append(args->message);
     if (args->severity == GPR_LOG_SEVERITY_ERROR) {
@@ -78,7 +78,7 @@ template <void (*F)(gpr_log_func_args*)>
 class GrpcLogGuard {
   public:
     explicit GrpcLogGuard() { gpr_set_log_function(F); }
-    ~GrpcLogGuard() { gpr_set_log_function(gpr_default_log); }
+    ~GrpcLogGuard() { gpr_set_log_function(gpr_silkworm_log); }
 };
 
 //! Utility class to disable gRPC logging for an instance lifetime.

--- a/silkworm/infra/grpc/common/util_test.cpp
+++ b/silkworm/infra/grpc/common/util_test.cpp
@@ -62,7 +62,6 @@ TEST_CASE("GrpcLogGuard", "[silkworm][rpc][util]") {
 }
 
 TEST_CASE("gpr_silkworm_log", "[silkworm][rpc][util]") {
-    test_util::SetLogVerbosityGuard guard{log::Level::kNone};
     const char* FILE_NAME{"file.cpp"};
     const int LINE_NUMBER{10};
     Grpc2SilkwormLogGuard log_guard;

--- a/silkworm/infra/grpc/server/call_test.cpp
+++ b/silkworm/infra/grpc/server/call_test.cpp
@@ -28,7 +28,6 @@ TEST_CASE("BaseRpc", "[silkworm][rpc][call][.]") {
         explicit FakeRpc(grpc::ServerContext& server_context) : server::Call(server_context) {}
     };
 
-    test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
     grpc::ServerContext server_context;
 
     SECTION("count live instances") {

--- a/silkworm/infra/grpc/server/server_context_pool_test.cpp
+++ b/silkworm/infra/grpc/server/server_context_pool_test.cpp
@@ -34,7 +34,6 @@ using namespace concurrency;
 // Exclude gRPC tests from sanitizer builds due to data race warnings inside gRPC library
 #ifndef SILKWORM_SANITIZE
 TEST_CASE("ServerContext", "[silkworm][infra][grpc][server][server_context]") {
-    test_util::SetLogVerbosityGuard guard{log::Level::kNone};
     grpc::ServerBuilder builder;
     std::unique_ptr<grpc::ServerCompletionQueue> scq = builder.AddCompletionQueue();
     grpc::ServerCompletionQueue* scq_ptr = scq.get();
@@ -80,7 +79,6 @@ TEST_CASE("ServerContext", "[silkworm][infra][grpc][server][server_context]") {
 }
 
 TEST_CASE("ServerContextPool", "[silkworm][infra][grpc][server][server_context]") {
-    test_util::SetLogVerbosityGuard guard{log::Level::kNone};
     grpc::ServerBuilder builder;
 
     SECTION("ServerContextPool OK") {
@@ -133,7 +131,6 @@ TEST_CASE("ServerContextPool", "[silkworm][infra][grpc][server][server_context]"
 }
 
 TEST_CASE("ServerContextPool: handle loop exception", "[silkworm][infra][grpc][client][client_context]") {
-    test_util::SetLogVerbosityGuard guard{log::Level::kNone};
     grpc::ServerBuilder builder;
 
     ServerContextPool cp{{3}, builder};

--- a/silkworm/infra/grpc/server/server_settings_test.cpp
+++ b/silkworm/infra/grpc/server/server_settings_test.cpp
@@ -26,7 +26,6 @@ namespace silkworm::rpc {
 // Exclude gRPC tests from sanitizer builds due to data race warnings inside gRPC library
 #ifndef SILKWORM_SANITIZE
 TEST_CASE("ServerConfig::ServerConfig", "[silkworm][rpc][server_settings]") {
-    test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
     ServerSettings config;
     CHECK(config.address_uri == kDefaultAddressUri);
     CHECK(config.context_pool_settings.num_contexts > 0);

--- a/silkworm/infra/grpc/server/server_test.cpp
+++ b/silkworm/infra/grpc/server/server_test.cpp
@@ -56,7 +56,6 @@ namespace {  // Trick suggested by gRPC team to avoid name clashes in multiple t
 static constexpr std::string_view kTestAddressUri{"localhost:12345"};
 
 TEST_CASE("Barebone gRPC Server", "[silkworm][node][rpc]") {
-    test_util::SetLogVerbosityGuard guard{log::Level::kNone};
     grpc::ServerBuilder builder;
     // Add *at least one non-empty* ServerCompletionQueue (otherwise: ASAN SIGSEGV error in Shutdown)
     std::unique_ptr<grpc::ServerCompletionQueue> cq = builder.AddCompletionQueue();
@@ -77,8 +76,6 @@ TEST_CASE("Barebone gRPC Server", "[silkworm][node][rpc]") {
 }
 
 TEST_CASE("Server::Server", "[silkworm][node][rpc]") {
-    test_util::SetLogVerbosityGuard guard{log::Level::kNone};
-
     SECTION("OK: create an empty Server", "[silkworm][node][rpc]") {
         ServerSettings settings;
         settings.address_uri = kTestAddressUri;
@@ -87,8 +84,6 @@ TEST_CASE("Server::Server", "[silkworm][node][rpc]") {
 }
 
 TEST_CASE("Server::build_and_start", "[silkworm][node][rpc]") {
-    test_util::SetLogVerbosityGuard set_log_verbosity_guard{log::Level::kNone};
-
     // TODO(canepat): use GMock
     class TestServer : public EmptyServer {
       public:
@@ -142,7 +137,6 @@ TEST_CASE("Server::build_and_start", "[silkworm][node][rpc]") {
 }
 
 TEST_CASE("Server::shutdown", "[silkworm][node][rpc]") {
-    test_util::SetLogVerbosityGuard guard{log::Level::kNone};
     ServerSettings settings;
     settings.address_uri = kTestAddressUri;
     EmptyServer server{settings};
@@ -160,7 +154,6 @@ TEST_CASE("Server::shutdown", "[silkworm][node][rpc]") {
 }
 
 TEST_CASE("Server::join", "[silkworm][node][rpc]") {
-    test_util::SetLogVerbosityGuard guard{log::Level::kNone};
     ServerSettings settings;
     settings.address_uri = kTestAddressUri;
     EmptyServer server{settings};

--- a/silkworm/infra/test_util/context_test_base.cpp
+++ b/silkworm/infra/test_util/context_test_base.cpp
@@ -19,8 +19,7 @@
 namespace silkworm::test_util {
 
 ContextTestBase::ContextTestBase()
-    : log_guard_{log::Level::kNone},
-      context_{0},
+    : context_{0},
       io_context_{*context_.io_context()},
       grpc_context_{*context_.grpc_context()},
       context_thread_{[&]() { context_.execute_loop(); }} {}

--- a/silkworm/infra/test_util/context_test_base.hpp
+++ b/silkworm/infra/test_util/context_test_base.hpp
@@ -53,7 +53,6 @@ class ContextTestBase {
     agrpc::GrpcContext& grpc_context() { return grpc_context_; }
 
   protected:
-    silkworm::test_util::SetLogVerbosityGuard log_guard_;
     rpc::ClientContext context_;
     boost::asio::io_context& io_context_;
     agrpc::GrpcContext& grpc_context_;

--- a/silkworm/node/execution/active_direct_service_test.cpp
+++ b/silkworm/node/execution/active_direct_service_test.cpp
@@ -37,7 +37,6 @@ using testing::NiceMock;
 
 using silkworm::db::test_util::TempChainData;
 using silkworm::node::test_util::make_node_settings_from_temp_chain_data;
-using silkworm::test_util::SetLogVerbosityGuard;
 using silkworm::test_util::TaskRunner;
 
 class ActiveDirectServiceForTest : public ActiveDirectService {
@@ -47,8 +46,7 @@ class ActiveDirectServiceForTest : public ActiveDirectService {
 
 struct ActiveDirectServiceTest : public TaskRunner {
     explicit ActiveDirectServiceTest()
-        : log_guard{log::Level::kNone},
-          settings{make_node_settings_from_temp_chain_data(tmp_chaindata)} {
+        : settings{make_node_settings_from_temp_chain_data(tmp_chaindata)} {
         tmp_chaindata.add_genesis_data();
         tmp_chaindata.commit_txn();
         mock_execution_engine = std::make_unique<NiceMock<MockExecutionEngine>>(executor(), settings, tmp_chaindata.chaindata_rw());
@@ -64,7 +62,6 @@ struct ActiveDirectServiceTest : public TaskRunner {
         }
     }
 
-    SetLogVerbosityGuard log_guard;
     TempChainData tmp_chaindata;
     NodeSettings settings;
     std::unique_ptr<MockExecutionEngine> mock_execution_engine;

--- a/silkworm/node/execution/direct_service_test.cpp
+++ b/silkworm/node/execution/direct_service_test.cpp
@@ -34,20 +34,17 @@ using testing::InvokeWithoutArgs;
 
 using silkworm::db::test_util::TempChainData;
 using silkworm::node::test_util::make_node_settings_from_temp_chain_data;
-using silkworm::test_util::SetLogVerbosityGuard;
 using silkworm::test_util::TaskRunner;
 
 struct DirectServiceTest : public TaskRunner {
     explicit DirectServiceTest()
-        : log_guard{log::Level::kNone},
-          settings{make_node_settings_from_temp_chain_data(tmp_chaindata)} {
+        : settings{make_node_settings_from_temp_chain_data(tmp_chaindata)} {
         tmp_chaindata.add_genesis_data();
         tmp_chaindata.commit_txn();
         mock_execution_engine = std::make_unique<MockExecutionEngine>(executor(), settings, tmp_chaindata.chaindata_rw());
         direct_service = std::make_unique<DirectService>(*mock_execution_engine);
     }
 
-    SetLogVerbosityGuard log_guard;
     TempChainData tmp_chaindata;
     NodeSettings settings;
     std::unique_ptr<MockExecutionEngine> mock_execution_engine;

--- a/silkworm/node/execution/header_chain_plus_exec_test.cpp
+++ b/silkworm/node/execution/header_chain_plus_exec_test.cpp
@@ -39,7 +39,6 @@ using namespace silkworm::db;
 
 using silkworm::execution::api::ValidChain;
 using silkworm::stagedsync::test_util::make_stages_factory;
-using silkworm::test_util::SetLogVerbosityGuard;
 using silkworm::test_util::TaskRunner;
 
 class HeaderChainForTest : public HeaderChain {
@@ -78,8 +77,6 @@ class DummyRuleSet : public protocol::RuleSet {
 };
 
 TEST_CASE("Headers receiving and saving") {
-    SetLogVerbosityGuard log_guard(log::Level::kNone);
-
     TaskRunner runner;
 
     db::test_util::TempChainDataStore context;

--- a/silkworm/node/remote/ethbackend/grpc/server/backend_server_test.cpp
+++ b/silkworm/node/remote/ethbackend/grpc/server/backend_server_test.cpp
@@ -225,9 +225,7 @@ using BackEndServer = ethbackend::grpc::server::BackEndServer;
 
 struct BackEndE2ETest {
     explicit BackEndE2ETest(
-        silkworm::log::Level log_verbosity = silkworm::log::Level::kNone,
-        const NodeSettings& options = {})
-        : set_verbosity_log_guard{log_verbosity} {
+        const NodeSettings& options = {}) {
         std::shared_ptr<grpc::Channel> channel =
             grpc::CreateChannel(kTestAddressUri, grpc::InsecureChannelCredentials());
         ethbackend_stub = remote::ETHBACKEND::NewStub(channel);
@@ -282,7 +280,6 @@ struct BackEndE2ETest {
         server->join();
     }
 
-    test_util::SetLogVerbosityGuard set_verbosity_log_guard;
     rpc::Grpc2SilkwormLogGuard grpc2silkworm_log_guard;
     std::unique_ptr<remote::ETHBACKEND::Stub> ethbackend_stub;
     std::unique_ptr<BackEndClient> backend_client;
@@ -301,7 +298,6 @@ namespace silkworm::ethbackend::grpc::server {
 // Exclude gRPC tests from sanitizer builds due to data race warnings inside gRPC library
 #ifndef SILKWORM_SANITIZE
 TEST_CASE("BackEndServer", "[silkworm][node][rpc]") {
-    test_util::SetLogVerbosityGuard guard{log::Level::kNone};
     rpc::Grpc2SilkwormLogGuard log_guard;
     rpc::ServerSettings srv_config;
     srv_config.address_uri = kTestAddressUri;
@@ -447,7 +443,7 @@ TEST_CASE("BackEndServer E2E: mainnet chain with zero etherbase", "[silkworm][no
     NodeSettings node_settings;
     node_settings.chain_config = kMainnetConfig;
     node_settings.etherbase = evmc::address{};
-    BackEndE2ETest test{silkworm::log::Level::kNone, node_settings};
+    BackEndE2ETest test{node_settings};
     auto backend_client = *test.backend_client;
 
     SECTION("Etherbase: return coinbase address") {

--- a/silkworm/node/stagedsync/execution_engine_test.cpp
+++ b/silkworm/node/stagedsync/execution_engine_test.cpp
@@ -47,7 +47,6 @@ using execution::api::ValidChain;
 
 using silkworm::stagedsync::test_util::make_stages_factory;
 using silkworm::test_util::generate_sample_child_blocks;
-using silkworm::test_util::SetLogVerbosityGuard;
 using silkworm::test_util::TaskRunner;
 
 class ExecutionEngineForTest : public stagedsync::ExecutionEngine {
@@ -57,7 +56,6 @@ class ExecutionEngineForTest : public stagedsync::ExecutionEngine {
 };
 
 TEST_CASE("ExecutionEngine Integration Test", "[node][execution][execution_engine]") {
-    SetLogVerbosityGuard log_guard(log::Level::kNone);
     TemporaryDirectory tmp_dir;
     TaskRunner runner;
     Environment::set_stop_before_stage(stages::kSendersKey);  // only headers, block hashes and bodies
@@ -811,8 +809,6 @@ TEST_CASE("ExecutionEngine Integration Test", "[node][execution][execution_engin
 }
 
 TEST_CASE("ExecutionEngine") {
-    SetLogVerbosityGuard log_guard(log::Level::kNone);
-
     TaskRunner runner;
 
     db::test_util::TempChainDataStore context;

--- a/silkworm/node/stagedsync/forks/fork_test.cpp
+++ b/silkworm/node/stagedsync/forks/fork_test.cpp
@@ -54,8 +54,6 @@ class ForkForTest : public Fork {
 };
 
 TEST_CASE("Fork") {
-    SetLogVerbosityGuard log_guard(log::Level::kNone);
-
     db::test_util::TempChainDataStore context;
     context.add_genesis_data();
     context.commit_txn();

--- a/silkworm/node/stagedsync/forks/main_chain_test.cpp
+++ b/silkworm/node/stagedsync/forks/main_chain_test.cpp
@@ -59,8 +59,6 @@ TEST_CASE("MainChain transaction handling") {
         auto keep_db_txn_open = i == 1;
 
         SECTION("keep_db_txn_open = " + std::to_string(keep_db_txn_open)) {
-            silkworm::test_util::SetLogVerbosityGuard log_guard(log::Level::kNone);
-
             asio::io_context io;
             asio::executor_work_guard<decltype(io.get_executor())> work{io.get_executor()};
 

--- a/silkworm/node/stagedsync/stages/stage_bodies_test.cpp
+++ b/silkworm/node/stagedsync/stages/stage_bodies_test.cpp
@@ -35,7 +35,6 @@ class BodiesStageForTest : public stagedsync::BodiesStage {
 using BodyDataModelForTest = BodiesStageForTest::BodyDataModel;
 
 TEST_CASE("BodiesStage - data model") {
-    silkworm::test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
     db::test_util::TempChainDataStore context;
     context.add_genesis_data();
     context.commit_txn();

--- a/silkworm/node/stagedsync/stages/stage_headers_test.cpp
+++ b/silkworm/node/stagedsync/stages/stage_headers_test.cpp
@@ -35,7 +35,6 @@ class HeadersStageForTest : public stagedsync::HeadersStage {
 using HeaderDataModelForTest = HeadersStageForTest::HeaderDataModel;
 
 TEST_CASE("HeadersStage - data model") {
-    silkworm::test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
     db::test_util::TempChainDataStore context;
     context.add_genesis_data();
     context.commit_txn();

--- a/silkworm/node/stagedsync/stages/stage_history_index_test.cpp
+++ b/silkworm/node/stagedsync/stages/stage_history_index_test.cpp
@@ -35,7 +35,6 @@ namespace silkworm {
 using namespace evmc::literals;
 using namespace silkworm::db;
 using db::test_util::TempChainData;
-using silkworm::test_util::SetLogVerbosityGuard;
 
 stagedsync::HistoryIndex make_stage_history_index(
     stagedsync::SyncContext* sync_context,
@@ -52,8 +51,6 @@ stagedsync::HistoryIndex make_stage_history_index(
 }
 
 TEST_CASE("Stage History Index") {
-    SetLogVerbosityGuard log_guard{log::Level::kNone};
-
     TempChainData context;
     RWTxn& txn{context.rw_txn()};
     txn.disable_commit();
@@ -440,12 +437,9 @@ TEST_CASE("Stage History Index") {
             REQUIRE(count == 1);
         }
     }
-
-    log::set_verbosity(log::Level::kInfo);
 }
 
 TEST_CASE("HistoryIndex + Account access_layer") {
-    SetLogVerbosityGuard log_guard{log::Level::kNone};
     TempChainData context;
     RWTxn& txn{context.rw_txn()};
 

--- a/silkworm/node/stagedsync/stages/stage_tx_lookup_test.cpp
+++ b/silkworm/node/stagedsync/stages/stage_tx_lookup_test.cpp
@@ -28,7 +28,6 @@ namespace silkworm {
 using namespace silkworm::db;
 using namespace evmc::literals;
 using db::test_util::TempChainDataStore;
-using silkworm::test_util::SetLogVerbosityGuard;
 
 stagedsync::TxLookup make_tx_lookup_stage(
     stagedsync::SyncContext* sync_context,
@@ -42,8 +41,6 @@ stagedsync::TxLookup make_tx_lookup_stage(
 }
 
 TEST_CASE("Stage Transaction Lookups") {
-    SetLogVerbosityGuard log_guard{log::Level::kNone};
-
     const evmc::bytes32 hash_0{0x3ac225168df54212a25c1c01fd35bebfea408fdac2e31ddd6f80a4bbf9a5f1cb_bytes32};
     const evmc::bytes32 hash_1{0xb5553de315e0edf504d9150af82dafa5c4667fa618ed0a6f19c69b41166c5510_bytes32};
 

--- a/silkworm/node/stagedsync/stages_test.cpp
+++ b/silkworm/node/stagedsync/stages_test.cpp
@@ -70,7 +70,6 @@ static stagedsync::CallTraceIndex make_call_traces_stage(
 }
 
 TEST_CASE("Sync Stages") {
-    silkworm::test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
     TemporaryDirectory tmp_dir;
     NodeSettings node_settings{};
     node_settings.data_directory = std::make_unique<DataDirectory>(tmp_dir.path());

--- a/silkworm/rpc/commands/debug_api_test.cpp
+++ b/silkworm/rpc/commands/debug_api_test.cpp
@@ -283,8 +283,6 @@ class DummyDatabase : public ethdb::Database {
 
 #ifndef SILKWORM_SANITIZE
 TEST_CASE("DebugRpcApi") {
-    test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
-
     boost::asio::io_context ioc;
     add_shared_service(ioc, std::make_shared<BlockCache>());
     add_shared_service<db::kv::api::StateCache>(ioc, std::make_shared<db::kv::api::CoherentStateCache>());

--- a/silkworm/rpc/commands/rpc_api_test.cpp
+++ b/silkworm/rpc/commands/rpc_api_test.cpp
@@ -26,7 +26,6 @@
 namespace silkworm::rpc::commands {
 
 #ifdef notdef  // commented Temporary wating implementaion local-transaction
-using silkworm::test_util::SetLogVerbosityGuard;
 using test_util::RequestHandlerForTest;
 using test_util::RpcApiTestBase;
 #endif
@@ -84,7 +83,6 @@ static const std::vector<std::string> kSubtestsToIgnore = {
 // Exclude tests from sanitizer builds due to ASAN/TSAN warnings inside gRPC library
 #ifndef SILKWORM_SANITIZE
 TEST_CASE("rpc_api io (all files)", "[rpc][rpc_api]") {
-    SetLogVerbosityGuard log_guard{log::Level::kNone};
     auto tests_dir = db::test_util::get_tests_dir();
     for (const auto& test_file : std::filesystem::recursive_directory_iterator(tests_dir)) {
         if (!test_file.is_directory() && test_file.path().extension() == ".io") {
@@ -138,8 +136,8 @@ TEST_CASE("rpc_api io (all files)", "[rpc][rpc_api]") {
     }
 }
 
-TEST_CASE("rpc_api io (individual)", "[rpc][rpc_api][ignore]") {
-    SetLogVerbosityGuard log_guard{log::Level::kNone};
+#ifdef SILKWORM_TEST_SKIP
+TEST_CASE("rpc_api io (individual)", "[rpc][rpc_api]") {
     TemporaryDirectory tmp_dir;
     auto context = db::test_util::TestDatabaseContext(tmp_dir);
     RpcApiTestBase<RequestHandlerForTest> test_base{context.mdbx_env()};
@@ -152,6 +150,8 @@ TEST_CASE("rpc_api io (individual)", "[rpc][rpc_api][ignore]") {
         CHECK(nlohmann::json::parse(response) == R"({"jsonrpc":"2.0","id":1,"result":"0xf8678084342770c182520894658bdf435d810c91414ec09147daa6db624063798203e880820a95a0af5fc351b9e457a31f37c84e5cd99dd3c5de60af3de33c6f4160177a2c786a60a0201da7a21046af55837330a2c52fc1543cd4d9ead00ddf178dd96935b607ff9b"})"_json);
     }
 }
+#endif  // SILKWORM_TEST_SKIP
+
 #endif  // SILKWORM_SANITIZE
 
 #endif

--- a/silkworm/rpc/commands/trace_api_test.cpp
+++ b/silkworm/rpc/commands/trace_api_test.cpp
@@ -25,8 +25,6 @@ namespace silkworm::rpc::commands {
 
 #ifndef SILKWORM_SANITIZE
 TEST_CASE("TraceRpcApi") {
-    silkworm::test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
-
     boost::asio::io_context ioc;
     WorkerPool workers{1};
 

--- a/silkworm/rpc/common/util_test.cpp
+++ b/silkworm/rpc/common/util_test.cpp
@@ -225,7 +225,6 @@ TEST_CASE("lookup_chain_config", "[rpc][common][util]") {
 }
 
 TEST_CASE("get_opcode_name") {
-    silkworm::test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
     const char* names[256] = {
         /* 0x00 */ "STOP",
         /* 0x01 */ "ADD",
@@ -262,7 +261,6 @@ TEST_CASE("get_opcode_name") {
 }
 
 TEST_CASE("get_opcode_hex") {
-    silkworm::test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
     SECTION("1 digit opcode") {
         auto op_code = get_opcode_hex(0x00);
         CHECK(op_code == "0x0");

--- a/silkworm/rpc/core/account_dumper_test.cpp
+++ b/silkworm/rpc/core/account_dumper_test.cpp
@@ -256,7 +256,6 @@ class DummyDatabase : public ethdb::Database {
 
 #ifdef TEST_DISABLED
 TEST_CASE("account dumper") {
-    silkworm::test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
     WorkerPool pool{1};
     nlohmann::json json;
     BlockCache block_cache(100, true);

--- a/silkworm/rpc/core/estimate_gas_oracle_test.cpp
+++ b/silkworm/rpc/core/estimate_gas_oracle_test.cpp
@@ -49,8 +49,6 @@ using testing::_;
 using testing::Return;
 
 TEST_CASE("EstimateGasException") {
-    silkworm::test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
-
     SECTION("EstimateGasException(int64_t, std::string const&)") {
         const char* kErrorMessage{"insufficient funds for transfer"};
         const int64_t kErrorCode{-1};
@@ -72,7 +70,6 @@ TEST_CASE("EstimateGasException") {
 }
 
 TEST_CASE("estimate gas") {
-    silkworm::test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
     WorkerPool pool{1};
     WorkerPool workers{1};
 

--- a/silkworm/rpc/core/evm_trace_test.cpp
+++ b/silkworm/rpc/core/evm_trace_test.cpp
@@ -3077,8 +3077,6 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_transaction") 
 }
 
 TEST_CASE("VmTrace json serialization") {
-    silkworm::test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
-
     TraceEx trace_ex;
     trace_ex.used = 5000;
     trace_ex.stack.emplace_back("0xdeadbeaf");
@@ -3165,8 +3163,6 @@ TEST_CASE("VmTrace json serialization") {
 }
 
 TEST_CASE("TraceAction json serialization") {
-    silkworm::test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
-
     TraceAction trace_action;
     trace_action.from = 0xe0a2Bd4258D2768837BAa26A28fE71Dc079f84c7_address;
     trace_action.gas = 1000;
@@ -3209,8 +3205,6 @@ TEST_CASE("TraceAction json serialization") {
 }
 
 TEST_CASE("TraceResult json serialization") {
-    silkworm::test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
-
     TraceResult trace_result;
     trace_result.address = 0xe0a2Bd4258D2768837BAa26A28fE71Dc079f84c7_address;
     trace_result.code = *silkworm::from_hex("0x1234567890abcdef");
@@ -3224,8 +3218,6 @@ TEST_CASE("TraceResult json serialization") {
 }
 
 TEST_CASE("Trace json serialization") {
-    silkworm::test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
-
     TraceAction trace_action;
     trace_action.from = 0xe0a2Bd4258D2768837BAa26A28fE71Dc079f84c7_address;
     trace_action.gas = 1000;
@@ -3314,8 +3306,6 @@ TEST_CASE("Trace json serialization") {
 }
 
 TEST_CASE("StateDiff json serialization") {
-    silkworm::test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
-
     StateDiff state_diff;
 
     SECTION("basic") {
@@ -3339,8 +3329,6 @@ TEST_CASE("StateDiff json serialization") {
 }
 
 TEST_CASE("DiffValue json serialization") {
-    silkworm::test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
-
     SECTION("no entries") {
         DiffValue dv;
 
@@ -3373,8 +3361,6 @@ TEST_CASE("DiffValue json serialization") {
 }
 
 TEST_CASE("copy_stack") {
-    silkworm::test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
-
     const size_t stack_size{32};
     evmone::uint256 stack[stack_size] = {
         {0x00}, {0x01}, {0x02}, {0x03}, {0x04}, {0x05}, {0x06}, {0x07}, {0x08}, {0x09}, {0x0A}, {0x0B}, {0x0C}, {0x0D}, {0x0E}, {0x0F}, {0x10}, {0x11}, {0x12}, {0x13}, {0x14}, {0x15}, {0x16}, {0x17}, {0x18}, {0x19}, {0x1A}, {0x1B}, {0x1C}, {0x1D}, {0x1E}, {0x1F}};
@@ -3559,8 +3545,6 @@ TEST_CASE("copy_stack") {
 }
 
 TEST_CASE("copy_memory") {
-    silkworm::test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
-
     evmone::Memory memory;
     for (std::uint8_t idx = 0; idx < 16; ++idx) {
         memory[idx] = idx;
@@ -3591,8 +3575,6 @@ TEST_CASE("copy_memory") {
 }
 
 TEST_CASE("copy_store") {
-    silkworm::test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
-
     const size_t stack_size{32};
     evmone::uint256 stack[stack_size] = {
         {0x00}, {0x01}, {0x02}, {0x03}, {0x04}, {0x05}, {0x06}, {0x07}, {0x08}, {0x09}, {0x0A}, {0x0B}, {0x0C}, {0x0D}, {0x0E}, {0x0F}, {0x10}, {0x11}, {0x12}, {0x13}, {0x14}, {0x15}, {0x16}, {0x17}, {0x18}, {0x19}, {0x1A}, {0x1B}, {0x1C}, {0x1D}, {0x1E}, {0x1F}};
@@ -3617,8 +3599,6 @@ TEST_CASE("copy_store") {
 }
 
 TEST_CASE("copy_memory_offset_len") {
-    silkworm::test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
-
     const size_t stack_size{32};
     evmone::uint256 stack[stack_size] = {
         {0x00}, {0x01}, {0x02}, {0x03}, {0x04}, {0x05}, {0x06}, {0x07}, {0x08}, {0x09}, {0x0A}, {0x0B}, {0x0C}, {0x0D}, {0x0E}, {0x0F}, {0x10}, {0x11}, {0x12}, {0x13}, {0x14}, {0x15}, {0x16}, {0x17}, {0x18}, {0x19}, {0x1A}, {0x1B}, {0x1C}, {0x1D}, {0x1E}, {0x1F}};
@@ -3685,8 +3665,6 @@ TEST_CASE("copy_memory_offset_len") {
 }
 
 TEST_CASE("push_memory_offset_len") {
-    silkworm::test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
-
     const size_t stack_size{32};
     evmone::uint256 stack[stack_size] = {
         {0x00}, {0x01}, {0x02}, {0x03}, {0x04}, {0x05}, {0x06}, {0x07}, {0x08}, {0x09}, {0x0A}, {0x0B}, {0x0C}, {0x0D}, {0x0E}, {0x0F}, {0x10}, {0x11}, {0x12}, {0x13}, {0x14}, {0x15}, {0x16}, {0x17}, {0x18}, {0x19}, {0x1A}, {0x1B}, {0x1C}, {0x1D}, {0x1E}, {0x1F}};
@@ -3744,7 +3722,6 @@ TEST_CASE("to_string") {
 }
 
 TEST_CASE("TraceConfig") {
-    silkworm::test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
     SECTION("dump on stream") {
         TraceConfig config{true, false, true};
 
@@ -3775,7 +3752,6 @@ TEST_CASE("TraceConfig") {
 }
 
 TEST_CASE("TraceFilter") {
-    silkworm::test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
     SECTION("dump on stream: simple") {
         TraceFilter config;
 
@@ -3849,8 +3825,6 @@ TEST_CASE("TraceFilter") {
 }
 
 TEST_CASE("TraceCall") {
-    silkworm::test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
-
     SECTION("json deserialization") {
         nlohmann::json json = R"([
             {
@@ -3881,8 +3855,6 @@ TEST_CASE("TraceCall") {
 }
 
 TEST_CASE("TraceCallTraces: json serialization") {
-    silkworm::test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
-
     TraceCallTraces tct;
     tct.output = "0xdeadbeaf";
 
@@ -3944,7 +3916,6 @@ TEST_CASE("TraceCallTraces: json serialization") {
 }
 
 TEST_CASE("TraceCallResult: json serialization") {
-    silkworm::test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
     TraceCallResult tcr;
 
     SECTION("with traces") {
@@ -3959,7 +3930,6 @@ TEST_CASE("TraceCallResult: json serialization") {
 }
 
 TEST_CASE("TraceManyCallResult: json serialization") {
-    silkworm::test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
     TraceManyCallResult tmcr;
 
     SECTION("with traces") {

--- a/silkworm/rpc/core/fee_history_oracle_test.cpp
+++ b/silkworm/rpc/core/fee_history_oracle_test.cpp
@@ -24,8 +24,6 @@
 namespace silkworm::rpc::fee_history {
 
 TEST_CASE("FeeHistory: json serialization") {
-    silkworm::test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
-
     SECTION("default value") {
         FeeHistory fh;
 

--- a/silkworm/rpc/core/filter_storage_test.cpp
+++ b/silkworm/rpc/core/filter_storage_test.cpp
@@ -27,8 +27,6 @@
 namespace silkworm::rpc {
 
 TEST_CASE("FilterStorage base") {
-    test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
-
     FilterStorage filter_storage{3, 0.01};
     SECTION("adding 1 entry") {
         StoredFilter filter;
@@ -110,8 +108,6 @@ TEST_CASE("FilterStorage base") {
 }
 
 TEST_CASE("FilterStorage enhanced") {
-    test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
-
     std::uint64_t count = 0;
     std::uint64_t max_keys = 3;
     Generator default_generator = [&]() { return count++ % max_keys; };

--- a/silkworm/rpc/core/receipts_test.cpp
+++ b/silkworm/rpc/core/receipts_test.cpp
@@ -64,7 +64,6 @@ static silkworm::Bytes kHeader{*silkworm::from_hex(
 static silkworm::Bytes kBody{*silkworm::from_hex("c68369e45a03c0")};
 
 TEST_CASE("read_receipts") {
-    silkworm::test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
     WorkerPool pool{1};
     db::test_util::MockTransaction transaction;
 
@@ -226,7 +225,6 @@ TEST_CASE("read_receipts") {
 }
 
 TEST_CASE("get_receipts") {
-    silkworm::test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
     WorkerPool pool{1};
     db::test_util::MockTransaction transaction;
     std::unique_ptr<ethbackend::BackEnd> backend = std::make_unique<test::BackEndMock>();

--- a/silkworm/rpc/ethdb/cbor_test.cpp
+++ b/silkworm/rpc/ethdb/cbor_test.cpp
@@ -42,21 +42,18 @@ using evmc::literals::operator""_address, evmc::literals::operator""_bytes32;
 using std::string_literals::operator""s;
 
 TEST_CASE("decode logs from empty bytes", "[rpc][ethdb][cbor]") {
-    test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
     Logs logs{};
     CHECK_NOTHROW(cbor_decode(*silkworm::from_hex(""), logs));
     CHECK(logs.empty());
 }
 
 TEST_CASE("decode logs from empty array", "[rpc][ethdb][cbor]") {
-    test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
     Logs logs{};
     CHECK_NOTHROW(cbor_decode(*silkworm::from_hex("80"), logs));
     CHECK(logs.empty());
 }
 
 TEST_CASE("decode logs from CBOR 1", "[rpc][ethdb][cbor]") {
-    test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
     Logs logs{};
     CHECK_NOTHROW(cbor_decode(*silkworm::from_hex("818354000000000000000000000000000000000000000080f6"), logs));
     CHECK(logs.size() == 1);
@@ -66,7 +63,6 @@ TEST_CASE("decode logs from CBOR 1", "[rpc][ethdb][cbor]") {
 }
 
 TEST_CASE("decode logs from CBOR 2", "[rpc][ethdb][cbor]") {
-    test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
     Logs logs{};
     CHECK_NOTHROW(cbor_decode(*silkworm::from_hex(
                                   "82"
@@ -83,7 +79,6 @@ TEST_CASE("decode logs from CBOR 2", "[rpc][ethdb][cbor]") {
 }
 
 TEST_CASE("decode logs from CBOR 3", "[rpc][ethdb][cbor]") {
-    test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
     Logs logs{};
     auto bytes = *silkworm::from_hex("818354ea674fdde714fd979de3edf0f56aa9716b898ec88043010043");
     CHECK_NOTHROW(cbor_decode(bytes, logs));
@@ -94,7 +89,6 @@ TEST_CASE("decode logs from CBOR 3", "[rpc][ethdb][cbor]") {
 }
 
 TEST_CASE("decode logs from CBOR 4", "[rpc][ethdb][cbor]") {
-    test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
     Logs logs{};
     auto bytes = *silkworm::from_hex(
         "81835456c0369e002852c2570ca0cc3442e26df98e01a2835820ddf252ad1be2c89b69c2b068fc37"
@@ -114,7 +108,6 @@ TEST_CASE("decode logs from CBOR 4", "[rpc][ethdb][cbor]") {
 }
 
 TEST_CASE("decode logs from incorrect bytes", "[rpc][ethdb][cbor]") {
-    test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
     Logs logs{};
     const Bytes b1 = *silkworm::from_hex("81");
     CHECK(!cbor_decode(b1, logs));
@@ -123,21 +116,18 @@ TEST_CASE("decode logs from incorrect bytes", "[rpc][ethdb][cbor]") {
 }
 
 TEST_CASE("decode receipts from empty bytes", "[rpc][ethdb][cbor]") {
-    test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
     Receipts receipts{};
     CHECK_NOTHROW(cbor_decode(*silkworm::from_hex(""), receipts));
     CHECK(receipts.empty());
 }
 
 TEST_CASE("decode receipts from empty array", "[rpc][ethdb][cbor]") {
-    test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
     Receipts receipts{};
     CHECK_NOTHROW(cbor_decode(*silkworm::from_hex("80"), receipts));
     CHECK(receipts.empty());
 }
 
 TEST_CASE("decode receipts from CBOR 1", "[rpc][ethdb][cbor]") {
-    test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
     Receipts receipts{};
     CHECK_NOTHROW(cbor_decode(*silkworm::from_hex("818400f60101"), receipts));
     CHECK(receipts.size() == 1);
@@ -147,7 +137,6 @@ TEST_CASE("decode receipts from CBOR 1", "[rpc][ethdb][cbor]") {
 }
 
 TEST_CASE("decode receipts from CBOR 2", "[rpc][ethdb][cbor]") {
-    test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
     Receipts receipts{};
     CHECK_NOTHROW(cbor_decode(*silkworm::from_hex(
                                   "82"
@@ -164,7 +153,6 @@ TEST_CASE("decode receipts from CBOR 2", "[rpc][ethdb][cbor]") {
 }
 
 TEST_CASE("decode receipts from CBOR 3", "[rpc][ethdb][cbor]") {
-    test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
     Receipts receipts{};
     auto bytes = *silkworm::from_hex("838400f601196d398400f6011a00371b0b8400f6011a003947f4");
     CHECK_NOTHROW(cbor_decode(bytes, receipts));
@@ -178,7 +166,6 @@ TEST_CASE("decode receipts from CBOR 3", "[rpc][ethdb][cbor]") {
 }
 
 TEST_CASE("decode receipts from incorrect bytes", "[rpc][ethdb][cbor]") {
-    test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
     Receipts receipts{};
     const Bytes b1 = *silkworm::from_hex("81");
     CHECK_THROWS(cbor_decode(b1, receipts));

--- a/silkworm/rpc/http/connection_test.cpp
+++ b/silkworm/rpc/http/connection_test.cpp
@@ -39,8 +39,6 @@ class ConnectionForTest : public Connection {
 };
 
 TEST_CASE("connection creation", "[rpc][http][connection]") {
-    test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
-
     SECTION("field initialization") {
         boost::asio::io_context ioc;
         boost::asio::ip::tcp::socket socket{ioc};
@@ -86,7 +84,6 @@ static RequestWithStringBody create_request_with_bearer_token(const std::string&
 }
 
 TEST_CASE("is_request_authorized", "[rpc][http][connection]") {
-    test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
     boost::asio::io_context ioc;
     RequestHandlerFactory handler_factory = [](auto*) -> RequestHandlerPtr { return nullptr; };
     std::vector<std::string> allowed_origins;

--- a/silkworm/rpc/http/jwt_test.cpp
+++ b/silkworm/rpc/http/jwt_test.cpp
@@ -28,7 +28,6 @@
 namespace silkworm {
 
 TEST_CASE("generate_jwt_token", "[silkworm][rpc][http][jwt]") {
-    test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
     test_util::TemporaryFile tmp_jwt_file;
 
     SECTION("empty file path") {
@@ -83,7 +82,6 @@ TEST_CASE("generate_jwt_token", "[silkworm][rpc][http][jwt]") {
 }
 
 TEST_CASE("load_jwt_token", "[silkworm][rpc][http][jwt]") {
-    test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
     test_util::TemporaryFile tmp_jwt_file;
     std::ofstream tmp_jwt_ofs{tmp_jwt_file.path()};
 

--- a/silkworm/rpc/json/types_test.cpp
+++ b/silkworm/rpc/json/types_test.cpp
@@ -70,7 +70,6 @@ TEST_CASE("serialize empty address using to_hex(char *)", "[rpc][to_json]") {
 }
 
 TEST_CASE("serialize empty address using to_hex(char *) small buffer", "[rpc][to_json]") {
-    test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
     evmc::address address{};
     char address_zero[10];
     CHECK_THROWS(to_hex(address_zero, address.bytes));

--- a/silkworm/rpc/test_util/api_test_database.hpp
+++ b/silkworm/rpc/test_util/api_test_database.hpp
@@ -136,7 +136,6 @@ class RpcApiE2ETest : public TestDataStoreBase, RpcApiTestBase<RequestHandlerFor
     using RpcApiTestBase<RequestHandlerForTest>::run;
 
   private:
-    static inline silkworm::test_util::SetLogVerbosityGuard log_guard_{log::Level::kNone};
     static inline bool jsonrpc_spec_loaded{false};
 };
 

--- a/silkworm/sync/internals/body_sequence_test.cpp
+++ b/silkworm/sync/internals/body_sequence_test.cpp
@@ -46,7 +46,6 @@ TEST_CASE("body downloading", "[silkworm][sync][BodySequence]") {
     using namespace std::chrono_literals;
     using intx::operator""_u256;
 
-    test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
     db::test_util::TempChainData context;
     context.add_genesis_data();
 

--- a/silkworm/sync/internals/header_chain_test.cpp
+++ b/silkworm/sync/internals/header_chain_test.cpp
@@ -50,8 +50,6 @@ class HeaderChainForTest : public HeaderChain {
 // ----------------------------------------------------------------------------
 
 TEST_CASE("HeaderList::split_into_segments no headers") {
-    test_util::SetLogVerbosityGuard guard{log::Level::kNone};
-
     std::vector<BlockHeader> headers;
     auto headerList = HeaderList::make(headers);
 
@@ -62,8 +60,6 @@ TEST_CASE("HeaderList::split_into_segments no headers") {
 }
 
 TEST_CASE("HeaderList::split_into_segments single header") {
-    test_util::SetLogVerbosityGuard guard{log::Level::kNone};
-
     std::vector<BlockHeader> headers;
     BlockHeader header;
     header.number = 5;
@@ -78,8 +74,6 @@ TEST_CASE("HeaderList::split_into_segments single header") {
 }
 
 TEST_CASE("HeaderList::split_into_segments single header repeated twice") {
-    test_util::SetLogVerbosityGuard guard{log::Level::kNone};
-
     std::vector<BlockHeader> headers;
     BlockHeader header;
     header.number = 5;
@@ -95,7 +89,6 @@ TEST_CASE("HeaderList::split_into_segments single header repeated twice") {
 }
 
 TEST_CASE("HeaderList::split_into_segments two connected headers") {
-    test_util::SetLogVerbosityGuard guard{log::Level::kNone};
     std::vector<BlockHeader> headers;
 
     BlockHeader header1;
@@ -121,7 +114,6 @@ TEST_CASE("HeaderList::split_into_segments two connected headers") {
 }
 
 TEST_CASE("HeaderList::split_into_segments two connected headers with wrong numbers") {
-    test_util::SetLogVerbosityGuard guard{log::Level::kNone};
     std::vector<BlockHeader> headers;
 
     BlockHeader header1;
@@ -150,7 +142,6 @@ TEST_CASE("HeaderList::split_into_segments two connected headers with wrong numb
  *         3 segments: {h3}, {h2}, {h1}   (in this order)
  */
 TEST_CASE("HeaderList::split_into_segments two headers connected to the third header") {
-    test_util::SetLogVerbosityGuard guard{log::Level::kNone};
     std::vector<BlockHeader> headers;
 
     BlockHeader header1;
@@ -187,7 +178,6 @@ TEST_CASE("HeaderList::split_into_segments two headers connected to the third he
 }
 
 TEST_CASE("HeaderList::split_into_segments same three headers, but in a reverse order") {
-    test_util::SetLogVerbosityGuard guard{log::Level::kNone};
     std::vector<BlockHeader> headers;
 
     BlockHeader header1;
@@ -229,7 +219,6 @@ TEST_CASE("HeaderList::split_into_segments same three headers, but in a reverse 
  *         2 segments: {h3?}, {h2?}
  */
 TEST_CASE("HeaderList::split_into_segments two headers not connected to each other") {
-    test_util::SetLogVerbosityGuard guard{log::Level::kNone};
     std::vector<BlockHeader> headers;
 
     BlockHeader header1;
@@ -268,7 +257,6 @@ TEST_CASE("HeaderList::split_into_segments two headers not connected to each oth
  *        1 segment: {h3, h2, h1}   (with header in this order)
  */
 TEST_CASE("HeaderList::split_into_segments three headers connected") {
-    test_util::SetLogVerbosityGuard guard{log::Level::kNone};
     std::vector<BlockHeader> headers;
 
     BlockHeader header1;
@@ -308,7 +296,6 @@ TEST_CASE("HeaderList::split_into_segments three headers connected") {
  *        3 segments: {h3?}, {h4?}, {h2, h1}
  */
 TEST_CASE("HeaderList::split_into_segments four headers connected") {
-    test_util::SetLogVerbosityGuard guard{log::Level::kNone};
     std::vector<BlockHeader> headers;
 
     BlockHeader header1;
@@ -354,8 +341,6 @@ TEST_CASE("HeaderList::split_into_segments four headers connected") {
 
 TEST_CASE("HeaderChain: (1) simple chain") {
     using namespace std;
-    test_util::SetLogVerbosityGuard guard{log::Level::kNone};
-
     ChainConfig chain_config{kMainnetConfig};
     chain_config.genesis_hash.emplace(kMainnetGenesisHash);
 
@@ -1239,7 +1224,6 @@ TEST_CASE("HeaderChain: (6) (malicious) siblings") {
 }
 
 TEST_CASE("HeaderChain: (7) invalidating anchor") {
-    test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
     using namespace std;
 
     ChainConfig chain_config{kMainnetConfig};
@@ -1340,7 +1324,6 @@ TEST_CASE("HeaderChain: (7) invalidating anchor") {
 }
 
 TEST_CASE("HeaderChain: (8) sibling with anchor invalidation and links reduction") {
-    test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
     using namespace std;
 
     ChainConfig chain_config{kMainnetConfig};

--- a/silkworm/sync/internals/header_retrieval_test.cpp
+++ b/silkworm/sync/internals/header_retrieval_test.cpp
@@ -24,7 +24,6 @@
 namespace silkworm {
 
 TEST_CASE("HeaderRetrieval") {
-    test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
     db::test_util::TempChainDataStore context;
     context.add_genesis_data();
     context.commit_txn();

--- a/silkworm/sync/messages/internal_message_test.cpp
+++ b/silkworm/sync/messages/internal_message_test.cpp
@@ -26,7 +26,6 @@ namespace silkworm {
 
 // Switch off the null sanitizer because nullptr SentryClient is formally dereferenced in command->execute.
 [[clang::no_sanitize("null")]] TEST_CASE("internal message") {
-    silkworm::test_util::SetLogVerbosityGuard log_guard{log::Level::kNone};
     db::test_util::TempChainDataStore context;
     // not used in the test execution
     db::DataStoreRef data_store = context->ref();


### PR DESCRIPTION
* remove SetLogVerbosityGuard from tests
  * default to NONE level in tests (set via Settings struct default value)
  * default to INFO level in CLI tools (set via add_logging_options)
* GrpcLogGuard: default to silkworm, never restore a default GRPC logger (produces sporadic logs in tests)
* improve run_smoke_tests:
  * silent smoke tests --help output
  * extend smoke tests list and remove unit tests from it
* improve run_unit_tests:
  * use SILKWORM_TEST_SKIP instead of [ignore] and SKIP (yields cleaner output)
  * use the same rng-seed for all test commands
  * prettier run_unit_tests output
  * improve output on crashes (see https://github.com/erigontech/silkworm/pull/2500)
* enable logging of slow unit tests (see https://github.com/erigontech/silkworm/issues/2502, https://github.com/erigontech/silkworm/issues/2504)
