### PR TITLE
snapshots: more state schema configurations

### DIFF
--- a/silkworm/db/blocks/blocks_index_builders_factory.cpp
+++ b/silkworm/db/blocks/blocks_index_builders_factory.cpp
@@ -72,7 +72,7 @@ SnapshotPathList BlocksIndexBuildersFactory::index_dependency_paths(const Snapsh
         SILKWORM_ASSERT(false);
         std::abort();
     }();
-    auto& segment_tag = schema_.entities().at(Schema::kDefaultEntityName).entities().at(segment_name).tag();
+    auto& segment_tag = schema_.entities().at(Schema::kDefaultEntityName)->entities().at(segment_name)->tag();
     SnapshotPath snapshot_path = index_path.related_path(segment_tag, db::blocks::kSegmentExtension);
     return {snapshot_path};
 }

--- a/silkworm/db/blocks/schema_config.hpp
+++ b/silkworm/db/blocks/schema_config.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <array>
 #include <memory>
 
 #include "../datastore/common/entity_name.hpp"
@@ -43,7 +44,8 @@ inline constexpr std::string_view kHeaderSegmentTag = kHeaderSegmentName.name;
 //! Index header_hash -> block_num -> headers_segment_offset
 inline constexpr datastore::EntityName kIdxHeaderHashName{"headers.idx"};
 inline constexpr std::string_view kIdxHeaderHashTag = kHeaderSegmentTag;
