### PR TITLE
sync: refactor MockBlockExchange for PoSSyncTest

### DIFF
--- a/silkworm/db/test_util/mock_chain_storage.hpp
+++ b/silkworm/db/test_util/mock_chain_storage.hpp
@@ -32,47 +32,47 @@ namespace silkworm::db::test_util {
 
 class MockChainStorage : public chain::ChainStorage {
   public:
-    MOCK_METHOD((Task<silkworm::ChainConfig>), read_chain_config, (), (const override));
+    MOCK_METHOD((Task<silkworm::ChainConfig>), read_chain_config, (), (const, override));
 
-    MOCK_METHOD((Task<BlockNum>), highest_block_number, (), (const override));
+    MOCK_METHOD((Task<BlockNum>), highest_block_number, (), (const, override));
 
-    MOCK_METHOD((Task<std::optional<BlockNum>>), read_block_number, (const Hash&), (const override));
+    MOCK_METHOD((Task<std::optional<BlockNum>>), read_block_number, (const Hash&), (const, override));
 
-    MOCK_METHOD((Task<bool>), read_block, (HashAsSpan, BlockNum, bool, silkworm::Block&), (const override));
-    MOCK_METHOD((Task<bool>), read_block, (const Hash&, BlockNum, silkworm::Block&), (const override));
-    MOCK_METHOD((Task<bool>), read_block, (const Hash&, silkworm::Block&), (const override));
-    MOCK_METHOD((Task<bool>), read_block, (BlockNum, bool, silkworm::Block&), (const override));
+    MOCK_METHOD((Task<bool>), read_block, (HashAsSpan, BlockNum, bool, silkworm::Block&), (const, override));
+    MOCK_METHOD((Task<bool>), read_block, (const Hash&, BlockNum, silkworm::Block&), (const, override));
+    MOCK_METHOD((Task<bool>), read_block, (const Hash&, silkworm::Block&), (const, override));
+    MOCK_METHOD((Task<bool>), read_block, (BlockNum, bool, silkworm::Block&), (const, override));
 
-    MOCK_METHOD((Task<std::optional<BlockHeader>>), read_header, (BlockNum number, HashAsArray hash), (const override));
-    MOCK_METHOD((Task<std::optional<BlockHeader>>), read_header, (BlockNum number, const Hash& hash), (const override));
-    MOCK_METHOD((Task<std::optional<BlockHeader>>), read_header, (const Hash& hash), (const override));
+    MOCK_METHOD((Task<std::optional<BlockHeader>>), read_header, (BlockNum number, HashAsArray hash), (const, override));
+    MOCK_METHOD((Task<std::optional<BlockHeader>>), read_header, (BlockNum number, const Hash& hash), (const, override));
+    MOCK_METHOD((Task<std::optional<BlockHeader>>), read_header, (const Hash& hash), (const, override));
 
-    MOCK_METHOD((Task<std::vector<BlockHeader>>), read_sibling_headers, (BlockNum), (const override));
+    MOCK_METHOD((Task<std::vector<BlockHeader>>), read_sibling_headers, (BlockNum), (const, override));
 
-    MOCK_METHOD((Task<bool>), read_body, (BlockNum, HashAsArray, bool, silkworm::BlockBody&), (const override));
-    MOCK_METHOD((Task<bool>), read_body, (const Hash&, BlockNum, silkworm::BlockBody&), (const override));
-    MOCK_METHOD((Task<bool>), read_body, (const Hash&, silkworm::BlockBody&), (const override));
+    MOCK_METHOD((Task<bool>), read_body, (BlockNum, HashAsArray, bool, silkworm::BlockBody&), (const, override));
+    MOCK_METHOD((Task<bool>), read_body, (const Hash&, BlockNum, silkworm::BlockBody&), (const, override));
+    MOCK_METHOD((Task<bool>), read_body, (const Hash&, silkworm::BlockBody&), (const, override));
 
-    MOCK_METHOD((Task<std::optional<Hash>>), read_canonical_header_hash, (BlockNum), (const override));
+    MOCK_METHOD((Task<std::optional<Hash>>), read_canonical_header_hash, (BlockNum), (const, override));
 
-    MOCK_METHOD((Task<std::optional<BlockHeader>>), read_canonical_header, (BlockNum), (const override));
+    MOCK_METHOD((Task<std::optional<BlockHeader>>), read_canonical_header, (BlockNum), (const, override));
 
-    MOCK_METHOD((Task<bool>), read_canonical_body, (BlockNum, BlockBody&), (const override));
+    MOCK_METHOD((Task<bool>), read_canonical_body, (BlockNum, BlockBody&), (const, override));
 
-    MOCK_METHOD((Task<bool>), read_canonical_block, (BlockNum, silkworm::Block&), (const override));
+    MOCK_METHOD((Task<bool>), read_canonical_block, (BlockNum, silkworm::Block&), (const, override));
 
-    MOCK_METHOD((Task<bool>), has_body, (BlockNum, HashAsArray), (const override));
+    MOCK_METHOD((Task<bool>), has_body, (BlockNum, HashAsArray), (const, override));
 
-    MOCK_METHOD((Task<bool>), has_body, (BlockNum, const Hash&), (const override));
+    MOCK_METHOD((Task<bool>), has_body, (BlockNum, const Hash&), (const, override));
 
-    MOCK_METHOD((Task<bool>), read_rlp_transactions, (BlockNum, const evmc::bytes32&, std::vector<Bytes>&), (const override));
+    MOCK_METHOD((Task<bool>), read_rlp_transactions, (BlockNum, const evmc::bytes32&, std::vector<Bytes>&), (const, override));
 
-    MOCK_METHOD((Task<bool>), read_rlp_transaction, (const evmc::bytes32&, Bytes&), (const override));
+    MOCK_METHOD((Task<bool>), read_rlp_transaction, (const evmc::bytes32&, Bytes&), (const, override));
 
-    MOCK_METHOD((Task<std::optional<intx::uint256>>), read_total_difficulty, (const Hash&, BlockNum), (const override));
+    MOCK_METHOD((Task<std::optional<intx::uint256>>), read_total_difficulty, (const Hash&, BlockNum), (const, override));
 
-    MOCK_METHOD((Task<std::optional<BlockNum>>), read_block_number_by_transaction_hash, (const evmc::bytes32&), (const override));
-    MOCK_METHOD((Task<std::optional<Transaction>>), read_transaction_by_idx_in_block, (BlockNum, uint64_t), (const override));
+    MOCK_METHOD((Task<std::optional<BlockNum>>), read_block_number_by_transaction_hash, (const evmc::bytes32&), (const, override));
+    MOCK_METHOD((Task<std::optional<Transaction>>), read_transaction_by_idx_in_block, (BlockNum, uint64_t), (const, override));
 };
 
 }  // namespace silkworm::db::test_util

