### PR TITLE
ci: fix unit test failure propagation

### DIFF
--- a/.github/workflows/run_integration_tests.sh
+++ b/.github/workflows/run_integration_tests.sh
@@ -5,7 +5,9 @@ if [ "$#" -ne 3 ]; then
   exit 1
 fi
 
+# TODO: why is this disabled?
 set +e # Disable exit on error
+set -o pipefail
 
 cd "$1" || exit 1
 rm -rf ./mainnet/results/

--- a/.github/workflows/start_integration_rpcdaemon.sh
+++ b/.github/workflows/start_integration_rpcdaemon.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -e
+set -o pipefail
+
 trap : SIGTERM SIGINT
 
 if [ "$#" -ne 2 ]; then

--- a/.github/workflows/stop_integration_rpcdaemon.sh
+++ b/.github/workflows/stop_integration_rpcdaemon.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -e
+set -o pipefail
+
 if [ "$#" -ne 1 ]; then
   echo "Usage: $0 <rpcdaemon_pid>"
   exit 1

--- a/cmake/parallel_jobs_count.sh
+++ b/cmake/parallel_jobs_count.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -e
+set -o pipefail
+
 case $(uname -s) in
 	Linux)
 		nproc

--- a/cmake/run_smoke_tests.sh
+++ b/cmake/run_smoke_tests.sh
@@ -1,4 +1,7 @@
-#!/bin/sh
+#!/bin/bash
+
+set -e
+set -o pipefail
 
 if test `uname -s` = Linux
 then

--- a/cmake/run_unit_tests.sh
+++ b/cmake/run_unit_tests.sh
@@ -1,4 +1,7 @@
-#!/bin/sh
+#!/bin/bash
+
+set -e
+set -o pipefail
 
 if test `uname -s` = Linux
 then

--- a/cmake/setup/compiler_install.sh
+++ b/cmake/setup/compiler_install.sh
@@ -3,6 +3,9 @@
 # $1 - compiler ID: gcc or clang
 # $2 - compiler version
 
+set -e
+set -o pipefail
+
 function install_gcc {
     GCC_VERSION="$1"
     echo "Installing GCC $GCC_VERSION..."

--- a/silkworm/core/chain/config_test.cpp
+++ b/silkworm/core/chain/config_test.cpp
@@ -26,14 +26,6 @@ using namespace evmc::literals;
 
 namespace silkworm {
 
-TEST_CASE("test1") {
-    CHECK(false);
-}
-
-TEST_CASE("test2") {
-    abort();
-}
-
 TEST_CASE("Known configs") {
     static_assert(kKnownChainConfigs.size() == kKnownChainNameToId.size());
     for (const auto& [_, id] : kKnownChainNameToId) {

--- a/silkworm/core/chain/config_test.cpp
+++ b/silkworm/core/chain/config_test.cpp
@@ -26,6 +26,14 @@ using namespace evmc::literals;
 
 namespace silkworm {
 
+TEST_CASE("test1") {
+    CHECK(false);
+}
+
+TEST_CASE("test2") {
+    abort();
+}
+
 TEST_CASE("Known configs") {
     static_assert(kKnownChainConfigs.size() == kKnownChainNameToId.size());
     for (const auto& [_, id] : kKnownChainNameToId) {

--- a/tests/docker/run-docker.sh
+++ b/tests/docker/run-docker.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -e
+set -o pipefail
+
 while [ True ]; do
 if [ "$1" = "--refresh-cache" -o "$1" = "-r" ]; then
     RENEW=1

--- a/tests/perf/run_with_perf.sh
+++ b/tests/perf/run_with_perf.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
+set -e
+set -o pipefail
+
 sudo perf stat --topdown -a -- taskset -c 0 build_gcc_release/cmd/rpcdaemon --target localhost:9090

--- a/tests/perf/run_with_toplev.sh
+++ b/tests/perf/run_with_toplev.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
+set -e
+set -o pipefail
+
 sudo toplev --core S0-C0 -l3 -v --no-desc taskset -c 0 build_gcc_release/cmd/rpcdaemon --target localhost:9090

--- a/tests/perf/vegeta_attack_getLogs_rpcdaemon.sh
+++ b/tests/perf/vegeta_attack_getLogs_rpcdaemon.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -e
+set -o pipefail
+
 RATE=${1:-200}
 DURATION=${2:-30}
 TIMEOUT=${3:-300}

--- a/tests/perf/vegeta_attack_getLogs_silkrpc.sh
+++ b/tests/perf/vegeta_attack_getLogs_silkrpc.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -e
+set -o pipefail
+
 RATE=${1:-200}
 DURATION=${2:-30}
 TIMEOUT=${3:-300}

--- a/tools/lint/log_macros_fix.sh
+++ b/tools/lint/log_macros_fix.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -e
+set -o pipefail
+
 script_dir=$(dirname "${BASH_SOURCE[0]}")
 project_dir="$script_dir/../.."
 


### PR DESCRIPTION
run_unit_tests.sh was always succeeding after adding a grep after cmake (see https://github.com/erigontech/silkworm/pull/2501 ), because the full `cmake | grep` pipe was always succeeding even if cmake fails. `set -o pipefail` fixes this.
Add `set -e && set -o pipefail` in all bash scripts for safety.