### PR TITLE
style: P9 move-only reference parameters

### DIFF
--- a/silkworm/core/trie/vector_root.hpp
+++ b/silkworm/core/trie/vector_root.hpp
@@ -40,7 +40,7 @@ inline size_t adjust_index_for_rlp(size_t i, size_t len) {
 // Trie root hash of RLP-encoded values, the keys are RLP-encoded integers.
 // See Section 4.3.2. "Holistic Validity" of the Yellow Paper.
 template <class Value, std::invocable<Bytes&, const Value&> Encoder>
-evmc::bytes32 root_hash(const std::vector<Value>& v, Encoder&& value_encoder) {
+evmc::bytes32 root_hash(const std::vector<Value>& v, const Encoder& value_encoder) {
     Bytes index_rlp;
     Bytes value_rlp;
 

--- a/silkworm/db/access_layer.cpp
+++ b/silkworm/db/access_layer.cpp
@@ -129,14 +129,14 @@ bool read_header(ROTxn& txn, const evmc::bytes32& hash, BlockNum number, BlockHe
 
 std::vector<BlockHeader> read_headers(ROTxn& txn, BlockNum height) {
     std::vector<BlockHeader> headers;
-    process_headers_at_height(txn, height, [&](BlockHeader&& header) {
+    process_headers_at_height(txn, height, [&](BlockHeader header) {
         headers.emplace_back(std::move(header));
     });
     return headers;
 }
 
 // process headers at specific height
-size_t process_headers_at_height(ROTxn& txn, BlockNum height, std::function<void(BlockHeader&&)> process_func) {
+size_t process_headers_at_height(ROTxn& txn, BlockNum height, std::function<void(BlockHeader)> process_func) {
     auto headers_cursor = txn.ro_cursor(table::kHeaders);
     auto key_prefix{block_key(height)};
 
@@ -1105,7 +1105,7 @@ std::vector<BlockHeader> DataModel::read_sibling_headers(BlockNum block_number) 
     std::vector<BlockHeader> sibling_headers;
 
     // Read all siblings headers at specified height from db
-    process_headers_at_height(txn_, block_number, [&](BlockHeader&& header) {
+    process_headers_at_height(txn_, block_number, [&](BlockHeader header) {
         sibling_headers.push_back(std::move(header));
     });
 
@@ -1193,7 +1193,7 @@ bool DataModel::read_block(const evmc::bytes32& hash, BlockNum number, Block& bl
     return read_block_from_snapshot(number, block);
 }
 
-void DataModel::for_last_n_headers(size_t n, absl::FunctionRef<void(BlockHeader&&)> callback) const {
+void DataModel::for_last_n_headers(size_t n, absl::FunctionRef<void(BlockHeader)> callback) const {
     const bool throw_notfound{false};
 
     // Try to read N headers from the database

--- a/silkworm/db/access_layer.hpp
+++ b/silkworm/db/access_layer.hpp
@@ -68,7 +68,7 @@ std::optional<BlockHeader> read_header(ROTxn& txn, const evmc::bytes32& hash);
 std::vector<BlockHeader> read_headers(ROTxn& txn, BlockNum height);
 
 //! \brief Apply a user defined func to the headers at specific height
-size_t process_headers_at_height(ROTxn& txn, BlockNum height, std::function<void(BlockHeader&&)> process_func);
+size_t process_headers_at_height(ROTxn& txn, BlockNum height, std::function<void(BlockHeader)> process_func);
 
 //! \brief Reads the canonical head
 std::tuple<BlockNum, evmc::bytes32> read_canonical_head(ROTxn& txn);
@@ -342,7 +342,7 @@ class DataModel {
     std::optional<intx::uint256> read_total_difficulty(ByteView key) const;
 
     //! Read all block headers up to limit in reverse order from last, processing each one via a user defined callback
-    void for_last_n_headers(size_t n, absl::FunctionRef<void(BlockHeader&&)> callback) const;
+    void for_last_n_headers(size_t n, absl::FunctionRef<void(BlockHeader)> callback) const;
 
   private:
     bool read_block_from_snapshot(BlockNum height, Block& block) const;

--- a/silkworm/db/datastore/snapshots/bittorrent/web_seed_client_test.cpp
+++ b/silkworm/db/datastore/snapshots/bittorrent/web_seed_client_test.cpp
@@ -41,7 +41,7 @@ class WebSeedClientForTest : public WebSeedClient {
     using WebSeedClient::is_whitelisted;
     using WebSeedClient::validate_torrent_file;
     using WebSeedClient::web_session;
-    using WebSeedClient::WebSeedClient;  // NOLINT(*-rvalue-reference-param-not-moved)
+    using WebSeedClient::WebSeedClient;  // NOLINT(cppcoreguidelines-rvalue-reference-param-not-moved)
 };
 
 //! Content for manifest file containing one torrent file

--- a/silkworm/db/datastore/snapshots/bittorrent/web_session_test.cpp
+++ b/silkworm/db/datastore/snapshots/bittorrent/web_session_test.cpp
@@ -210,8 +210,7 @@ std::string path_cat(beast::string_view base, beast::string_view path) {
 //! \brief Handle a response for the given request.
 //! \details The concrete type of the response message (which depends on the request) is type-erased in message_generator
 template <class Body, class Allocator>
-// NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
-http::message_generator handle_request(beast::string_view doc_root, http::request<Body, http::basic_fields<Allocator>>&& req) {
+http::message_generator handle_request(beast::string_view doc_root, http::request<Body, http::basic_fields<Allocator>> req) {
     // Return a bad request response
     const auto bad_request = [&req](beast::string_view why) {
         http::response<http::string_body> res{http::status::bad_request, req.version()};

--- a/silkworm/db/datastore/snapshots/rec_split/golomb_rice.hpp
+++ b/silkworm/db/datastore/snapshots/rec_split/golomb_rice.hpp
@@ -168,7 +168,7 @@ class GolombRiceVector {
     };
 
     GolombRiceVector() = default;
-    explicit GolombRiceVector(std::vector<uint64_t>&& input_data) : data_(std::move(input_data)) {}
+    explicit GolombRiceVector(std::vector<uint64_t> input_data) : data_(std::move(input_data)) {}
 
     size_t size() const { return data_.size(); }
 

--- a/silkworm/db/db_utils.hpp
+++ b/silkworm/db/db_utils.hpp
@@ -27,9 +27,6 @@
 
 namespace silkworm {
 
-//! \brief Read the lasdt n headers, in forward order, processing each via a user defined callback
-void for_last_n_headers(const db::DataModel&, size_t n, std::function<void(BlockHeader&&)> callback);
-
 //! \brief Return (block-num, hash) of the header with the biggest total difficulty skipping bad headers
 std::tuple<BlockNum, Hash> header_with_biggest_td(db::ROTxn& txn, const std::set<Hash>* bad_headers = nullptr);
 

--- a/silkworm/db/kv/api/local_transaction.cpp
+++ b/silkworm/db/kv/api/local_transaction.cpp
@@ -74,20 +74,17 @@ Task<TxnId> LocalTransaction::first_txn_num_in_block(BlockNum /*block_num*/) {
     throw std::logic_error{"not yet implemented"};
 }
 
-// NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
-Task<DomainPointResult> LocalTransaction::domain_get(DomainPointQuery&& /*query*/) {
+Task<DomainPointResult> LocalTransaction::domain_get(DomainPointQuery /*query*/) {
     // TODO(canepat) implement using E3-like aggregator abstraction [tx_id_ must be changed]
     co_return DomainPointResult{};
 }
 
-// NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
-Task<HistoryPointResult> LocalTransaction::history_seek(HistoryPointQuery&& /*query*/) {
+Task<HistoryPointResult> LocalTransaction::history_seek(HistoryPointQuery /*query*/) {
     // TODO(canepat) implement using E3-like aggregator abstraction [tx_id_ must be changed]
     co_return HistoryPointResult{};
 }
 
-// NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
-Task<PaginatedTimestamps> LocalTransaction::index_range(IndexRangeQuery&& /*query*/) {
+Task<PaginatedTimestamps> LocalTransaction::index_range(IndexRangeQuery /*query*/) {
     // TODO(canepat) implement using E3-like aggregator abstraction [tx_id_ must be changed]
     auto paginator = [](api::PaginatedTimestamps::PageToken) mutable -> Task<api::PaginatedTimestamps::PageResult> {
         co_return api::PaginatedTimestamps::PageResult{};
@@ -95,8 +92,7 @@ Task<PaginatedTimestamps> LocalTransaction::index_range(IndexRangeQuery&& /*quer
     co_return api::PaginatedTimestamps{std::move(paginator)};
 }
 
-// NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
-Task<PaginatedKeysValues> LocalTransaction::history_range(HistoryRangeQuery&& /*query*/) {
+Task<PaginatedKeysValues> LocalTransaction::history_range(HistoryRangeQuery /*query*/) {
     // TODO(canepat) implement using E3-like aggregator abstraction [tx_id_ must be changed]
     auto paginator = [](api::PaginatedKeysValues::PageToken) mutable -> Task<api::PaginatedKeysValues::PageResult> {
         co_return api::PaginatedKeysValues::PageResult{};
@@ -104,8 +100,7 @@ Task<PaginatedKeysValues> LocalTransaction::history_range(HistoryRangeQuery&& /*
     co_return api::PaginatedKeysValues{std::move(paginator)};
 }
 
-// NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
-Task<PaginatedKeysValues> LocalTransaction::domain_range(DomainRangeQuery&& /*query*/) {
+Task<PaginatedKeysValues> LocalTransaction::domain_range(DomainRangeQuery /*query*/) {
     // TODO(canepat) implement using E3-like aggregator abstraction [tx_id_ must be changed]
     auto paginator = [](api::PaginatedKeysValues::PageToken) mutable -> Task<api::PaginatedKeysValues::PageResult> {
         co_return api::PaginatedKeysValues::PageResult{};

--- a/silkworm/db/kv/api/local_transaction.hpp
+++ b/silkworm/db/kv/api/local_transaction.hpp
@@ -62,19 +62,19 @@ class LocalTransaction : public BaseTransaction {
     Task<void> close() override;
 
     // rpc DomainGet(DomainGetReq) returns (DomainGetReply);
-    Task<DomainPointResult> domain_get(DomainPointQuery&&) override;
+    Task<DomainPointResult> domain_get(DomainPointQuery query) override;
 
     // rpc HistorySeek(HistorySeekReq) returns (HistorySeekReply);
-    Task<HistoryPointResult> history_seek(HistoryPointQuery&& query) override;
+    Task<HistoryPointResult> history_seek(HistoryPointQuery query) override;
 
     // rpc IndexRange(IndexRangeReq) returns (IndexRangeReply);
-    Task<PaginatedTimestamps> index_range(IndexRangeQuery&& query) override;
+    Task<PaginatedTimestamps> index_range(IndexRangeQuery query) override;
 
     // rpc HistoryRange(HistoryRangeReq) returns (Pairs);
-    Task<PaginatedKeysValues> history_range(HistoryRangeQuery&& query) override;
+    Task<PaginatedKeysValues> history_range(HistoryRangeQuery query) override;
 
     // rpc DomainRange(DomainRangeReq) returns (Pairs);
-    Task<PaginatedKeysValues> domain_range(DomainRangeQuery&& query) override;
+    Task<PaginatedKeysValues> domain_range(DomainRangeQuery query) override;
 
   private:
     Task<std::shared_ptr<CursorDupSort>> get_cursor(const std::string& table, bool is_cursor_dup_sort);

--- a/silkworm/db/kv/api/transaction.hpp
+++ b/silkworm/db/kv/api/transaction.hpp
@@ -73,21 +73,21 @@ class Transaction {
     /** Temporal Point Queries **/
 
     // rpc DomainGet(DomainGetReq) returns (DomainGetReply);
-    virtual Task<DomainPointResult> domain_get(DomainPointQuery&& query) = 0;
+    virtual Task<DomainPointResult> domain_get(DomainPointQuery query) = 0;
 
     // rpc HistorySeek(HistorySeekReq) returns (HistorySeekReply);
-    virtual Task<HistoryPointResult> history_seek(HistoryPointQuery&& query) = 0;
+    virtual Task<HistoryPointResult> history_seek(HistoryPointQuery query) = 0;
 
     /** Temporal Range Queries **/
 
     // rpc IndexRange(IndexRangeReq) returns (IndexRangeReply);
-    virtual Task<PaginatedTimestamps> index_range(IndexRangeQuery&& query) = 0;
+    virtual Task<PaginatedTimestamps> index_range(IndexRangeQuery query) = 0;
 
     // rpc HistoryRange(HistoryRangeReq) returns (Pairs);
-    virtual Task<PaginatedKeysValues> history_range(HistoryRangeQuery&& query) = 0;
+    virtual Task<PaginatedKeysValues> history_range(HistoryRangeQuery query) = 0;
 
     // rpc DomainRange(DomainRangeReq) returns (Pairs);
-    virtual Task<PaginatedKeysValues> domain_range(DomainRangeQuery&& query) = 0;
+    virtual Task<PaginatedKeysValues> domain_range(DomainRangeQuery query) = 0;
 };
 
 }  // namespace silkworm::db::kv::api

--- a/silkworm/db/kv/grpc/client/remote_transaction.cpp
+++ b/silkworm/db/kv/grpc/client/remote_transaction.cpp
@@ -122,7 +122,7 @@ Task<TxnId> RemoteTransaction::first_txn_num_in_block(BlockNum block_num) {
     co_return min_txn_num + /*txn_index*/ 0;
 }
 
-Task<api::DomainPointResult> RemoteTransaction::domain_get(api::DomainPointQuery&& query) {  // NOLINT(*-rvalue-reference-param-not-moved)
+Task<api::DomainPointResult> RemoteTransaction::domain_get(api::DomainPointQuery query) {
     try {
         query.tx_id = tx_id_;
         auto request = domain_get_request_from_query(query);
@@ -135,7 +135,7 @@ Task<api::DomainPointResult> RemoteTransaction::domain_get(api::DomainPointQuery
     }
 }
 
-Task<api::HistoryPointResult> RemoteTransaction::history_seek(api::HistoryPointQuery&& query) {  // NOLINT(*-rvalue-reference-param-not-moved)
+Task<api::HistoryPointResult> RemoteTransaction::history_seek(api::HistoryPointQuery query) {
     try {
         query.tx_id = tx_id_;
         auto request = history_seek_request_from_query(query);
@@ -148,7 +148,7 @@ Task<api::HistoryPointResult> RemoteTransaction::history_seek(api::HistoryPointQ
     }
 }
 
-Task<api::PaginatedTimestamps> RemoteTransaction::index_range(api::IndexRangeQuery&& query) {
+Task<api::PaginatedTimestamps> RemoteTransaction::index_range(api::IndexRangeQuery query) {
     auto paginator = [&, query = std::move(query)](api::PaginatedTimestamps::PageToken page_token) mutable -> Task<api::PaginatedTimestamps::PageResult> {
         query.tx_id = tx_id_;
         query.page_token = std::move(page_token);
@@ -166,7 +166,7 @@ Task<api::PaginatedTimestamps> RemoteTransaction::index_range(api::IndexRangeQue
     co_return api::PaginatedTimestamps{std::move(paginator)};
 }
 
-Task<api::PaginatedKeysValues> RemoteTransaction::history_range(api::HistoryRangeQuery&& query) {
+Task<api::PaginatedKeysValues> RemoteTransaction::history_range(api::HistoryRangeQuery query) {
     auto paginator = [&, query = std::move(query)](api::PaginatedKeysValues::PageToken page_token) mutable -> Task<api::PaginatedKeysValues::PageResult> {
         query.tx_id = tx_id_;
         query.page_token = std::move(page_token);
@@ -184,7 +184,7 @@ Task<api::PaginatedKeysValues> RemoteTransaction::history_range(api::HistoryRang
     co_return api::PaginatedKeysValues{std::move(paginator)};
 }
 
-Task<api::PaginatedKeysValues> RemoteTransaction::domain_range(api::DomainRangeQuery&& query) {
+Task<api::PaginatedKeysValues> RemoteTransaction::domain_range(api::DomainRangeQuery query) {
     auto paginator = [&, query = std::move(query)](api::PaginatedKeysValues::PageToken page_token) mutable -> Task<api::PaginatedKeysValues::PageResult> {
         query.tx_id = tx_id_;
         query.page_token = std::move(page_token);

--- a/silkworm/db/kv/grpc/client/remote_transaction.hpp
+++ b/silkworm/db/kv/grpc/client/remote_transaction.hpp
@@ -63,19 +63,19 @@ class RemoteTransaction : public api::BaseTransaction {
     Task<void> close() override;
 
     // rpc DomainGet(DomainGetReq) returns (DomainGetReply);
-    Task<api::DomainPointResult> domain_get(api::DomainPointQuery&&) override;
+    Task<api::DomainPointResult> domain_get(api::DomainPointQuery query) override;
 
     // rpc HistorySeek(HistorySeekReq) returns (HistorySeekReply);
-    Task<api::HistoryPointResult> history_seek(api::HistoryPointQuery&& query) override;
+    Task<api::HistoryPointResult> history_seek(api::HistoryPointQuery query) override;
 
     // rpc IndexRange(IndexRangeReq) returns (IndexRangeReply);
-    Task<api::PaginatedTimestamps> index_range(api::IndexRangeQuery&& query) override;
+    Task<api::PaginatedTimestamps> index_range(api::IndexRangeQuery query) override;
 
     // rpc HistoryRange(HistoryRangeReq) returns (Pairs);
-    Task<api::PaginatedKeysValues> history_range(api::HistoryRangeQuery&& query) override;
+    Task<api::PaginatedKeysValues> history_range(api::HistoryRangeQuery query) override;
 
     // rpc DomainRange(DomainRangeReq) returns (Pairs);
-    Task<api::PaginatedKeysValues> domain_range(api::DomainRangeQuery&& query) override;
+    Task<api::PaginatedKeysValues> domain_range(api::DomainRangeQuery query) override;
 
   private:
     Task<std::shared_ptr<api::CursorDupSort>> get_cursor(const std::string& table, bool is_cursor_dup_sort);

--- a/silkworm/db/kv/grpc/server/kv_calls.cpp
+++ b/silkworm/db/kv/grpc/server/kv_calls.cpp
@@ -649,7 +649,7 @@ void TxCall::throw_with_internal_error(const std::string& message) {
     throw_with_error(::grpc::Status{::grpc::StatusCode::INTERNAL, message});
 }
 
-void TxCall::throw_with_error(::grpc::Status&& status) {
+void TxCall::throw_with_error(::grpc::Status status) {
     SILK_ERROR << "Tx peer: " << peer() << " " << status.error_message();
     throw rpc::server::CallException{std::move(status)};
 }

--- a/silkworm/db/kv/grpc/server/kv_calls.hpp
+++ b/silkworm/db/kv/grpc/server/kv_calls.hpp
@@ -138,7 +138,7 @@ class TxCall : public rpc::server::BidiStreamingCall<remote::Cursor, remote::Pai
 
     void throw_with_internal_error(const std::string& message);
 
-    void throw_with_error(::grpc::Status&& status);
+    void throw_with_error(::grpc::Status status);
 
     static std::chrono::milliseconds max_ttl_duration_;
     static inline uint64_t next_tx_id_{0};

--- a/silkworm/db/test_util/mock_transaction.hpp
+++ b/silkworm/db/test_util/mock_transaction.hpp
@@ -47,11 +47,11 @@ class MockTransaction : public kv::api::Transaction {
     MOCK_METHOD((Task<Bytes>), get_one, (const std::string&, ByteView), (override));
     MOCK_METHOD((Task<std::optional<Bytes>>), get_both_range,
                 (const std::string&, ByteView, ByteView), (override));
-    MOCK_METHOD((Task<kv::api::DomainPointResult>), domain_get, (kv::api::DomainPointQuery&&), (override));
-    MOCK_METHOD((Task<kv::api::HistoryPointResult>), history_seek, (kv::api::HistoryPointQuery&&), (override));
-    MOCK_METHOD((Task<kv::api::PaginatedTimestamps>), index_range, (kv::api::IndexRangeQuery&&), (override));
-    MOCK_METHOD((Task<kv::api::PaginatedKeysValues>), history_range, (kv::api::HistoryRangeQuery&&), (override));
-    MOCK_METHOD((Task<kv::api::PaginatedKeysValues>), domain_range, (kv::api::DomainRangeQuery&&), (override));
+    MOCK_METHOD((Task<kv::api::DomainPointResult>), domain_get, (kv::api::DomainPointQuery), (override));
+    MOCK_METHOD((Task<kv::api::HistoryPointResult>), history_seek, (kv::api::HistoryPointQuery), (override));
+    MOCK_METHOD((Task<kv::api::PaginatedTimestamps>), index_range, (kv::api::IndexRangeQuery), (override));
+    MOCK_METHOD((Task<kv::api::PaginatedKeysValues>), history_range, (kv::api::HistoryRangeQuery), (override));
+    MOCK_METHOD((Task<kv::api::PaginatedKeysValues>), domain_range, (kv::api::DomainRangeQuery), (override));
 };
 
 }  // namespace silkworm::db::test_util

--- a/silkworm/infra/common/memory_mapped_file.hpp
+++ b/silkworm/infra/common/memory_mapped_file.hpp
@@ -82,8 +82,8 @@ class MemoryMappedFile {
     MemoryMappedFile& operator=(const MemoryMappedFile&) = delete;
 
     // Only movable
-    MemoryMappedFile(MemoryMappedFile&& source) noexcept = default;
-    MemoryMappedFile& operator=(MemoryMappedFile&& other) noexcept = default;
+    MemoryMappedFile(MemoryMappedFile&&) noexcept = default;
+    MemoryMappedFile& operator=(MemoryMappedFile&&) noexcept = default;
 
     std::filesystem::path path() const {
         return path_;

--- a/silkworm/infra/concurrency/private_service.hpp
+++ b/silkworm/infra/concurrency/private_service.hpp
@@ -32,7 +32,7 @@ class PrivateService : public BaseService<PrivateService<T>> {
     void shutdown() override { unique_.reset(); }
 
     //! Explicitly *take ownership* of \code std::unique_ptr to enforce isolation
-    void set_unique(std::unique_ptr<T>&& unique) {
+    void set_unique(std::unique_ptr<T> unique) {
         unique_ = std::move(unique);
     }
     T* ptr() { return unique_.get(); }
@@ -42,7 +42,7 @@ class PrivateService : public BaseService<PrivateService<T>> {
 };
 
 template <typename T>
-void add_private_service(boost::asio::execution_context& context, std::unique_ptr<T>&& unique) {
+void add_private_service(boost::asio::execution_context& context, std::unique_ptr<T> unique) {
     if (!has_service<PrivateService<T>>(context)) {
         make_service<PrivateService<T>>(context);
     }

--- a/silkworm/infra/grpc/client/error.cpp
+++ b/silkworm/infra/grpc/client/error.cpp
@@ -23,7 +23,7 @@ class GrpcErrorCategory : public std::error_category {
     const char* name() const noexcept override;
     std::string message(int ev) const override;
 
-    void set_error(std::string&& error_message) {
+    void set_error(std::string error_message) {
         error_message_ = std::move(error_message);
     }
 
@@ -35,7 +35,7 @@ const char* GrpcErrorCategory::name() const noexcept { return "grpc"; }
 
 std::string GrpcErrorCategory::message(int /*ev*/) const { return error_message_; }
 
-std::error_code make_error_code(int error_code, std::string&& error_message) {
+std::error_code make_error_code(int error_code, std::string error_message) {
     thread_local GrpcErrorCategory tls_error_category{};
     tls_error_category.set_error(std::move(error_message));
     return {error_code, tls_error_category};

--- a/silkworm/infra/grpc/client/error.hpp
+++ b/silkworm/infra/grpc/client/error.hpp
@@ -19,4 +19,4 @@
 #include <string>
 #include <system_error>
 
-std::error_code make_error_code(int error_code, std::string&& error_message);
+std::error_code make_error_code(int error_code, std::string error_message);

--- a/silkworm/infra/grpc/server/call.hpp
+++ b/silkworm/infra/grpc/server/call.hpp
@@ -130,7 +130,7 @@ namespace server {
 
     class CallException : public std::runtime_error {
       public:
-        explicit CallException(grpc::Status&& status)
+        explicit CallException(grpc::Status status)
             : std::runtime_error(status.error_message()), status_(std::move(status)) {}
 
         grpc::Status status() const { return status_; }

--- a/silkworm/node/stagedsync/forks/extending_fork.cpp
+++ b/silkworm/node/stagedsync/forks/extending_fork.cpp
@@ -54,7 +54,7 @@ void ExtendingFork::execution_loop() {
     if (fork_) fork_->close();  // close the fork here, in the same thread where was created to comply to mdbx limitations
 }
 
-void ExtendingFork::start_with(BlockId new_head, std::list<std::shared_ptr<Block>>&& blocks) {
+void ExtendingFork::start_with(BlockId new_head, std::list<std::shared_ptr<Block>> blocks) {
     propagate_exception_if_any();
 
     executor_ = std::make_unique<io_context>();

--- a/silkworm/node/stagedsync/forks/extending_fork.hpp
+++ b/silkworm/node/stagedsync/forks/extending_fork.hpp
@@ -45,7 +45,7 @@ class ExtendingFork {
     ~ExtendingFork();
 
     // opening & closing
-    void start_with(BlockId new_head, std::list<std::shared_ptr<Block>>&&);
+    void start_with(BlockId new_head, std::list<std::shared_ptr<Block>> blocks);
     void close();
 
     // extension

--- a/silkworm/node/stagedsync/forks/main_chain.cpp
+++ b/silkworm/node/stagedsync/forks/main_chain.cpp
@@ -483,7 +483,7 @@ std::vector<BlockHeader> MainChain::get_last_headers(uint64_t limit) const {
     TransactionHandler tx_handler{tx_, db_access_, node_settings_.keep_db_txn_open};
     std::vector<BlockHeader> headers;
 
-    data_model().for_last_n_headers(limit, [&headers](BlockHeader&& header) {
+    data_model().for_last_n_headers(limit, [&headers](BlockHeader header) {
         headers.emplace_back(std::move(header));
     });
 

--- a/silkworm/rpc/commands/debug_api_test.cpp
+++ b/silkworm/rpc/commands/debug_api_test.cpp
@@ -234,28 +234,23 @@ class DummyTransaction : public db::kv::api::BaseTransaction {
         co_return;
     }
 
-    // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
-    Task<db::kv::api::DomainPointResult> domain_get(db::kv::api::DomainPointQuery&& /*query*/) override {
+    Task<db::kv::api::DomainPointResult> domain_get(db::kv::api::DomainPointQuery /*query*/) override {
         co_return db::kv::api::DomainPointResult{};
     }
 
-    // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
-    Task<db::kv::api::HistoryPointResult> history_seek(db::kv::api::HistoryPointQuery&& /*query*/) override {
+    Task<db::kv::api::HistoryPointResult> history_seek(db::kv::api::HistoryPointQuery /*query*/) override {
         co_return db::kv::api::HistoryPointResult{};
     }
 
-    // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
-    Task<db::kv::api::PaginatedTimestamps> index_range(db::kv::api::IndexRangeQuery&& /*query*/) override {
+    Task<db::kv::api::PaginatedTimestamps> index_range(db::kv::api::IndexRangeQuery /*query*/) override {
         co_return test::empty_paginated_timestamps();
     }
 
-    // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
-    Task<db::kv::api::PaginatedKeysValues> history_range(db::kv::api::HistoryRangeQuery&& /*query*/) override {
+    Task<db::kv::api::PaginatedKeysValues> history_range(db::kv::api::HistoryRangeQuery /*query*/) override {
         co_return test::empty_paginated_keys_and_values();
     }
 
-    // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
-    Task<db::kv::api::PaginatedKeysValues> domain_range(db::kv::api::DomainRangeQuery&& /*query*/) override {
+    Task<db::kv::api::PaginatedKeysValues> domain_range(db::kv::api::DomainRangeQuery /*query*/) override {
         co_return test::empty_paginated_keys_and_values();
     }
 

--- a/silkworm/rpc/core/account_dumper_test.cpp
+++ b/silkworm/rpc/core/account_dumper_test.cpp
@@ -210,28 +210,23 @@ class DummyTransaction : public BaseTransaction {
         co_return;
     }
 
-    // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
-    Task<db::kv::api::DomainPointResult> domain_get(db::kv::api::DomainPointQuery&& /*query*/) override {
+    Task<db::kv::api::DomainPointResult> domain_get(db::kv::api::DomainPointQuery /*query*/) override {
         co_return db::kv::api::DomainPointResult{};
     }
 
-    // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
-    Task<db::kv::api::HistoryPointResult> history_seek(db::kv::api::HistoryPointQuery&& /*query*/) override {
+    Task<db::kv::api::HistoryPointResult> history_seek(db::kv::api::HistoryPointQuery /*query*/) override {
         co_return db::kv::api::HistoryPointResult{};
     }
 
-    // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
-    Task<db::kv::api::PaginatedTimestamps> index_range(db::kv::api::IndexRangeQuery&& /*query*/) override {
+    Task<db::kv::api::PaginatedTimestamps> index_range(db::kv::api::IndexRangeQuery /*query*/) override {
         co_return test::empty_paginated_timestamps();
     }
 
-    // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
-    Task<db::kv::api::PaginatedKeysValues> history_range(db::kv::api::HistoryRangeQuery&& /*query*/) override {
+    Task<db::kv::api::PaginatedKeysValues> history_range(db::kv::api::HistoryRangeQuery /*query*/) override {
         co_return test::empty_paginated_keys_and_values();
     }
 
-    // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
-    Task<db::kv::api::PaginatedKeysValues> domain_range(db::kv::api::DomainRangeQuery&& /*query*/) override {
+    Task<db::kv::api::PaginatedKeysValues> domain_range(db::kv::api::DomainRangeQuery /*query*/) override {
         co_return test::empty_paginated_keys_and_values();
     }
 

--- a/silkworm/rpc/core/account_walker_test.cpp
+++ b/silkworm/rpc/core/account_walker_test.cpp
@@ -211,28 +211,23 @@ class DummyTransaction : public BaseTransaction {
         co_return;
     }
 
-    // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
-    Task<db::kv::api::DomainPointResult> domain_get(db::kv::api::DomainPointQuery&& /*query*/) override {
+    Task<db::kv::api::DomainPointResult> domain_get(db::kv::api::DomainPointQuery /*query*/) override {
         co_return db::kv::api::DomainPointResult{};
     }
 
-    // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
-    Task<db::kv::api::HistoryPointResult> history_seek(db::kv::api::HistoryPointQuery&& /*query*/) override {
+    Task<db::kv::api::HistoryPointResult> history_seek(db::kv::api::HistoryPointQuery /*query*/) override {
         co_return db::kv::api::HistoryPointResult{};
     }
 
-    // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
-    Task<db::kv::api::PaginatedTimestamps> index_range(db::kv::api::IndexRangeQuery&& /*query*/) override {
+    Task<db::kv::api::PaginatedTimestamps> index_range(db::kv::api::IndexRangeQuery /*query*/) override {
         co_return test::empty_paginated_timestamps();
     }
 
-    // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
-    Task<db::kv::api::PaginatedKeysValues> history_range(db::kv::api::HistoryRangeQuery&& /*query*/) override {
+    Task<db::kv::api::PaginatedKeysValues> history_range(db::kv::api::HistoryRangeQuery /*query*/) override {
         co_return test::empty_paginated_keys_and_values();
     }
 
-    // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
-    Task<db::kv::api::PaginatedKeysValues> domain_range(db::kv::api::DomainRangeQuery&& /*query*/) override {
+    Task<db::kv::api::PaginatedKeysValues> domain_range(db::kv::api::DomainRangeQuery /*query*/) override {
         co_return test::empty_paginated_keys_and_values();
     }
 

--- a/silkworm/rpc/core/storage_walker_test.cpp
+++ b/silkworm/rpc/core/storage_walker_test.cpp
@@ -210,28 +210,23 @@ class DummyTransaction : public BaseTransaction {
         co_return;
     }
 
-    // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
-    Task<db::kv::api::DomainPointResult> domain_get(db::kv::api::DomainPointQuery&& /*query*/) override {
+    Task<db::kv::api::DomainPointResult> domain_get(db::kv::api::DomainPointQuery /*query*/) override {
         co_return db::kv::api::DomainPointResult{};
     }
 
-    // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
-    Task<db::kv::api::HistoryPointResult> history_seek(db::kv::api::HistoryPointQuery&& /*query*/) override {
+    Task<db::kv::api::HistoryPointResult> history_seek(db::kv::api::HistoryPointQuery /*query*/) override {
         co_return db::kv::api::HistoryPointResult{};
     }
 
-    // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
-    Task<db::kv::api::PaginatedTimestamps> index_range(db::kv::api::IndexRangeQuery&& /*query*/) override {
+    Task<db::kv::api::PaginatedTimestamps> index_range(db::kv::api::IndexRangeQuery /*query*/) override {
         co_return test::empty_paginated_timestamps();
     }
 
-    // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
-    Task<db::kv::api::PaginatedKeysValues> history_range(db::kv::api::HistoryRangeQuery&& /*query*/) override {
+    Task<db::kv::api::PaginatedKeysValues> history_range(db::kv::api::HistoryRangeQuery /*query*/) override {
         co_return test::empty_paginated_keys_and_values();
     }
 
-    // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
-    Task<db::kv::api::PaginatedKeysValues> domain_range(db::kv::api::DomainRangeQuery&& /*query*/) override {
+    Task<db::kv::api::PaginatedKeysValues> domain_range(db::kv::api::DomainRangeQuery /*query*/) override {
         co_return test::empty_paginated_keys_and_values();
     }
 

--- a/silkworm/rpc/ethdb/kv/remote_database.cpp
+++ b/silkworm/rpc/ethdb/kv/remote_database.cpp
@@ -37,7 +37,7 @@ RemoteDatabase::RemoteDatabase(ethbackend::BackEnd* backend,
 RemoteDatabase::RemoteDatabase(ethbackend::BackEnd* backend,
                                StateCache* state_cache,
                                agrpc::GrpcContext& grpc_context,
-                               std::unique_ptr<remote::KV::StubInterface>&& stub)
+                               std::unique_ptr<remote::KV::StubInterface> stub)
     : backend_{backend}, state_cache_{state_cache}, grpc_context_{grpc_context}, stub_(std::move(stub)) {
     SILK_TRACE << "RemoteDatabase::ctor " << this;
 }

--- a/silkworm/rpc/ethdb/kv/remote_database.hpp
+++ b/silkworm/rpc/ethdb/kv/remote_database.hpp
@@ -41,7 +41,7 @@ class RemoteDatabase : public Database {
     RemoteDatabase(ethbackend::BackEnd* backend,
                    StateCache* state_cache,
                    agrpc::GrpcContext& grpc_context,
-                   std::unique_ptr<remote::KV::StubInterface>&& stub);
+                   std::unique_ptr<remote::KV::StubInterface> stub);
     ~RemoteDatabase() override;
 
     RemoteDatabase(const RemoteDatabase&) = delete;

--- a/silkworm/rpc/test_util/dummy_transaction.hpp
+++ b/silkworm/rpc/test_util/dummy_transaction.hpp
@@ -84,28 +84,23 @@ class DummyTransaction : public db::kv::api::BaseTransaction {
 
     Task<void> close() override { co_return; }
 
-    // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
-    Task<db::kv::api::DomainPointResult> domain_get(db::kv::api::DomainPointQuery&& /*query*/) override {
+    Task<db::kv::api::DomainPointResult> domain_get(db::kv::api::DomainPointQuery /*query*/) override {
         co_return db::kv::api::DomainPointResult{};
     }
 
-    // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
-    Task<db::kv::api::HistoryPointResult> history_seek(db::kv::api::HistoryPointQuery&& /*query*/) override {
+    Task<db::kv::api::HistoryPointResult> history_seek(db::kv::api::HistoryPointQuery /*query*/) override {
         co_return db::kv::api::HistoryPointResult{};
     }
 
-    // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
-    Task<db::kv::api::PaginatedTimestamps> index_range(db::kv::api::IndexRangeQuery&& /*query*/) override {
+    Task<db::kv::api::PaginatedTimestamps> index_range(db::kv::api::IndexRangeQuery /*query*/) override {
         co_return empty_paginated_timestamps();
     }
 
-    // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
-    Task<db::kv::api::PaginatedKeysValues> history_range(db::kv::api::HistoryRangeQuery&& /*query*/) override {
+    Task<db::kv::api::PaginatedKeysValues> history_range(db::kv::api::HistoryRangeQuery /*query*/) override {
         co_return empty_paginated_keys_and_values();
     }
 
-    // NOLINTNEXTLINE(*-rvalue-reference-param-not-moved)
-    Task<db::kv::api::PaginatedKeysValues> domain_range(db::kv::api::DomainRangeQuery&& /*query*/) override {
+    Task<db::kv::api::PaginatedKeysValues> domain_range(db::kv::api::DomainRangeQuery /*query*/) override {
         co_return test::empty_paginated_keys_and_values();
     }
 

--- a/silkworm/rpc/types/block.hpp
+++ b/silkworm/rpc/types/block.hpp
@@ -43,15 +43,16 @@ std::ostream& operator<<(std::ostream& out, const Block& b);
 
 class BlockNumberOrHash {
   public:
-    explicit BlockNumberOrHash(std::string const& bnoh) { build(bnoh); }
+    explicit BlockNumberOrHash(const std::string& bnoh) { build(bnoh); }
     explicit BlockNumberOrHash(BlockNum number) noexcept : value_{number} {}
 
     virtual ~BlockNumberOrHash() noexcept = default;
 
-    BlockNumberOrHash(BlockNumberOrHash&& bnoh) = default;
-    BlockNumberOrHash(BlockNumberOrHash const& bnoh) noexcept = default;
+    BlockNumberOrHash(const BlockNumberOrHash&) noexcept = default;
+    BlockNumberOrHash& operator=(const BlockNumberOrHash&) = default;
 
-    BlockNumberOrHash& operator=(BlockNumberOrHash const& bnoh) = default;
+    BlockNumberOrHash(BlockNumberOrHash&&) = default;
+    BlockNumberOrHash& operator=(BlockNumberOrHash&&) noexcept = default;
 
     bool is_number() const {
         return std::holds_alternative<uint64_t>(value_);

--- a/silkworm/sync/sync_pow.cpp
+++ b/silkworm/sync/sync_pow.cpp
@@ -224,7 +224,7 @@ void PoWSync::send_new_block_hash_announcements() {
 }
 
 // New block announcements propagation
-void PoWSync::send_new_block_announcements(Blocks&& blocks) {
+void PoWSync::send_new_block_announcements(Blocks blocks) {
     if (blocks.empty()) return;
 
     auto message = std::make_shared<OutboundNewBlock>(std::move(blocks), is_first_sync_);

--- a/silkworm/sync/sync_pow.hpp
+++ b/silkworm/sync/sync_pow.hpp
@@ -48,7 +48,7 @@ class PoWSync : public ChainSync, ActiveComponent {
     void unwind(UnwindPoint, std::optional<Hash> bad_block);
     std::shared_ptr<InternalMessage<void>> update_bad_headers(std::set<Hash>);
 
-    void send_new_block_announcements(Blocks&& blocks);
+    void send_new_block_announcements(Blocks blocks);
     void send_new_block_hash_announcements();
 
     asio::io_context io_context_;


### PR DESCRIPTION
Default to move by value in basic cases.
Keep `T&&` parameters for low-level and templated code. unique_ptr is already move-only.