--- a/silkworm/sync/chain_sync.cpp
+++ b/silkworm/sync/chain_sync.cpp
@@ -18,7 +18,7 @@
 
 namespace silkworm::chainsync {
 
-ChainSync::ChainSync(BlockExchange& block_exchange, execution::api::Client& exec_client)
+ChainSync::ChainSync(IBlockExchange& block_exchange, execution::api::Client& exec_client)
     : block_exchange_{block_exchange},
       exec_engine_{exec_client.service()},
       chain_fork_view_{ChainForkView::head_at_genesis(block_exchange.chain_config())} {

--- a/silkworm/sync/chain_sync.hpp
+++ b/silkworm/sync/chain_sync.hpp
@@ -26,7 +26,7 @@ namespace silkworm::chainsync {
 
 class ChainSync {
   public:
-    ChainSync(BlockExchange&, execution::api::Client&);
+    ChainSync(IBlockExchange&, execution::api::Client&);
     virtual ~ChainSync() = default;
 
     ChainSync(const ChainSync&) = delete;
@@ -35,7 +35,7 @@ class ChainSync {
     virtual Task<void> async_run() = 0;
 
   protected:
-    BlockExchange& block_exchange_;
+    IBlockExchange& block_exchange_;
     std::shared_ptr<execution::api::Service> exec_engine_;
     ChainForkView chain_fork_view_;
 };

--- a/silkworm/sync/sync_pos.cpp
+++ b/silkworm/sync/sync_pos.cpp
@@ -46,7 +46,7 @@ class PayloadValidationError : public std::logic_error {
     explicit PayloadValidationError(const std::string& reason) : std::logic_error(reason) {}
 };
 
-PoSSync::PoSSync(BlockExchange& block_exchange, execution::api::Client& exec_client)
+PoSSync::PoSSync(IBlockExchange& block_exchange, execution::api::Client& exec_client)
     : ChainSync(block_exchange, exec_client) {}
 
 Task<void> PoSSync::async_run() {

--- a/silkworm/sync/sync_pos.hpp
+++ b/silkworm/sync/sync_pos.hpp
@@ -32,7 +32,7 @@ namespace silkworm::chainsync {
 
 class PoSSync : public ChainSync, public rpc::engine::ExecutionEngine {
   public:
-    PoSSync(BlockExchange&, execution::api::Client&);
+    PoSSync(IBlockExchange&, execution::api::Client&);
 
     Task<void> async_run() override;
 

--- a/silkworm/sync/sync_pos_test.cpp
+++ b/silkworm/sync/sync_pos_test.cpp
@@ -18,17 +18,12 @@
 
 #include <array>
 
-#include <silkworm/infra/concurrency/task.hpp>
-
-#include <boost/asio/steady_timer.hpp>
-#include <boost/asio/this_coro.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <gmock/gmock.h>
 
-#include <silkworm/infra/test_util/log.hpp>
+#include <silkworm/infra/concurrency/sleep.hpp>
 #include <silkworm/rpc/test_util/service_context_test_base.hpp>
 #include <silkworm/sync/block_exchange.hpp>
-#include <silkworm/sync/sentry_client.hpp>
 
 #include "test_util/mock_block_exchange.hpp"
 #include "test_util/mock_execution_client.hpp"
@@ -37,26 +32,20 @@ namespace silkworm::chainsync {
 
 class PoSSyncTest : public rpc::test_util::ServiceContextTestBase {
   public:
-    TemporaryDirectory tmp_dir;
-    db::DataStore data_store{
-        mdbx::env_managed{},
-        db::blocks::make_blocks_repository(tmp_dir.path()),
-    };
-    SentryClient sentry_client{ioc_.get_executor(), nullptr};  // TODO(canepat) mock
-    test_util::MockBlockExchange block_exchange{data_store.ref(), sentry_client, kSepoliaConfig};
+    std::unique_ptr<test_util::MockBlockExchange> block_exchange{make_block_exchange()};
     std::shared_ptr<test_util::MockExecutionService> execution_service{std::make_shared<test_util::MockExecutionService>()};
     test_util::MockExecutionClient execution_client{execution_service};
 
   protected:
-    PoSSync sync_{block_exchange, execution_client};
-};
+    PoSSync sync_{*block_exchange, execution_client};
 
-Task<void> sleep(std::chrono::milliseconds duration) {
-    auto executor = co_await boost::asio::this_coro::executor;
-    boost::asio::steady_timer timer(executor);
-    timer.expires_after(duration);
-    co_await timer.async_wait(boost::asio::use_awaitable);
-}
+    static std::unique_ptr<test_util::MockBlockExchange> make_block_exchange() {
+        auto block_exchange = std::make_unique<test_util::MockBlockExchange>();
+        EXPECT_CALL(*block_exchange, chain_config)
+            .WillRepeatedly([]() -> const ChainConfig& { return kSepoliaConfig; });
+        return block_exchange;
+    }
+};
 
 static rpc::NewPayloadRequest make_fixed_payload_request(rpc::ExecutionPayload::Version version) {
     return {

--- a/silkworm/sync/sync_pow.cpp
+++ b/silkworm/sync/sync_pow.cpp
@@ -29,7 +29,7 @@ namespace silkworm::chainsync {
 
 using concurrency::spawn_future_and_wait;
 
-PoWSync::PoWSync(BlockExchange& block_exchange, execution::api::Client& exec_engine)
+PoWSync::PoWSync(IBlockExchange& block_exchange, execution::api::Client& exec_engine)
     : ChainSync(block_exchange, exec_engine) {}
 
 Task<void> PoWSync::async_run() {

--- a/silkworm/sync/sync_pow.hpp
+++ b/silkworm/sync/sync_pow.hpp
@@ -33,7 +33,7 @@ namespace asio = boost::asio;
 
 class PoWSync : public ChainSync, ActiveComponent {
   public:
-    PoWSync(BlockExchange&, execution::api::Client&);
+    PoWSync(IBlockExchange&, execution::api::Client&);
 
     Task<void> async_run() override;
 

--- a/silkworm/sync/test_util/mock_block_exchange.hpp
+++ b/silkworm/sync/test_util/mock_block_exchange.hpp
@@ -32,27 +32,26 @@
 namespace silkworm::chainsync::test_util {
 
 //! \brief MockBlockExchange is the gMock mock class for BlockExchange.
-class MockBlockExchange : public BlockExchange {
+class MockBlockExchange : public IBlockExchange {
   public:
-    MockBlockExchange(db::DataStoreRef data_store, SentryClient& client, const ChainConfig& config)
-        : BlockExchange{std::move(data_store), client, config, /* use_preverified_hashes = */ false} {}
+    ~MockBlockExchange() override = default;
 
-    MOCK_METHOD((void), initial_state, (std::vector<BlockHeader>));
+    MOCK_METHOD((void), initial_state, (std::vector<BlockHeader>), (override));
 
-    MOCK_METHOD((void), download_blocks, (BlockNum, TargetTracking));
-    MOCK_METHOD((void), new_target_block, (std::shared_ptr<Block>));
-    MOCK_METHOD((void), stop_downloading, ());
+    MOCK_METHOD((void), download_blocks, (BlockNum, TargetTracking), (override));
+    MOCK_METHOD((void), new_target_block, (std::shared_ptr<Block>), (override));
+    MOCK_METHOD((void), stop_downloading, (), (override));
 
-    MOCK_METHOD((ResultQueue&), result_queue, (Hash));
+    MOCK_METHOD((ResultQueue&), result_queue, (), (override));
 
-    MOCK_METHOD((bool), in_sync, (), (const));
-    MOCK_METHOD((BlockNum), current_height, (), (const));
+    MOCK_METHOD((bool), in_sync, (), (const, override));
+    MOCK_METHOD((BlockNum), current_height, (), (const, override));
 
-    MOCK_METHOD((void), accept, (std::shared_ptr<Message>));
-    MOCK_METHOD((void), execution_loop, ());
+    MOCK_METHOD((void), accept, (std::shared_ptr<Message>), (override));
+    MOCK_METHOD((void), execution_loop, (), (override));
 
-    MOCK_METHOD((const ChainConfig&), chain_config, (), (const));
-    MOCK_METHOD((SentryClient&), sentry, (), (const));
+    MOCK_METHOD((const ChainConfig&), chain_config, (), (const, override));
+    MOCK_METHOD((SentryClient&), sentry, (), (const, override));
 };
 
 }  // namespace silkworm::chainsync::test_util


### PR DESCRIPTION
Inherit both MockBlockExchange and BlockExchange from a common interface to avoid creating BlockExchange dependencies that are irrelevant for the test (sentry, data store).