-inline constexpr std::pair<datastore::EntityName, datastore::EntityName> kHeaderSegmentAndIdxNames{
+inline constexpr std::array<datastore::EntityName, 3> kHeaderSegmentAndIdxNames{
+    snapshots::Schema::kDefaultEntityName,
     kHeaderSegmentName,
     kIdxHeaderHashName,
 };
@@ -53,7 +55,8 @@ inline constexpr std::string_view kBodySegmentTag = kBodySegmentName.name;
 //! Index block_num -> bodies_segment_offset
 inline constexpr datastore::EntityName kIdxBodyNumberName{"bodies.idx"};
 inline constexpr std::string_view kIdxBodyNumberTag = kBodySegmentTag;
-inline constexpr std::pair<datastore::EntityName, datastore::EntityName> kBodySegmentAndIdxNames{
+inline constexpr std::array<datastore::EntityName, 3> kBodySegmentAndIdxNames{
+    snapshots::Schema::kDefaultEntityName,
     kBodySegmentName,
     kIdxBodyNumberName,
 };
@@ -63,7 +66,8 @@ inline constexpr std::string_view kTxnSegmentTag = kTxnSegmentName.name;
 //! Index transaction_hash -> txn_id -> transactions_segment_offset
 inline constexpr datastore::EntityName kIdxTxnHashName{"transactions.idx"};
 inline constexpr std::string_view kIdxTxnHashTag = kTxnSegmentTag;
-inline constexpr std::pair<datastore::EntityName, datastore::EntityName> kTxnSegmentAndIdxNames{
+inline constexpr std::array<datastore::EntityName, 3> kTxnSegmentAndIdxNames{
+    snapshots::Schema::kDefaultEntityName,
     kTxnSegmentName,
     kIdxTxnHashName,
 };

--- a/silkworm/db/datastore/snapshot_merger.cpp
+++ b/silkworm/db/datastore/snapshot_merger.cpp
@@ -102,7 +102,7 @@ std::shared_ptr<DataMigrationResult> SnapshotMerger::migrate(std::unique_ptr<Dat
 
         for (auto& bundle_ptr : snapshots_.bundles_in_range(StepRange::from_block_num_range(range))) {
             auto& bundle = *bundle_ptr;
-            SegmentReader<RawDecoder> reader{bundle.segment(name)};
+            SegmentReader<RawDecoder> reader{bundle.segment(Schema::kDefaultEntityName, name)};
             std::copy(reader.begin(), reader.end(), compressor.add_word_iterator());
         }
 

--- a/silkworm/db/datastore/snapshots/schema.cpp
+++ b/silkworm/db/datastore/snapshots/schema.cpp
@@ -107,6 +107,7 @@ Schema::EntityDef Schema::RepositoryDef::make_history_schema(datastore::EntityNa
 
 void Schema::RepositoryDef::define_history_schema(datastore::EntityName name, EntityDef& schema) {
     schema.segment(kHistorySegmentName)
+        .compression_enabled(false)
         .sub_dir_name(kHistorySegmentSubDirName)
         .tag(name2tag(name))
         .file_ext(kHistorySegmentFileExt);

--- a/silkworm/db/datastore/snapshots/schema.cpp
+++ b/silkworm/db/datastore/snapshots/schema.cpp
@@ -118,6 +118,12 @@ void Schema::RepositoryDef::define_history_schema(datastore::EntityName name, En
     define_inverted_index_schema(name, schema);
 }
 
+void Schema::RepositoryDef::undefine_history_schema(EntityDef& schema) {
+    schema.undefine(kHistorySegmentName);
+    schema.undefine(kHistoryAccessorIndexName);
+    undefine_inverted_index_schema(schema);
+}
+
 Schema::EntityDef Schema::RepositoryDef::make_inverted_index_schema(datastore::EntityName name) {
     Schema::EntityDef schema;
     define_inverted_index_schema(name, schema);
@@ -134,6 +140,11 @@ void Schema::RepositoryDef::define_inverted_index_schema(datastore::EntityName n
         .sub_dir_name(kInvIdxAccessorIndexSubDirName)
         .tag(name2tag(name))
         .file_ext(kInvIdxAccessorIndexFileExt);
+}
+
+void Schema::RepositoryDef::undefine_inverted_index_schema(EntityDef& schema) {
+    schema.undefine(kInvIdxKVSegmentName);
+    schema.undefine(kInvIdxAccessorIndexName);
 }
 
 }  // namespace silkworm::snapshots

--- a/silkworm/db/datastore/snapshots/schema.cpp
+++ b/silkworm/db/datastore/snapshots/schema.cpp
@@ -86,7 +86,14 @@ Schema::EntityDef Schema::RepositoryDef::make_domain_schema(datastore::EntityNam
         .sub_dir_name(kDomainAccessorIndexSubDirName)
         .tag(name2tag(name))
         .file_ext(kDomainAccessorIndexFileExt);
-    // TODO: add .kvei and .bt
+    schema.existence_index(kDomainExistenceIndexName)
+        .sub_dir_name(kDomainExistenceIndexSubDirName)
+        .tag(name2tag(name))
+        .file_ext(kDomainExistenceIndexFileExt);
+    schema.btree_index(kDomainBTreeIndexName)
+        .sub_dir_name(kDomainBTreeIndexSubDirName)
+        .tag(name2tag(name))
+        .file_ext(kDomainBTreeIndexFileExt);
     define_history_schema(name, schema);
     return schema;
 }

--- a/silkworm/db/datastore/snapshots/schema.hpp
+++ b/silkworm/db/datastore/snapshots/schema.hpp
@@ -33,6 +33,8 @@ class Schema {
             kSegment,
             kKVSegment,
             kRecSplitIndex,
+            kExistenceIndex,
+            kBTreeIndex,
         };
 
         SnapshotFileDef& format(Format format) {
@@ -81,6 +83,14 @@ class Schema {
 
         SnapshotFileDef& rec_split_index(datastore::EntityName name) {
             return file_defs_[name].format(SnapshotFileDef::Format::kRecSplitIndex);
+        }
+
+        SnapshotFileDef& existence_index(datastore::EntityName name) {
+            return file_defs_[name].format(SnapshotFileDef::Format::kExistenceIndex);
+        }
+
+        SnapshotFileDef& btree_index(datastore::EntityName name) {
+            return file_defs_[name].format(SnapshotFileDef::Format::kBTreeIndex);
         }
 
         EntityDef& tag_override(std::string_view tag);

--- a/silkworm/db/datastore/snapshots/schema.hpp
+++ b/silkworm/db/datastore/snapshots/schema.hpp
@@ -131,6 +131,11 @@ class Schema {
             return *file_defs_.at(name);
         }
 
+        EntityDef& undefine(datastore::EntityName name) {
+            file_defs_.erase(name);
+            return *this;
+        }
+
         EntityDef& tag_override(std::string_view tag);
 
         const std::map<datastore::EntityName, std::shared_ptr<SnapshotFileDef>>& entities() const { return file_defs_; }
@@ -152,6 +157,11 @@ class Schema {
 
         DomainDef& history_compression_enabled(bool value) {
             segment(kHistorySegmentName).compression_enabled(value);
+            return *this;
+        }
+
+        DomainDef& without_history() {
+            RepositoryDef::undefine_history_schema(*this);
             return *this;
         }
     };
@@ -178,11 +188,14 @@ class Schema {
         std::optional<std::pair<datastore::EntityName, datastore::EntityName>> entity_name_by_path(const SnapshotPath& path) const;
 
       private:
+        friend DomainDef;
         static DomainDef make_domain_schema(datastore::EntityName name);
         static EntityDef make_history_schema(datastore::EntityName name);
         static void define_history_schema(datastore::EntityName name, EntityDef& schema);
+        static void undefine_history_schema(EntityDef& schema);
         static EntityDef make_inverted_index_schema(datastore::EntityName name);
         static void define_inverted_index_schema(datastore::EntityName name, EntityDef& schema);
+        static void undefine_inverted_index_schema(EntityDef& schema);
 
         std::map<datastore::EntityName, std::shared_ptr<EntityDef>> entity_defs_;
     };

--- a/silkworm/db/datastore/snapshots/schema.hpp
+++ b/silkworm/db/datastore/snapshots/schema.hpp
@@ -22,6 +22,7 @@
 
 #include "../common/entity_name.hpp"
 #include "common/snapshot_path.hpp"
+#include "seg/compression_kind.hpp"
 
 namespace silkworm::snapshots {
 
@@ -37,10 +38,8 @@ class Schema {
             kBTreeIndex,
         };
 
-        SnapshotFileDef& format(Format format) {
-            format_ = format;
-            return *this;
-        }
+        explicit SnapshotFileDef(Format format) : format_{format} {}
+        virtual ~SnapshotFileDef() = default;
 
         SnapshotFileDef& sub_dir_name(std::string_view name) {
             sub_dir_name_ = name;
@@ -59,78 +58,112 @@ class Schema {
 
         SnapshotPath make_path(const std::filesystem::path& dir_path, StepRange range) const;
 
-        Format format() const { return format_.value(); }
+        Format format() const { return format_; }
         const std::optional<std::string>& sub_dir_name() const { return sub_dir_name_; }
         const std::string& tag() const { return tag_.value(); }
         const std::string& file_ext() const { return file_ext_.value(); }
 
       private:
-        std::optional<Format> format_;
+        Format format_;
         std::optional<std::string> sub_dir_name_;
         std::optional<std::string> tag_;
         std::optional<std::string> file_ext_;
     };
 
-    class EntityDef {
+    class KVSegmentDef : public SnapshotFileDef {
       public:
-        SnapshotFileDef& segment(datastore::EntityName name) {
-            return file_defs_[name].format(SnapshotFileDef::Format::kSegment);
+        explicit KVSegmentDef() : SnapshotFileDef{SnapshotFileDef::Format::kKVSegment} {}
+        ~KVSegmentDef() override = default;
+
+        KVSegmentDef& compression_kind(seg::CompressionKind compression_kind) {
+            compression_kind_ = compression_kind;
+            return *this;
         }
 
-        SnapshotFileDef& kv_segment(datastore::EntityName name) {
-            return file_defs_[name].format(SnapshotFileDef::Format::kKVSegment);
+        seg::CompressionKind compression_kind() const { return *compression_kind_; }
+
+      private:
+        std::optional<seg::CompressionKind> compression_kind_;
+    };
+
+    class EntityDef {
+      public:
+        virtual ~EntityDef() = default;
+
+        SnapshotFileDef& segment(datastore::EntityName name) {
+            file_defs_.try_emplace(name, std::make_shared<SnapshotFileDef>(SnapshotFileDef::Format::kSegment));
+            return *file_defs_.at(name);
+        }
+
+        KVSegmentDef& kv_segment(datastore::EntityName name) {
+            file_defs_.try_emplace(name, std::make_shared<KVSegmentDef>());
+            return dynamic_cast<KVSegmentDef&>(*file_defs_.at(name));
         }
 
         SnapshotFileDef& rec_split_index(datastore::EntityName name) {
-            return file_defs_[name].format(SnapshotFileDef::Format::kRecSplitIndex);
+            file_defs_.try_emplace(name, std::make_shared<SnapshotFileDef>(SnapshotFileDef::Format::kRecSplitIndex));
+            return *file_defs_.at(name);
         }
 
         SnapshotFileDef& existence_index(datastore::EntityName name) {
-            return file_defs_[name].format(SnapshotFileDef::Format::kExistenceIndex);
+            file_defs_.try_emplace(name, std::make_shared<SnapshotFileDef>(SnapshotFileDef::Format::kExistenceIndex));
+            return *file_defs_.at(name);
         }
 
         SnapshotFileDef& btree_index(datastore::EntityName name) {
-            return file_defs_[name].format(SnapshotFileDef::Format::kBTreeIndex);
+            file_defs_.try_emplace(name, std::make_shared<SnapshotFileDef>(SnapshotFileDef::Format::kBTreeIndex));
+            return *file_defs_.at(name);
         }
 
         EntityDef& tag_override(std::string_view tag);
 
-        const std::map<datastore::EntityName, SnapshotFileDef>& entities() const { return file_defs_; }
+        const std::map<datastore::EntityName, std::shared_ptr<SnapshotFileDef>>& entities() const { return file_defs_; }
         std::vector<std::string> file_extensions() const;
         std::optional<datastore::EntityName> entity_name_by_path(const SnapshotPath& path) const;
 
       private:
-        std::map<datastore::EntityName, SnapshotFileDef> file_defs_;
+        std::map<datastore::EntityName, std::shared_ptr<SnapshotFileDef>> file_defs_;
+    };
+
+    class DomainDef : public EntityDef {
+      public:
+        ~DomainDef() override = default;
+
+        DomainDef& kv_segment_compression_kind(seg::CompressionKind compression_kind) {
+            kv_segment(kDomainKVSegmentName).compression_kind(compression_kind);
+            return *this;
+        }
     };
 
     class RepositoryDef {
       public:
         EntityDef& default_entity() {
-            return entity_defs_[kDefaultEntityName];
+            entity_defs_.try_emplace(kDefaultEntityName, std::make_shared<EntityDef>());
+            return *entity_defs_.at(kDefaultEntityName);
         }
 
-        EntityDef& domain(datastore::EntityName name) {
-            entity_defs_.try_emplace(name, make_domain_schema(name));
-            return entity_defs_.at(name);
+        DomainDef& domain(datastore::EntityName name) {
+            entity_defs_.try_emplace(name, std::make_shared<DomainDef>(make_domain_schema(name)));
+            return dynamic_cast<DomainDef&>(*entity_defs_.at(name));
         }
 
         EntityDef& inverted_index(datastore::EntityName name) {
-            entity_defs_.try_emplace(name, make_inverted_index_schema(name));
-            return entity_defs_.at(name);
+            entity_defs_.try_emplace(name, std::make_shared<EntityDef>(make_inverted_index_schema(name)));
+            return *entity_defs_.at(name);
         }
 
-        const std::map<datastore::EntityName, EntityDef>& entities() const { return entity_defs_; }
+        const std::map<datastore::EntityName, std::shared_ptr<EntityDef>>& entities() const { return entity_defs_; }
         std::vector<std::string> file_extensions() const;
         std::optional<std::pair<datastore::EntityName, datastore::EntityName>> entity_name_by_path(const SnapshotPath& path) const;
 
       private:
-        static EntityDef make_domain_schema(datastore::EntityName name);
+        static DomainDef make_domain_schema(datastore::EntityName name);
         static EntityDef make_history_schema(datastore::EntityName name);
         static void define_history_schema(datastore::EntityName name, EntityDef& schema);
         static EntityDef make_inverted_index_schema(datastore::EntityName name);
         static void define_inverted_index_schema(datastore::EntityName name, EntityDef& schema);
 
-        std::map<datastore::EntityName, EntityDef> entity_defs_;
+        std::map<datastore::EntityName, std::shared_ptr<EntityDef>> entity_defs_;
     };
 
     RepositoryDef& repository(datastore::EntityName name) {

--- a/silkworm/db/datastore/snapshots/segment/segment_reader.cpp
+++ b/silkworm/db/datastore/snapshots/segment/segment_reader.cpp
@@ -25,9 +25,14 @@ namespace silkworm::snapshots {
 
 SegmentFileReader::SegmentFileReader(
     SnapshotPath path,
-    std::optional<MemoryMappedRegion> segment_region)
+    std::optional<MemoryMappedRegion> segment_region,
+    bool is_compressed)
     : path_(std::move(path)),
-      decompressor_{path_.path(), segment_region} {}
+      decompressor_{
+          path_.path(),
+          segment_region,
+          is_compressed ? seg::CompressionKind::kAll : seg::CompressionKind::kNone,
+      } {}
 
 SegmentFileReader::~SegmentFileReader() {
     close();
@@ -61,7 +66,7 @@ SegmentFileReader::Iterator& SegmentFileReader::Iterator::operator++() {
 
 SegmentFileReader::Iterator& SegmentFileReader::Iterator::operator+=(size_t count) {
     while ((count > 1) && it_.has_next()) {
-        it_.skip();
+        it_.skip_auto();
         --count;
     }
     if (count > 0) {

--- a/silkworm/db/datastore/snapshots/segment/segment_reader.hpp
+++ b/silkworm/db/datastore/snapshots/segment/segment_reader.hpp
@@ -86,7 +86,8 @@ class SegmentFileReader {
 
     explicit SegmentFileReader(
         SnapshotPath path,
-        std::optional<MemoryMappedRegion> segment_region = std::nullopt);
+        std::optional<MemoryMappedRegion> segment_region = std::nullopt,
+        bool is_compressed = true);
     ~SegmentFileReader();
 
     SegmentFileReader(SegmentFileReader&&) = default;

--- a/silkworm/db/datastore/snapshots/segment/segment_writer.cpp
+++ b/silkworm/db/datastore/snapshots/segment/segment_writer.cpp
@@ -20,10 +20,14 @@ namespace silkworm::snapshots {
 
 SegmentFileWriter::SegmentFileWriter(
     SnapshotPath path,
-    const std::filesystem::path& tmp_dir_path)
-    : path_(std::move(path)),
-      compressor_(path_.path(), tmp_dir_path) {
-}
+    const std::filesystem::path& tmp_dir_path,
+    bool is_compressed)
+    : path_{std::move(path)},
+      compressor_{
+          path_.path(),
+          tmp_dir_path,
+          is_compressed ? seg::CompressionKind::kAll : seg::CompressionKind::kNone,
+      } {}
 
 SegmentFileWriter::Iterator& SegmentFileWriter::Iterator::operator=(const SegmentFileWriter::Iterator::value_type& value) {
     *it_ = value->encode_word();

--- a/silkworm/db/datastore/snapshots/segment/segment_writer.hpp
+++ b/silkworm/db/datastore/snapshots/segment/segment_writer.hpp
@@ -64,7 +64,8 @@ class SegmentFileWriter {
 
     explicit SegmentFileWriter(
         SnapshotPath path,
-        const std::filesystem::path& tmp_dir_path);
+        const std::filesystem::path& tmp_dir_path,
+        bool is_compressed = true);
 
     SegmentFileWriter(SegmentFileWriter&&) = default;
     SegmentFileWriter& operator=(SegmentFileWriter&&) = default;

--- a/silkworm/db/datastore/snapshots/snapshot_bundle.cpp
+++ b/silkworm/db/datastore/snapshots/snapshot_bundle.cpp
@@ -169,12 +169,16 @@ void SnapshotBundle::close() {
     }
 }
 
-const SegmentFileReader& SnapshotBundle::segment(datastore::EntityName name) const {
-    return data_.entities.at(Schema::kDefaultEntityName).segments.at(name);
+const SegmentFileReader& SnapshotBundle::segment(
+    datastore::EntityName entity_name,
+    datastore::EntityName segment_name) const {
+    return data_.entities.at(entity_name).segments.at(segment_name);
 }
 
-const Index& SnapshotBundle::rec_split_index(datastore::EntityName name) const {
-    return data_.entities.at(Schema::kDefaultEntityName).rec_split_indexes.at(name);
+const Index& SnapshotBundle::rec_split_index(
+    datastore::EntityName entity_name,
+    datastore::EntityName index_name) const {
+    return data_.entities.at(entity_name).rec_split_indexes.at(index_name);
 }
 
 Domain SnapshotBundle::domain(datastore::EntityName name) const {

--- a/silkworm/db/datastore/snapshots/snapshot_bundle.cpp
+++ b/silkworm/db/datastore/snapshots/snapshot_bundle.cpp
@@ -27,8 +27,8 @@ static std::map<datastore::EntityName, SnapshotPath> make_snapshot_paths(
     StepRange range) {
     std::map<datastore::EntityName, SnapshotPath> results;
     for (auto& [name, def] : entity.entities()) {
-        if (def.format() == format) {
-            auto path = def.make_path(dir_path, range);
+        if (def->format() == format) {
+            auto path = def->make_path(dir_path, range);
             results.emplace(name, std::move(path));
         }
     }
@@ -51,8 +51,11 @@ std::map<datastore::EntityName, KVSegmentFileReader> make_kv_segments(
     const std::filesystem::path& dir_path,
     StepRange range) {
     std::map<datastore::EntityName, KVSegmentFileReader> results;
-    for (auto& [name, path] : make_snapshot_paths(Schema::SnapshotFileDef::Format::kKVSegment, entity, dir_path, range)) {
-        results.emplace(name, KVSegmentFileReader{path, seg::CompressionKind::kAll});
+    for (auto& [name, anyDef] : entity.entities()) {
+        if (anyDef->format() != Schema::SnapshotFileDef::Format::kKVSegment) continue;
+        auto& def = dynamic_cast<const Schema::KVSegmentDef&>(*anyDef);
+        auto path = def.make_path(dir_path, range);
+        results.emplace(name, KVSegmentFileReader{std::move(path), def.compression_kind()});
     }
     return results;
 }
@@ -99,7 +102,8 @@ SnapshotBundleData make_bundle_data(
     const std::filesystem::path& dir_path,
     StepRange step_range) {
     SnapshotBundleData data;
-    for (auto& [name, entity_schema] : schema.entities()) {
+    for (auto& [name, entity_schema_ptr] : schema.entities()) {
+        auto& entity_schema = *entity_schema_ptr;
         data.entities.emplace(
             name,
             SnapshotBundleEntityData{
@@ -224,20 +228,20 @@ std::vector<SnapshotPath> SnapshotBundle::segment_paths() const {
 }
 
 std::map<datastore::EntityName, SnapshotPath> SnapshotBundlePaths::segment_paths() const {
-    auto& entity = schema_.entities().at(Schema::kDefaultEntityName);
+    auto& entity = *schema_.entities().at(Schema::kDefaultEntityName);
     return make_snapshot_paths(Schema::SnapshotFileDef::Format::kSegment, entity, dir_path_, step_range_);
 }
 
 std::map<datastore::EntityName, SnapshotPath> SnapshotBundlePaths::rec_split_index_paths() const {
-    auto& entity = schema_.entities().at(Schema::kDefaultEntityName);
+    auto& entity = *schema_.entities().at(Schema::kDefaultEntityName);
     return make_snapshot_paths(Schema::SnapshotFileDef::Format::kRecSplitIndex, entity, dir_path_, step_range_);
 }
 
 std::vector<std::filesystem::path> SnapshotBundlePaths::files() const {
     std::vector<std::filesystem::path> results;
     for (auto& entity_entry : schema_.entities()) {
-        for (auto& file_entry : entity_entry.second.entities()) {
-            auto path = file_entry.second.make_path(dir_path_, step_range_);
+        for (auto& file_entry : entity_entry.second->entities()) {
+            auto path = file_entry.second->make_path(dir_path_, step_range_);
             results.push_back(path.path());
         }
     }

--- a/silkworm/db/datastore/snapshots/snapshot_bundle.hpp
+++ b/silkworm/db/datastore/snapshots/snapshot_bundle.hpp
@@ -21,6 +21,8 @@
 #include <functional>
 #include <vector>
 
+#include "bloom_filter/bloom_filter.hpp"
+#include "btree/btree_index.hpp"
 #include "common/snapshot_path.hpp"
 #include "common/util/iterator/map_values_view.hpp"
 #include "domain.hpp"
@@ -37,6 +39,8 @@ struct SnapshotBundleEntityData {
     std::map<datastore::EntityName, SegmentFileReader> segments;
     std::map<datastore::EntityName, KVSegmentFileReader> kv_segments;
     std::map<datastore::EntityName, Index> rec_split_indexes;
+    std::map<datastore::EntityName, bloom_filter::BloomFilter> existence_indexes;
+    std::map<datastore::EntityName, btree::BTreeIndex> btree_indexes;
 };
 
 struct SnapshotBundleData {

--- a/silkworm/db/datastore/snapshots/snapshot_bundle.hpp
+++ b/silkworm/db/datastore/snapshots/snapshot_bundle.hpp
@@ -95,11 +95,18 @@ struct SnapshotBundle {
     auto segments() const {
         return make_map_values_view(data_.entities.at(Schema::kDefaultEntityName).segments);
     }
-    const SegmentFileReader& segment(datastore::EntityName name) const;
-    const Index& rec_split_index(datastore::EntityName name) const;
+    const SegmentFileReader& segment(
+        datastore::EntityName entity_name,
+        datastore::EntityName segment_name) const;
+    const Index& rec_split_index(
+        datastore::EntityName entity_name,
+        datastore::EntityName index_name) const;
     SegmentAndIndex segment_and_rec_split_index(
-        std::pair<datastore::EntityName, datastore::EntityName> names) const {
-        return {segment(names.first), rec_split_index(names.second)};
+        std::array<datastore::EntityName, 3> names) const {
+        return {
+            segment(names[0], names[1]),
+            rec_split_index(names[0], names[2]),
+        };
     }
 
     Domain domain(datastore::EntityName name) const;

--- a/silkworm/db/datastore/snapshots/snapshot_repository.cpp
+++ b/silkworm/db/datastore/snapshots/snapshot_repository.cpp
@@ -96,7 +96,7 @@ Step SnapshotRepository::max_end_step() const {
 }
 
 std::pair<std::optional<SegmentAndIndex>, std::shared_ptr<SnapshotBundle>> SnapshotRepository::find_segment(
-    std::pair<datastore::EntityName, datastore::EntityName> names,
+    std::array<datastore::EntityName, 3> names,
     Timestamp t) const {
     auto bundle = find_bundle(step_converter_->step_from_timestamp(t));
     if (bundle) {

--- a/silkworm/db/datastore/snapshots/snapshot_repository.hpp
+++ b/silkworm/db/datastore/snapshots/snapshot_repository.hpp
@@ -107,7 +107,7 @@ class SnapshotRepository {
     }
 
     std::pair<std::optional<SegmentAndIndex>, std::shared_ptr<SnapshotBundle>> find_segment(
-        std::pair<datastore::EntityName, datastore::EntityName> names,
+        std::array<datastore::EntityName, 3> names,
         Timestamp t) const;
     std::shared_ptr<SnapshotBundle> find_bundle(Step step) const;
 

--- a/silkworm/db/state/schema_config.cpp
+++ b/silkworm/db/state/schema_config.cpp
@@ -22,15 +22,23 @@ namespace silkworm::db::state {
 
 snapshots::Schema::RepositoryDef make_state_repository_schema() {
     snapshots::Schema::RepositoryDef schema;
-    schema.domain(kDomainNameAccounts).tag_override(kDomainAccountsTag);
-    schema.domain(kDomainNameStorage);
-    schema.domain(kDomainNameCode);
-    schema.domain(kDomainNameCommitment);
+
+    schema.domain(kDomainNameAccounts)
+        .tag_override(kDomainAccountsTag);
+    schema.domain(kDomainNameStorage)
+        .kv_segment_compression_kind(snapshots::seg::CompressionKind::kKeys);
+    schema.domain(kDomainNameCode)
+        .kv_segment_compression_kind(snapshots::seg::CompressionKind::kValues);
+    schema.domain(kDomainNameCommitment)
+        .kv_segment_compression_kind(snapshots::seg::CompressionKind::kKeys);
     schema.domain(kDomainNameReceipts);
-    schema.inverted_index(kInvIdxNameLogAddress).tag_override(kInvIdxLogAddressTag);
+
+    schema.inverted_index(kInvIdxNameLogAddress)
+        .tag_override(kInvIdxLogAddressTag);
     schema.inverted_index(kInvIdxNameLogTopics);
     schema.inverted_index(kInvIdxNameTracesFrom);
     schema.inverted_index(kInvIdxNameTracesTo);
+
     return schema;
 }
 

--- a/silkworm/db/state/schema_config.cpp
+++ b/silkworm/db/state/schema_config.cpp
@@ -31,6 +31,7 @@ snapshots::Schema::RepositoryDef make_state_repository_schema() {
         .history_compression_enabled(true)
         .kv_segment_compression_kind(snapshots::seg::CompressionKind::kValues);
     schema.domain(kDomainNameCommitment)
+        .without_history()
         .kv_segment_compression_kind(snapshots::seg::CompressionKind::kKeys);
     schema.domain(kDomainNameReceipts);
 

--- a/silkworm/db/state/schema_config.cpp
+++ b/silkworm/db/state/schema_config.cpp
@@ -28,6 +28,7 @@ snapshots::Schema::RepositoryDef make_state_repository_schema() {
     schema.domain(kDomainNameStorage)
         .kv_segment_compression_kind(snapshots::seg::CompressionKind::kKeys);
     schema.domain(kDomainNameCode)
+        .history_compression_enabled(true)
         .kv_segment_compression_kind(snapshots::seg::CompressionKind::kValues);
     schema.domain(kDomainNameCommitment)
         .kv_segment_compression_kind(snapshots::seg::CompressionKind::kKeys);

--- a/silkworm/db/state/schema_config.hpp
+++ b/silkworm/db/state/schema_config.hpp
@@ -58,10 +58,10 @@ struct BundleDataRef {
     datastore::Domain commitment_domain() const { return {bundle.domain(kDomainNameCommitment)}; }
     datastore::Domain receipts_domain() const { return {bundle.domain(kDomainNameReceipts)}; }
 
-    datastore::InvertedIndex log_address_inv_idx() const { return {bundle.inverted_index(kInvIdxNameLogAddress)}; }
-    datastore::InvertedIndex log_topics_inv_idx() const { return {bundle.inverted_index(kInvIdxNameLogTopics)}; }
-    datastore::InvertedIndex traces_from_inv_idx() const { return {bundle.inverted_index(kInvIdxNameTracesFrom)}; }
-    datastore::InvertedIndex traces_to_inv_idx() const { return {bundle.inverted_index(kInvIdxNameTracesTo)}; }
+    datastore::InvertedIndex log_address_inverted_index() const { return {bundle.inverted_index(kInvIdxNameLogAddress)}; }
+    datastore::InvertedIndex log_topics_inverted_index() const { return {bundle.inverted_index(kInvIdxNameLogTopics)}; }
+    datastore::InvertedIndex traces_from_inverted_index() const { return {bundle.inverted_index(kInvIdxNameTracesFrom)}; }
+    datastore::InvertedIndex traces_to_inverted_index() const { return {bundle.inverted_index(kInvIdxNameTracesTo)}; }
 };
 
 }  // namespace silkworm::db::state


### PR DESCRIPTION
* .kvei and .bt schema (only schema for now, TODOs added for opening files)
* configure KVSegment compression kind: uncompressed by default, Storage & Commitment .kv has keys compressed, Code .kv has values compressed (.ef is always uncompressed)
* configure Segment compression: history is uncompressed by default, compressed for Code .v
* disable Commitment history
