### PR TITLE
db: rename TKV Domain methods

### DIFF
--- a/.github/workflows/run_integration_tests.sh
+++ b/.github/workflows/run_integration_tests.sh
@@ -21,7 +21,6 @@ rm -rf ./mainnet/results/
 # ots_searchTransactionsBefore: new algo using TKV
 
 python3 ./run_tests.py --continue --blockchain mainnet --jwt "$2" --display-only-fail --json-diff --port 51515 --transport_type http,websocket -x \
-debug_accountAt,\
 debug_accountRange,\
 debug_traceBlockByHash/test_05,\
 debug_traceBlockByHash/test_08,\

--- a/cmd/dev/grpc_toolbox.cpp
+++ b/cmd/dev/grpc_toolbox.cpp
@@ -848,18 +848,18 @@ int kv_seek() {
     return kv_seek(target, table_name, key_bytes.value());
 }
 
-Task<void> kv_domain_get_query(const std::shared_ptr<Service>& kv_service,
+Task<void> kv_get_latest_query(const std::shared_ptr<Service>& kv_service,
                                DomainPointQuery&& query,
                                const bool /*verbose*/) {
     try {
         auto tx = co_await kv_service->begin_transaction();
-        std::cout << "KV DomainGet -> " << query.table << " key=" << to_hex(query.key)
+        std::cout << "KV GetLatest -> " << query.table << " key=" << to_hex(query.key)
                   << " ts=" << (query.timestamp ? *query.timestamp : -1) << " [latest: " << !query.timestamp.has_value() << "]\n";
-        const auto result = co_await tx->domain_get(std::move(query));
-        std::cout << "KV DomainGet <- success: " << result.success << " value=" << to_hex(result.value) << "\n";
+        const auto result = co_await tx->get_latest(std::move(query));
+        std::cout << "KV GetLatest <- success: " << result.success << " value=" << to_hex(result.value) << "\n";
         co_await tx->close();
     } catch (const std::exception& e) {
-        std::cout << "KV DomainGet <- error: " << e.what() << "\n";
+        std::cout << "KV GetLatest <- error: " << e.what() << "\n";
     }
 }
 
@@ -931,15 +931,15 @@ Task<void> kv_history_range_query(const std::shared_ptr<Service>& kv_service,
     }
 }
 
-Task<void> kv_domain_range_query(const std::shared_ptr<Service>& kv_service,
-                                 DomainRangeQuery&& query,
-                                 const bool verbose) {
+Task<void> kv_range_as_of_query(const std::shared_ptr<Service>& kv_service,
+                                DomainRangeQuery&& query,
+                                const bool verbose) {
     try {
         auto tx = co_await kv_service->begin_transaction();
-        std::cout << "KV DomainRange -> " << query.table << " limit=" << query.limit << "\n";
-        auto paginated_result = co_await tx->domain_range(std::move(query));
+        std::cout << "KV RangeAsOf -> " << query.table << " limit=" << query.limit << "\n";
+        auto paginated_result = co_await tx->range_as_of(std::move(query));
         auto it = co_await paginated_result.begin();
-        std::cout << "KV DomainRange <- #keys and #values: ";
+        std::cout << "KV RangeAsOf <- #keys and #values: ";
         int count{0};
         std::vector<KeyValue> keys_and_values;
         while (const auto key_value = co_await it.next()) {
@@ -954,7 +954,7 @@ Task<void> kv_domain_range_query(const std::shared_ptr<Service>& kv_service,
         }
         co_await tx->close();
     } catch (const std::exception& e) {
-        std::cout << "KV DomainRange <- error: " << e.what() << "\n";
+        std::cout << "KV RangeAsOf <- error: " << e.what() << "\n";
     }
 }
 
@@ -1003,7 +1003,7 @@ int execute_temporal_kv_query(const std::string& target, KVQueryFunc<Q> query_fu
     return 0;
 }
 
-int kv_domain_get() {
+int kv_get_latest() {
     const auto target{absl::GetFlag(FLAGS_target)};
     if (target.empty() || !absl::StrContains(target, ":")) {
         std::cerr << "Parameter target is invalid: [" << target << "]\n";
@@ -1040,7 +1040,7 @@ int kv_domain_get() {
         .key = *key_bytes,
         .timestamp = timestamp > -1 ? std::make_optional(timestamp) : std::nullopt,
     };
-    return execute_temporal_kv_query(target, kv_domain_get_query, std::move(query), verbose);
+    return execute_temporal_kv_query(target, kv_get_latest_query, std::move(query), verbose);
 }
 
 int kv_history_seek() {
@@ -1160,7 +1160,7 @@ int kv_history_range() {
     return execute_temporal_kv_query(target, kv_history_range_query, std::move(query), verbose);
 }
 
-int kv_domain_range() {
+int kv_get_as_of() {
     const auto target{absl::GetFlag(FLAGS_target)};
     if (target.empty() || !absl::StrContains(target, ":")) {
         std::cerr << "Parameter target is invalid: [" << target << "]\n";
@@ -1215,7 +1215,7 @@ int kv_domain_range() {
         .ascending_order = true,
         .limit = limit,
     };
-    return execute_temporal_kv_query(target, kv_domain_range_query, std::move(query), verbose);
+    return execute_temporal_kv_query(target, kv_range_as_of_query, std::move(query), verbose);
 }
 
 int main(int argc, char* argv[]) {
@@ -1228,11 +1228,11 @@ int main(int argc, char* argv[]) {
         "\tkv_seek_async\t\t\tquery using SEEK the Erigon/Silkworm Key-Value (KV) remote interface to database\n"
         "\tkv_seek_async_callback\t\tquery using SEEK the Erigon/Silkworm Key-Value (KV) remote interface to database\n"
         "\tkv_seek_both\t\t\tquery using SEEK_BOTH the Erigon/Silkworm Key-Value (KV) remote interface to database\n"
-        "\tkv_domain_get\t\tquery the Erigon/Silkworm Key-Value (KV) remote interface to data storage using DOMAIN_GET\n"
+        "\tkv_get_latest\t\tquery the Erigon/Silkworm Key-Value (KV) remote interface to data storage using DOMAIN_GET\n"
         "\tkv_history_seek\t\tquery using HISTORY_SEEK the Erigon/Silkworm Key-Value (KV) remote interface to data storage\n"
         "\tkv_index_range\t\tquery using INDEX_RANGE the Erigon/Silkworm Key-Value (KV) remote interface to data storage\n"
         "\tkv_history_range\t\tquery using HISTORY_RANGE the Erigon/Silkworm Key-Value (KV) remote interface to data storage\n"
-        "\tkv_domain_range\t\tquery using DOMAIN_RANGE the Erigon/Silkworm Key-Value (KV) remote interface to data storage\n");
+        "\tkv_get_as_of\t\tquery using DOMAIN_RANGE the Erigon/Silkworm Key-Value (KV) remote interface to data storage\n");
     const auto positional_args = absl::ParseCommandLine(argc, argv);
     if (positional_args.size() < 2) {
         std::cerr << "No gRPC tool specified as first positional argument\n\n";
@@ -1264,8 +1264,8 @@ int main(int argc, char* argv[]) {
     if (tool == "kv_seek") {
         return kv_seek();
     }
-    if (tool == "kv_domain_get") {
-        return kv_domain_get();
+    if (tool == "kv_get_latest") {
+        return kv_get_latest();
     }
     if (tool == "kv_history_seek") {
         return kv_history_seek();
@@ -1276,8 +1276,8 @@ int main(int argc, char* argv[]) {
     if (tool == "kv_history_range") {
         return kv_history_range();
     }
-    if (tool == "kv_domain_range") {
-        return kv_domain_range();
+    if (tool == "kv_get_as_of") {
+        return kv_get_as_of();
     }
 
     std::cerr << "Unknown tool " << tool << " specified as first argument\n\n";

--- a/silkworm/db/kv/api/local_transaction.cpp
+++ b/silkworm/db/kv/api/local_transaction.cpp
@@ -74,7 +74,7 @@ Task<TxnId> LocalTransaction::first_txn_num_in_block(BlockNum /*block_num*/) {
     throw std::logic_error{"not yet implemented"};
 }
 
-Task<DomainPointResult> LocalTransaction::domain_get(DomainPointQuery /*query*/) {
+Task<DomainPointResult> LocalTransaction::get_latest(DomainPointQuery /*query*/) {
     // TODO(canepat) implement using E3-like aggregator abstraction [tx_id_ must be changed]
     co_return DomainPointResult{};
 }
@@ -100,7 +100,7 @@ Task<PaginatedKeysValues> LocalTransaction::history_range(HistoryRangeQuery /*qu
     co_return api::PaginatedKeysValues{std::move(paginator)};
 }
 
-Task<PaginatedKeysValues> LocalTransaction::domain_range(DomainRangeQuery /*query*/) {
+Task<PaginatedKeysValues> LocalTransaction::range_as_of(DomainRangeQuery /*query*/) {
     // TODO(canepat) implement using E3-like aggregator abstraction [tx_id_ must be changed]
     auto paginator = [](api::PaginatedKeysValues::PageToken) mutable -> Task<api::PaginatedKeysValues::PageResult> {
         co_return api::PaginatedKeysValues::PageResult{};

--- a/silkworm/db/kv/api/local_transaction.hpp
+++ b/silkworm/db/kv/api/local_transaction.hpp
@@ -61,8 +61,8 @@ class LocalTransaction : public BaseTransaction {
 
     Task<void> close() override;
 
-    // rpc DomainGet(GetLatestReq) returns (GetLatestReply);
-    Task<DomainPointResult> domain_get(DomainPointQuery query) override;
+    // rpc GetLatest(GetLatestReq) returns (GetLatestReply);
+    Task<DomainPointResult> get_latest(DomainPointQuery query) override;
 
     // rpc HistorySeek(HistorySeekReq) returns (HistorySeekReply);
     Task<HistoryPointResult> history_seek(HistoryPointQuery query) override;
@@ -73,8 +73,8 @@ class LocalTransaction : public BaseTransaction {
     // rpc HistoryRange(HistoryRangeReq) returns (Pairs);
     Task<PaginatedKeysValues> history_range(HistoryRangeQuery query) override;
 
-    // rpc DomainRange(RangeAsOfReq) returns (Pairs);
-    Task<PaginatedKeysValues> domain_range(DomainRangeQuery query) override;
+    // rpc RangeAsOf(RangeAsOfReq) returns (Pairs);
+    Task<PaginatedKeysValues> range_as_of(DomainRangeQuery query) override;
 
   private:
     Task<std::shared_ptr<CursorDupSort>> get_cursor(const std::string& table, bool is_cursor_dup_sort);

--- a/silkworm/db/kv/api/local_transaction.hpp
+++ b/silkworm/db/kv/api/local_transaction.hpp
@@ -61,7 +61,7 @@ class LocalTransaction : public BaseTransaction {
 
     Task<void> close() override;
 
-    // rpc DomainGet(DomainGetReq) returns (DomainGetReply);
+    // rpc DomainGet(GetLatestReq) returns (GetLatestReply);
     Task<DomainPointResult> domain_get(DomainPointQuery query) override;
 
     // rpc HistorySeek(HistorySeekReq) returns (HistorySeekReply);
@@ -73,7 +73,7 @@ class LocalTransaction : public BaseTransaction {
     // rpc HistoryRange(HistoryRangeReq) returns (Pairs);
     Task<PaginatedKeysValues> history_range(HistoryRangeQuery query) override;
 
-    // rpc DomainRange(DomainRangeReq) returns (Pairs);
+    // rpc DomainRange(RangeAsOfReq) returns (Pairs);
     Task<PaginatedKeysValues> domain_range(DomainRangeQuery query) override;
 
   private:

--- a/silkworm/db/kv/api/transaction.hpp
+++ b/silkworm/db/kv/api/transaction.hpp
@@ -72,8 +72,8 @@ class Transaction {
 
     /** Temporal Point Queries **/
 
-    // rpc DomainGet(GetLatestReq) returns (GetLatestReply);
-    virtual Task<DomainPointResult> domain_get(DomainPointQuery query) = 0;
+    // rpc GetLatest(GetLatestReq) returns (GetLatestReply);
+    virtual Task<DomainPointResult> get_latest(DomainPointQuery query) = 0;
 
     // rpc HistorySeek(HistorySeekReq) returns (HistorySeekReply);
     virtual Task<HistoryPointResult> history_seek(HistoryPointQuery query) = 0;
@@ -86,8 +86,8 @@ class Transaction {
     // rpc HistoryRange(HistoryRangeReq) returns (Pairs);
     virtual Task<PaginatedKeysValues> history_range(HistoryRangeQuery query) = 0;
 
-    // rpc DomainRange(RangeAsOfReq) returns (Pairs);
-    virtual Task<PaginatedKeysValues> domain_range(DomainRangeQuery query) = 0;
+    // rpc RangeAsOf(RangeAsOfReq) returns (Pairs);
+    virtual Task<PaginatedKeysValues> range_as_of(DomainRangeQuery query) = 0;
 };
 
 }  // namespace silkworm::db::kv::api

--- a/silkworm/db/kv/api/transaction.hpp
+++ b/silkworm/db/kv/api/transaction.hpp
@@ -72,7 +72,7 @@ class Transaction {
 
     /** Temporal Point Queries **/
 
-    // rpc DomainGet(DomainGetReq) returns (DomainGetReply);
+    // rpc DomainGet(GetLatestReq) returns (GetLatestReply);
     virtual Task<DomainPointResult> domain_get(DomainPointQuery query) = 0;
 
     // rpc HistorySeek(HistorySeekReq) returns (HistorySeekReply);
@@ -86,7 +86,7 @@ class Transaction {
     // rpc HistoryRange(HistoryRangeReq) returns (Pairs);
     virtual Task<PaginatedKeysValues> history_range(HistoryRangeQuery query) = 0;
 
-    // rpc DomainRange(DomainRangeReq) returns (Pairs);
+    // rpc DomainRange(RangeAsOfReq) returns (Pairs);
     virtual Task<PaginatedKeysValues> domain_range(DomainRangeQuery query) = 0;
 };
 

--- a/silkworm/db/kv/grpc/client/endpoint/temporal_point.cpp
+++ b/silkworm/db/kv/grpc/client/endpoint/temporal_point.cpp
@@ -39,8 +39,8 @@ api::HistoryPointResult history_seek_result_from_response(const proto::HistorySe
     return result;
 }
 
-proto::DomainGetReq domain_get_request_from_query(const api::DomainPointQuery& query) {
-    proto::DomainGetReq request;
+proto::GetLatestReq domain_get_request_from_query(const api::DomainPointQuery& query) {
+    proto::GetLatestReq request;
     request.set_tx_id(query.tx_id);
     request.set_table(query.table);
     request.set_k(query.key.data(), query.key.size());
@@ -53,7 +53,7 @@ proto::DomainGetReq domain_get_request_from_query(const api::DomainPointQuery& q
     return request;
 }
 
-api::DomainPointResult domain_get_result_from_response(const proto::DomainGetReply& response) {
+api::DomainPointResult domain_get_result_from_response(const proto::GetLatestReply& response) {
     api::DomainPointResult result;
     result.success = response.ok();
     result.value = string_to_bytes(response.v());

--- a/silkworm/db/kv/grpc/client/endpoint/temporal_point.hpp
+++ b/silkworm/db/kv/grpc/client/endpoint/temporal_point.hpp
@@ -25,7 +25,7 @@ namespace silkworm::db::kv::grpc::client {
 ::remote::HistorySeekReq history_seek_request_from_query(const api::HistoryPointQuery&);
 api::HistoryPointResult history_seek_result_from_response(const ::remote::HistorySeekReply&);
 
-::remote::DomainGetReq domain_get_request_from_query(const api::DomainPointQuery&);
-api::DomainPointResult domain_get_result_from_response(const ::remote::DomainGetReply&);
+::remote::GetLatestReq domain_get_request_from_query(const api::DomainPointQuery&);
+api::DomainPointResult domain_get_result_from_response(const ::remote::GetLatestReply&);
 
 }  // namespace silkworm::db::kv::grpc::client

--- a/silkworm/db/kv/grpc/client/endpoint/temporal_point_test.cpp
+++ b/silkworm/db/kv/grpc/client/endpoint/temporal_point_test.cpp
@@ -62,7 +62,7 @@ TEST_CASE("history_get_result_from_response", "[node][remote][kv][grpc]") {
 }
 
 TEST_CASE("domain_get_request_from_query", "[node][remote][kv][grpc]") {
-    const Fixtures<api::DomainPointQuery, proto::DomainGetReq> fixtures{
+    const Fixtures<api::DomainPointQuery, proto::GetLatestReq> fixtures{
         {sample_domain_point_query(), sample_proto_domain_point_request()},
     };
     for (const auto& [query, expected_point_request] : fixtures) {
@@ -80,7 +80,7 @@ TEST_CASE("domain_get_request_from_query", "[node][remote][kv][grpc]") {
 }
 
 TEST_CASE("domain_get_result_from_response", "[node][remote][kv][grpc]") {
-    const Fixtures<proto::DomainGetReply, api::DomainPointResult> fixtures{
+    const Fixtures<proto::GetLatestReply, api::DomainPointResult> fixtures{
         {{}, {}},
         {sample_proto_domain_get_response(), sample_domain_point_result()},
     };

--- a/silkworm/db/kv/grpc/client/endpoint/temporal_range.cpp
+++ b/silkworm/db/kv/grpc/client/endpoint/temporal_range.cpp
@@ -71,8 +71,8 @@ api::HistoryRangeResult history_range_result_from_response(const proto::Pairs& r
     return result;
 }
 
-::remote::DomainRangeReq domain_range_request_from_query(const api::DomainRangeQuery& query) {
-    ::remote::DomainRangeReq request;
+::remote::RangeAsOfReq domain_range_request_from_query(const api::DomainRangeQuery& query) {
+    ::remote::RangeAsOfReq request;
     request.set_tx_id(query.tx_id);
     request.set_table(query.table);
     request.set_from_key(query.from_key.data(), query.from_key.size());

--- a/silkworm/db/kv/grpc/client/endpoint/temporal_range.hpp
+++ b/silkworm/db/kv/grpc/client/endpoint/temporal_range.hpp
@@ -28,7 +28,7 @@ api::IndexRangeResult index_range_result_from_response(const ::remote::IndexRang
 ::remote::HistoryRangeReq history_range_request_from_query(const api::HistoryRangeQuery&);
 api::HistoryRangeResult history_range_result_from_response(const ::remote::Pairs&);
 
-::remote::DomainRangeReq domain_range_request_from_query(const api::DomainRangeQuery&);
+::remote::RangeAsOfReq domain_range_request_from_query(const api::DomainRangeQuery&);
 api::DomainRangeResult domain_range_result_from_response(const ::remote::Pairs&);
 
 }  // namespace silkworm::db::kv::grpc::client

--- a/silkworm/db/kv/grpc/client/endpoint/temporal_range_test.cpp
+++ b/silkworm/db/kv/grpc/client/endpoint/temporal_range_test.cpp
@@ -104,7 +104,7 @@ TEST_CASE("history_range_result_from_response", "[node][remote][kv][grpc]") {
 }
 
 TEST_CASE("domain_range_request_from_query", "[node][remote][kv][grpc]") {
-    const Fixtures<api::DomainRangeQuery, proto::DomainRangeReq> fixtures{
+    const Fixtures<api::DomainRangeQuery, proto::RangeAsOfReq> fixtures{
         {{}, default_proto_domain_range_request()},
         {sample_domain_range_query(), sample_proto_domain_range_request()},
     };

--- a/silkworm/db/kv/grpc/client/remote_transaction.cpp
+++ b/silkworm/db/kv/grpc/client/remote_transaction.cpp
@@ -126,7 +126,7 @@ Task<api::DomainPointResult> RemoteTransaction::domain_get(api::DomainPointQuery
     try {
         query.tx_id = tx_id_;
         auto request = domain_get_request_from_query(query);
-        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncDomainGet, stub_, std::move(request), grpc_context_);
+        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncGetLatest, stub_, std::move(request), grpc_context_);
         auto result = domain_get_result_from_response(reply);
         co_return result;
     } catch (rpc::GrpcStatusError& gse) {
@@ -190,7 +190,7 @@ Task<api::PaginatedKeysValues> RemoteTransaction::domain_range(api::DomainRangeQ
         query.page_token = std::move(page_token);
         auto request = domain_range_request_from_query(query);
         try {
-            const auto reply = co_await rpc::unary_rpc(&Stub::AsyncDomainRange, stub_, std::move(request), grpc_context_);
+            const auto reply = co_await rpc::unary_rpc(&Stub::AsyncRangeAsOf, stub_, std::move(request), grpc_context_);
             auto result = history_range_result_from_response(reply);
 
             co_return api::PaginatedKeysValues::PageResult{std::move(result.keys), std::move(result.values), std::move(result.next_page_token)};

--- a/silkworm/db/kv/grpc/client/remote_transaction.cpp
+++ b/silkworm/db/kv/grpc/client/remote_transaction.cpp
@@ -122,7 +122,7 @@ Task<TxnId> RemoteTransaction::first_txn_num_in_block(BlockNum block_num) {
     co_return min_txn_num + /*txn_index*/ 0;
 }
 
-Task<api::DomainPointResult> RemoteTransaction::domain_get(api::DomainPointQuery query) {
+Task<api::DomainPointResult> RemoteTransaction::get_latest(api::DomainPointQuery query) {
     try {
         query.tx_id = tx_id_;
         auto request = domain_get_request_from_query(query);
@@ -130,7 +130,7 @@ Task<api::DomainPointResult> RemoteTransaction::domain_get(api::DomainPointQuery
         auto result = domain_get_result_from_response(reply);
         co_return result;
     } catch (rpc::GrpcStatusError& gse) {
-        SILK_WARN << "KV::DomainGet RPC failed status=" << gse.status();
+        SILK_WARN << "KV::GetLatest RPC failed status=" << gse.status();
         throw boost::system::system_error{rpc::to_system_code(gse.status().error_code())};
     }
 }
@@ -184,7 +184,7 @@ Task<api::PaginatedKeysValues> RemoteTransaction::history_range(api::HistoryRang
     co_return api::PaginatedKeysValues{std::move(paginator)};
 }
 
-Task<api::PaginatedKeysValues> RemoteTransaction::domain_range(api::DomainRangeQuery query) {
+Task<api::PaginatedKeysValues> RemoteTransaction::range_as_of(api::DomainRangeQuery query) {
     auto paginator = [&, query = std::move(query)](api::PaginatedKeysValues::PageToken page_token) mutable -> Task<api::PaginatedKeysValues::PageResult> {
         query.tx_id = tx_id_;
         query.page_token = std::move(page_token);
@@ -195,7 +195,7 @@ Task<api::PaginatedKeysValues> RemoteTransaction::domain_range(api::DomainRangeQ
 
             co_return api::PaginatedKeysValues::PageResult{std::move(result.keys), std::move(result.values), std::move(result.next_page_token)};
         } catch (rpc::GrpcStatusError& gse) {
-            SILK_WARN << "KV::DomainRange RPC failed status=" << gse.status();
+            SILK_WARN << "KV::RangeAsOf RPC failed status=" << gse.status();
             throw boost::system::system_error{rpc::to_system_code(gse.status().error_code())};
         }
     };

--- a/silkworm/db/kv/grpc/client/remote_transaction.hpp
+++ b/silkworm/db/kv/grpc/client/remote_transaction.hpp
@@ -62,8 +62,8 @@ class RemoteTransaction : public api::BaseTransaction {
 
     Task<void> close() override;
 
-    // rpc DomainGet(GetLatestReq) returns (GetLatestReply);
-    Task<api::DomainPointResult> domain_get(api::DomainPointQuery query) override;
+    // rpc GetLatest(GetLatestReq) returns (GetLatestReply);
+    Task<api::DomainPointResult> get_latest(api::DomainPointQuery query) override;
 
     // rpc HistorySeek(HistorySeekReq) returns (HistorySeekReply);
     Task<api::HistoryPointResult> history_seek(api::HistoryPointQuery query) override;
@@ -74,8 +74,8 @@ class RemoteTransaction : public api::BaseTransaction {
     // rpc HistoryRange(HistoryRangeReq) returns (Pairs);
     Task<api::PaginatedKeysValues> history_range(api::HistoryRangeQuery query) override;
 
-    // rpc DomainRange(RangeAsOfReq) returns (Pairs);
-    Task<api::PaginatedKeysValues> domain_range(api::DomainRangeQuery query) override;
+    // rpc RangeAsOf(RangeAsOfReq) returns (Pairs);
+    Task<api::PaginatedKeysValues> range_as_of(api::DomainRangeQuery query) override;
 
   private:
     Task<std::shared_ptr<api::CursorDupSort>> get_cursor(const std::string& table, bool is_cursor_dup_sort);

--- a/silkworm/db/kv/grpc/client/remote_transaction.hpp
+++ b/silkworm/db/kv/grpc/client/remote_transaction.hpp
@@ -62,7 +62,7 @@ class RemoteTransaction : public api::BaseTransaction {
 
     Task<void> close() override;
 
-    // rpc DomainGet(DomainGetReq) returns (DomainGetReply);
+    // rpc DomainGet(GetLatestReq) returns (GetLatestReply);
     Task<api::DomainPointResult> domain_get(api::DomainPointQuery query) override;
 
     // rpc HistorySeek(HistorySeekReq) returns (HistorySeekReply);
@@ -74,7 +74,7 @@ class RemoteTransaction : public api::BaseTransaction {
     // rpc HistoryRange(HistoryRangeReq) returns (Pairs);
     Task<api::PaginatedKeysValues> history_range(api::HistoryRangeQuery query) override;
 
-    // rpc DomainRange(DomainRangeReq) returns (Pairs);
+    // rpc DomainRange(RangeAsOfReq) returns (Pairs);
     Task<api::PaginatedKeysValues> domain_range(api::DomainRangeQuery query) override;
 
   private:

--- a/silkworm/db/kv/grpc/client/remote_transaction_test.cpp
+++ b/silkworm/db/kv/grpc/client/remote_transaction_test.cpp
@@ -444,13 +444,13 @@ TEST_CASE_METHOD(RemoteTransactionTest, "RemoteTransaction::domain_get", "[db][k
         co_return result;
     };
 
-    rpc::test::StrictMockAsyncResponseReader<proto::DomainGetReply> reader;
-    EXPECT_CALL(*stub_, AsyncDomainGetRaw).WillOnce(testing::Return(&reader));
+    rpc::test::StrictMockAsyncResponseReader<proto::GetLatestReply> reader;
+    EXPECT_CALL(*stub_, AsyncGetLatestRaw).WillOnce(testing::Return(&reader));
 
     api::DomainPointResult result;
 
     SECTION("call domain_get and get result") {
-        proto::DomainGetReply reply{sample_proto_domain_get_response()};
+        proto::GetLatestReply reply{sample_proto_domain_get_response()};
         EXPECT_CALL(reader, Finish).WillOnce(rpc::test::finish_with(grpc_context_, std::move(reply)));
 
         CHECK_NOTHROW((result = spawn_and_wait(domain_get)));
@@ -717,8 +717,8 @@ TEST_CASE_METHOD(RemoteTransactionTest, "RemoteTransaction::domain_range", "[db]
     rpc::test::StrictMockAsyncResponseReader<proto::Pairs> reader;
     SECTION("throw on error") {
         // Set the call expectations:
-        // 1. remote::KV::StubInterface::AsyncDomainRangeRaw call succeeds
-        EXPECT_CALL(*stub_, AsyncDomainRangeRaw).WillOnce(Return(&reader));
+        // 1. remote::KV::StubInterface::AsyncRangeAsOfRaw call succeeds
+        EXPECT_CALL(*stub_, AsyncRangeAsOfRaw).WillOnce(Return(&reader));
         // 2. AsyncResponseReader<>::Finish call fails
         EXPECT_CALL(reader, Finish).WillOnce(test::finish_error_aborted(grpc_context_, proto::Pairs{}));
         // Execute the test: trying to *use* index_range lazy result should throw
@@ -726,8 +726,8 @@ TEST_CASE_METHOD(RemoteTransactionTest, "RemoteTransaction::domain_range", "[db]
     }
     SECTION("success: empty") {
         // Set the call expectations:
-        // 1. remote::KV::StubInterface::AsyncDomainRangeRaw call succeeds
-        EXPECT_CALL(*stub_, AsyncDomainRangeRaw).WillRepeatedly(Return(&reader));
+        // 1. remote::KV::StubInterface::AsyncRangeAsOfRaw call succeeds
+        EXPECT_CALL(*stub_, AsyncRangeAsOfRaw).WillRepeatedly(Return(&reader));
         // 2. AsyncResponseReader<>::Finish call succeeds 3 times
         EXPECT_CALL(reader, Finish)
             .WillOnce(test::finish_with(grpc_context_, make_key_value_range_reply({}, /*has_more*/ false)));
@@ -737,8 +737,8 @@ TEST_CASE_METHOD(RemoteTransactionTest, "RemoteTransaction::domain_range", "[db]
     }
     SECTION("success: one page") {
         // Set the call expectations:
-        // 1. remote::KV::StubInterface::AsyncDomainRangeRaw call succeeds
-        EXPECT_CALL(*stub_, AsyncDomainRangeRaw).WillRepeatedly(Return(&reader));
+        // 1. remote::KV::StubInterface::AsyncRangeAsOfRaw call succeeds
+        EXPECT_CALL(*stub_, AsyncRangeAsOfRaw).WillRepeatedly(Return(&reader));
         // 2. AsyncResponseReader<>::Finish call succeeds
         EXPECT_CALL(reader, Finish)
             .WillOnce(test::finish_with(grpc_context_, make_key_value_range_reply({kv1}, /*has_more*/ false)));
@@ -758,8 +758,8 @@ TEST_CASE_METHOD(RemoteTransactionTest, "RemoteTransaction::domain_range", "[db]
         EXPECT_CALL(reader_writer_, WritesDone).WillOnce(test::writes_done_success(grpc_context_));
         // 4. AsyncReaderWriter<remote::Cursor, remote::Pair>::Finish call succeeds w/ status OK
         EXPECT_CALL(reader_writer_, Finish).WillOnce(test::finish_streaming_ok(grpc_context_));
-        // 5. remote::KV::StubInterface::AsyncDomainRangeRaw call succeeds
-        EXPECT_CALL(*stub_, AsyncDomainRangeRaw).WillRepeatedly(Return(&reader));
+        // 5. remote::KV::StubInterface::AsyncRangeAsOfRaw call succeeds
+        EXPECT_CALL(*stub_, AsyncRangeAsOfRaw).WillRepeatedly(Return(&reader));
         // 6. AsyncResponseReader<>::Finish call succeeds 3 times
         EXPECT_CALL(reader, Finish)
             .WillOnce(test::finish_with(grpc_context_, make_key_value_range_reply({kv1, kv2}, /*has_more*/ true)))

--- a/silkworm/db/kv/grpc/server/kv_calls.cpp
+++ b/silkworm/db/kv/grpc/server/kv_calls.cpp
@@ -734,7 +734,7 @@ Task<void> HistorySeekCall::operator()() {
 
 Task<void> DomainGetCall::operator()() {
     SILK_TRACE << "DomainGetCall START";
-    remote::DomainGetReply response;
+    remote::GetLatestReply response;
     // TODO(canepat) implement properly
     co_await agrpc::finish(responder_, response, ::grpc::Status::OK);
     SILK_TRACE << "DomainGetCall END ok: " << response.ok() << " value: " << response.v();

--- a/silkworm/db/kv/grpc/server/kv_calls.cpp
+++ b/silkworm/db/kv/grpc/server/kv_calls.cpp
@@ -732,12 +732,12 @@ Task<void> HistorySeekCall::operator()() {
     SILK_TRACE << "HistorySeekCall END ok: " << response.ok() << " value: " << response.v();
 }
 
-Task<void> DomainGetCall::operator()() {
-    SILK_TRACE << "DomainGetCall START";
+Task<void> GetLatestCall::operator()() {
+    SILK_TRACE << "GetLatestCall START";
     remote::GetLatestReply response;
     // TODO(canepat) implement properly
     co_await agrpc::finish(responder_, response, ::grpc::Status::OK);
-    SILK_TRACE << "DomainGetCall END ok: " << response.ok() << " value: " << response.v();
+    SILK_TRACE << "GetLatestCall END ok: " << response.ok() << " value: " << response.v();
 }
 
 Task<void> IndexRangeCall::operator()() {
@@ -757,12 +757,12 @@ Task<void> HistoryRangeCall::operator()() {
                << " next_page_token: " << response.next_page_token();
 }
 
-Task<void> DomainRangeCall::operator()() {
-    SILK_TRACE << "DomainRangeCall START";
+Task<void> RangeAsOfCall::operator()() {
+    SILK_TRACE << "RangeAsOfCall START";
     remote::Pairs response;
     // TODO(canepat) implement properly
     co_await agrpc::finish(responder_, response, ::grpc::Status::OK);
-    SILK_TRACE << "DomainRangeCall END #keys: " << response.keys_size() << " #values: " << response.values_size()
+    SILK_TRACE << "RangeAsOfCall END #keys: " << response.keys_size() << " #values: " << response.values_size()
                << " next_page_token: " << response.next_page_token();
 }
 

--- a/silkworm/db/kv/grpc/server/kv_calls.hpp
+++ b/silkworm/db/kv/grpc/server/kv_calls.hpp
@@ -176,8 +176,8 @@ class HistorySeekCall : public rpc::server::UnaryCall<remote::HistorySeekReq, re
 };
 
 //! Unary RPC for DomainGet method of 'kv' gRPC protocol.
-//! rpc DomainGet(DomainGetReq) returns (DomainGetReply);
-class DomainGetCall : public rpc::server::UnaryCall<remote::DomainGetReq, remote::DomainGetReply> {
+//! rpc DomainGet(GetLatestReq) returns (GetLatestReply);
+class DomainGetCall : public rpc::server::UnaryCall<remote::GetLatestReq, remote::GetLatestReply> {
   public:
     using Base::UnaryCall;
 
@@ -203,8 +203,8 @@ class HistoryRangeCall : public rpc::server::UnaryCall<remote::HistoryRangeReq, 
 };
 
 //! Unary RPC for IndexRange method of 'kv' gRPC protocol.
-//! rpc DomainRange(DomainRangeReq) returns (Pairs);
-class DomainRangeCall : public rpc::server::UnaryCall<remote::DomainRangeReq, remote::Pairs> {
+//! rpc DomainRange(RangeAsOfReq) returns (Pairs);
+class DomainRangeCall : public rpc::server::UnaryCall<remote::RangeAsOfReq, remote::Pairs> {
   public:
     using Base::UnaryCall;
 

--- a/silkworm/db/kv/grpc/server/kv_calls.hpp
+++ b/silkworm/db/kv/grpc/server/kv_calls.hpp
@@ -175,9 +175,9 @@ class HistorySeekCall : public rpc::server::UnaryCall<remote::HistorySeekReq, re
     Task<void> operator()();
 };
 
-//! Unary RPC for DomainGet method of 'kv' gRPC protocol.
-//! rpc DomainGet(GetLatestReq) returns (GetLatestReply);
-class DomainGetCall : public rpc::server::UnaryCall<remote::GetLatestReq, remote::GetLatestReply> {
+//! Unary RPC for GetLatest method of 'kv' gRPC protocol.
+//! rpc GetLatest(GetLatestReq) returns (GetLatestReply);
+class GetLatestCall : public rpc::server::UnaryCall<remote::GetLatestReq, remote::GetLatestReply> {
   public:
     using Base::UnaryCall;
 
@@ -193,7 +193,7 @@ class IndexRangeCall : public rpc::server::UnaryCall<remote::IndexRangeReq, remo
     Task<void> operator()();
 };
 
-//! Unary RPC for IndexRange method of 'kv' gRPC protocol.
+//! Unary RPC for HistoryRange method of 'kv' gRPC protocol.
 //! rpc HistoryRange(HistoryRangeReq) returns (Pairs);
 class HistoryRangeCall : public rpc::server::UnaryCall<remote::HistoryRangeReq, remote::Pairs> {
   public:
@@ -202,9 +202,9 @@ class HistoryRangeCall : public rpc::server::UnaryCall<remote::HistoryRangeReq, 
     Task<void> operator()();
 };
 
-//! Unary RPC for IndexRange method of 'kv' gRPC protocol.
-//! rpc DomainRange(RangeAsOfReq) returns (Pairs);
-class DomainRangeCall : public rpc::server::UnaryCall<remote::RangeAsOfReq, remote::Pairs> {
+//! Unary RPC for RangeAsOf method of 'kv' gRPC protocol.
+//! rpc RangeAsOf(RangeAsOfReq) returns (Pairs);
+class RangeAsOfCall : public rpc::server::UnaryCall<remote::RangeAsOfReq, remote::Pairs> {
   public:
     using Base::UnaryCall;
 

--- a/silkworm/db/kv/grpc/server/kv_server.cpp
+++ b/silkworm/db/kv/grpc/server/kv_server.cpp
@@ -67,7 +67,7 @@ void KvServer::register_kv_request_calls(agrpc::GrpcContext* grpc_context) {
                        [](auto&&... args) -> Task<void> {
                            co_await SnapshotsCall{std::forward<decltype(args)>(args)...}();
                        });
-    request_repeatedly(*grpc_context, service, &remote::KV::AsyncService::RequestDomainGet,
+    request_repeatedly(*grpc_context, service, &remote::KV::AsyncService::RequestGetLatest,
                        [](auto&&... args) -> Task<void> {
                            co_await DomainGetCall{std::forward<decltype(args)>(args)...}();
                        });
@@ -83,7 +83,7 @@ void KvServer::register_kv_request_calls(agrpc::GrpcContext* grpc_context) {
                        [](auto&&... args) -> Task<void> {
                            co_await HistoryRangeCall{std::forward<decltype(args)>(args)...}();
                        });
-    request_repeatedly(*grpc_context, service, &remote::KV::AsyncService::RequestDomainRange,
+    request_repeatedly(*grpc_context, service, &remote::KV::AsyncService::RequestRangeAsOf,
                        [](auto&&... args) -> Task<void> {
                            co_await DomainRangeCall{std::forward<decltype(args)>(args)...}();
                        });

--- a/silkworm/db/kv/grpc/server/kv_server.cpp
+++ b/silkworm/db/kv/grpc/server/kv_server.cpp
@@ -69,7 +69,7 @@ void KvServer::register_kv_request_calls(agrpc::GrpcContext* grpc_context) {
                        });
     request_repeatedly(*grpc_context, service, &remote::KV::AsyncService::RequestGetLatest,
                        [](auto&&... args) -> Task<void> {
-                           co_await DomainGetCall{std::forward<decltype(args)>(args)...}();
+                           co_await GetLatestCall{std::forward<decltype(args)>(args)...}();
                        });
     request_repeatedly(*grpc_context, service, &remote::KV::AsyncService::RequestHistorySeek,
                        [](auto&&... args) -> Task<void> {
@@ -85,7 +85,7 @@ void KvServer::register_kv_request_calls(agrpc::GrpcContext* grpc_context) {
                        });
     request_repeatedly(*grpc_context, service, &remote::KV::AsyncService::RequestRangeAsOf,
                        [](auto&&... args) -> Task<void> {
-                           co_await DomainRangeCall{std::forward<decltype(args)>(args)...}();
+                           co_await RangeAsOfCall{std::forward<decltype(args)>(args)...}();
                        });
     SILK_TRACE << "KvServer::register_kv_request_calls END";
 }

--- a/silkworm/db/kv/grpc/server/kv_server_test.cpp
+++ b/silkworm/db/kv/grpc/server/kv_server_test.cpp
@@ -102,7 +102,7 @@ class KvClient {
         return stub_->HistorySeek(&context, request, response);
     }
 
-    grpc::Status domain_get(const remote::GetLatestReq& request, remote::GetLatestReply* response) {
+    grpc::Status get_latest(const remote::GetLatestReq& request, remote::GetLatestReply* response) {
         grpc::ClientContext context;
         return stub_->GetLatest(&context, request, response);
     }
@@ -117,7 +117,7 @@ class KvClient {
         return stub_->HistoryRange(&context, request, response);
     }
 
-    grpc::Status domain_range(const remote::RangeAsOfReq& request, remote::Pairs* response) {
+    grpc::Status range_as_of(const remote::RangeAsOfReq& request, remote::Pairs* response) {
         grpc::ClientContext context;
         return stub_->RangeAsOf(&context, request, response);
     }
@@ -661,10 +661,10 @@ TEST_CASE_METHOD(KvEnd2EndTest, "KvServer E2E: KV", "[silkworm][node][rpc]") {
         CHECK(status.ok());
     }
 
-    SECTION("DomainGet: return value in target domain") {
+    SECTION("GetLatest: return value in target domain") {
         remote::GetLatestReq request;
         remote::GetLatestReply response;
-        const auto status = kv_client->domain_get(request, &response);
+        const auto status = kv_client->get_latest(request, &response);
         CHECK(status.ok());
     }
 
@@ -682,10 +682,10 @@ TEST_CASE_METHOD(KvEnd2EndTest, "KvServer E2E: KV", "[silkworm][node][rpc]") {
         CHECK(status.ok());
     }
 
-    SECTION("DomainRange: return value in target domain range") {
+    SECTION("RangeAsOf: return value in target domain range") {
         remote::RangeAsOfReq request;
         remote::Pairs response;
-        const auto status = kv_client->domain_range(request, &response);
+        const auto status = kv_client->range_as_of(request, &response);
         CHECK(status.ok());
     }
 }

--- a/silkworm/db/kv/grpc/server/kv_server_test.cpp
+++ b/silkworm/db/kv/grpc/server/kv_server_test.cpp
@@ -102,9 +102,9 @@ class KvClient {
         return stub_->HistorySeek(&context, request, response);
     }
 
-    grpc::Status domain_get(const remote::DomainGetReq& request, remote::DomainGetReply* response) {
+    grpc::Status domain_get(const remote::GetLatestReq& request, remote::GetLatestReply* response) {
         grpc::ClientContext context;
-        return stub_->DomainGet(&context, request, response);
+        return stub_->GetLatest(&context, request, response);
     }
 
     grpc::Status index_range(const remote::IndexRangeReq& request, remote::IndexRangeReply* response) {
@@ -117,9 +117,9 @@ class KvClient {
         return stub_->HistoryRange(&context, request, response);
     }
 
-    grpc::Status domain_range(const remote::DomainRangeReq& request, remote::Pairs* response) {
+    grpc::Status domain_range(const remote::RangeAsOfReq& request, remote::Pairs* response) {
         grpc::ClientContext context;
-        return stub_->DomainRange(&context, request, response);
+        return stub_->RangeAsOf(&context, request, response);
     }
 
   private:
@@ -662,8 +662,8 @@ TEST_CASE_METHOD(KvEnd2EndTest, "KvServer E2E: KV", "[silkworm][node][rpc]") {
     }
 
     SECTION("DomainGet: return value in target domain") {
-        remote::DomainGetReq request;
-        remote::DomainGetReply response;
+        remote::GetLatestReq request;
+        remote::GetLatestReply response;
         const auto status = kv_client->domain_get(request, &response);
         CHECK(status.ok());
     }
@@ -683,7 +683,7 @@ TEST_CASE_METHOD(KvEnd2EndTest, "KvServer E2E: KV", "[silkworm][node][rpc]") {
     }
 
     SECTION("DomainRange: return value in target domain range") {
-        remote::DomainRangeReq request;
+        remote::RangeAsOfReq request;
         remote::Pairs response;
         const auto status = kv_client->domain_range(request, &response);
         CHECK(status.ok());

--- a/silkworm/db/kv/grpc/test_util/sample_protos.hpp
+++ b/silkworm/db/kv/grpc/test_util/sample_protos.hpp
@@ -75,8 +75,8 @@ inline api::DomainPointQuery sample_domain_point_query() {
     };
 }
 
-inline proto::DomainGetReq sample_proto_domain_point_request() {
-    proto::DomainGetReq request;
+inline proto::GetLatestReq sample_proto_domain_point_request() {
+    proto::GetLatestReq request;
     request.set_tx_id(1);
     request.set_table("AAA");
     request.set_k(ascii_from_hex("0011ff"));
@@ -85,8 +85,8 @@ inline proto::DomainGetReq sample_proto_domain_point_request() {
     return request;
 }
 
-inline proto::DomainGetReply sample_proto_domain_get_response() {
-    proto::DomainGetReply response;
+inline proto::GetLatestReply sample_proto_domain_get_response() {
+    proto::GetLatestReply response;
     response.set_ok(true);
     response.set_v(ascii_from_hex("ff00ff00"));
     return response;
@@ -212,14 +212,14 @@ inline api::DomainRangeQuery sample_domain_range_query() {
     };
 }
 
-inline proto::DomainRangeReq default_proto_domain_range_request() {
-    proto::DomainRangeReq request;
+inline proto::RangeAsOfReq default_proto_domain_range_request() {
+    proto::RangeAsOfReq request;
     request.set_limit(api::kUnlimited);  // default value for type is 0 whilst we're choosing unlimited (-1) in API
     return request;
 }
 
-inline proto::DomainRangeReq sample_proto_domain_range_request() {
-    proto::DomainRangeReq request;
+inline proto::RangeAsOfReq sample_proto_domain_range_request() {
+    proto::RangeAsOfReq request;
     request.set_tx_id(1);
     request.set_table("AAA");
     request.set_from_key(ascii_from_hex("0011aa"));

--- a/silkworm/db/state/remote_state_test.cpp
+++ b/silkworm/db/state/remote_state_test.cpp
@@ -66,7 +66,7 @@ TEST_CASE_METHOD(RemoteStateTest, "async remote buffer", "[rpc][core][remote_buf
         EXPECT_CALL(transaction, first_txn_num_in_block(1'000'001)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 0;
         }));
-        EXPECT_CALL(transaction, domain_get(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kCode};
@@ -84,7 +84,7 @@ TEST_CASE_METHOD(RemoteStateTest, "async remote buffer", "[rpc][core][remote_buf
         EXPECT_CALL(transaction, first_txn_num_in_block(1'000'001)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 0;
         }));
-        EXPECT_CALL(transaction, domain_get(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = Bytes{}};
@@ -104,7 +104,7 @@ TEST_CASE_METHOD(RemoteStateTest, "async remote buffer", "[rpc][core][remote_buf
         EXPECT_CALL(transaction, first_txn_num_in_block(1'000'001)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 0;
         }));
-        EXPECT_CALL(transaction, domain_get(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = Bytes{}};
@@ -124,7 +124,7 @@ TEST_CASE_METHOD(RemoteStateTest, "async remote buffer", "[rpc][core][remote_buf
         EXPECT_CALL(transaction, first_txn_num_in_block(1'000'001)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 0;
         }));
-        EXPECT_CALL(transaction, domain_get(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = false,
                 .value = Bytes{}};
@@ -274,7 +274,7 @@ TEST_CASE_METHOD(RemoteStateTest, "async remote buffer", "[rpc][core][remote_buf
         EXPECT_CALL(transaction, first_txn_num_in_block(1'000'001)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 0;
         }));
-        EXPECT_CALL(transaction, domain_get(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = false,
                 .value = Bytes{}};
@@ -290,7 +290,7 @@ TEST_CASE_METHOD(RemoteStateTest, "async remote buffer", "[rpc][core][remote_buf
         EXPECT_CALL(transaction, first_txn_num_in_block(1'000'001)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 0;
         }));
-        EXPECT_CALL(transaction, domain_get(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = Bytes{}};
@@ -307,7 +307,7 @@ TEST_CASE_METHOD(RemoteStateTest, "async remote buffer", "[rpc][core][remote_buf
         EXPECT_CALL(transaction, first_txn_num_in_block(1'000'001)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 0;
         }));
-        EXPECT_CALL(transaction, domain_get(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = Bytes{}};

--- a/silkworm/db/state/state_reader.cpp
+++ b/silkworm/db/state/state_reader.cpp
@@ -38,7 +38,7 @@ Task<std::optional<Account>> StateReader::read_account(const evmc::address& addr
         .key = db::account_domain_key(address),
         .timestamp = txn_number_,
     };
-    const auto result = co_await tx_.domain_get(std::move(query));
+    const auto result = co_await tx_.get_latest(std::move(query));
     if (!result.success) {
         co_return std::nullopt;
     }
@@ -59,7 +59,7 @@ Task<evmc::bytes32> StateReader::read_storage(const evmc::address& address,
         .key = db::storage_domain_key(address, location_hash),
         .timestamp = txn_number_,
     };
-    const auto result = co_await tx_.domain_get(std::move(query));
+    const auto result = co_await tx_.get_latest(std::move(query));
     if (!result.success) {
         co_return evmc::bytes32{};
     }
@@ -79,7 +79,7 @@ Task<std::optional<Bytes>> StateReader::read_code(const evmc::address& address, 
         .key = db::code_domain_key(address),
         .timestamp = txn_number_,
     };
-    const auto result = co_await tx_.domain_get(std::move(query));
+    const auto result = co_await tx_.get_latest(std::move(query));
     if (!result.success) {
         co_return std::nullopt;
     }

--- a/silkworm/db/state/state_reader_test.cpp
+++ b/silkworm/db/state/state_reader_test.cpp
@@ -56,7 +56,7 @@ TEST_CASE_METHOD(StateReaderTest, "StateReader::read_account") {
     }));
 
     SECTION("no account for history empty and current state empty") {
-        EXPECT_CALL(transaction_, domain_get(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction_, get_latest(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = false,
                 .value = Bytes{}};
@@ -70,7 +70,7 @@ TEST_CASE_METHOD(StateReaderTest, "StateReader::read_account") {
     }
 
     SECTION("account found in current state") {
-        EXPECT_CALL(transaction_, domain_get(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction_, get_latest(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kEncodedAccount};
@@ -90,7 +90,7 @@ TEST_CASE_METHOD(StateReaderTest, "StateReader::read_account") {
     }
 
     SECTION("account found in history") {
-        EXPECT_CALL(transaction_, domain_get(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction_, get_latest(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kEncodedAccount};
@@ -116,7 +116,7 @@ TEST_CASE_METHOD(StateReaderTest, "StateReader::read_storage") {
     }));
 
     SECTION("empty storage for history empty and current state empty") {
-        EXPECT_CALL(transaction_, domain_get(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction_, get_latest(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = false,
                 .value = Bytes{}};
@@ -130,7 +130,7 @@ TEST_CASE_METHOD(StateReaderTest, "StateReader::read_storage") {
     }
 
     SECTION("storage found in current state") {
-        EXPECT_CALL(transaction_, domain_get(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction_, get_latest(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kStorageLocation};
@@ -143,7 +143,7 @@ TEST_CASE_METHOD(StateReaderTest, "StateReader::read_storage") {
     }
 
     SECTION("storage found in history") {
-        EXPECT_CALL(transaction_, domain_get(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction_, get_latest(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kStorageLocation};
@@ -170,7 +170,7 @@ TEST_CASE_METHOD(StateReaderTest, "StateReader::read_code") {
             co_return 0;
         }));
 
-        EXPECT_CALL(transaction_, domain_get(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction_, get_latest(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = Bytes{}};
@@ -191,7 +191,7 @@ TEST_CASE_METHOD(StateReaderTest, "StateReader::read_code") {
             co_return 0;
         }));
 
-        EXPECT_CALL(transaction_, domain_get(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction_, get_latest(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kBinaryCode};

--- a/silkworm/db/test_util/mock_transaction.hpp
+++ b/silkworm/db/test_util/mock_transaction.hpp
@@ -47,11 +47,11 @@ class MockTransaction : public kv::api::Transaction {
     MOCK_METHOD((Task<Bytes>), get_one, (const std::string&, ByteView), (override));
     MOCK_METHOD((Task<std::optional<Bytes>>), get_both_range,
                 (const std::string&, ByteView, ByteView), (override));
-    MOCK_METHOD((Task<kv::api::DomainPointResult>), domain_get, (kv::api::DomainPointQuery), (override));
+    MOCK_METHOD((Task<kv::api::DomainPointResult>), get_latest, (kv::api::DomainPointQuery), (override));
     MOCK_METHOD((Task<kv::api::HistoryPointResult>), history_seek, (kv::api::HistoryPointQuery), (override));
     MOCK_METHOD((Task<kv::api::PaginatedTimestamps>), index_range, (kv::api::IndexRangeQuery), (override));
     MOCK_METHOD((Task<kv::api::PaginatedKeysValues>), history_range, (kv::api::HistoryRangeQuery), (override));
-    MOCK_METHOD((Task<kv::api::PaginatedKeysValues>), domain_range, (kv::api::DomainRangeQuery), (override));
+    MOCK_METHOD((Task<kv::api::PaginatedKeysValues>), range_as_of, (kv::api::DomainRangeQuery), (override));
 };
 
 }  // namespace silkworm::db::test_util

--- a/silkworm/infra/grpc/test_util/interfaces/kv_mock_fix24351.grpc.pb.h
+++ b/silkworm/infra/grpc/test_util/interfaces/kv_mock_fix24351.grpc.pb.h
@@ -30,16 +30,16 @@ class FixIssue24351_MockKVStub : public remote::MockKVStub {
   MOCK_METHOD2(ReceiveStateChanges, ::grpc::ClientReaderInterface< ::remote::StateChange>*(::grpc::ClientContext* context, const ::google::protobuf::Empty& request));
   MOCK_METHOD4(AsyncReceiveStateChanges, ::grpc::ClientAsyncReaderInterface< ::remote::StateChange>*(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq, void* tag));
   MOCK_METHOD3(PrepareAsyncReceiveStateChanges, ::grpc::ClientAsyncReaderInterface< ::remote::StateChange>*(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq));
-  MOCK_METHOD3(AsyncDomainGet, ::grpc::ClientAsyncResponseReaderInterface< ::remote::DomainGetReply>*(::grpc::ClientContext* context, const ::remote::DomainGetReq& request, ::grpc::CompletionQueue* cq));
-  MOCK_METHOD3(PrepareAsyncDomainGet, ::grpc::ClientAsyncResponseReaderInterface< ::remote::DomainGetReply>*(::grpc::ClientContext* context, const ::remote::DomainGetReq& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD3(AsyncGetLatest, ::grpc::ClientAsyncResponseReaderInterface< ::remote::GetLatestReply>*(::grpc::ClientContext* context, const ::remote::GetLatestReq& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD3(PrepareAsyncGetLatest, ::grpc::ClientAsyncResponseReaderInterface< ::remote::GetLatestReply>*(::grpc::ClientContext* context, const ::remote::GetLatestReq& request, ::grpc::CompletionQueue* cq));
   MOCK_METHOD3(AsyncHistorySeek, ::grpc::ClientAsyncResponseReaderInterface< ::remote::HistorySeekReply>*(::grpc::ClientContext* context, const ::remote::HistorySeekReq& request, ::grpc::CompletionQueue* cq));
   MOCK_METHOD3(PrepareAsyncHistorySeek, ::grpc::ClientAsyncResponseReaderInterface< ::remote::HistorySeekReply>*(::grpc::ClientContext* context, const ::remote::HistorySeekReq& request, ::grpc::CompletionQueue* cq));
   MOCK_METHOD3(AsyncIndexRange, ::grpc::ClientAsyncResponseReaderInterface< ::remote::IndexRangeReply>*(::grpc::ClientContext* context, const ::remote::IndexRangeReq& request, ::grpc::CompletionQueue* cq));
   MOCK_METHOD3(PrepareAsyncIndexRange, ::grpc::ClientAsyncResponseReaderInterface< ::remote::IndexRangeReply>*(::grpc::ClientContext* context, const ::remote::IndexRangeReq& request, ::grpc::CompletionQueue* cq));
   MOCK_METHOD3(AsyncHistoryRange, ::grpc::ClientAsyncResponseReaderInterface< ::remote::Pairs>*(::grpc::ClientContext* context, const ::remote::HistoryRangeReq& request, ::grpc::CompletionQueue* cq));
   MOCK_METHOD3(PrepareAsyncHistoryRange, ::grpc::ClientAsyncResponseReaderInterface< ::remote::Pairs>*(::grpc::ClientContext* context, const ::remote::HistoryRangeReq& request, ::grpc::CompletionQueue* cq));
-  MOCK_METHOD3(AsyncDomainRange, ::grpc::ClientAsyncResponseReaderInterface< ::remote::Pairs>*(::grpc::ClientContext* context, const ::remote::DomainRangeReq& request, ::grpc::CompletionQueue* cq));
-  MOCK_METHOD3(PrepareAsyncDomainRange, ::grpc::ClientAsyncResponseReaderInterface< ::remote::Pairs>*(::grpc::ClientContext* context, const ::remote::DomainRangeReq& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD3(AsyncRangeAsOf, ::grpc::ClientAsyncResponseReaderInterface< ::remote::Pairs>*(::grpc::ClientContext* context, const ::remote::RangeAsOfReq& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD3(PrepareAsyncRangeAsOf, ::grpc::ClientAsyncResponseReaderInterface< ::remote::Pairs>*(::grpc::ClientContext* context, const ::remote::RangeAsOfReq& request, ::grpc::CompletionQueue* cq));
 };
 
 } // namespace remote

--- a/silkworm/interfaces/3.21.12/remote/kv.grpc.pb.cc
+++ b/silkworm/interfaces/3.21.12/remote/kv.grpc.pb.cc
@@ -27,11 +27,11 @@ static const char* KV_method_names[] = {
   "/remote.KV/StateChanges",
   "/remote.KV/Snapshots",
   "/remote.KV/Range",
-  "/remote.KV/DomainGet",
+  "/remote.KV/GetLatest",
   "/remote.KV/HistorySeek",
   "/remote.KV/IndexRange",
   "/remote.KV/HistoryRange",
-  "/remote.KV/DomainRange",
+  "/remote.KV/RangeAsOf",
 };
 
 std::unique_ptr< KV::Stub> KV::NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options) {
@@ -46,11 +46,11 @@ KV::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const 
   , rpcmethod_StateChanges_(KV_method_names[2], options.suffix_for_stats(),::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
   , rpcmethod_Snapshots_(KV_method_names[3], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_Range_(KV_method_names[4], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_DomainGet_(KV_method_names[5], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_GetLatest_(KV_method_names[5], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_HistorySeek_(KV_method_names[6], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_IndexRange_(KV_method_names[7], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_HistoryRange_(KV_method_names[8], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_DomainRange_(KV_method_names[9], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_RangeAsOf_(KV_method_names[9], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   {}
 
 ::grpc::Status KV::Stub::Version(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::types::VersionReply* response) {
@@ -154,25 +154,25 @@ void KV::Stub::async::Range(::grpc::ClientContext* context, const ::remote::Rang
   return result;
 }
 
-::grpc::Status KV::Stub::DomainGet(::grpc::ClientContext* context, const ::remote::DomainGetReq& request, ::remote::DomainGetReply* response) {
-  return ::grpc::internal::BlockingUnaryCall< ::remote::DomainGetReq, ::remote::DomainGetReply, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_DomainGet_, context, request, response);
+::grpc::Status KV::Stub::GetLatest(::grpc::ClientContext* context, const ::remote::GetLatestReq& request, ::remote::GetLatestReply* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::remote::GetLatestReq, ::remote::GetLatestReply, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_GetLatest_, context, request, response);
 }
 
-void KV::Stub::async::DomainGet(::grpc::ClientContext* context, const ::remote::DomainGetReq* request, ::remote::DomainGetReply* response, std::function<void(::grpc::Status)> f) {
-  ::grpc::internal::CallbackUnaryCall< ::remote::DomainGetReq, ::remote::DomainGetReply, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_DomainGet_, context, request, response, std::move(f));
+void KV::Stub::async::GetLatest(::grpc::ClientContext* context, const ::remote::GetLatestReq* request, ::remote::GetLatestReply* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::remote::GetLatestReq, ::remote::GetLatestReply, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_GetLatest_, context, request, response, std::move(f));
 }
 
-void KV::Stub::async::DomainGet(::grpc::ClientContext* context, const ::remote::DomainGetReq* request, ::remote::DomainGetReply* response, ::grpc::ClientUnaryReactor* reactor) {
-  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_DomainGet_, context, request, response, reactor);
+void KV::Stub::async::GetLatest(::grpc::ClientContext* context, const ::remote::GetLatestReq* request, ::remote::GetLatestReply* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_GetLatest_, context, request, response, reactor);
 }
 
-::grpc::ClientAsyncResponseReader< ::remote::DomainGetReply>* KV::Stub::PrepareAsyncDomainGetRaw(::grpc::ClientContext* context, const ::remote::DomainGetReq& request, ::grpc::CompletionQueue* cq) {
-  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::remote::DomainGetReply, ::remote::DomainGetReq, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_DomainGet_, context, request);
+::grpc::ClientAsyncResponseReader< ::remote::GetLatestReply>* KV::Stub::PrepareAsyncGetLatestRaw(::grpc::ClientContext* context, const ::remote::GetLatestReq& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::remote::GetLatestReply, ::remote::GetLatestReq, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_GetLatest_, context, request);
 }
 
-::grpc::ClientAsyncResponseReader< ::remote::DomainGetReply>* KV::Stub::AsyncDomainGetRaw(::grpc::ClientContext* context, const ::remote::DomainGetReq& request, ::grpc::CompletionQueue* cq) {
+::grpc::ClientAsyncResponseReader< ::remote::GetLatestReply>* KV::Stub::AsyncGetLatestRaw(::grpc::ClientContext* context, const ::remote::GetLatestReq& request, ::grpc::CompletionQueue* cq) {
   auto* result =
-    this->PrepareAsyncDomainGetRaw(context, request, cq);
+    this->PrepareAsyncGetLatestRaw(context, request, cq);
   result->StartCall();
   return result;
 }
@@ -246,25 +246,25 @@ void KV::Stub::async::HistoryRange(::grpc::ClientContext* context, const ::remot
   return result;
 }
 
-::grpc::Status KV::Stub::DomainRange(::grpc::ClientContext* context, const ::remote::DomainRangeReq& request, ::remote::Pairs* response) {
-  return ::grpc::internal::BlockingUnaryCall< ::remote::DomainRangeReq, ::remote::Pairs, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_DomainRange_, context, request, response);
+::grpc::Status KV::Stub::RangeAsOf(::grpc::ClientContext* context, const ::remote::RangeAsOfReq& request, ::remote::Pairs* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::remote::RangeAsOfReq, ::remote::Pairs, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_RangeAsOf_, context, request, response);
 }
 
-void KV::Stub::async::DomainRange(::grpc::ClientContext* context, const ::remote::DomainRangeReq* request, ::remote::Pairs* response, std::function<void(::grpc::Status)> f) {
-  ::grpc::internal::CallbackUnaryCall< ::remote::DomainRangeReq, ::remote::Pairs, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_DomainRange_, context, request, response, std::move(f));
+void KV::Stub::async::RangeAsOf(::grpc::ClientContext* context, const ::remote::RangeAsOfReq* request, ::remote::Pairs* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::remote::RangeAsOfReq, ::remote::Pairs, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_RangeAsOf_, context, request, response, std::move(f));
 }
 
-void KV::Stub::async::DomainRange(::grpc::ClientContext* context, const ::remote::DomainRangeReq* request, ::remote::Pairs* response, ::grpc::ClientUnaryReactor* reactor) {
-  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_DomainRange_, context, request, response, reactor);
+void KV::Stub::async::RangeAsOf(::grpc::ClientContext* context, const ::remote::RangeAsOfReq* request, ::remote::Pairs* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_RangeAsOf_, context, request, response, reactor);
 }
 
-::grpc::ClientAsyncResponseReader< ::remote::Pairs>* KV::Stub::PrepareAsyncDomainRangeRaw(::grpc::ClientContext* context, const ::remote::DomainRangeReq& request, ::grpc::CompletionQueue* cq) {
-  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::remote::Pairs, ::remote::DomainRangeReq, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_DomainRange_, context, request);
+::grpc::ClientAsyncResponseReader< ::remote::Pairs>* KV::Stub::PrepareAsyncRangeAsOfRaw(::grpc::ClientContext* context, const ::remote::RangeAsOfReq& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::remote::Pairs, ::remote::RangeAsOfReq, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_RangeAsOf_, context, request);
 }
 
-::grpc::ClientAsyncResponseReader< ::remote::Pairs>* KV::Stub::AsyncDomainRangeRaw(::grpc::ClientContext* context, const ::remote::DomainRangeReq& request, ::grpc::CompletionQueue* cq) {
+::grpc::ClientAsyncResponseReader< ::remote::Pairs>* KV::Stub::AsyncRangeAsOfRaw(::grpc::ClientContext* context, const ::remote::RangeAsOfReq& request, ::grpc::CompletionQueue* cq) {
   auto* result =
-    this->PrepareAsyncDomainRangeRaw(context, request, cq);
+    this->PrepareAsyncRangeAsOfRaw(context, request, cq);
   result->StartCall();
   return result;
 }
@@ -323,12 +323,12 @@ KV::Service::Service() {
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       KV_method_names[5],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
-      new ::grpc::internal::RpcMethodHandler< KV::Service, ::remote::DomainGetReq, ::remote::DomainGetReply, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+      new ::grpc::internal::RpcMethodHandler< KV::Service, ::remote::GetLatestReq, ::remote::GetLatestReply, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](KV::Service* service,
              ::grpc::ServerContext* ctx,
-             const ::remote::DomainGetReq* req,
-             ::remote::DomainGetReply* resp) {
-               return service->DomainGet(ctx, req, resp);
+             const ::remote::GetLatestReq* req,
+             ::remote::GetLatestReply* resp) {
+               return service->GetLatest(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       KV_method_names[6],
@@ -363,12 +363,12 @@ KV::Service::Service() {
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       KV_method_names[9],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
-      new ::grpc::internal::RpcMethodHandler< KV::Service, ::remote::DomainRangeReq, ::remote::Pairs, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+      new ::grpc::internal::RpcMethodHandler< KV::Service, ::remote::RangeAsOfReq, ::remote::Pairs, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](KV::Service* service,
              ::grpc::ServerContext* ctx,
-             const ::remote::DomainRangeReq* req,
+             const ::remote::RangeAsOfReq* req,
              ::remote::Pairs* resp) {
-               return service->DomainRange(ctx, req, resp);
+               return service->RangeAsOf(ctx, req, resp);
              }, this)));
 }
 
@@ -409,7 +409,7 @@ KV::Service::~Service() {
   return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
 }
 
-::grpc::Status KV::Service::DomainGet(::grpc::ServerContext* context, const ::remote::DomainGetReq* request, ::remote::DomainGetReply* response) {
+::grpc::Status KV::Service::GetLatest(::grpc::ServerContext* context, const ::remote::GetLatestReq* request, ::remote::GetLatestReply* response) {
   (void) context;
   (void) request;
   (void) response;
@@ -437,7 +437,7 @@ KV::Service::~Service() {
   return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
 }
 
-::grpc::Status KV::Service::DomainRange(::grpc::ServerContext* context, const ::remote::DomainRangeReq* request, ::remote::Pairs* response) {
+::grpc::Status KV::Service::RangeAsOf(::grpc::ServerContext* context, const ::remote::RangeAsOfReq* request, ::remote::Pairs* response) {
   (void) context;
   (void) request;
   (void) response;

--- a/silkworm/interfaces/3.21.12/remote/kv.grpc.pb.h
+++ b/silkworm/interfaces/3.21.12/remote/kv.grpc.pb.h
@@ -110,12 +110,12 @@ class KV final {
     }
     //    rpc Stream(RangeReq) returns (stream Pairs);
     // Temporal methods
-    virtual ::grpc::Status DomainGet(::grpc::ClientContext* context, const ::remote::DomainGetReq& request, ::remote::DomainGetReply* response) = 0;
-    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::remote::DomainGetReply>> AsyncDomainGet(::grpc::ClientContext* context, const ::remote::DomainGetReq& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::remote::DomainGetReply>>(AsyncDomainGetRaw(context, request, cq));
+    virtual ::grpc::Status GetLatest(::grpc::ClientContext* context, const ::remote::GetLatestReq& request, ::remote::GetLatestReply* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::remote::GetLatestReply>> AsyncGetLatest(::grpc::ClientContext* context, const ::remote::GetLatestReq& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::remote::GetLatestReply>>(AsyncGetLatestRaw(context, request, cq));
     }
-    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::remote::DomainGetReply>> PrepareAsyncDomainGet(::grpc::ClientContext* context, const ::remote::DomainGetReq& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::remote::DomainGetReply>>(PrepareAsyncDomainGetRaw(context, request, cq));
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::remote::GetLatestReply>> PrepareAsyncGetLatest(::grpc::ClientContext* context, const ::remote::GetLatestReq& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::remote::GetLatestReply>>(PrepareAsyncGetLatestRaw(context, request, cq));
     }
     // can return latest value or as of given timestamp
     virtual ::grpc::Status HistorySeek(::grpc::ClientContext* context, const ::remote::HistorySeekReq& request, ::remote::HistorySeekReply* response) = 0;
@@ -139,12 +139,12 @@ class KV final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::remote::Pairs>> PrepareAsyncHistoryRange(::grpc::ClientContext* context, const ::remote::HistoryRangeReq& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::remote::Pairs>>(PrepareAsyncHistoryRangeRaw(context, request, cq));
     }
-    virtual ::grpc::Status DomainRange(::grpc::ClientContext* context, const ::remote::DomainRangeReq& request, ::remote::Pairs* response) = 0;
-    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::remote::Pairs>> AsyncDomainRange(::grpc::ClientContext* context, const ::remote::DomainRangeReq& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::remote::Pairs>>(AsyncDomainRangeRaw(context, request, cq));
+    virtual ::grpc::Status RangeAsOf(::grpc::ClientContext* context, const ::remote::RangeAsOfReq& request, ::remote::Pairs* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::remote::Pairs>> AsyncRangeAsOf(::grpc::ClientContext* context, const ::remote::RangeAsOfReq& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::remote::Pairs>>(AsyncRangeAsOfRaw(context, request, cq));
     }
-    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::remote::Pairs>> PrepareAsyncDomainRange(::grpc::ClientContext* context, const ::remote::DomainRangeReq& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::remote::Pairs>>(PrepareAsyncDomainRangeRaw(context, request, cq));
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::remote::Pairs>> PrepareAsyncRangeAsOf(::grpc::ClientContext* context, const ::remote::RangeAsOfReq& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::remote::Pairs>>(PrepareAsyncRangeAsOfRaw(context, request, cq));
     }
     class async_interface {
      public:
@@ -170,8 +170,8 @@ class KV final {
       virtual void Range(::grpc::ClientContext* context, const ::remote::RangeReq* request, ::remote::Pairs* response, ::grpc::ClientUnaryReactor* reactor) = 0;
       //    rpc Stream(RangeReq) returns (stream Pairs);
       // Temporal methods
-      virtual void DomainGet(::grpc::ClientContext* context, const ::remote::DomainGetReq* request, ::remote::DomainGetReply* response, std::function<void(::grpc::Status)>) = 0;
-      virtual void DomainGet(::grpc::ClientContext* context, const ::remote::DomainGetReq* request, ::remote::DomainGetReply* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      virtual void GetLatest(::grpc::ClientContext* context, const ::remote::GetLatestReq* request, ::remote::GetLatestReply* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void GetLatest(::grpc::ClientContext* context, const ::remote::GetLatestReq* request, ::remote::GetLatestReply* response, ::grpc::ClientUnaryReactor* reactor) = 0;
       // can return latest value or as of given timestamp
       virtual void HistorySeek(::grpc::ClientContext* context, const ::remote::HistorySeekReq* request, ::remote::HistorySeekReply* response, std::function<void(::grpc::Status)>) = 0;
       virtual void HistorySeek(::grpc::ClientContext* context, const ::remote::HistorySeekReq* request, ::remote::HistorySeekReply* response, ::grpc::ClientUnaryReactor* reactor) = 0;
@@ -179,8 +179,8 @@ class KV final {
       virtual void IndexRange(::grpc::ClientContext* context, const ::remote::IndexRangeReq* request, ::remote::IndexRangeReply* response, ::grpc::ClientUnaryReactor* reactor) = 0;
       virtual void HistoryRange(::grpc::ClientContext* context, const ::remote::HistoryRangeReq* request, ::remote::Pairs* response, std::function<void(::grpc::Status)>) = 0;
       virtual void HistoryRange(::grpc::ClientContext* context, const ::remote::HistoryRangeReq* request, ::remote::Pairs* response, ::grpc::ClientUnaryReactor* reactor) = 0;
-      virtual void DomainRange(::grpc::ClientContext* context, const ::remote::DomainRangeReq* request, ::remote::Pairs* response, std::function<void(::grpc::Status)>) = 0;
-      virtual void DomainRange(::grpc::ClientContext* context, const ::remote::DomainRangeReq* request, ::remote::Pairs* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      virtual void RangeAsOf(::grpc::ClientContext* context, const ::remote::RangeAsOfReq* request, ::remote::Pairs* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void RangeAsOf(::grpc::ClientContext* context, const ::remote::RangeAsOfReq* request, ::remote::Pairs* response, ::grpc::ClientUnaryReactor* reactor) = 0;
     };
     typedef class async_interface experimental_async_interface;
     virtual class async_interface* async() { return nullptr; }
@@ -198,16 +198,16 @@ class KV final {
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::remote::SnapshotsReply>* PrepareAsyncSnapshotsRaw(::grpc::ClientContext* context, const ::remote::SnapshotsRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::remote::Pairs>* AsyncRangeRaw(::grpc::ClientContext* context, const ::remote::RangeReq& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::remote::Pairs>* PrepareAsyncRangeRaw(::grpc::ClientContext* context, const ::remote::RangeReq& request, ::grpc::CompletionQueue* cq) = 0;
-    virtual ::grpc::ClientAsyncResponseReaderInterface< ::remote::DomainGetReply>* AsyncDomainGetRaw(::grpc::ClientContext* context, const ::remote::DomainGetReq& request, ::grpc::CompletionQueue* cq) = 0;
-    virtual ::grpc::ClientAsyncResponseReaderInterface< ::remote::DomainGetReply>* PrepareAsyncDomainGetRaw(::grpc::ClientContext* context, const ::remote::DomainGetReq& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::remote::GetLatestReply>* AsyncGetLatestRaw(::grpc::ClientContext* context, const ::remote::GetLatestReq& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::remote::GetLatestReply>* PrepareAsyncGetLatestRaw(::grpc::ClientContext* context, const ::remote::GetLatestReq& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::remote::HistorySeekReply>* AsyncHistorySeekRaw(::grpc::ClientContext* context, const ::remote::HistorySeekReq& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::remote::HistorySeekReply>* PrepareAsyncHistorySeekRaw(::grpc::ClientContext* context, const ::remote::HistorySeekReq& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::remote::IndexRangeReply>* AsyncIndexRangeRaw(::grpc::ClientContext* context, const ::remote::IndexRangeReq& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::remote::IndexRangeReply>* PrepareAsyncIndexRangeRaw(::grpc::ClientContext* context, const ::remote::IndexRangeReq& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::remote::Pairs>* AsyncHistoryRangeRaw(::grpc::ClientContext* context, const ::remote::HistoryRangeReq& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::remote::Pairs>* PrepareAsyncHistoryRangeRaw(::grpc::ClientContext* context, const ::remote::HistoryRangeReq& request, ::grpc::CompletionQueue* cq) = 0;
-    virtual ::grpc::ClientAsyncResponseReaderInterface< ::remote::Pairs>* AsyncDomainRangeRaw(::grpc::ClientContext* context, const ::remote::DomainRangeReq& request, ::grpc::CompletionQueue* cq) = 0;
-    virtual ::grpc::ClientAsyncResponseReaderInterface< ::remote::Pairs>* PrepareAsyncDomainRangeRaw(::grpc::ClientContext* context, const ::remote::DomainRangeReq& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::remote::Pairs>* AsyncRangeAsOfRaw(::grpc::ClientContext* context, const ::remote::RangeAsOfReq& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::remote::Pairs>* PrepareAsyncRangeAsOfRaw(::grpc::ClientContext* context, const ::remote::RangeAsOfReq& request, ::grpc::CompletionQueue* cq) = 0;
   };
   class Stub final : public StubInterface {
    public:
@@ -251,12 +251,12 @@ class KV final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::remote::Pairs>> PrepareAsyncRange(::grpc::ClientContext* context, const ::remote::RangeReq& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::remote::Pairs>>(PrepareAsyncRangeRaw(context, request, cq));
     }
-    ::grpc::Status DomainGet(::grpc::ClientContext* context, const ::remote::DomainGetReq& request, ::remote::DomainGetReply* response) override;
-    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::remote::DomainGetReply>> AsyncDomainGet(::grpc::ClientContext* context, const ::remote::DomainGetReq& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::remote::DomainGetReply>>(AsyncDomainGetRaw(context, request, cq));
+    ::grpc::Status GetLatest(::grpc::ClientContext* context, const ::remote::GetLatestReq& request, ::remote::GetLatestReply* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::remote::GetLatestReply>> AsyncGetLatest(::grpc::ClientContext* context, const ::remote::GetLatestReq& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::remote::GetLatestReply>>(AsyncGetLatestRaw(context, request, cq));
     }
-    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::remote::DomainGetReply>> PrepareAsyncDomainGet(::grpc::ClientContext* context, const ::remote::DomainGetReq& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::remote::DomainGetReply>>(PrepareAsyncDomainGetRaw(context, request, cq));
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::remote::GetLatestReply>> PrepareAsyncGetLatest(::grpc::ClientContext* context, const ::remote::GetLatestReq& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::remote::GetLatestReply>>(PrepareAsyncGetLatestRaw(context, request, cq));
     }
     ::grpc::Status HistorySeek(::grpc::ClientContext* context, const ::remote::HistorySeekReq& request, ::remote::HistorySeekReply* response) override;
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::remote::HistorySeekReply>> AsyncHistorySeek(::grpc::ClientContext* context, const ::remote::HistorySeekReq& request, ::grpc::CompletionQueue* cq) {
@@ -279,12 +279,12 @@ class KV final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::remote::Pairs>> PrepareAsyncHistoryRange(::grpc::ClientContext* context, const ::remote::HistoryRangeReq& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::remote::Pairs>>(PrepareAsyncHistoryRangeRaw(context, request, cq));
     }
-    ::grpc::Status DomainRange(::grpc::ClientContext* context, const ::remote::DomainRangeReq& request, ::remote::Pairs* response) override;
-    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::remote::Pairs>> AsyncDomainRange(::grpc::ClientContext* context, const ::remote::DomainRangeReq& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::remote::Pairs>>(AsyncDomainRangeRaw(context, request, cq));
+    ::grpc::Status RangeAsOf(::grpc::ClientContext* context, const ::remote::RangeAsOfReq& request, ::remote::Pairs* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::remote::Pairs>> AsyncRangeAsOf(::grpc::ClientContext* context, const ::remote::RangeAsOfReq& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::remote::Pairs>>(AsyncRangeAsOfRaw(context, request, cq));
     }
-    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::remote::Pairs>> PrepareAsyncDomainRange(::grpc::ClientContext* context, const ::remote::DomainRangeReq& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::remote::Pairs>>(PrepareAsyncDomainRangeRaw(context, request, cq));
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::remote::Pairs>> PrepareAsyncRangeAsOf(::grpc::ClientContext* context, const ::remote::RangeAsOfReq& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::remote::Pairs>>(PrepareAsyncRangeAsOfRaw(context, request, cq));
     }
     class async final :
       public StubInterface::async_interface {
@@ -297,16 +297,16 @@ class KV final {
       void Snapshots(::grpc::ClientContext* context, const ::remote::SnapshotsRequest* request, ::remote::SnapshotsReply* response, ::grpc::ClientUnaryReactor* reactor) override;
       void Range(::grpc::ClientContext* context, const ::remote::RangeReq* request, ::remote::Pairs* response, std::function<void(::grpc::Status)>) override;
       void Range(::grpc::ClientContext* context, const ::remote::RangeReq* request, ::remote::Pairs* response, ::grpc::ClientUnaryReactor* reactor) override;
-      void DomainGet(::grpc::ClientContext* context, const ::remote::DomainGetReq* request, ::remote::DomainGetReply* response, std::function<void(::grpc::Status)>) override;
-      void DomainGet(::grpc::ClientContext* context, const ::remote::DomainGetReq* request, ::remote::DomainGetReply* response, ::grpc::ClientUnaryReactor* reactor) override;
+      void GetLatest(::grpc::ClientContext* context, const ::remote::GetLatestReq* request, ::remote::GetLatestReply* response, std::function<void(::grpc::Status)>) override;
+      void GetLatest(::grpc::ClientContext* context, const ::remote::GetLatestReq* request, ::remote::GetLatestReply* response, ::grpc::ClientUnaryReactor* reactor) override;
       void HistorySeek(::grpc::ClientContext* context, const ::remote::HistorySeekReq* request, ::remote::HistorySeekReply* response, std::function<void(::grpc::Status)>) override;
       void HistorySeek(::grpc::ClientContext* context, const ::remote::HistorySeekReq* request, ::remote::HistorySeekReply* response, ::grpc::ClientUnaryReactor* reactor) override;
       void IndexRange(::grpc::ClientContext* context, const ::remote::IndexRangeReq* request, ::remote::IndexRangeReply* response, std::function<void(::grpc::Status)>) override;
       void IndexRange(::grpc::ClientContext* context, const ::remote::IndexRangeReq* request, ::remote::IndexRangeReply* response, ::grpc::ClientUnaryReactor* reactor) override;
       void HistoryRange(::grpc::ClientContext* context, const ::remote::HistoryRangeReq* request, ::remote::Pairs* response, std::function<void(::grpc::Status)>) override;
       void HistoryRange(::grpc::ClientContext* context, const ::remote::HistoryRangeReq* request, ::remote::Pairs* response, ::grpc::ClientUnaryReactor* reactor) override;
-      void DomainRange(::grpc::ClientContext* context, const ::remote::DomainRangeReq* request, ::remote::Pairs* response, std::function<void(::grpc::Status)>) override;
-      void DomainRange(::grpc::ClientContext* context, const ::remote::DomainRangeReq* request, ::remote::Pairs* response, ::grpc::ClientUnaryReactor* reactor) override;
+      void RangeAsOf(::grpc::ClientContext* context, const ::remote::RangeAsOfReq* request, ::remote::Pairs* response, std::function<void(::grpc::Status)>) override;
+      void RangeAsOf(::grpc::ClientContext* context, const ::remote::RangeAsOfReq* request, ::remote::Pairs* response, ::grpc::ClientUnaryReactor* reactor) override;
      private:
       friend class Stub;
       explicit async(Stub* stub): stub_(stub) { }
@@ -330,26 +330,26 @@ class KV final {
     ::grpc::ClientAsyncResponseReader< ::remote::SnapshotsReply>* PrepareAsyncSnapshotsRaw(::grpc::ClientContext* context, const ::remote::SnapshotsRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::remote::Pairs>* AsyncRangeRaw(::grpc::ClientContext* context, const ::remote::RangeReq& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::remote::Pairs>* PrepareAsyncRangeRaw(::grpc::ClientContext* context, const ::remote::RangeReq& request, ::grpc::CompletionQueue* cq) override;
-    ::grpc::ClientAsyncResponseReader< ::remote::DomainGetReply>* AsyncDomainGetRaw(::grpc::ClientContext* context, const ::remote::DomainGetReq& request, ::grpc::CompletionQueue* cq) override;
-    ::grpc::ClientAsyncResponseReader< ::remote::DomainGetReply>* PrepareAsyncDomainGetRaw(::grpc::ClientContext* context, const ::remote::DomainGetReq& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::remote::GetLatestReply>* AsyncGetLatestRaw(::grpc::ClientContext* context, const ::remote::GetLatestReq& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::remote::GetLatestReply>* PrepareAsyncGetLatestRaw(::grpc::ClientContext* context, const ::remote::GetLatestReq& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::remote::HistorySeekReply>* AsyncHistorySeekRaw(::grpc::ClientContext* context, const ::remote::HistorySeekReq& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::remote::HistorySeekReply>* PrepareAsyncHistorySeekRaw(::grpc::ClientContext* context, const ::remote::HistorySeekReq& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::remote::IndexRangeReply>* AsyncIndexRangeRaw(::grpc::ClientContext* context, const ::remote::IndexRangeReq& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::remote::IndexRangeReply>* PrepareAsyncIndexRangeRaw(::grpc::ClientContext* context, const ::remote::IndexRangeReq& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::remote::Pairs>* AsyncHistoryRangeRaw(::grpc::ClientContext* context, const ::remote::HistoryRangeReq& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::remote::Pairs>* PrepareAsyncHistoryRangeRaw(::grpc::ClientContext* context, const ::remote::HistoryRangeReq& request, ::grpc::CompletionQueue* cq) override;
-    ::grpc::ClientAsyncResponseReader< ::remote::Pairs>* AsyncDomainRangeRaw(::grpc::ClientContext* context, const ::remote::DomainRangeReq& request, ::grpc::CompletionQueue* cq) override;
-    ::grpc::ClientAsyncResponseReader< ::remote::Pairs>* PrepareAsyncDomainRangeRaw(::grpc::ClientContext* context, const ::remote::DomainRangeReq& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::remote::Pairs>* AsyncRangeAsOfRaw(::grpc::ClientContext* context, const ::remote::RangeAsOfReq& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::remote::Pairs>* PrepareAsyncRangeAsOfRaw(::grpc::ClientContext* context, const ::remote::RangeAsOfReq& request, ::grpc::CompletionQueue* cq) override;
     const ::grpc::internal::RpcMethod rpcmethod_Version_;
     const ::grpc::internal::RpcMethod rpcmethod_Tx_;
     const ::grpc::internal::RpcMethod rpcmethod_StateChanges_;
     const ::grpc::internal::RpcMethod rpcmethod_Snapshots_;
     const ::grpc::internal::RpcMethod rpcmethod_Range_;
-    const ::grpc::internal::RpcMethod rpcmethod_DomainGet_;
+    const ::grpc::internal::RpcMethod rpcmethod_GetLatest_;
     const ::grpc::internal::RpcMethod rpcmethod_HistorySeek_;
     const ::grpc::internal::RpcMethod rpcmethod_IndexRange_;
     const ::grpc::internal::RpcMethod rpcmethod_HistoryRange_;
-    const ::grpc::internal::RpcMethod rpcmethod_DomainRange_;
+    const ::grpc::internal::RpcMethod rpcmethod_RangeAsOf_;
   };
   static std::unique_ptr<Stub> NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options = ::grpc::StubOptions());
 
@@ -375,12 +375,12 @@ class KV final {
     virtual ::grpc::Status Range(::grpc::ServerContext* context, const ::remote::RangeReq* request, ::remote::Pairs* response);
     //    rpc Stream(RangeReq) returns (stream Pairs);
     // Temporal methods
-    virtual ::grpc::Status DomainGet(::grpc::ServerContext* context, const ::remote::DomainGetReq* request, ::remote::DomainGetReply* response);
+    virtual ::grpc::Status GetLatest(::grpc::ServerContext* context, const ::remote::GetLatestReq* request, ::remote::GetLatestReply* response);
     // can return latest value or as of given timestamp
     virtual ::grpc::Status HistorySeek(::grpc::ServerContext* context, const ::remote::HistorySeekReq* request, ::remote::HistorySeekReply* response);
     virtual ::grpc::Status IndexRange(::grpc::ServerContext* context, const ::remote::IndexRangeReq* request, ::remote::IndexRangeReply* response);
     virtual ::grpc::Status HistoryRange(::grpc::ServerContext* context, const ::remote::HistoryRangeReq* request, ::remote::Pairs* response);
-    virtual ::grpc::Status DomainRange(::grpc::ServerContext* context, const ::remote::DomainRangeReq* request, ::remote::Pairs* response);
+    virtual ::grpc::Status RangeAsOf(::grpc::ServerContext* context, const ::remote::RangeAsOfReq* request, ::remote::Pairs* response);
   };
   template <class BaseClass>
   class WithAsyncMethod_Version : public BaseClass {
@@ -483,22 +483,22 @@ class KV final {
     }
   };
   template <class BaseClass>
-  class WithAsyncMethod_DomainGet : public BaseClass {
+  class WithAsyncMethod_GetLatest : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
-    WithAsyncMethod_DomainGet() {
+    WithAsyncMethod_GetLatest() {
       ::grpc::Service::MarkMethodAsync(5);
     }
-    ~WithAsyncMethod_DomainGet() override {
+    ~WithAsyncMethod_GetLatest() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status DomainGet(::grpc::ServerContext* /*context*/, const ::remote::DomainGetReq* /*request*/, ::remote::DomainGetReply* /*response*/) override {
+    ::grpc::Status GetLatest(::grpc::ServerContext* /*context*/, const ::remote::GetLatestReq* /*request*/, ::remote::GetLatestReply* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    void RequestDomainGet(::grpc::ServerContext* context, ::remote::DomainGetReq* request, ::grpc::ServerAsyncResponseWriter< ::remote::DomainGetReply>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+    void RequestGetLatest(::grpc::ServerContext* context, ::remote::GetLatestReq* request, ::grpc::ServerAsyncResponseWriter< ::remote::GetLatestReply>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
       ::grpc::Service::RequestAsyncUnary(5, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
@@ -563,26 +563,26 @@ class KV final {
     }
   };
   template <class BaseClass>
-  class WithAsyncMethod_DomainRange : public BaseClass {
+  class WithAsyncMethod_RangeAsOf : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
-    WithAsyncMethod_DomainRange() {
+    WithAsyncMethod_RangeAsOf() {
       ::grpc::Service::MarkMethodAsync(9);
     }
-    ~WithAsyncMethod_DomainRange() override {
+    ~WithAsyncMethod_RangeAsOf() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status DomainRange(::grpc::ServerContext* /*context*/, const ::remote::DomainRangeReq* /*request*/, ::remote::Pairs* /*response*/) override {
+    ::grpc::Status RangeAsOf(::grpc::ServerContext* /*context*/, const ::remote::RangeAsOfReq* /*request*/, ::remote::Pairs* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    void RequestDomainRange(::grpc::ServerContext* context, ::remote::DomainRangeReq* request, ::grpc::ServerAsyncResponseWriter< ::remote::Pairs>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+    void RequestRangeAsOf(::grpc::ServerContext* context, ::remote::RangeAsOfReq* request, ::grpc::ServerAsyncResponseWriter< ::remote::Pairs>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
       ::grpc::Service::RequestAsyncUnary(9, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
-  typedef WithAsyncMethod_Version<WithAsyncMethod_Tx<WithAsyncMethod_StateChanges<WithAsyncMethod_Snapshots<WithAsyncMethod_Range<WithAsyncMethod_DomainGet<WithAsyncMethod_HistorySeek<WithAsyncMethod_IndexRange<WithAsyncMethod_HistoryRange<WithAsyncMethod_DomainRange<Service > > > > > > > > > > AsyncService;
+  typedef WithAsyncMethod_Version<WithAsyncMethod_Tx<WithAsyncMethod_StateChanges<WithAsyncMethod_Snapshots<WithAsyncMethod_Range<WithAsyncMethod_GetLatest<WithAsyncMethod_HistorySeek<WithAsyncMethod_IndexRange<WithAsyncMethod_HistoryRange<WithAsyncMethod_RangeAsOf<Service > > > > > > > > > > AsyncService;
   template <class BaseClass>
   class WithCallbackMethod_Version : public BaseClass {
    private:
@@ -710,31 +710,31 @@ class KV final {
       ::grpc::CallbackServerContext* /*context*/, const ::remote::RangeReq* /*request*/, ::remote::Pairs* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
-  class WithCallbackMethod_DomainGet : public BaseClass {
+  class WithCallbackMethod_GetLatest : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
-    WithCallbackMethod_DomainGet() {
+    WithCallbackMethod_GetLatest() {
       ::grpc::Service::MarkMethodCallback(5,
-          new ::grpc::internal::CallbackUnaryHandler< ::remote::DomainGetReq, ::remote::DomainGetReply>(
+          new ::grpc::internal::CallbackUnaryHandler< ::remote::GetLatestReq, ::remote::GetLatestReply>(
             [this](
-                   ::grpc::CallbackServerContext* context, const ::remote::DomainGetReq* request, ::remote::DomainGetReply* response) { return this->DomainGet(context, request, response); }));}
-    void SetMessageAllocatorFor_DomainGet(
-        ::grpc::MessageAllocator< ::remote::DomainGetReq, ::remote::DomainGetReply>* allocator) {
+                   ::grpc::CallbackServerContext* context, const ::remote::GetLatestReq* request, ::remote::GetLatestReply* response) { return this->GetLatest(context, request, response); }));}
+    void SetMessageAllocatorFor_GetLatest(
+        ::grpc::MessageAllocator< ::remote::GetLatestReq, ::remote::GetLatestReply>* allocator) {
       ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(5);
-      static_cast<::grpc::internal::CallbackUnaryHandler< ::remote::DomainGetReq, ::remote::DomainGetReply>*>(handler)
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::remote::GetLatestReq, ::remote::GetLatestReply>*>(handler)
               ->SetMessageAllocator(allocator);
     }
-    ~WithCallbackMethod_DomainGet() override {
+    ~WithCallbackMethod_GetLatest() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status DomainGet(::grpc::ServerContext* /*context*/, const ::remote::DomainGetReq* /*request*/, ::remote::DomainGetReply* /*response*/) override {
+    ::grpc::Status GetLatest(::grpc::ServerContext* /*context*/, const ::remote::GetLatestReq* /*request*/, ::remote::GetLatestReply* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    virtual ::grpc::ServerUnaryReactor* DomainGet(
-      ::grpc::CallbackServerContext* /*context*/, const ::remote::DomainGetReq* /*request*/, ::remote::DomainGetReply* /*response*/)  { return nullptr; }
+    virtual ::grpc::ServerUnaryReactor* GetLatest(
+      ::grpc::CallbackServerContext* /*context*/, const ::remote::GetLatestReq* /*request*/, ::remote::GetLatestReply* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
   class WithCallbackMethod_HistorySeek : public BaseClass {
@@ -818,33 +818,33 @@ class KV final {
       ::grpc::CallbackServerContext* /*context*/, const ::remote::HistoryRangeReq* /*request*/, ::remote::Pairs* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
-  class WithCallbackMethod_DomainRange : public BaseClass {
+  class WithCallbackMethod_RangeAsOf : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
-    WithCallbackMethod_DomainRange() {
+    WithCallbackMethod_RangeAsOf() {
       ::grpc::Service::MarkMethodCallback(9,
-          new ::grpc::internal::CallbackUnaryHandler< ::remote::DomainRangeReq, ::remote::Pairs>(
+          new ::grpc::internal::CallbackUnaryHandler< ::remote::RangeAsOfReq, ::remote::Pairs>(
             [this](
-                   ::grpc::CallbackServerContext* context, const ::remote::DomainRangeReq* request, ::remote::Pairs* response) { return this->DomainRange(context, request, response); }));}
-    void SetMessageAllocatorFor_DomainRange(
-        ::grpc::MessageAllocator< ::remote::DomainRangeReq, ::remote::Pairs>* allocator) {
+                   ::grpc::CallbackServerContext* context, const ::remote::RangeAsOfReq* request, ::remote::Pairs* response) { return this->RangeAsOf(context, request, response); }));}
+    void SetMessageAllocatorFor_RangeAsOf(
+        ::grpc::MessageAllocator< ::remote::RangeAsOfReq, ::remote::Pairs>* allocator) {
       ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(9);
-      static_cast<::grpc::internal::CallbackUnaryHandler< ::remote::DomainRangeReq, ::remote::Pairs>*>(handler)
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::remote::RangeAsOfReq, ::remote::Pairs>*>(handler)
               ->SetMessageAllocator(allocator);
     }
-    ~WithCallbackMethod_DomainRange() override {
+    ~WithCallbackMethod_RangeAsOf() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status DomainRange(::grpc::ServerContext* /*context*/, const ::remote::DomainRangeReq* /*request*/, ::remote::Pairs* /*response*/) override {
+    ::grpc::Status RangeAsOf(::grpc::ServerContext* /*context*/, const ::remote::RangeAsOfReq* /*request*/, ::remote::Pairs* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    virtual ::grpc::ServerUnaryReactor* DomainRange(
-      ::grpc::CallbackServerContext* /*context*/, const ::remote::DomainRangeReq* /*request*/, ::remote::Pairs* /*response*/)  { return nullptr; }
+    virtual ::grpc::ServerUnaryReactor* RangeAsOf(
+      ::grpc::CallbackServerContext* /*context*/, const ::remote::RangeAsOfReq* /*request*/, ::remote::Pairs* /*response*/)  { return nullptr; }
   };
-  typedef WithCallbackMethod_Version<WithCallbackMethod_Tx<WithCallbackMethod_StateChanges<WithCallbackMethod_Snapshots<WithCallbackMethod_Range<WithCallbackMethod_DomainGet<WithCallbackMethod_HistorySeek<WithCallbackMethod_IndexRange<WithCallbackMethod_HistoryRange<WithCallbackMethod_DomainRange<Service > > > > > > > > > > CallbackService;
+  typedef WithCallbackMethod_Version<WithCallbackMethod_Tx<WithCallbackMethod_StateChanges<WithCallbackMethod_Snapshots<WithCallbackMethod_Range<WithCallbackMethod_GetLatest<WithCallbackMethod_HistorySeek<WithCallbackMethod_IndexRange<WithCallbackMethod_HistoryRange<WithCallbackMethod_RangeAsOf<Service > > > > > > > > > > CallbackService;
   typedef CallbackService ExperimentalCallbackService;
   template <class BaseClass>
   class WithGenericMethod_Version : public BaseClass {
@@ -932,18 +932,18 @@ class KV final {
     }
   };
   template <class BaseClass>
-  class WithGenericMethod_DomainGet : public BaseClass {
+  class WithGenericMethod_GetLatest : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
-    WithGenericMethod_DomainGet() {
+    WithGenericMethod_GetLatest() {
       ::grpc::Service::MarkMethodGeneric(5);
     }
-    ~WithGenericMethod_DomainGet() override {
+    ~WithGenericMethod_GetLatest() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status DomainGet(::grpc::ServerContext* /*context*/, const ::remote::DomainGetReq* /*request*/, ::remote::DomainGetReply* /*response*/) override {
+    ::grpc::Status GetLatest(::grpc::ServerContext* /*context*/, const ::remote::GetLatestReq* /*request*/, ::remote::GetLatestReply* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
@@ -1000,18 +1000,18 @@ class KV final {
     }
   };
   template <class BaseClass>
-  class WithGenericMethod_DomainRange : public BaseClass {
+  class WithGenericMethod_RangeAsOf : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
-    WithGenericMethod_DomainRange() {
+    WithGenericMethod_RangeAsOf() {
       ::grpc::Service::MarkMethodGeneric(9);
     }
-    ~WithGenericMethod_DomainRange() override {
+    ~WithGenericMethod_RangeAsOf() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status DomainRange(::grpc::ServerContext* /*context*/, const ::remote::DomainRangeReq* /*request*/, ::remote::Pairs* /*response*/) override {
+    ::grpc::Status RangeAsOf(::grpc::ServerContext* /*context*/, const ::remote::RangeAsOfReq* /*request*/, ::remote::Pairs* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
@@ -1117,22 +1117,22 @@ class KV final {
     }
   };
   template <class BaseClass>
-  class WithRawMethod_DomainGet : public BaseClass {
+  class WithRawMethod_GetLatest : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
-    WithRawMethod_DomainGet() {
+    WithRawMethod_GetLatest() {
       ::grpc::Service::MarkMethodRaw(5);
     }
-    ~WithRawMethod_DomainGet() override {
+    ~WithRawMethod_GetLatest() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status DomainGet(::grpc::ServerContext* /*context*/, const ::remote::DomainGetReq* /*request*/, ::remote::DomainGetReply* /*response*/) override {
+    ::grpc::Status GetLatest(::grpc::ServerContext* /*context*/, const ::remote::GetLatestReq* /*request*/, ::remote::GetLatestReply* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    void RequestDomainGet(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+    void RequestGetLatest(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
       ::grpc::Service::RequestAsyncUnary(5, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
@@ -1197,22 +1197,22 @@ class KV final {
     }
   };
   template <class BaseClass>
-  class WithRawMethod_DomainRange : public BaseClass {
+  class WithRawMethod_RangeAsOf : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
-    WithRawMethod_DomainRange() {
+    WithRawMethod_RangeAsOf() {
       ::grpc::Service::MarkMethodRaw(9);
     }
-    ~WithRawMethod_DomainRange() override {
+    ~WithRawMethod_RangeAsOf() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status DomainRange(::grpc::ServerContext* /*context*/, const ::remote::DomainRangeReq* /*request*/, ::remote::Pairs* /*response*/) override {
+    ::grpc::Status RangeAsOf(::grpc::ServerContext* /*context*/, const ::remote::RangeAsOfReq* /*request*/, ::remote::Pairs* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    void RequestDomainRange(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+    void RequestRangeAsOf(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
       ::grpc::Service::RequestAsyncUnary(9, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
@@ -1328,25 +1328,25 @@ class KV final {
       ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
-  class WithRawCallbackMethod_DomainGet : public BaseClass {
+  class WithRawCallbackMethod_GetLatest : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
-    WithRawCallbackMethod_DomainGet() {
+    WithRawCallbackMethod_GetLatest() {
       ::grpc::Service::MarkMethodRawCallback(5,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
-                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->DomainGet(context, request, response); }));
+                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->GetLatest(context, request, response); }));
     }
-    ~WithRawCallbackMethod_DomainGet() override {
+    ~WithRawCallbackMethod_GetLatest() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status DomainGet(::grpc::ServerContext* /*context*/, const ::remote::DomainGetReq* /*request*/, ::remote::DomainGetReply* /*response*/) override {
+    ::grpc::Status GetLatest(::grpc::ServerContext* /*context*/, const ::remote::GetLatestReq* /*request*/, ::remote::GetLatestReply* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    virtual ::grpc::ServerUnaryReactor* DomainGet(
+    virtual ::grpc::ServerUnaryReactor* GetLatest(
       ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
@@ -1416,25 +1416,25 @@ class KV final {
       ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
-  class WithRawCallbackMethod_DomainRange : public BaseClass {
+  class WithRawCallbackMethod_RangeAsOf : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
-    WithRawCallbackMethod_DomainRange() {
+    WithRawCallbackMethod_RangeAsOf() {
       ::grpc::Service::MarkMethodRawCallback(9,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
-                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->DomainRange(context, request, response); }));
+                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->RangeAsOf(context, request, response); }));
     }
-    ~WithRawCallbackMethod_DomainRange() override {
+    ~WithRawCallbackMethod_RangeAsOf() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status DomainRange(::grpc::ServerContext* /*context*/, const ::remote::DomainRangeReq* /*request*/, ::remote::Pairs* /*response*/) override {
+    ::grpc::Status RangeAsOf(::grpc::ServerContext* /*context*/, const ::remote::RangeAsOfReq* /*request*/, ::remote::Pairs* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    virtual ::grpc::ServerUnaryReactor* DomainRange(
+    virtual ::grpc::ServerUnaryReactor* RangeAsOf(
       ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
@@ -1519,31 +1519,31 @@ class KV final {
     virtual ::grpc::Status StreamedRange(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::remote::RangeReq,::remote::Pairs>* server_unary_streamer) = 0;
   };
   template <class BaseClass>
-  class WithStreamedUnaryMethod_DomainGet : public BaseClass {
+  class WithStreamedUnaryMethod_GetLatest : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
-    WithStreamedUnaryMethod_DomainGet() {
+    WithStreamedUnaryMethod_GetLatest() {
       ::grpc::Service::MarkMethodStreamed(5,
         new ::grpc::internal::StreamedUnaryHandler<
-          ::remote::DomainGetReq, ::remote::DomainGetReply>(
+          ::remote::GetLatestReq, ::remote::GetLatestReply>(
             [this](::grpc::ServerContext* context,
                    ::grpc::ServerUnaryStreamer<
-                     ::remote::DomainGetReq, ::remote::DomainGetReply>* streamer) {
-                       return this->StreamedDomainGet(context,
+                     ::remote::GetLatestReq, ::remote::GetLatestReply>* streamer) {
+                       return this->StreamedGetLatest(context,
                          streamer);
                   }));
     }
-    ~WithStreamedUnaryMethod_DomainGet() override {
+    ~WithStreamedUnaryMethod_GetLatest() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable regular version of this method
-    ::grpc::Status DomainGet(::grpc::ServerContext* /*context*/, const ::remote::DomainGetReq* /*request*/, ::remote::DomainGetReply* /*response*/) override {
+    ::grpc::Status GetLatest(::grpc::ServerContext* /*context*/, const ::remote::GetLatestReq* /*request*/, ::remote::GetLatestReply* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     // replace default version of method with streamed unary
-    virtual ::grpc::Status StreamedDomainGet(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::remote::DomainGetReq,::remote::DomainGetReply>* server_unary_streamer) = 0;
+    virtual ::grpc::Status StreamedGetLatest(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::remote::GetLatestReq,::remote::GetLatestReply>* server_unary_streamer) = 0;
   };
   template <class BaseClass>
   class WithStreamedUnaryMethod_HistorySeek : public BaseClass {
@@ -1627,33 +1627,33 @@ class KV final {
     virtual ::grpc::Status StreamedHistoryRange(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::remote::HistoryRangeReq,::remote::Pairs>* server_unary_streamer) = 0;
   };
   template <class BaseClass>
-  class WithStreamedUnaryMethod_DomainRange : public BaseClass {
+  class WithStreamedUnaryMethod_RangeAsOf : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
-    WithStreamedUnaryMethod_DomainRange() {
+    WithStreamedUnaryMethod_RangeAsOf() {
       ::grpc::Service::MarkMethodStreamed(9,
         new ::grpc::internal::StreamedUnaryHandler<
-          ::remote::DomainRangeReq, ::remote::Pairs>(
+          ::remote::RangeAsOfReq, ::remote::Pairs>(
             [this](::grpc::ServerContext* context,
                    ::grpc::ServerUnaryStreamer<
-                     ::remote::DomainRangeReq, ::remote::Pairs>* streamer) {
-                       return this->StreamedDomainRange(context,
+                     ::remote::RangeAsOfReq, ::remote::Pairs>* streamer) {
+                       return this->StreamedRangeAsOf(context,
                          streamer);
                   }));
     }
-    ~WithStreamedUnaryMethod_DomainRange() override {
+    ~WithStreamedUnaryMethod_RangeAsOf() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable regular version of this method
-    ::grpc::Status DomainRange(::grpc::ServerContext* /*context*/, const ::remote::DomainRangeReq* /*request*/, ::remote::Pairs* /*response*/) override {
+    ::grpc::Status RangeAsOf(::grpc::ServerContext* /*context*/, const ::remote::RangeAsOfReq* /*request*/, ::remote::Pairs* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     // replace default version of method with streamed unary
-    virtual ::grpc::Status StreamedDomainRange(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::remote::DomainRangeReq,::remote::Pairs>* server_unary_streamer) = 0;
+    virtual ::grpc::Status StreamedRangeAsOf(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::remote::RangeAsOfReq,::remote::Pairs>* server_unary_streamer) = 0;
   };
-  typedef WithStreamedUnaryMethod_Version<WithStreamedUnaryMethod_Snapshots<WithStreamedUnaryMethod_Range<WithStreamedUnaryMethod_DomainGet<WithStreamedUnaryMethod_HistorySeek<WithStreamedUnaryMethod_IndexRange<WithStreamedUnaryMethod_HistoryRange<WithStreamedUnaryMethod_DomainRange<Service > > > > > > > > StreamedUnaryService;
+  typedef WithStreamedUnaryMethod_Version<WithStreamedUnaryMethod_Snapshots<WithStreamedUnaryMethod_Range<WithStreamedUnaryMethod_GetLatest<WithStreamedUnaryMethod_HistorySeek<WithStreamedUnaryMethod_IndexRange<WithStreamedUnaryMethod_HistoryRange<WithStreamedUnaryMethod_RangeAsOf<Service > > > > > > > > StreamedUnaryService;
   template <class BaseClass>
   class WithSplitStreamingMethod_StateChanges : public BaseClass {
    private:
@@ -1682,7 +1682,7 @@ class KV final {
     virtual ::grpc::Status StreamedStateChanges(::grpc::ServerContext* context, ::grpc::ServerSplitStreamer< ::remote::StateChangeRequest,::remote::StateChangeBatch>* server_split_streamer) = 0;
   };
   typedef WithSplitStreamingMethod_StateChanges<Service > SplitStreamedService;
-  typedef WithStreamedUnaryMethod_Version<WithSplitStreamingMethod_StateChanges<WithStreamedUnaryMethod_Snapshots<WithStreamedUnaryMethod_Range<WithStreamedUnaryMethod_DomainGet<WithStreamedUnaryMethod_HistorySeek<WithStreamedUnaryMethod_IndexRange<WithStreamedUnaryMethod_HistoryRange<WithStreamedUnaryMethod_DomainRange<Service > > > > > > > > > StreamedService;
+  typedef WithStreamedUnaryMethod_Version<WithSplitStreamingMethod_StateChanges<WithStreamedUnaryMethod_Snapshots<WithStreamedUnaryMethod_Range<WithStreamedUnaryMethod_GetLatest<WithStreamedUnaryMethod_HistorySeek<WithStreamedUnaryMethod_IndexRange<WithStreamedUnaryMethod_HistoryRange<WithStreamedUnaryMethod_RangeAsOf<Service > > > > > > > > > StreamedService;
 };
 
 }  // namespace remote

--- a/silkworm/interfaces/3.21.12/remote/kv.pb.cc
+++ b/silkworm/interfaces/3.21.12/remote/kv.pb.cc
@@ -181,7 +181,7 @@ struct RangeReqDefaultTypeInternal {
   };
 };
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 RangeReqDefaultTypeInternal _RangeReq_default_instance_;
-PROTOBUF_CONSTEXPR DomainGetReq::DomainGetReq(
+PROTOBUF_CONSTEXPR GetLatestReq::GetLatestReq(
     ::_pbi::ConstantInitialized): _impl_{
     /*decltype(_impl_.table_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
   , /*decltype(_impl_.k_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
@@ -190,29 +190,29 @@ PROTOBUF_CONSTEXPR DomainGetReq::DomainGetReq(
   , /*decltype(_impl_.ts_)*/uint64_t{0u}
   , /*decltype(_impl_.latest_)*/false
   , /*decltype(_impl_._cached_size_)*/{}} {}
-struct DomainGetReqDefaultTypeInternal {
-  PROTOBUF_CONSTEXPR DomainGetReqDefaultTypeInternal()
+struct GetLatestReqDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR GetLatestReqDefaultTypeInternal()
       : _instance(::_pbi::ConstantInitialized{}) {}
-  ~DomainGetReqDefaultTypeInternal() {}
+  ~GetLatestReqDefaultTypeInternal() {}
   union {
-    DomainGetReq _instance;
+    GetLatestReq _instance;
   };
 };
-PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 DomainGetReqDefaultTypeInternal _DomainGetReq_default_instance_;
-PROTOBUF_CONSTEXPR DomainGetReply::DomainGetReply(
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 GetLatestReqDefaultTypeInternal _GetLatestReq_default_instance_;
+PROTOBUF_CONSTEXPR GetLatestReply::GetLatestReply(
     ::_pbi::ConstantInitialized): _impl_{
     /*decltype(_impl_.v_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
   , /*decltype(_impl_.ok_)*/false
   , /*decltype(_impl_._cached_size_)*/{}} {}
-struct DomainGetReplyDefaultTypeInternal {
-  PROTOBUF_CONSTEXPR DomainGetReplyDefaultTypeInternal()
+struct GetLatestReplyDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR GetLatestReplyDefaultTypeInternal()
       : _instance(::_pbi::ConstantInitialized{}) {}
-  ~DomainGetReplyDefaultTypeInternal() {}
+  ~GetLatestReplyDefaultTypeInternal() {}
   union {
-    DomainGetReply _instance;
+    GetLatestReply _instance;
   };
 };
-PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 DomainGetReplyDefaultTypeInternal _DomainGetReply_default_instance_;
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 GetLatestReplyDefaultTypeInternal _GetLatestReply_default_instance_;
 PROTOBUF_CONSTEXPR HistorySeekReq::HistorySeekReq(
     ::_pbi::ConstantInitialized): _impl_{
     /*decltype(_impl_.table_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
@@ -299,7 +299,7 @@ struct HistoryRangeReqDefaultTypeInternal {
   };
 };
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 HistoryRangeReqDefaultTypeInternal _HistoryRangeReq_default_instance_;
-PROTOBUF_CONSTEXPR DomainRangeReq::DomainRangeReq(
+PROTOBUF_CONSTEXPR RangeAsOfReq::RangeAsOfReq(
     ::_pbi::ConstantInitialized): _impl_{
     /*decltype(_impl_.table_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
   , /*decltype(_impl_.from_key_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
@@ -312,15 +312,15 @@ PROTOBUF_CONSTEXPR DomainRangeReq::DomainRangeReq(
   , /*decltype(_impl_.page_size_)*/0
   , /*decltype(_impl_.limit_)*/int64_t{0}
   , /*decltype(_impl_._cached_size_)*/{}} {}
-struct DomainRangeReqDefaultTypeInternal {
-  PROTOBUF_CONSTEXPR DomainRangeReqDefaultTypeInternal()
+struct RangeAsOfReqDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR RangeAsOfReqDefaultTypeInternal()
       : _instance(::_pbi::ConstantInitialized{}) {}
-  ~DomainRangeReqDefaultTypeInternal() {}
+  ~RangeAsOfReqDefaultTypeInternal() {}
   union {
-    DomainRangeReq _instance;
+    RangeAsOfReq _instance;
   };
 };
-PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 DomainRangeReqDefaultTypeInternal _DomainRangeReq_default_instance_;
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 RangeAsOfReqDefaultTypeInternal _RangeAsOfReq_default_instance_;
 PROTOBUF_CONSTEXPR Pairs::Pairs(
     ::_pbi::ConstantInitialized): _impl_{
     /*decltype(_impl_.keys_)*/{}
@@ -472,25 +472,25 @@ const uint32_t TableStruct_remote_2fkv_2eproto::offsets[] PROTOBUF_SECTION_VARIA
   PROTOBUF_FIELD_OFFSET(::remote::RangeReq, _impl_.page_size_),
   PROTOBUF_FIELD_OFFSET(::remote::RangeReq, _impl_.page_token_),
   ~0u,  // no _has_bits_
-  PROTOBUF_FIELD_OFFSET(::remote::DomainGetReq, _internal_metadata_),
+  PROTOBUF_FIELD_OFFSET(::remote::GetLatestReq, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
   ~0u,  // no _inlined_string_donated_
-  PROTOBUF_FIELD_OFFSET(::remote::DomainGetReq, _impl_.tx_id_),
-  PROTOBUF_FIELD_OFFSET(::remote::DomainGetReq, _impl_.table_),
-  PROTOBUF_FIELD_OFFSET(::remote::DomainGetReq, _impl_.k_),
-  PROTOBUF_FIELD_OFFSET(::remote::DomainGetReq, _impl_.ts_),
-  PROTOBUF_FIELD_OFFSET(::remote::DomainGetReq, _impl_.k2_),
-  PROTOBUF_FIELD_OFFSET(::remote::DomainGetReq, _impl_.latest_),
+  PROTOBUF_FIELD_OFFSET(::remote::GetLatestReq, _impl_.tx_id_),
+  PROTOBUF_FIELD_OFFSET(::remote::GetLatestReq, _impl_.table_),
+  PROTOBUF_FIELD_OFFSET(::remote::GetLatestReq, _impl_.k_),
+  PROTOBUF_FIELD_OFFSET(::remote::GetLatestReq, _impl_.ts_),
+  PROTOBUF_FIELD_OFFSET(::remote::GetLatestReq, _impl_.k2_),
+  PROTOBUF_FIELD_OFFSET(::remote::GetLatestReq, _impl_.latest_),
   ~0u,  // no _has_bits_
-  PROTOBUF_FIELD_OFFSET(::remote::DomainGetReply, _internal_metadata_),
+  PROTOBUF_FIELD_OFFSET(::remote::GetLatestReply, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
   ~0u,  // no _inlined_string_donated_
-  PROTOBUF_FIELD_OFFSET(::remote::DomainGetReply, _impl_.v_),
-  PROTOBUF_FIELD_OFFSET(::remote::DomainGetReply, _impl_.ok_),
+  PROTOBUF_FIELD_OFFSET(::remote::GetLatestReply, _impl_.v_),
+  PROTOBUF_FIELD_OFFSET(::remote::GetLatestReply, _impl_.ok_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::remote::HistorySeekReq, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -547,21 +547,21 @@ const uint32_t TableStruct_remote_2fkv_2eproto::offsets[] PROTOBUF_SECTION_VARIA
   PROTOBUF_FIELD_OFFSET(::remote::HistoryRangeReq, _impl_.page_size_),
   PROTOBUF_FIELD_OFFSET(::remote::HistoryRangeReq, _impl_.page_token_),
   ~0u,  // no _has_bits_
-  PROTOBUF_FIELD_OFFSET(::remote::DomainRangeReq, _internal_metadata_),
+  PROTOBUF_FIELD_OFFSET(::remote::RangeAsOfReq, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
   ~0u,  // no _inlined_string_donated_
-  PROTOBUF_FIELD_OFFSET(::remote::DomainRangeReq, _impl_.tx_id_),
-  PROTOBUF_FIELD_OFFSET(::remote::DomainRangeReq, _impl_.table_),
-  PROTOBUF_FIELD_OFFSET(::remote::DomainRangeReq, _impl_.from_key_),
-  PROTOBUF_FIELD_OFFSET(::remote::DomainRangeReq, _impl_.to_key_),
-  PROTOBUF_FIELD_OFFSET(::remote::DomainRangeReq, _impl_.ts_),
-  PROTOBUF_FIELD_OFFSET(::remote::DomainRangeReq, _impl_.latest_),
-  PROTOBUF_FIELD_OFFSET(::remote::DomainRangeReq, _impl_.order_ascend_),
-  PROTOBUF_FIELD_OFFSET(::remote::DomainRangeReq, _impl_.limit_),
-  PROTOBUF_FIELD_OFFSET(::remote::DomainRangeReq, _impl_.page_size_),
-  PROTOBUF_FIELD_OFFSET(::remote::DomainRangeReq, _impl_.page_token_),
+  PROTOBUF_FIELD_OFFSET(::remote::RangeAsOfReq, _impl_.tx_id_),
+  PROTOBUF_FIELD_OFFSET(::remote::RangeAsOfReq, _impl_.table_),
+  PROTOBUF_FIELD_OFFSET(::remote::RangeAsOfReq, _impl_.from_key_),
+  PROTOBUF_FIELD_OFFSET(::remote::RangeAsOfReq, _impl_.to_key_),
+  PROTOBUF_FIELD_OFFSET(::remote::RangeAsOfReq, _impl_.ts_),
+  PROTOBUF_FIELD_OFFSET(::remote::RangeAsOfReq, _impl_.latest_),
+  PROTOBUF_FIELD_OFFSET(::remote::RangeAsOfReq, _impl_.order_ascend_),
+  PROTOBUF_FIELD_OFFSET(::remote::RangeAsOfReq, _impl_.limit_),
+  PROTOBUF_FIELD_OFFSET(::remote::RangeAsOfReq, _impl_.page_size_),
+  PROTOBUF_FIELD_OFFSET(::remote::RangeAsOfReq, _impl_.page_token_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::remote::Pairs, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -599,14 +599,14 @@ static const ::_pbi::MigrationSchema schemas[] PROTOBUF_SECTION_VARIABLE(protode
   { 73, -1, -1, sizeof(::remote::SnapshotsRequest)},
   { 79, -1, -1, sizeof(::remote::SnapshotsReply)},
   { 87, -1, -1, sizeof(::remote::RangeReq)},
-  { 101, -1, -1, sizeof(::remote::DomainGetReq)},
-  { 113, -1, -1, sizeof(::remote::DomainGetReply)},
+  { 101, -1, -1, sizeof(::remote::GetLatestReq)},
+  { 113, -1, -1, sizeof(::remote::GetLatestReply)},
   { 121, -1, -1, sizeof(::remote::HistorySeekReq)},
   { 131, -1, -1, sizeof(::remote::HistorySeekReply)},
   { 139, -1, -1, sizeof(::remote::IndexRangeReq)},
   { 154, -1, -1, sizeof(::remote::IndexRangeReply)},
   { 162, -1, -1, sizeof(::remote::HistoryRangeReq)},
-  { 176, -1, -1, sizeof(::remote::DomainRangeReq)},
+  { 176, -1, -1, sizeof(::remote::RangeAsOfReq)},
   { 192, -1, -1, sizeof(::remote::Pairs)},
   { 201, -1, -1, sizeof(::remote::PairsPagination)},
   { 209, -1, -1, sizeof(::remote::IndexPagination)},
@@ -623,14 +623,14 @@ static const ::_pb::Message* const file_default_instances[] = {
   &::remote::_SnapshotsRequest_default_instance_._instance,
   &::remote::_SnapshotsReply_default_instance_._instance,
   &::remote::_RangeReq_default_instance_._instance,
-  &::remote::_DomainGetReq_default_instance_._instance,
-  &::remote::_DomainGetReply_default_instance_._instance,
+  &::remote::_GetLatestReq_default_instance_._instance,
+  &::remote::_GetLatestReply_default_instance_._instance,
   &::remote::_HistorySeekReq_default_instance_._instance,
   &::remote::_HistorySeekReply_default_instance_._instance,
   &::remote::_IndexRangeReq_default_instance_._instance,
   &::remote::_IndexRangeReply_default_instance_._instance,
   &::remote::_HistoryRangeReq_default_instance_._instance,
-  &::remote::_DomainRangeReq_default_instance_._instance,
+  &::remote::_RangeAsOfReq_default_instance_._instance,
   &::remote::_Pairs_default_instance_._instance,
   &::remote::_PairsPagination_default_instance_._instance,
   &::remote::_IndexPagination_default_instance_._instance,
@@ -666,9 +666,9 @@ const char descriptor_table_protodef_remote_2fkv_2eproto[] PROTOBUF_SECTION_VARI
   "table\030\002 \001(\t\022\023\n\013from_prefix\030\003 \001(\014\022\021\n\tto_p"
   "refix\030\004 \001(\014\022\024\n\014order_ascend\030\005 \001(\010\022\r\n\005lim"
   "it\030\006 \001(\022\022\021\n\tpage_size\030\007 \001(\005\022\022\n\npage_toke"
-  "n\030\010 \001(\t\"_\n\014DomainGetReq\022\r\n\005tx_id\030\001 \001(\004\022\r"
+  "n\030\010 \001(\t\"_\n\014GetLatestReq\022\r\n\005tx_id\030\001 \001(\004\022\r"
   "\n\005table\030\002 \001(\t\022\t\n\001k\030\003 \001(\014\022\n\n\002ts\030\004 \001(\004\022\n\n\002"
-  "k2\030\005 \001(\014\022\016\n\006latest\030\006 \001(\010\"\'\n\016DomainGetRep"
+  "k2\030\005 \001(\014\022\016\n\006latest\030\006 \001(\010\"\'\n\016GetLatestRep"
   "ly\022\t\n\001v\030\001 \001(\014\022\n\n\002ok\030\002 \001(\010\"E\n\016HistorySeek"
   "Req\022\r\n\005tx_id\030\001 \001(\004\022\r\n\005table\030\002 \001(\t\022\t\n\001k\030\003"
   " \001(\014\022\n\n\002ts\030\004 \001(\004\")\n\020HistorySeekReply\022\t\n\001"
@@ -682,40 +682,40 @@ const char descriptor_table_protodef_remote_2fkv_2eproto[] PROTOBUF_SECTION_VARI
   "\001 \001(\004\022\r\n\005table\030\002 \001(\t\022\017\n\007from_ts\030\004 \001(\022\022\r\n"
   "\005to_ts\030\005 \001(\022\022\024\n\014order_ascend\030\006 \001(\010\022\r\n\005li"
   "mit\030\007 \001(\022\022\021\n\tpage_size\030\010 \001(\005\022\022\n\npage_tok"
-  "en\030\t \001(\t\"\270\001\n\016DomainRangeReq\022\r\n\005tx_id\030\001 \001"
-  "(\004\022\r\n\005table\030\002 \001(\t\022\020\n\010from_key\030\003 \001(\014\022\016\n\006t"
-  "o_key\030\004 \001(\014\022\n\n\002ts\030\005 \001(\004\022\016\n\006latest\030\006 \001(\010\022"
-  "\024\n\014order_ascend\030\007 \001(\010\022\r\n\005limit\030\010 \001(\022\022\021\n\t"
-  "page_size\030\t \001(\005\022\022\n\npage_token\030\n \001(\t\">\n\005P"
-  "airs\022\014\n\004keys\030\001 \003(\014\022\016\n\006values\030\002 \003(\014\022\027\n\017ne"
-  "xt_page_token\030\003 \001(\t\"2\n\017PairsPagination\022\020"
-  "\n\010next_key\030\001 \001(\014\022\r\n\005limit\030\002 \001(\022\"9\n\017Index"
-  "Pagination\022\027\n\017next_time_stamp\030\001 \001(\022\022\r\n\005l"
-  "imit\030\002 \001(\022*\373\001\n\002Op\022\t\n\005FIRST\020\000\022\r\n\tFIRST_DU"
-  "P\020\001\022\010\n\004SEEK\020\002\022\r\n\tSEEK_BOTH\020\003\022\013\n\007CURRENT\020"
-  "\004\022\010\n\004LAST\020\006\022\014\n\010LAST_DUP\020\007\022\010\n\004NEXT\020\010\022\014\n\010N"
-  "EXT_DUP\020\t\022\017\n\013NEXT_NO_DUP\020\013\022\010\n\004PREV\020\014\022\014\n\010"
-  "PREV_DUP\020\r\022\017\n\013PREV_NO_DUP\020\016\022\016\n\nSEEK_EXAC"
-  "T\020\017\022\023\n\017SEEK_BOTH_EXACT\020\020\022\010\n\004OPEN\020\036\022\t\n\005CL"
-  "OSE\020\037\022\021\n\rOPEN_DUP_SORT\020 *H\n\006Action\022\013\n\007ST"
-  "ORAGE\020\000\022\n\n\006UPSERT\020\001\022\010\n\004CODE\020\002\022\017\n\013UPSERT_"
-  "CODE\020\003\022\n\n\006REMOVE\020\004*$\n\tDirection\022\013\n\007FORWA"
-  "RD\020\000\022\n\n\006UNWIND\020\0012\275\004\n\002KV\0226\n\007Version\022\026.goo"
-  "gle.protobuf.Empty\032\023.types.VersionReply\022"
-  "&\n\002Tx\022\016.remote.Cursor\032\014.remote.Pair(\0010\001\022"
-  "F\n\014StateChanges\022\032.remote.StateChangeRequ"
-  "est\032\030.remote.StateChangeBatch0\001\022=\n\tSnaps"
-  "hots\022\030.remote.SnapshotsRequest\032\026.remote."
-  "SnapshotsReply\022(\n\005Range\022\020.remote.RangeRe"
-  "q\032\r.remote.Pairs\0229\n\tDomainGet\022\024.remote.D"
-  "omainGetReq\032\026.remote.DomainGetReply\022\?\n\013H"
-  "istorySeek\022\026.remote.HistorySeekReq\032\030.rem"
-  "ote.HistorySeekReply\022<\n\nIndexRange\022\025.rem"
-  "ote.IndexRangeReq\032\027.remote.IndexRangeRep"
-  "ly\0226\n\014HistoryRange\022\027.remote.HistoryRange"
-  "Req\032\r.remote.Pairs\0224\n\013DomainRange\022\026.remo"
-  "te.DomainRangeReq\032\r.remote.PairsB\026Z\024./re"
-  "mote;remoteprotob\006proto3"
+  "en\030\t \001(\t\"\266\001\n\014RangeAsOfReq\022\r\n\005tx_id\030\001 \001(\004"
+  "\022\r\n\005table\030\002 \001(\t\022\020\n\010from_key\030\003 \001(\014\022\016\n\006to_"
+  "key\030\004 \001(\014\022\n\n\002ts\030\005 \001(\004\022\016\n\006latest\030\006 \001(\010\022\024\n"
+  "\014order_ascend\030\007 \001(\010\022\r\n\005limit\030\010 \001(\022\022\021\n\tpa"
+  "ge_size\030\t \001(\005\022\022\n\npage_token\030\n \001(\t\">\n\005Pai"
+  "rs\022\014\n\004keys\030\001 \003(\014\022\016\n\006values\030\002 \003(\014\022\027\n\017next"
+  "_page_token\030\003 \001(\t\"2\n\017PairsPagination\022\020\n\010"
+  "next_key\030\001 \001(\014\022\r\n\005limit\030\002 \001(\022\"9\n\017IndexPa"
+  "gination\022\027\n\017next_time_stamp\030\001 \001(\022\022\r\n\005lim"
+  "it\030\002 \001(\022*\373\001\n\002Op\022\t\n\005FIRST\020\000\022\r\n\tFIRST_DUP\020"
+  "\001\022\010\n\004SEEK\020\002\022\r\n\tSEEK_BOTH\020\003\022\013\n\007CURRENT\020\004\022"
+  "\010\n\004LAST\020\006\022\014\n\010LAST_DUP\020\007\022\010\n\004NEXT\020\010\022\014\n\010NEX"
+  "T_DUP\020\t\022\017\n\013NEXT_NO_DUP\020\013\022\010\n\004PREV\020\014\022\014\n\010PR"
+  "EV_DUP\020\r\022\017\n\013PREV_NO_DUP\020\016\022\016\n\nSEEK_EXACT\020"
+  "\017\022\023\n\017SEEK_BOTH_EXACT\020\020\022\010\n\004OPEN\020\036\022\t\n\005CLOS"
+  "E\020\037\022\021\n\rOPEN_DUP_SORT\020 *H\n\006Action\022\013\n\007STOR"
+  "AGE\020\000\022\n\n\006UPSERT\020\001\022\010\n\004CODE\020\002\022\017\n\013UPSERT_CO"
+  "DE\020\003\022\n\n\006REMOVE\020\004*$\n\tDirection\022\013\n\007FORWARD"
+  "\020\000\022\n\n\006UNWIND\020\0012\271\004\n\002KV\0226\n\007Version\022\026.googl"
+  "e.protobuf.Empty\032\023.types.VersionReply\022&\n"
+  "\002Tx\022\016.remote.Cursor\032\014.remote.Pair(\0010\001\022F\n"
+  "\014StateChanges\022\032.remote.StateChangeReques"
+  "t\032\030.remote.StateChangeBatch0\001\022=\n\tSnapsho"
+  "ts\022\030.remote.SnapshotsRequest\032\026.remote.Sn"
+  "apshotsReply\022(\n\005Range\022\020.remote.RangeReq\032"
+  "\r.remote.Pairs\0229\n\tGetLatest\022\024.remote.Get"
+  "LatestReq\032\026.remote.GetLatestReply\022\?\n\013His"
+  "torySeek\022\026.remote.HistorySeekReq\032\030.remot"
+  "e.HistorySeekReply\022<\n\nIndexRange\022\025.remot"
+  "e.IndexRangeReq\032\027.remote.IndexRangeReply"
+  "\0226\n\014HistoryRange\022\027.remote.HistoryRangeRe"
+  "q\032\r.remote.Pairs\0220\n\tRangeAsOf\022\024.remote.R"
+  "angeAsOfReq\032\r.remote.PairsB\026Z\024./remote;r"
+  "emoteprotob\006proto3"
   ;
 static const ::_pbi::DescriptorTable* const descriptor_table_remote_2fkv_2eproto_deps[2] = {
   &::descriptor_table_google_2fprotobuf_2fempty_2eproto,
@@ -723,7 +723,7 @@ static const ::_pbi::DescriptorTable* const descriptor_table_remote_2fkv_2eproto
 };
 static ::_pbi::once_flag descriptor_table_remote_2fkv_2eproto_once;
 const ::_pbi::DescriptorTable descriptor_table_remote_2fkv_2eproto = {
-    false, false, 3144, descriptor_table_protodef_remote_2fkv_2eproto,
+    false, false, 3138, descriptor_table_protodef_remote_2fkv_2eproto,
     "remote/kv.proto",
     &descriptor_table_remote_2fkv_2eproto_once, descriptor_table_remote_2fkv_2eproto_deps, 2, 21,
     schemas, file_default_instances, TableStruct_remote_2fkv_2eproto::offsets,
@@ -3694,19 +3694,19 @@ void RangeReq::InternalSwap(RangeReq* other) {
 
 // ===================================================================
 
-class DomainGetReq::_Internal {
+class GetLatestReq::_Internal {
  public:
 };
 
-DomainGetReq::DomainGetReq(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+GetLatestReq::GetLatestReq(::PROTOBUF_NAMESPACE_ID::Arena* arena,
                          bool is_message_owned)
   : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
   SharedCtor(arena, is_message_owned);
-  // @@protoc_insertion_point(arena_constructor:remote.DomainGetReq)
+  // @@protoc_insertion_point(arena_constructor:remote.GetLatestReq)
 }
-DomainGetReq::DomainGetReq(const DomainGetReq& from)
+GetLatestReq::GetLatestReq(const GetLatestReq& from)
   : ::PROTOBUF_NAMESPACE_ID::Message() {
-  DomainGetReq* const _this = this; (void)_this;
+  GetLatestReq* const _this = this; (void)_this;
   new (&_impl_) Impl_{
       decltype(_impl_.table_){}
     , decltype(_impl_.k_){}
@@ -3744,10 +3744,10 @@ DomainGetReq::DomainGetReq(const DomainGetReq& from)
   ::memcpy(&_impl_.tx_id_, &from._impl_.tx_id_,
     static_cast<size_t>(reinterpret_cast<char*>(&_impl_.latest_) -
     reinterpret_cast<char*>(&_impl_.tx_id_)) + sizeof(_impl_.latest_));
-  // @@protoc_insertion_point(copy_constructor:remote.DomainGetReq)
+  // @@protoc_insertion_point(copy_constructor:remote.GetLatestReq)
 }
 
-inline void DomainGetReq::SharedCtor(
+inline void GetLatestReq::SharedCtor(
     ::_pb::Arena* arena, bool is_message_owned) {
   (void)arena;
   (void)is_message_owned;
@@ -3774,8 +3774,8 @@ inline void DomainGetReq::SharedCtor(
   #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
 }
 
-DomainGetReq::~DomainGetReq() {
-  // @@protoc_insertion_point(destructor:remote.DomainGetReq)
+GetLatestReq::~GetLatestReq() {
+  // @@protoc_insertion_point(destructor:remote.GetLatestReq)
   if (auto *arena = _internal_metadata_.DeleteReturnArena<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>()) {
   (void)arena;
     return;
@@ -3783,19 +3783,19 @@ DomainGetReq::~DomainGetReq() {
   SharedDtor();
 }
 
-inline void DomainGetReq::SharedDtor() {
+inline void GetLatestReq::SharedDtor() {
   GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
   _impl_.table_.Destroy();
   _impl_.k_.Destroy();
   _impl_.k2_.Destroy();
 }
 
-void DomainGetReq::SetCachedSize(int size) const {
+void GetLatestReq::SetCachedSize(int size) const {
   _impl_._cached_size_.Set(size);
 }
 
-void DomainGetReq::Clear() {
-// @@protoc_insertion_point(message_clear_start:remote.DomainGetReq)
+void GetLatestReq::Clear() {
+// @@protoc_insertion_point(message_clear_start:remote.GetLatestReq)
   uint32_t cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
@@ -3809,7 +3809,7 @@ void DomainGetReq::Clear() {
   _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
-const char* DomainGetReq::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
+const char* GetLatestReq::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
 #define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
   while (!ctx->Done(&ptr)) {
     uint32_t tag;
@@ -3829,7 +3829,7 @@ const char* DomainGetReq::_InternalParse(const char* ptr, ::_pbi::ParseContext* 
           auto str = _internal_mutable_table();
           ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
           CHK_(ptr);
-          CHK_(::_pbi::VerifyUTF8(str, "remote.DomainGetReq.table"));
+          CHK_(::_pbi::VerifyUTF8(str, "remote.GetLatestReq.table"));
         } else
           goto handle_unusual;
         continue;
@@ -3890,9 +3890,9 @@ failure:
 #undef CHK_
 }
 
-uint8_t* DomainGetReq::_InternalSerialize(
+uint8_t* GetLatestReq::_InternalSerialize(
     uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
-  // @@protoc_insertion_point(serialize_to_array_start:remote.DomainGetReq)
+  // @@protoc_insertion_point(serialize_to_array_start:remote.GetLatestReq)
   uint32_t cached_has_bits = 0;
   (void) cached_has_bits;
 
@@ -3907,7 +3907,7 @@ uint8_t* DomainGetReq::_InternalSerialize(
     ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
       this->_internal_table().data(), static_cast<int>(this->_internal_table().length()),
       ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
-      "remote.DomainGetReq.table");
+      "remote.GetLatestReq.table");
     target = stream->WriteStringMaybeAliased(
         2, this->_internal_table(), target);
   }
@@ -3940,12 +3940,12 @@ uint8_t* DomainGetReq::_InternalSerialize(
     target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
         _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
   }
-  // @@protoc_insertion_point(serialize_to_array_end:remote.DomainGetReq)
+  // @@protoc_insertion_point(serialize_to_array_end:remote.GetLatestReq)
   return target;
 }
 
-size_t DomainGetReq::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:remote.DomainGetReq)
+size_t GetLatestReq::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:remote.GetLatestReq)
   size_t total_size = 0;
 
   uint32_t cached_has_bits = 0;
@@ -3991,17 +3991,17 @@ size_t DomainGetReq::ByteSizeLong() const {
   return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
 }
 
-const ::PROTOBUF_NAMESPACE_ID::Message::ClassData DomainGetReq::_class_data_ = {
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData GetLatestReq::_class_data_ = {
     ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSourceCheck,
-    DomainGetReq::MergeImpl
+    GetLatestReq::MergeImpl
 };
-const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*DomainGetReq::GetClassData() const { return &_class_data_; }
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetLatestReq::GetClassData() const { return &_class_data_; }
 
 
-void DomainGetReq::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg) {
-  auto* const _this = static_cast<DomainGetReq*>(&to_msg);
-  auto& from = static_cast<const DomainGetReq&>(from_msg);
-  // @@protoc_insertion_point(class_specific_merge_from_start:remote.DomainGetReq)
+void GetLatestReq::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg) {
+  auto* const _this = static_cast<GetLatestReq*>(&to_msg);
+  auto& from = static_cast<const GetLatestReq&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:remote.GetLatestReq)
   GOOGLE_DCHECK_NE(&from, _this);
   uint32_t cached_has_bits = 0;
   (void) cached_has_bits;
@@ -4027,18 +4027,18 @@ void DomainGetReq::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::P
   _this->_internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
 }
 
-void DomainGetReq::CopyFrom(const DomainGetReq& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:remote.DomainGetReq)
+void GetLatestReq::CopyFrom(const GetLatestReq& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:remote.GetLatestReq)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
-bool DomainGetReq::IsInitialized() const {
+bool GetLatestReq::IsInitialized() const {
   return true;
 }
 
-void DomainGetReq::InternalSwap(DomainGetReq* other) {
+void GetLatestReq::InternalSwap(GetLatestReq* other) {
   using std::swap;
   auto* lhs_arena = GetArenaForAllocation();
   auto* rhs_arena = other->GetArenaForAllocation();
@@ -4056,14 +4056,14 @@ void DomainGetReq::InternalSwap(DomainGetReq* other) {
       &other->_impl_.k2_, rhs_arena
   );
   ::PROTOBUF_NAMESPACE_ID::internal::memswap<
-      PROTOBUF_FIELD_OFFSET(DomainGetReq, _impl_.latest_)
-      + sizeof(DomainGetReq::_impl_.latest_)
-      - PROTOBUF_FIELD_OFFSET(DomainGetReq, _impl_.tx_id_)>(
+      PROTOBUF_FIELD_OFFSET(GetLatestReq, _impl_.latest_)
+      + sizeof(GetLatestReq::_impl_.latest_)
+      - PROTOBUF_FIELD_OFFSET(GetLatestReq, _impl_.tx_id_)>(
           reinterpret_cast<char*>(&_impl_.tx_id_),
           reinterpret_cast<char*>(&other->_impl_.tx_id_));
 }
 
-::PROTOBUF_NAMESPACE_ID::Metadata DomainGetReq::GetMetadata() const {
+::PROTOBUF_NAMESPACE_ID::Metadata GetLatestReq::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_remote_2fkv_2eproto_getter, &descriptor_table_remote_2fkv_2eproto_once,
       file_level_metadata_remote_2fkv_2eproto[10]);
@@ -4071,19 +4071,19 @@ void DomainGetReq::InternalSwap(DomainGetReq* other) {
 
 // ===================================================================
 
-class DomainGetReply::_Internal {
+class GetLatestReply::_Internal {
  public:
 };
 
-DomainGetReply::DomainGetReply(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+GetLatestReply::GetLatestReply(::PROTOBUF_NAMESPACE_ID::Arena* arena,
                          bool is_message_owned)
   : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
   SharedCtor(arena, is_message_owned);
-  // @@protoc_insertion_point(arena_constructor:remote.DomainGetReply)
+  // @@protoc_insertion_point(arena_constructor:remote.GetLatestReply)
 }
-DomainGetReply::DomainGetReply(const DomainGetReply& from)
+GetLatestReply::GetLatestReply(const GetLatestReply& from)
   : ::PROTOBUF_NAMESPACE_ID::Message() {
-  DomainGetReply* const _this = this; (void)_this;
+  GetLatestReply* const _this = this; (void)_this;
   new (&_impl_) Impl_{
       decltype(_impl_.v_){}
     , decltype(_impl_.ok_){}
@@ -4099,10 +4099,10 @@ DomainGetReply::DomainGetReply(const DomainGetReply& from)
       _this->GetArenaForAllocation());
   }
   _this->_impl_.ok_ = from._impl_.ok_;
-  // @@protoc_insertion_point(copy_constructor:remote.DomainGetReply)
+  // @@protoc_insertion_point(copy_constructor:remote.GetLatestReply)
 }
 
-inline void DomainGetReply::SharedCtor(
+inline void GetLatestReply::SharedCtor(
     ::_pb::Arena* arena, bool is_message_owned) {
   (void)arena;
   (void)is_message_owned;
@@ -4117,8 +4117,8 @@ inline void DomainGetReply::SharedCtor(
   #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
 }
 
-DomainGetReply::~DomainGetReply() {
-  // @@protoc_insertion_point(destructor:remote.DomainGetReply)
+GetLatestReply::~GetLatestReply() {
+  // @@protoc_insertion_point(destructor:remote.GetLatestReply)
   if (auto *arena = _internal_metadata_.DeleteReturnArena<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>()) {
   (void)arena;
     return;
@@ -4126,17 +4126,17 @@ DomainGetReply::~DomainGetReply() {
   SharedDtor();
 }
 
-inline void DomainGetReply::SharedDtor() {
+inline void GetLatestReply::SharedDtor() {
   GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
   _impl_.v_.Destroy();
 }
 
-void DomainGetReply::SetCachedSize(int size) const {
+void GetLatestReply::SetCachedSize(int size) const {
   _impl_._cached_size_.Set(size);
 }
 
-void DomainGetReply::Clear() {
-// @@protoc_insertion_point(message_clear_start:remote.DomainGetReply)
+void GetLatestReply::Clear() {
+// @@protoc_insertion_point(message_clear_start:remote.GetLatestReply)
   uint32_t cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
@@ -4146,7 +4146,7 @@ void DomainGetReply::Clear() {
   _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
-const char* DomainGetReply::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
+const char* GetLatestReply::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
 #define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
   while (!ctx->Done(&ptr)) {
     uint32_t tag;
@@ -4192,9 +4192,9 @@ failure:
 #undef CHK_
 }
 
-uint8_t* DomainGetReply::_InternalSerialize(
+uint8_t* GetLatestReply::_InternalSerialize(
     uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
-  // @@protoc_insertion_point(serialize_to_array_start:remote.DomainGetReply)
+  // @@protoc_insertion_point(serialize_to_array_start:remote.GetLatestReply)
   uint32_t cached_has_bits = 0;
   (void) cached_has_bits;
 
@@ -4214,12 +4214,12 @@ uint8_t* DomainGetReply::_InternalSerialize(
     target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
         _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
   }
-  // @@protoc_insertion_point(serialize_to_array_end:remote.DomainGetReply)
+  // @@protoc_insertion_point(serialize_to_array_end:remote.GetLatestReply)
   return target;
 }
 
-size_t DomainGetReply::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:remote.DomainGetReply)
+size_t GetLatestReply::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:remote.GetLatestReply)
   size_t total_size = 0;
 
   uint32_t cached_has_bits = 0;
@@ -4241,17 +4241,17 @@ size_t DomainGetReply::ByteSizeLong() const {
   return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
 }
 
-const ::PROTOBUF_NAMESPACE_ID::Message::ClassData DomainGetReply::_class_data_ = {
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData GetLatestReply::_class_data_ = {
     ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSourceCheck,
-    DomainGetReply::MergeImpl
+    GetLatestReply::MergeImpl
 };
-const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*DomainGetReply::GetClassData() const { return &_class_data_; }
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetLatestReply::GetClassData() const { return &_class_data_; }
 
 
-void DomainGetReply::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg) {
-  auto* const _this = static_cast<DomainGetReply*>(&to_msg);
-  auto& from = static_cast<const DomainGetReply&>(from_msg);
-  // @@protoc_insertion_point(class_specific_merge_from_start:remote.DomainGetReply)
+void GetLatestReply::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg) {
+  auto* const _this = static_cast<GetLatestReply*>(&to_msg);
+  auto& from = static_cast<const GetLatestReply&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:remote.GetLatestReply)
   GOOGLE_DCHECK_NE(&from, _this);
   uint32_t cached_has_bits = 0;
   (void) cached_has_bits;
@@ -4265,18 +4265,18 @@ void DomainGetReply::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const :
   _this->_internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
 }
 
-void DomainGetReply::CopyFrom(const DomainGetReply& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:remote.DomainGetReply)
+void GetLatestReply::CopyFrom(const GetLatestReply& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:remote.GetLatestReply)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
-bool DomainGetReply::IsInitialized() const {
+bool GetLatestReply::IsInitialized() const {
   return true;
 }
 
-void DomainGetReply::InternalSwap(DomainGetReply* other) {
+void GetLatestReply::InternalSwap(GetLatestReply* other) {
   using std::swap;
   auto* lhs_arena = GetArenaForAllocation();
   auto* rhs_arena = other->GetArenaForAllocation();
@@ -4288,7 +4288,7 @@ void DomainGetReply::InternalSwap(DomainGetReply* other) {
   swap(_impl_.ok_, other->_impl_.ok_);
 }
 
-::PROTOBUF_NAMESPACE_ID::Metadata DomainGetReply::GetMetadata() const {
+::PROTOBUF_NAMESPACE_ID::Metadata GetLatestReply::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_remote_2fkv_2eproto_getter, &descriptor_table_remote_2fkv_2eproto_once,
       file_level_metadata_remote_2fkv_2eproto[11]);
@@ -5937,19 +5937,19 @@ void HistoryRangeReq::InternalSwap(HistoryRangeReq* other) {
 
 // ===================================================================
 
-class DomainRangeReq::_Internal {
+class RangeAsOfReq::_Internal {
  public:
 };
 
-DomainRangeReq::DomainRangeReq(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+RangeAsOfReq::RangeAsOfReq(::PROTOBUF_NAMESPACE_ID::Arena* arena,
                          bool is_message_owned)
   : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
   SharedCtor(arena, is_message_owned);
-  // @@protoc_insertion_point(arena_constructor:remote.DomainRangeReq)
+  // @@protoc_insertion_point(arena_constructor:remote.RangeAsOfReq)
 }
-DomainRangeReq::DomainRangeReq(const DomainRangeReq& from)
+RangeAsOfReq::RangeAsOfReq(const RangeAsOfReq& from)
   : ::PROTOBUF_NAMESPACE_ID::Message() {
-  DomainRangeReq* const _this = this; (void)_this;
+  RangeAsOfReq* const _this = this; (void)_this;
   new (&_impl_) Impl_{
       decltype(_impl_.table_){}
     , decltype(_impl_.from_key_){}
@@ -5999,10 +5999,10 @@ DomainRangeReq::DomainRangeReq(const DomainRangeReq& from)
   ::memcpy(&_impl_.tx_id_, &from._impl_.tx_id_,
     static_cast<size_t>(reinterpret_cast<char*>(&_impl_.limit_) -
     reinterpret_cast<char*>(&_impl_.tx_id_)) + sizeof(_impl_.limit_));
-  // @@protoc_insertion_point(copy_constructor:remote.DomainRangeReq)
+  // @@protoc_insertion_point(copy_constructor:remote.RangeAsOfReq)
 }
 
-inline void DomainRangeReq::SharedCtor(
+inline void RangeAsOfReq::SharedCtor(
     ::_pb::Arena* arena, bool is_message_owned) {
   (void)arena;
   (void)is_message_owned;
@@ -6037,8 +6037,8 @@ inline void DomainRangeReq::SharedCtor(
   #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
 }
 
-DomainRangeReq::~DomainRangeReq() {
-  // @@protoc_insertion_point(destructor:remote.DomainRangeReq)
+RangeAsOfReq::~RangeAsOfReq() {
+  // @@protoc_insertion_point(destructor:remote.RangeAsOfReq)
   if (auto *arena = _internal_metadata_.DeleteReturnArena<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>()) {
   (void)arena;
     return;
@@ -6046,7 +6046,7 @@ DomainRangeReq::~DomainRangeReq() {
   SharedDtor();
 }
 
-inline void DomainRangeReq::SharedDtor() {
+inline void RangeAsOfReq::SharedDtor() {
   GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
   _impl_.table_.Destroy();
   _impl_.from_key_.Destroy();
@@ -6054,12 +6054,12 @@ inline void DomainRangeReq::SharedDtor() {
   _impl_.page_token_.Destroy();
 }
 
-void DomainRangeReq::SetCachedSize(int size) const {
+void RangeAsOfReq::SetCachedSize(int size) const {
   _impl_._cached_size_.Set(size);
 }
 
-void DomainRangeReq::Clear() {
-// @@protoc_insertion_point(message_clear_start:remote.DomainRangeReq)
+void RangeAsOfReq::Clear() {
+// @@protoc_insertion_point(message_clear_start:remote.RangeAsOfReq)
   uint32_t cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
@@ -6074,7 +6074,7 @@ void DomainRangeReq::Clear() {
   _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
-const char* DomainRangeReq::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
+const char* RangeAsOfReq::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
 #define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
   while (!ctx->Done(&ptr)) {
     uint32_t tag;
@@ -6094,7 +6094,7 @@ const char* DomainRangeReq::_InternalParse(const char* ptr, ::_pbi::ParseContext
           auto str = _internal_mutable_table();
           ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
           CHK_(ptr);
-          CHK_(::_pbi::VerifyUTF8(str, "remote.DomainRangeReq.table"));
+          CHK_(::_pbi::VerifyUTF8(str, "remote.RangeAsOfReq.table"));
         } else
           goto handle_unusual;
         continue;
@@ -6162,7 +6162,7 @@ const char* DomainRangeReq::_InternalParse(const char* ptr, ::_pbi::ParseContext
           auto str = _internal_mutable_page_token();
           ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
           CHK_(ptr);
-          CHK_(::_pbi::VerifyUTF8(str, "remote.DomainRangeReq.page_token"));
+          CHK_(::_pbi::VerifyUTF8(str, "remote.RangeAsOfReq.page_token"));
         } else
           goto handle_unusual;
         continue;
@@ -6189,9 +6189,9 @@ failure:
 #undef CHK_
 }
 
-uint8_t* DomainRangeReq::_InternalSerialize(
+uint8_t* RangeAsOfReq::_InternalSerialize(
     uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
-  // @@protoc_insertion_point(serialize_to_array_start:remote.DomainRangeReq)
+  // @@protoc_insertion_point(serialize_to_array_start:remote.RangeAsOfReq)
   uint32_t cached_has_bits = 0;
   (void) cached_has_bits;
 
@@ -6206,7 +6206,7 @@ uint8_t* DomainRangeReq::_InternalSerialize(
     ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
       this->_internal_table().data(), static_cast<int>(this->_internal_table().length()),
       ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
-      "remote.DomainRangeReq.table");
+      "remote.RangeAsOfReq.table");
     target = stream->WriteStringMaybeAliased(
         2, this->_internal_table(), target);
   }
@@ -6258,7 +6258,7 @@ uint8_t* DomainRangeReq::_InternalSerialize(
     ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
       this->_internal_page_token().data(), static_cast<int>(this->_internal_page_token().length()),
       ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
-      "remote.DomainRangeReq.page_token");
+      "remote.RangeAsOfReq.page_token");
     target = stream->WriteStringMaybeAliased(
         10, this->_internal_page_token(), target);
   }
@@ -6267,12 +6267,12 @@ uint8_t* DomainRangeReq::_InternalSerialize(
     target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
         _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
   }
-  // @@protoc_insertion_point(serialize_to_array_end:remote.DomainRangeReq)
+  // @@protoc_insertion_point(serialize_to_array_end:remote.RangeAsOfReq)
   return target;
 }
 
-size_t DomainRangeReq::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:remote.DomainRangeReq)
+size_t RangeAsOfReq::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:remote.RangeAsOfReq)
   size_t total_size = 0;
 
   uint32_t cached_has_bits = 0;
@@ -6340,17 +6340,17 @@ size_t DomainRangeReq::ByteSizeLong() const {
   return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
 }
 
-const ::PROTOBUF_NAMESPACE_ID::Message::ClassData DomainRangeReq::_class_data_ = {
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData RangeAsOfReq::_class_data_ = {
     ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSourceCheck,
-    DomainRangeReq::MergeImpl
+    RangeAsOfReq::MergeImpl
 };
-const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*DomainRangeReq::GetClassData() const { return &_class_data_; }
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*RangeAsOfReq::GetClassData() const { return &_class_data_; }
 
 
-void DomainRangeReq::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg) {
-  auto* const _this = static_cast<DomainRangeReq*>(&to_msg);
-  auto& from = static_cast<const DomainRangeReq&>(from_msg);
-  // @@protoc_insertion_point(class_specific_merge_from_start:remote.DomainRangeReq)
+void RangeAsOfReq::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg) {
+  auto* const _this = static_cast<RangeAsOfReq*>(&to_msg);
+  auto& from = static_cast<const RangeAsOfReq&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:remote.RangeAsOfReq)
   GOOGLE_DCHECK_NE(&from, _this);
   uint32_t cached_has_bits = 0;
   (void) cached_has_bits;
@@ -6388,18 +6388,18 @@ void DomainRangeReq::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const :
   _this->_internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
 }
 
-void DomainRangeReq::CopyFrom(const DomainRangeReq& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:remote.DomainRangeReq)
+void RangeAsOfReq::CopyFrom(const RangeAsOfReq& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:remote.RangeAsOfReq)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
-bool DomainRangeReq::IsInitialized() const {
+bool RangeAsOfReq::IsInitialized() const {
   return true;
 }
 
-void DomainRangeReq::InternalSwap(DomainRangeReq* other) {
+void RangeAsOfReq::InternalSwap(RangeAsOfReq* other) {
   using std::swap;
   auto* lhs_arena = GetArenaForAllocation();
   auto* rhs_arena = other->GetArenaForAllocation();
@@ -6421,14 +6421,14 @@ void DomainRangeReq::InternalSwap(DomainRangeReq* other) {
       &other->_impl_.page_token_, rhs_arena
   );
   ::PROTOBUF_NAMESPACE_ID::internal::memswap<
-      PROTOBUF_FIELD_OFFSET(DomainRangeReq, _impl_.limit_)
-      + sizeof(DomainRangeReq::_impl_.limit_)
-      - PROTOBUF_FIELD_OFFSET(DomainRangeReq, _impl_.tx_id_)>(
+      PROTOBUF_FIELD_OFFSET(RangeAsOfReq, _impl_.limit_)
+      + sizeof(RangeAsOfReq::_impl_.limit_)
+      - PROTOBUF_FIELD_OFFSET(RangeAsOfReq, _impl_.tx_id_)>(
           reinterpret_cast<char*>(&_impl_.tx_id_),
           reinterpret_cast<char*>(&other->_impl_.tx_id_));
 }
 
-::PROTOBUF_NAMESPACE_ID::Metadata DomainRangeReq::GetMetadata() const {
+::PROTOBUF_NAMESPACE_ID::Metadata RangeAsOfReq::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_remote_2fkv_2eproto_getter, &descriptor_table_remote_2fkv_2eproto_once,
       file_level_metadata_remote_2fkv_2eproto[17]);
@@ -7184,13 +7184,13 @@ template<> PROTOBUF_NOINLINE ::remote::RangeReq*
 Arena::CreateMaybeMessage< ::remote::RangeReq >(Arena* arena) {
   return Arena::CreateMessageInternal< ::remote::RangeReq >(arena);
 }
-template<> PROTOBUF_NOINLINE ::remote::DomainGetReq*
-Arena::CreateMaybeMessage< ::remote::DomainGetReq >(Arena* arena) {
-  return Arena::CreateMessageInternal< ::remote::DomainGetReq >(arena);
+template<> PROTOBUF_NOINLINE ::remote::GetLatestReq*
+Arena::CreateMaybeMessage< ::remote::GetLatestReq >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::remote::GetLatestReq >(arena);
 }
-template<> PROTOBUF_NOINLINE ::remote::DomainGetReply*
-Arena::CreateMaybeMessage< ::remote::DomainGetReply >(Arena* arena) {
-  return Arena::CreateMessageInternal< ::remote::DomainGetReply >(arena);
+template<> PROTOBUF_NOINLINE ::remote::GetLatestReply*
+Arena::CreateMaybeMessage< ::remote::GetLatestReply >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::remote::GetLatestReply >(arena);
 }
 template<> PROTOBUF_NOINLINE ::remote::HistorySeekReq*
 Arena::CreateMaybeMessage< ::remote::HistorySeekReq >(Arena* arena) {
@@ -7212,9 +7212,9 @@ template<> PROTOBUF_NOINLINE ::remote::HistoryRangeReq*
 Arena::CreateMaybeMessage< ::remote::HistoryRangeReq >(Arena* arena) {
   return Arena::CreateMessageInternal< ::remote::HistoryRangeReq >(arena);
 }
-template<> PROTOBUF_NOINLINE ::remote::DomainRangeReq*
-Arena::CreateMaybeMessage< ::remote::DomainRangeReq >(Arena* arena) {
-  return Arena::CreateMessageInternal< ::remote::DomainRangeReq >(arena);
+template<> PROTOBUF_NOINLINE ::remote::RangeAsOfReq*
+Arena::CreateMaybeMessage< ::remote::RangeAsOfReq >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::remote::RangeAsOfReq >(arena);
 }
 template<> PROTOBUF_NOINLINE ::remote::Pairs*
 Arena::CreateMaybeMessage< ::remote::Pairs >(Arena* arena) {

--- a/silkworm/interfaces/3.21.12/remote/kv.pb.h
+++ b/silkworm/interfaces/3.21.12/remote/kv.pb.h
@@ -55,15 +55,12 @@ extern AccountChangeDefaultTypeInternal _AccountChange_default_instance_;
 class Cursor;
 struct CursorDefaultTypeInternal;
 extern CursorDefaultTypeInternal _Cursor_default_instance_;
-class DomainGetReply;
-struct DomainGetReplyDefaultTypeInternal;
-extern DomainGetReplyDefaultTypeInternal _DomainGetReply_default_instance_;
-class DomainGetReq;
-struct DomainGetReqDefaultTypeInternal;
-extern DomainGetReqDefaultTypeInternal _DomainGetReq_default_instance_;
-class DomainRangeReq;
-struct DomainRangeReqDefaultTypeInternal;
-extern DomainRangeReqDefaultTypeInternal _DomainRangeReq_default_instance_;
+class GetLatestReply;
+struct GetLatestReplyDefaultTypeInternal;
+extern GetLatestReplyDefaultTypeInternal _GetLatestReply_default_instance_;
+class GetLatestReq;
+struct GetLatestReqDefaultTypeInternal;
+extern GetLatestReqDefaultTypeInternal _GetLatestReq_default_instance_;
 class HistoryRangeReq;
 struct HistoryRangeReqDefaultTypeInternal;
 extern HistoryRangeReqDefaultTypeInternal _HistoryRangeReq_default_instance_;
@@ -91,6 +88,9 @@ extern PairsDefaultTypeInternal _Pairs_default_instance_;
 class PairsPagination;
 struct PairsPaginationDefaultTypeInternal;
 extern PairsPaginationDefaultTypeInternal _PairsPagination_default_instance_;
+class RangeAsOfReq;
+struct RangeAsOfReqDefaultTypeInternal;
+extern RangeAsOfReqDefaultTypeInternal _RangeAsOfReq_default_instance_;
 class RangeReq;
 struct RangeReqDefaultTypeInternal;
 extern RangeReqDefaultTypeInternal _RangeReq_default_instance_;
@@ -116,9 +116,8 @@ extern StorageChangeDefaultTypeInternal _StorageChange_default_instance_;
 PROTOBUF_NAMESPACE_OPEN
 template<> ::remote::AccountChange* Arena::CreateMaybeMessage<::remote::AccountChange>(Arena*);
 template<> ::remote::Cursor* Arena::CreateMaybeMessage<::remote::Cursor>(Arena*);
-template<> ::remote::DomainGetReply* Arena::CreateMaybeMessage<::remote::DomainGetReply>(Arena*);
-template<> ::remote::DomainGetReq* Arena::CreateMaybeMessage<::remote::DomainGetReq>(Arena*);
-template<> ::remote::DomainRangeReq* Arena::CreateMaybeMessage<::remote::DomainRangeReq>(Arena*);
+template<> ::remote::GetLatestReply* Arena::CreateMaybeMessage<::remote::GetLatestReply>(Arena*);
+template<> ::remote::GetLatestReq* Arena::CreateMaybeMessage<::remote::GetLatestReq>(Arena*);
 template<> ::remote::HistoryRangeReq* Arena::CreateMaybeMessage<::remote::HistoryRangeReq>(Arena*);
 template<> ::remote::HistorySeekReply* Arena::CreateMaybeMessage<::remote::HistorySeekReply>(Arena*);
 template<> ::remote::HistorySeekReq* Arena::CreateMaybeMessage<::remote::HistorySeekReq>(Arena*);
@@ -128,6 +127,7 @@ template<> ::remote::IndexRangeReq* Arena::CreateMaybeMessage<::remote::IndexRan
 template<> ::remote::Pair* Arena::CreateMaybeMessage<::remote::Pair>(Arena*);
 template<> ::remote::Pairs* Arena::CreateMaybeMessage<::remote::Pairs>(Arena*);
 template<> ::remote::PairsPagination* Arena::CreateMaybeMessage<::remote::PairsPagination>(Arena*);
+template<> ::remote::RangeAsOfReq* Arena::CreateMaybeMessage<::remote::RangeAsOfReq>(Arena*);
 template<> ::remote::RangeReq* Arena::CreateMaybeMessage<::remote::RangeReq>(Arena*);
 template<> ::remote::SnapshotsReply* Arena::CreateMaybeMessage<::remote::SnapshotsReply>(Arena*);
 template<> ::remote::SnapshotsRequest* Arena::CreateMaybeMessage<::remote::SnapshotsRequest>(Arena*);
@@ -2195,24 +2195,24 @@ class RangeReq final :
 };
 // -------------------------------------------------------------------
 
-class DomainGetReq final :
-    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:remote.DomainGetReq) */ {
+class GetLatestReq final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:remote.GetLatestReq) */ {
  public:
-  inline DomainGetReq() : DomainGetReq(nullptr) {}
-  ~DomainGetReq() override;
-  explicit PROTOBUF_CONSTEXPR DomainGetReq(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+  inline GetLatestReq() : GetLatestReq(nullptr) {}
+  ~GetLatestReq() override;
+  explicit PROTOBUF_CONSTEXPR GetLatestReq(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
 
-  DomainGetReq(const DomainGetReq& from);
-  DomainGetReq(DomainGetReq&& from) noexcept
-    : DomainGetReq() {
+  GetLatestReq(const GetLatestReq& from);
+  GetLatestReq(GetLatestReq&& from) noexcept
+    : GetLatestReq() {
     *this = ::std::move(from);
   }
 
-  inline DomainGetReq& operator=(const DomainGetReq& from) {
+  inline GetLatestReq& operator=(const GetLatestReq& from) {
     CopyFrom(from);
     return *this;
   }
-  inline DomainGetReq& operator=(DomainGetReq&& from) noexcept {
+  inline GetLatestReq& operator=(GetLatestReq&& from) noexcept {
     if (this == &from) return *this;
     if (GetOwningArena() == from.GetOwningArena()
   #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
@@ -2235,20 +2235,20 @@ class DomainGetReq final :
   static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
     return default_instance().GetMetadata().reflection;
   }
-  static const DomainGetReq& default_instance() {
+  static const GetLatestReq& default_instance() {
     return *internal_default_instance();
   }
-  static inline const DomainGetReq* internal_default_instance() {
-    return reinterpret_cast<const DomainGetReq*>(
-               &_DomainGetReq_default_instance_);
+  static inline const GetLatestReq* internal_default_instance() {
+    return reinterpret_cast<const GetLatestReq*>(
+               &_GetLatestReq_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
     10;
 
-  friend void swap(DomainGetReq& a, DomainGetReq& b) {
+  friend void swap(GetLatestReq& a, GetLatestReq& b) {
     a.Swap(&b);
   }
-  inline void Swap(DomainGetReq* other) {
+  inline void Swap(GetLatestReq* other) {
     if (other == this) return;
   #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
     if (GetOwningArena() != nullptr &&
@@ -2261,7 +2261,7 @@ class DomainGetReq final :
       ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
     }
   }
-  void UnsafeArenaSwap(DomainGetReq* other) {
+  void UnsafeArenaSwap(GetLatestReq* other) {
     if (other == this) return;
     GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
     InternalSwap(other);
@@ -2269,14 +2269,14 @@ class DomainGetReq final :
 
   // implements Message ----------------------------------------------
 
-  DomainGetReq* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
-    return CreateMaybeMessage<DomainGetReq>(arena);
+  GetLatestReq* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
+    return CreateMaybeMessage<GetLatestReq>(arena);
   }
   using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
-  void CopyFrom(const DomainGetReq& from);
+  void CopyFrom(const GetLatestReq& from);
   using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
-  void MergeFrom( const DomainGetReq& from) {
-    DomainGetReq::MergeImpl(*this, from);
+  void MergeFrom( const GetLatestReq& from) {
+    GetLatestReq::MergeImpl(*this, from);
   }
   private:
   static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg);
@@ -2294,15 +2294,15 @@ class DomainGetReq final :
   void SharedCtor(::PROTOBUF_NAMESPACE_ID::Arena* arena, bool is_message_owned);
   void SharedDtor();
   void SetCachedSize(int size) const final;
-  void InternalSwap(DomainGetReq* other);
+  void InternalSwap(GetLatestReq* other);
 
   private:
   friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
   static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
-    return "remote.DomainGetReq";
+    return "remote.GetLatestReq";
   }
   protected:
-  explicit DomainGetReq(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+  explicit GetLatestReq(::PROTOBUF_NAMESPACE_ID::Arena* arena,
                        bool is_message_owned = false);
   public:
 
@@ -2392,7 +2392,7 @@ class DomainGetReq final :
   void _internal_set_latest(bool value);
   public:
 
-  // @@protoc_insertion_point(class_scope:remote.DomainGetReq)
+  // @@protoc_insertion_point(class_scope:remote.GetLatestReq)
  private:
   class _Internal;
 
@@ -2413,24 +2413,24 @@ class DomainGetReq final :
 };
 // -------------------------------------------------------------------
 
-class DomainGetReply final :
-    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:remote.DomainGetReply) */ {
+class GetLatestReply final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:remote.GetLatestReply) */ {
  public:
-  inline DomainGetReply() : DomainGetReply(nullptr) {}
-  ~DomainGetReply() override;
-  explicit PROTOBUF_CONSTEXPR DomainGetReply(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+  inline GetLatestReply() : GetLatestReply(nullptr) {}
+  ~GetLatestReply() override;
+  explicit PROTOBUF_CONSTEXPR GetLatestReply(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
 
-  DomainGetReply(const DomainGetReply& from);
-  DomainGetReply(DomainGetReply&& from) noexcept
-    : DomainGetReply() {
+  GetLatestReply(const GetLatestReply& from);
+  GetLatestReply(GetLatestReply&& from) noexcept
+    : GetLatestReply() {
     *this = ::std::move(from);
   }
 
-  inline DomainGetReply& operator=(const DomainGetReply& from) {
+  inline GetLatestReply& operator=(const GetLatestReply& from) {
     CopyFrom(from);
     return *this;
   }
-  inline DomainGetReply& operator=(DomainGetReply&& from) noexcept {
+  inline GetLatestReply& operator=(GetLatestReply&& from) noexcept {
     if (this == &from) return *this;
     if (GetOwningArena() == from.GetOwningArena()
   #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
@@ -2453,20 +2453,20 @@ class DomainGetReply final :
   static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
     return default_instance().GetMetadata().reflection;
   }
-  static const DomainGetReply& default_instance() {
+  static const GetLatestReply& default_instance() {
     return *internal_default_instance();
   }
-  static inline const DomainGetReply* internal_default_instance() {
-    return reinterpret_cast<const DomainGetReply*>(
-               &_DomainGetReply_default_instance_);
+  static inline const GetLatestReply* internal_default_instance() {
+    return reinterpret_cast<const GetLatestReply*>(
+               &_GetLatestReply_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
     11;
 
-  friend void swap(DomainGetReply& a, DomainGetReply& b) {
+  friend void swap(GetLatestReply& a, GetLatestReply& b) {
     a.Swap(&b);
   }
-  inline void Swap(DomainGetReply* other) {
+  inline void Swap(GetLatestReply* other) {
     if (other == this) return;
   #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
     if (GetOwningArena() != nullptr &&
@@ -2479,7 +2479,7 @@ class DomainGetReply final :
       ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
     }
   }
-  void UnsafeArenaSwap(DomainGetReply* other) {
+  void UnsafeArenaSwap(GetLatestReply* other) {
     if (other == this) return;
     GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
     InternalSwap(other);
@@ -2487,14 +2487,14 @@ class DomainGetReply final :
 
   // implements Message ----------------------------------------------
 
-  DomainGetReply* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
-    return CreateMaybeMessage<DomainGetReply>(arena);
+  GetLatestReply* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
+    return CreateMaybeMessage<GetLatestReply>(arena);
   }
   using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
-  void CopyFrom(const DomainGetReply& from);
+  void CopyFrom(const GetLatestReply& from);
   using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
-  void MergeFrom( const DomainGetReply& from) {
-    DomainGetReply::MergeImpl(*this, from);
+  void MergeFrom( const GetLatestReply& from) {
+    GetLatestReply::MergeImpl(*this, from);
   }
   private:
   static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg);
@@ -2512,15 +2512,15 @@ class DomainGetReply final :
   void SharedCtor(::PROTOBUF_NAMESPACE_ID::Arena* arena, bool is_message_owned);
   void SharedDtor();
   void SetCachedSize(int size) const final;
-  void InternalSwap(DomainGetReply* other);
+  void InternalSwap(GetLatestReply* other);
 
   private:
   friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
   static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
-    return "remote.DomainGetReply";
+    return "remote.GetLatestReply";
   }
   protected:
-  explicit DomainGetReply(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+  explicit GetLatestReply(::PROTOBUF_NAMESPACE_ID::Arena* arena,
                        bool is_message_owned = false);
   public:
 
@@ -2560,7 +2560,7 @@ class DomainGetReply final :
   void _internal_set_ok(bool value);
   public:
 
-  // @@protoc_insertion_point(class_scope:remote.DomainGetReply)
+  // @@protoc_insertion_point(class_scope:remote.GetLatestReply)
  private:
   class _Internal;
 
@@ -3596,24 +3596,24 @@ class HistoryRangeReq final :
 };
 // -------------------------------------------------------------------
 
-class DomainRangeReq final :
-    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:remote.DomainRangeReq) */ {
+class RangeAsOfReq final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:remote.RangeAsOfReq) */ {
  public:
-  inline DomainRangeReq() : DomainRangeReq(nullptr) {}
-  ~DomainRangeReq() override;
-  explicit PROTOBUF_CONSTEXPR DomainRangeReq(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+  inline RangeAsOfReq() : RangeAsOfReq(nullptr) {}
+  ~RangeAsOfReq() override;
+  explicit PROTOBUF_CONSTEXPR RangeAsOfReq(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
 
-  DomainRangeReq(const DomainRangeReq& from);
-  DomainRangeReq(DomainRangeReq&& from) noexcept
-    : DomainRangeReq() {
+  RangeAsOfReq(const RangeAsOfReq& from);
+  RangeAsOfReq(RangeAsOfReq&& from) noexcept
+    : RangeAsOfReq() {
     *this = ::std::move(from);
   }
 
-  inline DomainRangeReq& operator=(const DomainRangeReq& from) {
+  inline RangeAsOfReq& operator=(const RangeAsOfReq& from) {
     CopyFrom(from);
     return *this;
   }
-  inline DomainRangeReq& operator=(DomainRangeReq&& from) noexcept {
+  inline RangeAsOfReq& operator=(RangeAsOfReq&& from) noexcept {
     if (this == &from) return *this;
     if (GetOwningArena() == from.GetOwningArena()
   #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
@@ -3636,20 +3636,20 @@ class DomainRangeReq final :
   static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
     return default_instance().GetMetadata().reflection;
   }
-  static const DomainRangeReq& default_instance() {
+  static const RangeAsOfReq& default_instance() {
     return *internal_default_instance();
   }
-  static inline const DomainRangeReq* internal_default_instance() {
-    return reinterpret_cast<const DomainRangeReq*>(
-               &_DomainRangeReq_default_instance_);
+  static inline const RangeAsOfReq* internal_default_instance() {
+    return reinterpret_cast<const RangeAsOfReq*>(
+               &_RangeAsOfReq_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
     17;
 
-  friend void swap(DomainRangeReq& a, DomainRangeReq& b) {
+  friend void swap(RangeAsOfReq& a, RangeAsOfReq& b) {
     a.Swap(&b);
   }
-  inline void Swap(DomainRangeReq* other) {
+  inline void Swap(RangeAsOfReq* other) {
     if (other == this) return;
   #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
     if (GetOwningArena() != nullptr &&
@@ -3662,7 +3662,7 @@ class DomainRangeReq final :
       ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
     }
   }
-  void UnsafeArenaSwap(DomainRangeReq* other) {
+  void UnsafeArenaSwap(RangeAsOfReq* other) {
     if (other == this) return;
     GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
     InternalSwap(other);
@@ -3670,14 +3670,14 @@ class DomainRangeReq final :
 
   // implements Message ----------------------------------------------
 
-  DomainRangeReq* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
-    return CreateMaybeMessage<DomainRangeReq>(arena);
+  RangeAsOfReq* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
+    return CreateMaybeMessage<RangeAsOfReq>(arena);
   }
   using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
-  void CopyFrom(const DomainRangeReq& from);
+  void CopyFrom(const RangeAsOfReq& from);
   using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
-  void MergeFrom( const DomainRangeReq& from) {
-    DomainRangeReq::MergeImpl(*this, from);
+  void MergeFrom( const RangeAsOfReq& from) {
+    RangeAsOfReq::MergeImpl(*this, from);
   }
   private:
   static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg);
@@ -3695,15 +3695,15 @@ class DomainRangeReq final :
   void SharedCtor(::PROTOBUF_NAMESPACE_ID::Arena* arena, bool is_message_owned);
   void SharedDtor();
   void SetCachedSize(int size) const final;
-  void InternalSwap(DomainRangeReq* other);
+  void InternalSwap(RangeAsOfReq* other);
 
   private:
   friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
   static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
-    return "remote.DomainRangeReq";
+    return "remote.RangeAsOfReq";
   }
   protected:
-  explicit DomainRangeReq(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+  explicit RangeAsOfReq(::PROTOBUF_NAMESPACE_ID::Arena* arena,
                        bool is_message_owned = false);
   public:
 
@@ -3838,7 +3838,7 @@ class DomainRangeReq final :
   void _internal_set_limit(int64_t value);
   public:
 
-  // @@protoc_insertion_point(class_scope:remote.DomainRangeReq)
+  // @@protoc_insertion_point(class_scope:remote.RangeAsOfReq)
  private:
   class _Internal;
 
@@ -6038,64 +6038,64 @@ inline void RangeReq::set_allocated_page_token(std::string* page_token) {
 
 // -------------------------------------------------------------------
 
-// DomainGetReq
+// GetLatestReq
 
 // uint64 tx_id = 1;
-inline void DomainGetReq::clear_tx_id() {
+inline void GetLatestReq::clear_tx_id() {
   _impl_.tx_id_ = uint64_t{0u};
 }
-inline uint64_t DomainGetReq::_internal_tx_id() const {
+inline uint64_t GetLatestReq::_internal_tx_id() const {
   return _impl_.tx_id_;
 }
-inline uint64_t DomainGetReq::tx_id() const {
-  // @@protoc_insertion_point(field_get:remote.DomainGetReq.tx_id)
+inline uint64_t GetLatestReq::tx_id() const {
+  // @@protoc_insertion_point(field_get:remote.GetLatestReq.tx_id)
   return _internal_tx_id();
 }
-inline void DomainGetReq::_internal_set_tx_id(uint64_t value) {
+inline void GetLatestReq::_internal_set_tx_id(uint64_t value) {
   
   _impl_.tx_id_ = value;
 }
-inline void DomainGetReq::set_tx_id(uint64_t value) {
+inline void GetLatestReq::set_tx_id(uint64_t value) {
   _internal_set_tx_id(value);
-  // @@protoc_insertion_point(field_set:remote.DomainGetReq.tx_id)
+  // @@protoc_insertion_point(field_set:remote.GetLatestReq.tx_id)
 }
 
 // string table = 2;
-inline void DomainGetReq::clear_table() {
+inline void GetLatestReq::clear_table() {
   _impl_.table_.ClearToEmpty();
 }
-inline const std::string& DomainGetReq::table() const {
-  // @@protoc_insertion_point(field_get:remote.DomainGetReq.table)
+inline const std::string& GetLatestReq::table() const {
+  // @@protoc_insertion_point(field_get:remote.GetLatestReq.table)
   return _internal_table();
 }
 template <typename ArgT0, typename... ArgT>
 inline PROTOBUF_ALWAYS_INLINE
-void DomainGetReq::set_table(ArgT0&& arg0, ArgT... args) {
+void GetLatestReq::set_table(ArgT0&& arg0, ArgT... args) {
  
  _impl_.table_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
-  // @@protoc_insertion_point(field_set:remote.DomainGetReq.table)
+  // @@protoc_insertion_point(field_set:remote.GetLatestReq.table)
 }
-inline std::string* DomainGetReq::mutable_table() {
+inline std::string* GetLatestReq::mutable_table() {
   std::string* _s = _internal_mutable_table();
-  // @@protoc_insertion_point(field_mutable:remote.DomainGetReq.table)
+  // @@protoc_insertion_point(field_mutable:remote.GetLatestReq.table)
   return _s;
 }
-inline const std::string& DomainGetReq::_internal_table() const {
+inline const std::string& GetLatestReq::_internal_table() const {
   return _impl_.table_.Get();
 }
-inline void DomainGetReq::_internal_set_table(const std::string& value) {
+inline void GetLatestReq::_internal_set_table(const std::string& value) {
   
   _impl_.table_.Set(value, GetArenaForAllocation());
 }
-inline std::string* DomainGetReq::_internal_mutable_table() {
+inline std::string* GetLatestReq::_internal_mutable_table() {
   
   return _impl_.table_.Mutable(GetArenaForAllocation());
 }
-inline std::string* DomainGetReq::release_table() {
-  // @@protoc_insertion_point(field_release:remote.DomainGetReq.table)
+inline std::string* GetLatestReq::release_table() {
+  // @@protoc_insertion_point(field_release:remote.GetLatestReq.table)
   return _impl_.table_.Release();
 }
-inline void DomainGetReq::set_allocated_table(std::string* table) {
+inline void GetLatestReq::set_allocated_table(std::string* table) {
   if (table != nullptr) {
     
   } else {
@@ -6107,45 +6107,45 @@ inline void DomainGetReq::set_allocated_table(std::string* table) {
     _impl_.table_.Set("", GetArenaForAllocation());
   }
 #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  // @@protoc_insertion_point(field_set_allocated:remote.DomainGetReq.table)
+  // @@protoc_insertion_point(field_set_allocated:remote.GetLatestReq.table)
 }
 
 // bytes k = 3;
-inline void DomainGetReq::clear_k() {
+inline void GetLatestReq::clear_k() {
   _impl_.k_.ClearToEmpty();
 }
-inline const std::string& DomainGetReq::k() const {
-  // @@protoc_insertion_point(field_get:remote.DomainGetReq.k)
+inline const std::string& GetLatestReq::k() const {
+  // @@protoc_insertion_point(field_get:remote.GetLatestReq.k)
   return _internal_k();
 }
 template <typename ArgT0, typename... ArgT>
 inline PROTOBUF_ALWAYS_INLINE
-void DomainGetReq::set_k(ArgT0&& arg0, ArgT... args) {
+void GetLatestReq::set_k(ArgT0&& arg0, ArgT... args) {
  
  _impl_.k_.SetBytes(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
-  // @@protoc_insertion_point(field_set:remote.DomainGetReq.k)
+  // @@protoc_insertion_point(field_set:remote.GetLatestReq.k)
 }
-inline std::string* DomainGetReq::mutable_k() {
+inline std::string* GetLatestReq::mutable_k() {
   std::string* _s = _internal_mutable_k();
-  // @@protoc_insertion_point(field_mutable:remote.DomainGetReq.k)
+  // @@protoc_insertion_point(field_mutable:remote.GetLatestReq.k)
   return _s;
 }
-inline const std::string& DomainGetReq::_internal_k() const {
+inline const std::string& GetLatestReq::_internal_k() const {
   return _impl_.k_.Get();
 }
-inline void DomainGetReq::_internal_set_k(const std::string& value) {
+inline void GetLatestReq::_internal_set_k(const std::string& value) {
   
   _impl_.k_.Set(value, GetArenaForAllocation());
 }
-inline std::string* DomainGetReq::_internal_mutable_k() {
+inline std::string* GetLatestReq::_internal_mutable_k() {
   
   return _impl_.k_.Mutable(GetArenaForAllocation());
 }
-inline std::string* DomainGetReq::release_k() {
-  // @@protoc_insertion_point(field_release:remote.DomainGetReq.k)
+inline std::string* GetLatestReq::release_k() {
+  // @@protoc_insertion_point(field_release:remote.GetLatestReq.k)
   return _impl_.k_.Release();
 }
-inline void DomainGetReq::set_allocated_k(std::string* k) {
+inline void GetLatestReq::set_allocated_k(std::string* k) {
   if (k != nullptr) {
     
   } else {
@@ -6157,65 +6157,65 @@ inline void DomainGetReq::set_allocated_k(std::string* k) {
     _impl_.k_.Set("", GetArenaForAllocation());
   }
 #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  // @@protoc_insertion_point(field_set_allocated:remote.DomainGetReq.k)
+  // @@protoc_insertion_point(field_set_allocated:remote.GetLatestReq.k)
 }
 
 // uint64 ts = 4;
-inline void DomainGetReq::clear_ts() {
+inline void GetLatestReq::clear_ts() {
   _impl_.ts_ = uint64_t{0u};
 }
-inline uint64_t DomainGetReq::_internal_ts() const {
+inline uint64_t GetLatestReq::_internal_ts() const {
   return _impl_.ts_;
 }
-inline uint64_t DomainGetReq::ts() const {
-  // @@protoc_insertion_point(field_get:remote.DomainGetReq.ts)
+inline uint64_t GetLatestReq::ts() const {
+  // @@protoc_insertion_point(field_get:remote.GetLatestReq.ts)
   return _internal_ts();
 }
-inline void DomainGetReq::_internal_set_ts(uint64_t value) {
+inline void GetLatestReq::_internal_set_ts(uint64_t value) {
   
   _impl_.ts_ = value;
 }
-inline void DomainGetReq::set_ts(uint64_t value) {
+inline void GetLatestReq::set_ts(uint64_t value) {
   _internal_set_ts(value);
-  // @@protoc_insertion_point(field_set:remote.DomainGetReq.ts)
+  // @@protoc_insertion_point(field_set:remote.GetLatestReq.ts)
 }
 
 // bytes k2 = 5;
-inline void DomainGetReq::clear_k2() {
+inline void GetLatestReq::clear_k2() {
   _impl_.k2_.ClearToEmpty();
 }
-inline const std::string& DomainGetReq::k2() const {
-  // @@protoc_insertion_point(field_get:remote.DomainGetReq.k2)
+inline const std::string& GetLatestReq::k2() const {
+  // @@protoc_insertion_point(field_get:remote.GetLatestReq.k2)
   return _internal_k2();
 }
 template <typename ArgT0, typename... ArgT>
 inline PROTOBUF_ALWAYS_INLINE
-void DomainGetReq::set_k2(ArgT0&& arg0, ArgT... args) {
+void GetLatestReq::set_k2(ArgT0&& arg0, ArgT... args) {
  
  _impl_.k2_.SetBytes(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
-  // @@protoc_insertion_point(field_set:remote.DomainGetReq.k2)
+  // @@protoc_insertion_point(field_set:remote.GetLatestReq.k2)
 }
-inline std::string* DomainGetReq::mutable_k2() {
+inline std::string* GetLatestReq::mutable_k2() {
   std::string* _s = _internal_mutable_k2();
-  // @@protoc_insertion_point(field_mutable:remote.DomainGetReq.k2)
+  // @@protoc_insertion_point(field_mutable:remote.GetLatestReq.k2)
   return _s;
 }
-inline const std::string& DomainGetReq::_internal_k2() const {
+inline const std::string& GetLatestReq::_internal_k2() const {
   return _impl_.k2_.Get();
 }
-inline void DomainGetReq::_internal_set_k2(const std::string& value) {
+inline void GetLatestReq::_internal_set_k2(const std::string& value) {
   
   _impl_.k2_.Set(value, GetArenaForAllocation());
 }
-inline std::string* DomainGetReq::_internal_mutable_k2() {
+inline std::string* GetLatestReq::_internal_mutable_k2() {
   
   return _impl_.k2_.Mutable(GetArenaForAllocation());
 }
-inline std::string* DomainGetReq::release_k2() {
-  // @@protoc_insertion_point(field_release:remote.DomainGetReq.k2)
+inline std::string* GetLatestReq::release_k2() {
+  // @@protoc_insertion_point(field_release:remote.GetLatestReq.k2)
   return _impl_.k2_.Release();
 }
-inline void DomainGetReq::set_allocated_k2(std::string* k2) {
+inline void GetLatestReq::set_allocated_k2(std::string* k2) {
   if (k2 != nullptr) {
     
   } else {
@@ -6227,69 +6227,69 @@ inline void DomainGetReq::set_allocated_k2(std::string* k2) {
     _impl_.k2_.Set("", GetArenaForAllocation());
   }
 #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  // @@protoc_insertion_point(field_set_allocated:remote.DomainGetReq.k2)
+  // @@protoc_insertion_point(field_set_allocated:remote.GetLatestReq.k2)
 }
 
 // bool latest = 6;
-inline void DomainGetReq::clear_latest() {
+inline void GetLatestReq::clear_latest() {
   _impl_.latest_ = false;
 }
-inline bool DomainGetReq::_internal_latest() const {
+inline bool GetLatestReq::_internal_latest() const {
   return _impl_.latest_;
 }
-inline bool DomainGetReq::latest() const {
-  // @@protoc_insertion_point(field_get:remote.DomainGetReq.latest)
+inline bool GetLatestReq::latest() const {
+  // @@protoc_insertion_point(field_get:remote.GetLatestReq.latest)
   return _internal_latest();
 }
-inline void DomainGetReq::_internal_set_latest(bool value) {
+inline void GetLatestReq::_internal_set_latest(bool value) {
   
   _impl_.latest_ = value;
 }
-inline void DomainGetReq::set_latest(bool value) {
+inline void GetLatestReq::set_latest(bool value) {
   _internal_set_latest(value);
-  // @@protoc_insertion_point(field_set:remote.DomainGetReq.latest)
+  // @@protoc_insertion_point(field_set:remote.GetLatestReq.latest)
 }
 
 // -------------------------------------------------------------------
 
-// DomainGetReply
+// GetLatestReply
 
 // bytes v = 1;
-inline void DomainGetReply::clear_v() {
+inline void GetLatestReply::clear_v() {
   _impl_.v_.ClearToEmpty();
 }
-inline const std::string& DomainGetReply::v() const {
-  // @@protoc_insertion_point(field_get:remote.DomainGetReply.v)
+inline const std::string& GetLatestReply::v() const {
+  // @@protoc_insertion_point(field_get:remote.GetLatestReply.v)
   return _internal_v();
 }
 template <typename ArgT0, typename... ArgT>
 inline PROTOBUF_ALWAYS_INLINE
-void DomainGetReply::set_v(ArgT0&& arg0, ArgT... args) {
+void GetLatestReply::set_v(ArgT0&& arg0, ArgT... args) {
  
  _impl_.v_.SetBytes(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
-  // @@protoc_insertion_point(field_set:remote.DomainGetReply.v)
+  // @@protoc_insertion_point(field_set:remote.GetLatestReply.v)
 }
-inline std::string* DomainGetReply::mutable_v() {
+inline std::string* GetLatestReply::mutable_v() {
   std::string* _s = _internal_mutable_v();
-  // @@protoc_insertion_point(field_mutable:remote.DomainGetReply.v)
+  // @@protoc_insertion_point(field_mutable:remote.GetLatestReply.v)
   return _s;
 }
-inline const std::string& DomainGetReply::_internal_v() const {
+inline const std::string& GetLatestReply::_internal_v() const {
   return _impl_.v_.Get();
 }
-inline void DomainGetReply::_internal_set_v(const std::string& value) {
+inline void GetLatestReply::_internal_set_v(const std::string& value) {
   
   _impl_.v_.Set(value, GetArenaForAllocation());
 }
-inline std::string* DomainGetReply::_internal_mutable_v() {
+inline std::string* GetLatestReply::_internal_mutable_v() {
   
   return _impl_.v_.Mutable(GetArenaForAllocation());
 }
-inline std::string* DomainGetReply::release_v() {
-  // @@protoc_insertion_point(field_release:remote.DomainGetReply.v)
+inline std::string* GetLatestReply::release_v() {
+  // @@protoc_insertion_point(field_release:remote.GetLatestReply.v)
   return _impl_.v_.Release();
 }
-inline void DomainGetReply::set_allocated_v(std::string* v) {
+inline void GetLatestReply::set_allocated_v(std::string* v) {
   if (v != nullptr) {
     
   } else {
@@ -6301,27 +6301,27 @@ inline void DomainGetReply::set_allocated_v(std::string* v) {
     _impl_.v_.Set("", GetArenaForAllocation());
   }
 #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  // @@protoc_insertion_point(field_set_allocated:remote.DomainGetReply.v)
+  // @@protoc_insertion_point(field_set_allocated:remote.GetLatestReply.v)
 }
 
 // bool ok = 2;
-inline void DomainGetReply::clear_ok() {
+inline void GetLatestReply::clear_ok() {
   _impl_.ok_ = false;
 }
-inline bool DomainGetReply::_internal_ok() const {
+inline bool GetLatestReply::_internal_ok() const {
   return _impl_.ok_;
 }
-inline bool DomainGetReply::ok() const {
-  // @@protoc_insertion_point(field_get:remote.DomainGetReply.ok)
+inline bool GetLatestReply::ok() const {
+  // @@protoc_insertion_point(field_get:remote.GetLatestReply.ok)
   return _internal_ok();
 }
-inline void DomainGetReply::_internal_set_ok(bool value) {
+inline void GetLatestReply::_internal_set_ok(bool value) {
   
   _impl_.ok_ = value;
 }
-inline void DomainGetReply::set_ok(bool value) {
+inline void GetLatestReply::set_ok(bool value) {
   _internal_set_ok(value);
-  // @@protoc_insertion_point(field_set:remote.DomainGetReply.ok)
+  // @@protoc_insertion_point(field_set:remote.GetLatestReply.ok)
 }
 
 // -------------------------------------------------------------------
@@ -7143,64 +7143,64 @@ inline void HistoryRangeReq::set_allocated_page_token(std::string* page_token) {
 
 // -------------------------------------------------------------------
 
-// DomainRangeReq
+// RangeAsOfReq
 
 // uint64 tx_id = 1;
-inline void DomainRangeReq::clear_tx_id() {
+inline void RangeAsOfReq::clear_tx_id() {
   _impl_.tx_id_ = uint64_t{0u};
 }
-inline uint64_t DomainRangeReq::_internal_tx_id() const {
+inline uint64_t RangeAsOfReq::_internal_tx_id() const {
   return _impl_.tx_id_;
 }
-inline uint64_t DomainRangeReq::tx_id() const {
-  // @@protoc_insertion_point(field_get:remote.DomainRangeReq.tx_id)
+inline uint64_t RangeAsOfReq::tx_id() const {
+  // @@protoc_insertion_point(field_get:remote.RangeAsOfReq.tx_id)
   return _internal_tx_id();
 }
-inline void DomainRangeReq::_internal_set_tx_id(uint64_t value) {
+inline void RangeAsOfReq::_internal_set_tx_id(uint64_t value) {
   
   _impl_.tx_id_ = value;
 }
-inline void DomainRangeReq::set_tx_id(uint64_t value) {
+inline void RangeAsOfReq::set_tx_id(uint64_t value) {
   _internal_set_tx_id(value);
-  // @@protoc_insertion_point(field_set:remote.DomainRangeReq.tx_id)
+  // @@protoc_insertion_point(field_set:remote.RangeAsOfReq.tx_id)
 }
 
 // string table = 2;
-inline void DomainRangeReq::clear_table() {
+inline void RangeAsOfReq::clear_table() {
   _impl_.table_.ClearToEmpty();
 }
-inline const std::string& DomainRangeReq::table() const {
-  // @@protoc_insertion_point(field_get:remote.DomainRangeReq.table)
+inline const std::string& RangeAsOfReq::table() const {
+  // @@protoc_insertion_point(field_get:remote.RangeAsOfReq.table)
   return _internal_table();
 }
 template <typename ArgT0, typename... ArgT>
 inline PROTOBUF_ALWAYS_INLINE
-void DomainRangeReq::set_table(ArgT0&& arg0, ArgT... args) {
+void RangeAsOfReq::set_table(ArgT0&& arg0, ArgT... args) {
  
  _impl_.table_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
-  // @@protoc_insertion_point(field_set:remote.DomainRangeReq.table)
+  // @@protoc_insertion_point(field_set:remote.RangeAsOfReq.table)
 }
-inline std::string* DomainRangeReq::mutable_table() {
+inline std::string* RangeAsOfReq::mutable_table() {
   std::string* _s = _internal_mutable_table();
-  // @@protoc_insertion_point(field_mutable:remote.DomainRangeReq.table)
+  // @@protoc_insertion_point(field_mutable:remote.RangeAsOfReq.table)
   return _s;
 }
-inline const std::string& DomainRangeReq::_internal_table() const {
+inline const std::string& RangeAsOfReq::_internal_table() const {
   return _impl_.table_.Get();
 }
-inline void DomainRangeReq::_internal_set_table(const std::string& value) {
+inline void RangeAsOfReq::_internal_set_table(const std::string& value) {
   
   _impl_.table_.Set(value, GetArenaForAllocation());
 }
-inline std::string* DomainRangeReq::_internal_mutable_table() {
+inline std::string* RangeAsOfReq::_internal_mutable_table() {
   
   return _impl_.table_.Mutable(GetArenaForAllocation());
 }
-inline std::string* DomainRangeReq::release_table() {
-  // @@protoc_insertion_point(field_release:remote.DomainRangeReq.table)
+inline std::string* RangeAsOfReq::release_table() {
+  // @@protoc_insertion_point(field_release:remote.RangeAsOfReq.table)
   return _impl_.table_.Release();
 }
-inline void DomainRangeReq::set_allocated_table(std::string* table) {
+inline void RangeAsOfReq::set_allocated_table(std::string* table) {
   if (table != nullptr) {
     
   } else {
@@ -7212,45 +7212,45 @@ inline void DomainRangeReq::set_allocated_table(std::string* table) {
     _impl_.table_.Set("", GetArenaForAllocation());
   }
 #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  // @@protoc_insertion_point(field_set_allocated:remote.DomainRangeReq.table)
+  // @@protoc_insertion_point(field_set_allocated:remote.RangeAsOfReq.table)
 }
 
 // bytes from_key = 3;
-inline void DomainRangeReq::clear_from_key() {
+inline void RangeAsOfReq::clear_from_key() {
   _impl_.from_key_.ClearToEmpty();
 }
-inline const std::string& DomainRangeReq::from_key() const {
-  // @@protoc_insertion_point(field_get:remote.DomainRangeReq.from_key)
+inline const std::string& RangeAsOfReq::from_key() const {
+  // @@protoc_insertion_point(field_get:remote.RangeAsOfReq.from_key)
   return _internal_from_key();
 }
 template <typename ArgT0, typename... ArgT>
 inline PROTOBUF_ALWAYS_INLINE
-void DomainRangeReq::set_from_key(ArgT0&& arg0, ArgT... args) {
+void RangeAsOfReq::set_from_key(ArgT0&& arg0, ArgT... args) {
  
  _impl_.from_key_.SetBytes(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
-  // @@protoc_insertion_point(field_set:remote.DomainRangeReq.from_key)
+  // @@protoc_insertion_point(field_set:remote.RangeAsOfReq.from_key)
 }
-inline std::string* DomainRangeReq::mutable_from_key() {
+inline std::string* RangeAsOfReq::mutable_from_key() {
   std::string* _s = _internal_mutable_from_key();
-  // @@protoc_insertion_point(field_mutable:remote.DomainRangeReq.from_key)
+  // @@protoc_insertion_point(field_mutable:remote.RangeAsOfReq.from_key)
   return _s;
 }
-inline const std::string& DomainRangeReq::_internal_from_key() const {
+inline const std::string& RangeAsOfReq::_internal_from_key() const {
   return _impl_.from_key_.Get();
 }
-inline void DomainRangeReq::_internal_set_from_key(const std::string& value) {
+inline void RangeAsOfReq::_internal_set_from_key(const std::string& value) {
   
   _impl_.from_key_.Set(value, GetArenaForAllocation());
 }
-inline std::string* DomainRangeReq::_internal_mutable_from_key() {
+inline std::string* RangeAsOfReq::_internal_mutable_from_key() {
   
   return _impl_.from_key_.Mutable(GetArenaForAllocation());
 }
-inline std::string* DomainRangeReq::release_from_key() {
-  // @@protoc_insertion_point(field_release:remote.DomainRangeReq.from_key)
+inline std::string* RangeAsOfReq::release_from_key() {
+  // @@protoc_insertion_point(field_release:remote.RangeAsOfReq.from_key)
   return _impl_.from_key_.Release();
 }
-inline void DomainRangeReq::set_allocated_from_key(std::string* from_key) {
+inline void RangeAsOfReq::set_allocated_from_key(std::string* from_key) {
   if (from_key != nullptr) {
     
   } else {
@@ -7262,45 +7262,45 @@ inline void DomainRangeReq::set_allocated_from_key(std::string* from_key) {
     _impl_.from_key_.Set("", GetArenaForAllocation());
   }
 #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  // @@protoc_insertion_point(field_set_allocated:remote.DomainRangeReq.from_key)
+  // @@protoc_insertion_point(field_set_allocated:remote.RangeAsOfReq.from_key)
 }
 
 // bytes to_key = 4;
-inline void DomainRangeReq::clear_to_key() {
+inline void RangeAsOfReq::clear_to_key() {
   _impl_.to_key_.ClearToEmpty();
 }
-inline const std::string& DomainRangeReq::to_key() const {
-  // @@protoc_insertion_point(field_get:remote.DomainRangeReq.to_key)
+inline const std::string& RangeAsOfReq::to_key() const {
+  // @@protoc_insertion_point(field_get:remote.RangeAsOfReq.to_key)
   return _internal_to_key();
 }
 template <typename ArgT0, typename... ArgT>
 inline PROTOBUF_ALWAYS_INLINE
-void DomainRangeReq::set_to_key(ArgT0&& arg0, ArgT... args) {
+void RangeAsOfReq::set_to_key(ArgT0&& arg0, ArgT... args) {
  
  _impl_.to_key_.SetBytes(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
-  // @@protoc_insertion_point(field_set:remote.DomainRangeReq.to_key)
+  // @@protoc_insertion_point(field_set:remote.RangeAsOfReq.to_key)
 }
-inline std::string* DomainRangeReq::mutable_to_key() {
+inline std::string* RangeAsOfReq::mutable_to_key() {
   std::string* _s = _internal_mutable_to_key();
-  // @@protoc_insertion_point(field_mutable:remote.DomainRangeReq.to_key)
+  // @@protoc_insertion_point(field_mutable:remote.RangeAsOfReq.to_key)
   return _s;
 }
-inline const std::string& DomainRangeReq::_internal_to_key() const {
+inline const std::string& RangeAsOfReq::_internal_to_key() const {
   return _impl_.to_key_.Get();
 }
-inline void DomainRangeReq::_internal_set_to_key(const std::string& value) {
+inline void RangeAsOfReq::_internal_set_to_key(const std::string& value) {
   
   _impl_.to_key_.Set(value, GetArenaForAllocation());
 }
-inline std::string* DomainRangeReq::_internal_mutable_to_key() {
+inline std::string* RangeAsOfReq::_internal_mutable_to_key() {
   
   return _impl_.to_key_.Mutable(GetArenaForAllocation());
 }
-inline std::string* DomainRangeReq::release_to_key() {
-  // @@protoc_insertion_point(field_release:remote.DomainRangeReq.to_key)
+inline std::string* RangeAsOfReq::release_to_key() {
+  // @@protoc_insertion_point(field_release:remote.RangeAsOfReq.to_key)
   return _impl_.to_key_.Release();
 }
-inline void DomainRangeReq::set_allocated_to_key(std::string* to_key) {
+inline void RangeAsOfReq::set_allocated_to_key(std::string* to_key) {
   if (to_key != nullptr) {
     
   } else {
@@ -7312,145 +7312,145 @@ inline void DomainRangeReq::set_allocated_to_key(std::string* to_key) {
     _impl_.to_key_.Set("", GetArenaForAllocation());
   }
 #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  // @@protoc_insertion_point(field_set_allocated:remote.DomainRangeReq.to_key)
+  // @@protoc_insertion_point(field_set_allocated:remote.RangeAsOfReq.to_key)
 }
 
 // uint64 ts = 5;
-inline void DomainRangeReq::clear_ts() {
+inline void RangeAsOfReq::clear_ts() {
   _impl_.ts_ = uint64_t{0u};
 }
-inline uint64_t DomainRangeReq::_internal_ts() const {
+inline uint64_t RangeAsOfReq::_internal_ts() const {
   return _impl_.ts_;
 }
-inline uint64_t DomainRangeReq::ts() const {
-  // @@protoc_insertion_point(field_get:remote.DomainRangeReq.ts)
+inline uint64_t RangeAsOfReq::ts() const {
+  // @@protoc_insertion_point(field_get:remote.RangeAsOfReq.ts)
   return _internal_ts();
 }
-inline void DomainRangeReq::_internal_set_ts(uint64_t value) {
+inline void RangeAsOfReq::_internal_set_ts(uint64_t value) {
   
   _impl_.ts_ = value;
 }
-inline void DomainRangeReq::set_ts(uint64_t value) {
+inline void RangeAsOfReq::set_ts(uint64_t value) {
   _internal_set_ts(value);
-  // @@protoc_insertion_point(field_set:remote.DomainRangeReq.ts)
+  // @@protoc_insertion_point(field_set:remote.RangeAsOfReq.ts)
 }
 
 // bool latest = 6;
-inline void DomainRangeReq::clear_latest() {
+inline void RangeAsOfReq::clear_latest() {
   _impl_.latest_ = false;
 }
-inline bool DomainRangeReq::_internal_latest() const {
+inline bool RangeAsOfReq::_internal_latest() const {
   return _impl_.latest_;
 }
-inline bool DomainRangeReq::latest() const {
-  // @@protoc_insertion_point(field_get:remote.DomainRangeReq.latest)
+inline bool RangeAsOfReq::latest() const {
+  // @@protoc_insertion_point(field_get:remote.RangeAsOfReq.latest)
   return _internal_latest();
 }
-inline void DomainRangeReq::_internal_set_latest(bool value) {
+inline void RangeAsOfReq::_internal_set_latest(bool value) {
   
   _impl_.latest_ = value;
 }
-inline void DomainRangeReq::set_latest(bool value) {
+inline void RangeAsOfReq::set_latest(bool value) {
   _internal_set_latest(value);
-  // @@protoc_insertion_point(field_set:remote.DomainRangeReq.latest)
+  // @@protoc_insertion_point(field_set:remote.RangeAsOfReq.latest)
 }
 
 // bool order_ascend = 7;
-inline void DomainRangeReq::clear_order_ascend() {
+inline void RangeAsOfReq::clear_order_ascend() {
   _impl_.order_ascend_ = false;
 }
-inline bool DomainRangeReq::_internal_order_ascend() const {
+inline bool RangeAsOfReq::_internal_order_ascend() const {
   return _impl_.order_ascend_;
 }
-inline bool DomainRangeReq::order_ascend() const {
-  // @@protoc_insertion_point(field_get:remote.DomainRangeReq.order_ascend)
+inline bool RangeAsOfReq::order_ascend() const {
+  // @@protoc_insertion_point(field_get:remote.RangeAsOfReq.order_ascend)
   return _internal_order_ascend();
 }
-inline void DomainRangeReq::_internal_set_order_ascend(bool value) {
+inline void RangeAsOfReq::_internal_set_order_ascend(bool value) {
   
   _impl_.order_ascend_ = value;
 }
-inline void DomainRangeReq::set_order_ascend(bool value) {
+inline void RangeAsOfReq::set_order_ascend(bool value) {
   _internal_set_order_ascend(value);
-  // @@protoc_insertion_point(field_set:remote.DomainRangeReq.order_ascend)
+  // @@protoc_insertion_point(field_set:remote.RangeAsOfReq.order_ascend)
 }
 
 // sint64 limit = 8;
-inline void DomainRangeReq::clear_limit() {
+inline void RangeAsOfReq::clear_limit() {
   _impl_.limit_ = int64_t{0};
 }
-inline int64_t DomainRangeReq::_internal_limit() const {
+inline int64_t RangeAsOfReq::_internal_limit() const {
   return _impl_.limit_;
 }
-inline int64_t DomainRangeReq::limit() const {
-  // @@protoc_insertion_point(field_get:remote.DomainRangeReq.limit)
+inline int64_t RangeAsOfReq::limit() const {
+  // @@protoc_insertion_point(field_get:remote.RangeAsOfReq.limit)
   return _internal_limit();
 }
-inline void DomainRangeReq::_internal_set_limit(int64_t value) {
+inline void RangeAsOfReq::_internal_set_limit(int64_t value) {
   
   _impl_.limit_ = value;
 }
-inline void DomainRangeReq::set_limit(int64_t value) {
+inline void RangeAsOfReq::set_limit(int64_t value) {
   _internal_set_limit(value);
-  // @@protoc_insertion_point(field_set:remote.DomainRangeReq.limit)
+  // @@protoc_insertion_point(field_set:remote.RangeAsOfReq.limit)
 }
 
 // int32 page_size = 9;
-inline void DomainRangeReq::clear_page_size() {
+inline void RangeAsOfReq::clear_page_size() {
   _impl_.page_size_ = 0;
 }
-inline int32_t DomainRangeReq::_internal_page_size() const {
+inline int32_t RangeAsOfReq::_internal_page_size() const {
   return _impl_.page_size_;
 }
-inline int32_t DomainRangeReq::page_size() const {
-  // @@protoc_insertion_point(field_get:remote.DomainRangeReq.page_size)
+inline int32_t RangeAsOfReq::page_size() const {
+  // @@protoc_insertion_point(field_get:remote.RangeAsOfReq.page_size)
   return _internal_page_size();
 }
-inline void DomainRangeReq::_internal_set_page_size(int32_t value) {
+inline void RangeAsOfReq::_internal_set_page_size(int32_t value) {
   
   _impl_.page_size_ = value;
 }
-inline void DomainRangeReq::set_page_size(int32_t value) {
+inline void RangeAsOfReq::set_page_size(int32_t value) {
   _internal_set_page_size(value);
-  // @@protoc_insertion_point(field_set:remote.DomainRangeReq.page_size)
+  // @@protoc_insertion_point(field_set:remote.RangeAsOfReq.page_size)
 }
 
 // string page_token = 10;
-inline void DomainRangeReq::clear_page_token() {
+inline void RangeAsOfReq::clear_page_token() {
   _impl_.page_token_.ClearToEmpty();
 }
-inline const std::string& DomainRangeReq::page_token() const {
-  // @@protoc_insertion_point(field_get:remote.DomainRangeReq.page_token)
+inline const std::string& RangeAsOfReq::page_token() const {
+  // @@protoc_insertion_point(field_get:remote.RangeAsOfReq.page_token)
   return _internal_page_token();
 }
 template <typename ArgT0, typename... ArgT>
 inline PROTOBUF_ALWAYS_INLINE
-void DomainRangeReq::set_page_token(ArgT0&& arg0, ArgT... args) {
+void RangeAsOfReq::set_page_token(ArgT0&& arg0, ArgT... args) {
  
  _impl_.page_token_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
-  // @@protoc_insertion_point(field_set:remote.DomainRangeReq.page_token)
+  // @@protoc_insertion_point(field_set:remote.RangeAsOfReq.page_token)
 }
-inline std::string* DomainRangeReq::mutable_page_token() {
+inline std::string* RangeAsOfReq::mutable_page_token() {
   std::string* _s = _internal_mutable_page_token();
-  // @@protoc_insertion_point(field_mutable:remote.DomainRangeReq.page_token)
+  // @@protoc_insertion_point(field_mutable:remote.RangeAsOfReq.page_token)
   return _s;
 }
-inline const std::string& DomainRangeReq::_internal_page_token() const {
+inline const std::string& RangeAsOfReq::_internal_page_token() const {
   return _impl_.page_token_.Get();
 }
-inline void DomainRangeReq::_internal_set_page_token(const std::string& value) {
+inline void RangeAsOfReq::_internal_set_page_token(const std::string& value) {
   
   _impl_.page_token_.Set(value, GetArenaForAllocation());
 }
-inline std::string* DomainRangeReq::_internal_mutable_page_token() {
+inline std::string* RangeAsOfReq::_internal_mutable_page_token() {
   
   return _impl_.page_token_.Mutable(GetArenaForAllocation());
 }
-inline std::string* DomainRangeReq::release_page_token() {
-  // @@protoc_insertion_point(field_release:remote.DomainRangeReq.page_token)
+inline std::string* RangeAsOfReq::release_page_token() {
+  // @@protoc_insertion_point(field_release:remote.RangeAsOfReq.page_token)
   return _impl_.page_token_.Release();
 }
-inline void DomainRangeReq::set_allocated_page_token(std::string* page_token) {
+inline void RangeAsOfReq::set_allocated_page_token(std::string* page_token) {
   if (page_token != nullptr) {
     
   } else {
@@ -7462,7 +7462,7 @@ inline void DomainRangeReq::set_allocated_page_token(std::string* page_token) {
     _impl_.page_token_.Set("", GetArenaForAllocation());
   }
 #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  // @@protoc_insertion_point(field_set_allocated:remote.DomainRangeReq.page_token)
+  // @@protoc_insertion_point(field_set_allocated:remote.RangeAsOfReq.page_token)
 }
 
 // -------------------------------------------------------------------

--- a/silkworm/interfaces/3.21.12/remote/kv_mock.grpc.pb.h
+++ b/silkworm/interfaces/3.21.12/remote/kv_mock.grpc.pb.h
@@ -30,9 +30,9 @@ class MockKVStub : public KV::StubInterface {
   MOCK_METHOD3(Range, ::grpc::Status(::grpc::ClientContext* context, const ::remote::RangeReq& request, ::remote::Pairs* response));
   MOCK_METHOD3(AsyncRangeRaw, ::grpc::ClientAsyncResponseReaderInterface< ::remote::Pairs>*(::grpc::ClientContext* context, const ::remote::RangeReq& request, ::grpc::CompletionQueue* cq));
   MOCK_METHOD3(PrepareAsyncRangeRaw, ::grpc::ClientAsyncResponseReaderInterface< ::remote::Pairs>*(::grpc::ClientContext* context, const ::remote::RangeReq& request, ::grpc::CompletionQueue* cq));
-  MOCK_METHOD3(DomainGet, ::grpc::Status(::grpc::ClientContext* context, const ::remote::DomainGetReq& request, ::remote::DomainGetReply* response));
-  MOCK_METHOD3(AsyncDomainGetRaw, ::grpc::ClientAsyncResponseReaderInterface< ::remote::DomainGetReply>*(::grpc::ClientContext* context, const ::remote::DomainGetReq& request, ::grpc::CompletionQueue* cq));
-  MOCK_METHOD3(PrepareAsyncDomainGetRaw, ::grpc::ClientAsyncResponseReaderInterface< ::remote::DomainGetReply>*(::grpc::ClientContext* context, const ::remote::DomainGetReq& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD3(GetLatest, ::grpc::Status(::grpc::ClientContext* context, const ::remote::GetLatestReq& request, ::remote::GetLatestReply* response));
+  MOCK_METHOD3(AsyncGetLatestRaw, ::grpc::ClientAsyncResponseReaderInterface< ::remote::GetLatestReply>*(::grpc::ClientContext* context, const ::remote::GetLatestReq& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD3(PrepareAsyncGetLatestRaw, ::grpc::ClientAsyncResponseReaderInterface< ::remote::GetLatestReply>*(::grpc::ClientContext* context, const ::remote::GetLatestReq& request, ::grpc::CompletionQueue* cq));
   MOCK_METHOD3(HistorySeek, ::grpc::Status(::grpc::ClientContext* context, const ::remote::HistorySeekReq& request, ::remote::HistorySeekReply* response));
   MOCK_METHOD3(AsyncHistorySeekRaw, ::grpc::ClientAsyncResponseReaderInterface< ::remote::HistorySeekReply>*(::grpc::ClientContext* context, const ::remote::HistorySeekReq& request, ::grpc::CompletionQueue* cq));
   MOCK_METHOD3(PrepareAsyncHistorySeekRaw, ::grpc::ClientAsyncResponseReaderInterface< ::remote::HistorySeekReply>*(::grpc::ClientContext* context, const ::remote::HistorySeekReq& request, ::grpc::CompletionQueue* cq));
@@ -42,9 +42,9 @@ class MockKVStub : public KV::StubInterface {
   MOCK_METHOD3(HistoryRange, ::grpc::Status(::grpc::ClientContext* context, const ::remote::HistoryRangeReq& request, ::remote::Pairs* response));
   MOCK_METHOD3(AsyncHistoryRangeRaw, ::grpc::ClientAsyncResponseReaderInterface< ::remote::Pairs>*(::grpc::ClientContext* context, const ::remote::HistoryRangeReq& request, ::grpc::CompletionQueue* cq));
   MOCK_METHOD3(PrepareAsyncHistoryRangeRaw, ::grpc::ClientAsyncResponseReaderInterface< ::remote::Pairs>*(::grpc::ClientContext* context, const ::remote::HistoryRangeReq& request, ::grpc::CompletionQueue* cq));
-  MOCK_METHOD3(DomainRange, ::grpc::Status(::grpc::ClientContext* context, const ::remote::DomainRangeReq& request, ::remote::Pairs* response));
-  MOCK_METHOD3(AsyncDomainRangeRaw, ::grpc::ClientAsyncResponseReaderInterface< ::remote::Pairs>*(::grpc::ClientContext* context, const ::remote::DomainRangeReq& request, ::grpc::CompletionQueue* cq));
-  MOCK_METHOD3(PrepareAsyncDomainRangeRaw, ::grpc::ClientAsyncResponseReaderInterface< ::remote::Pairs>*(::grpc::ClientContext* context, const ::remote::DomainRangeReq& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD3(RangeAsOf, ::grpc::Status(::grpc::ClientContext* context, const ::remote::RangeAsOfReq& request, ::remote::Pairs* response));
+  MOCK_METHOD3(AsyncRangeAsOfRaw, ::grpc::ClientAsyncResponseReaderInterface< ::remote::Pairs>*(::grpc::ClientContext* context, const ::remote::RangeAsOfReq& request, ::grpc::CompletionQueue* cq));
+  MOCK_METHOD3(PrepareAsyncRangeAsOfRaw, ::grpc::ClientAsyncResponseReaderInterface< ::remote::Pairs>*(::grpc::ClientContext* context, const ::remote::RangeAsOfReq& request, ::grpc::CompletionQueue* cq));
 };
 
 }  // namespace remote

--- a/silkworm/rpc/commands/debug_api.cpp
+++ b/silkworm/rpc/commands/debug_api.cpp
@@ -325,7 +325,7 @@ Task<void> DebugRpcApi::handle_debug_account_at(const nlohmann::json& request, n
             .timestamp = min_tx_num + tx_index + 1,
         };
 
-        const auto result = co_await tx->domain_get(std::move(query_account));
+        const auto result = co_await tx->get_latest(std::move(query_account));
         nlohmann::json json_result{};
 
         if (!result.success || result.value.empty()) {
@@ -350,7 +350,7 @@ Task<void> DebugRpcApi::handle_debug_account_at(const nlohmann::json& request, n
                 .timestamp = min_tx_num + tx_index,
             };
 
-            const auto code = co_await tx->domain_get(std::move(query_code));
+            const auto code = co_await tx->get_latest(std::move(query_code));
             json_result["code"] = "0x" + silkworm::to_hex(code.value);
         } else {
             json_result["balance"] = "0x0";

--- a/silkworm/rpc/commands/debug_api_test.cpp
+++ b/silkworm/rpc/commands/debug_api_test.cpp
@@ -231,7 +231,7 @@ class DummyTransaction : public db::kv::api::BaseTransaction {
         co_return;
     }
 
-    Task<db::kv::api::DomainPointResult> domain_get(db::kv::api::DomainPointQuery /*query*/) override {
+    Task<db::kv::api::DomainPointResult> get_latest(db::kv::api::DomainPointQuery /*query*/) override {
         co_return db::kv::api::DomainPointResult{};
     }
 
@@ -247,7 +247,7 @@ class DummyTransaction : public db::kv::api::BaseTransaction {
         co_return test::empty_paginated_keys_and_values();
     }
 
-    Task<db::kv::api::PaginatedKeysValues> domain_range(db::kv::api::DomainRangeQuery /*query*/) override {
+    Task<db::kv::api::PaginatedKeysValues> range_as_of(db::kv::api::DomainRangeQuery /*query*/) override {
         co_return test::empty_paginated_keys_and_values();
     }
 

--- a/silkworm/rpc/commands/parity_api.cpp
+++ b/silkworm/rpc/commands/parity_api.cpp
@@ -86,7 +86,7 @@ Task<void> ParityRpcApi::handle_parity_list_storage_keys(const nlohmann::json& r
             .timestamp = txn_number,
             .ascending_order = true,
             .limit = quantity};
-        auto paginated_result = co_await tx->domain_range(std::move(query));
+        auto paginated_result = co_await tx->range_as_of(std::move(query));
         auto it = co_await paginated_result.begin();
 
         std::vector<std::string> keys;

--- a/silkworm/rpc/core/account_dumper_test.cpp
+++ b/silkworm/rpc/core/account_dumper_test.cpp
@@ -210,7 +210,7 @@ class DummyTransaction : public BaseTransaction {
         co_return;
     }
 
-    Task<db::kv::api::DomainPointResult> domain_get(db::kv::api::DomainPointQuery /*query*/) override {
+    Task<db::kv::api::DomainPointResult> get_latest(db::kv::api::DomainPointQuery /*query*/) override {
         co_return db::kv::api::DomainPointResult{};
     }
 
@@ -226,7 +226,7 @@ class DummyTransaction : public BaseTransaction {
         co_return test::empty_paginated_keys_and_values();
     }
 
-    Task<db::kv::api::PaginatedKeysValues> domain_range(db::kv::api::DomainRangeQuery /*query*/) override {
+    Task<db::kv::api::PaginatedKeysValues> range_as_of(db::kv::api::DomainRangeQuery /*query*/) override {
         co_return test::empty_paginated_keys_and_values();
     }
 

--- a/silkworm/rpc/core/account_walker_test.cpp
+++ b/silkworm/rpc/core/account_walker_test.cpp
@@ -211,7 +211,7 @@ class DummyTransaction : public BaseTransaction {
         co_return;
     }
 
-    Task<db::kv::api::DomainPointResult> domain_get(db::kv::api::DomainPointQuery /*query*/) override {
+    Task<db::kv::api::DomainPointResult> get_latest(db::kv::api::DomainPointQuery /*query*/) override {
         co_return db::kv::api::DomainPointResult{};
     }
 
@@ -227,7 +227,7 @@ class DummyTransaction : public BaseTransaction {
         co_return test::empty_paginated_keys_and_values();
     }
 
-    Task<db::kv::api::PaginatedKeysValues> domain_range(db::kv::api::DomainRangeQuery /*query*/) override {
+    Task<db::kv::api::PaginatedKeysValues> range_as_of(db::kv::api::DomainRangeQuery /*query*/) override {
         co_return test::empty_paginated_keys_and_values();
     }
 

--- a/silkworm/rpc/core/evm_debug_test.cpp
+++ b/silkworm/rpc/core/evm_debug_test.cpp
@@ -119,19 +119,19 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute precompiled") {
         EXPECT_CALL(transaction, first_txn_num_in_block(10'336'007)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult rsp1{
                 .success = true,
                 .value = kAccountHistoryValue1};
             co_return rsp1;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult rsp1{
                 .success = true,
                 .value = Bytes{}};
             co_return rsp1;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query3))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query3))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult rsp1{
                 .success = true,
                 .value = Bytes{}};
@@ -244,19 +244,19 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 1") {
         EXPECT_CALL(transaction, first_txn_num_in_block(5'405'096)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kAccountHistoryValue1};
             co_return response;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = Bytes{}};
             co_return response;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kAccountHistoryValue3};
@@ -362,19 +362,19 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 1") {
         EXPECT_CALL(transaction, first_txn_num_in_block(5'405'096)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kAccountHistoryValue1};
             co_return response;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = Bytes{}};
             co_return response;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kAccountHistoryValue3};
@@ -472,19 +472,19 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 1") {
         EXPECT_CALL(transaction, first_txn_num_in_block(5'405'096)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kAccountHistoryValue1};
             co_return response;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = Bytes{}};
             co_return response;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kAccountHistoryValue3};
@@ -587,19 +587,19 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 1") {
         EXPECT_CALL(transaction, first_txn_num_in_block(5'405'096)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kAccountHistoryValue1};
             co_return response;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = Bytes{}};
             co_return response;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kAccountHistoryValue3};
@@ -703,19 +703,19 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 1") {
         EXPECT_CALL(transaction, first_txn_num_in_block(5'405'096)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kAccountHistoryValue1};
             co_return response;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = Bytes{}};
             co_return response;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kAccountHistoryValue3};
@@ -806,19 +806,19 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 1") {
         EXPECT_CALL(transaction, first_txn_num_in_block(5'405'096)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kAccountHistoryValue1};
             co_return response;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = Bytes{}};
             co_return response;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kAccountHistoryValue3};
@@ -926,19 +926,19 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 2") {
         EXPECT_CALL(transaction, first_txn_num_in_block(4'417'197)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kAccountHistoryValue1};
             co_return response;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kAccountHistoryValue2};
             co_return response;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query3))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query3))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kAccountHistoryValue3};
@@ -1016,19 +1016,19 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call with error") {
     EXPECT_CALL(transaction, first_txn_num_in_block(5'405'096)).WillOnce(Invoke([]() -> Task<TxnId> {
         co_return 244087591818873;
     }));
-    EXPECT_CALL(transaction, domain_get(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+    EXPECT_CALL(transaction, get_latest(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
         db::kv::api::DomainPointResult response{
             .success = true,
             .value = kAccountHistoryValue1};
         co_return response;
     }));
-    EXPECT_CALL(transaction, domain_get(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+    EXPECT_CALL(transaction, get_latest(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
         db::kv::api::DomainPointResult response{
             .success = true,
             .value = Bytes{}};
         co_return response;
     }));
-    EXPECT_CALL(transaction, domain_get(std::move(query3))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+    EXPECT_CALL(transaction, get_latest(std::move(query3))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
         db::kv::api::DomainPointResult response{
             .success = true,
             .value = kAccountHistoryValue3};

--- a/silkworm/rpc/core/evm_executor_test.cpp
+++ b/silkworm/rpc/core/evm_executor_test.cpp
@@ -112,7 +112,7 @@ TEST_CASE_METHOD(EVMExecutorTest, "EVMExecutor") {
         EXPECT_CALL(transaction, first_txn_num_in_block(6'000'001)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, domain_get(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = Bytes{}};
@@ -138,7 +138,7 @@ TEST_CASE_METHOD(EVMExecutorTest, "EVMExecutor") {
         EXPECT_CALL(transaction, first_txn_num_in_block(6'000'001)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, domain_get(_)).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(_)).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = Bytes{}};
@@ -173,7 +173,7 @@ TEST_CASE_METHOD(EVMExecutorTest, "EVMExecutor") {
         EXPECT_CALL(transaction, first_txn_num_in_block(6'000'001)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, domain_get(_)).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(_)).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = Bytes{}};

--- a/silkworm/rpc/core/evm_trace_test.cpp
+++ b/silkworm/rpc/core/evm_trace_test.cpp
@@ -102,19 +102,19 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_call precompil
         EXPECT_CALL(transaction, first_txn_num_in_block(10'336'007)).Times(2).WillRepeatedly(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult rsp1{
                 .success = false,
                 .value = Bytes{}};
             co_return rsp1;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult rsp1{
                 .success = false,
                 .value = Bytes{}};
             co_return rsp1;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult rsp1{
                 .success = false,
                 .value = Bytes{}};
@@ -244,19 +244,19 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_call 1") {
         EXPECT_CALL(transaction, first_txn_num_in_block(5'405'096)).Times(2).WillRepeatedly(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kAccountHistoryValue1};
             co_return response;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = false,
                 .value = Bytes{}};
             co_return response;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kAccountHistoryValue3};
@@ -433,19 +433,19 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_call 1") {
         EXPECT_CALL(transaction, first_txn_num_in_block(5'405'096)).Times(2).WillRepeatedly(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kAccountHistoryValue1};
             co_return response;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = false,
                 .value = Bytes{}};
             co_return response;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kAccountHistoryValue3};
@@ -559,19 +559,19 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_call 1") {
         EXPECT_CALL(transaction, first_txn_num_in_block(5'405'096)).Times(2).WillRepeatedly(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kAccountHistoryValue1};
             co_return response;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = false,
                 .value = Bytes{}};
             co_return response;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kAccountHistoryValue3};
@@ -731,19 +731,19 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_call 1") {
         EXPECT_CALL(transaction, first_txn_num_in_block(5'405'096)).Times(2).WillRepeatedly(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kAccountHistoryValue1};
             co_return response;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = false,
                 .value = Bytes{}};
             co_return response;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kAccountHistoryValue3};
@@ -881,19 +881,19 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_call 1") {
         EXPECT_CALL(transaction, first_txn_num_in_block(5'405'096)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kAccountHistoryValue1};
             co_return response;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = false,
                 .value = Bytes{}};
             co_return response;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kAccountHistoryValue3};
@@ -965,19 +965,19 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_call 2") {
         EXPECT_CALL(transaction, first_txn_num_in_block(4'417'197)).Times(2).WillRepeatedly(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kAccountHistoryValue1};
             co_return response;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kAccountHistoryValue2};
             co_return response;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = false,
                 .value = Bytes{}};
@@ -1113,19 +1113,19 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_call with erro
     EXPECT_CALL(transaction, first_txn_num_in_block(5'405'096)).Times(2).WillRepeatedly(Invoke([]() -> Task<TxnId> {
         co_return 244087591818873;
     }));
-    EXPECT_CALL(transaction, domain_get(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+    EXPECT_CALL(transaction, get_latest(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
         db::kv::api::DomainPointResult response{
             .success = true,
             .value = kAccountHistoryValue1};
         co_return response;
     }));
-    EXPECT_CALL(transaction, domain_get(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+    EXPECT_CALL(transaction, get_latest(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
         db::kv::api::DomainPointResult response{
             .success = true,
             .value = kAccountHistoryValue2};
         co_return response;
     }));
-    EXPECT_CALL(transaction, domain_get(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+    EXPECT_CALL(transaction, get_latest(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
         db::kv::api::DomainPointResult response{
             .success = true,
             .value = kAccountHistoryValue3};
@@ -1304,19 +1304,19 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_calls") {
         EXPECT_CALL(transaction, first_txn_num_in_block(5'405'096)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kAccountHistoryValue1};
             co_return response;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = false,
                 .value = Bytes{}};
             co_return response;
         }));
-        EXPECT_CALL(transaction, domain_get(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kAccountHistoryValue3};
@@ -1512,19 +1512,19 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_block_transact
     EXPECT_CALL(transaction, first_txn_num_in_block(1'024'165)).Times(2).WillRepeatedly(Invoke([]() -> Task<TxnId> {
         co_return 244087591818873;
     }));
-    EXPECT_CALL(transaction, domain_get(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+    EXPECT_CALL(transaction, get_latest(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
         db::kv::api::DomainPointResult response{
             .success = true,
             .value = kAccountHistoryValue1};
         co_return response;
     }));
-    EXPECT_CALL(transaction, domain_get(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+    EXPECT_CALL(transaction, get_latest(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
         db::kv::api::DomainPointResult response{
             .success = false,
             .value = Bytes{}};
         co_return response;
     }));
-    EXPECT_CALL(transaction, domain_get(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+    EXPECT_CALL(transaction, get_latest(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
         db::kv::api::DomainPointResult response{
             .success = true,
             .value = kAccountHistoryValue3};
@@ -1968,19 +1968,19 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_block") {
     EXPECT_CALL(transaction, first_txn_num_in_block(1'024'165)).Times(2).WillRepeatedly(Invoke([]() -> Task<TxnId> {
         co_return 244087591818873;
     }));
-    EXPECT_CALL(transaction, domain_get(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+    EXPECT_CALL(transaction, get_latest(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
         db::kv::api::DomainPointResult response{
             .success = false,
             .value = Bytes{}};
         co_return response;
     }));
-    EXPECT_CALL(transaction, domain_get(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+    EXPECT_CALL(transaction, get_latest(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
         db::kv::api::DomainPointResult response{
             .success = true,
             .value = kAccountHistoryValue2};
         co_return response;
     }));
-    EXPECT_CALL(transaction, domain_get(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+    EXPECT_CALL(transaction, get_latest(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
         db::kv::api::DomainPointResult response{
             .success = true,
             .value = kAccountHistoryValue3};
@@ -2107,19 +2107,19 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_replayTransact
         EXPECT_CALL(transaction, first_txn_num_in_block(1'024'165)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, domain_get(silkworm::db::kv::api::DomainPointQuery{query1})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(silkworm::db::kv::api::DomainPointQuery{query1})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kAccountHistoryValue1};
             co_return response;
         }));
-        EXPECT_CALL(transaction, domain_get(silkworm::db::kv::api::DomainPointQuery{query2})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(silkworm::db::kv::api::DomainPointQuery{query2})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = false,
                 .value = Bytes{}};
             co_return response;
         }));
-        EXPECT_CALL(transaction, domain_get(silkworm::db::kv::api::DomainPointQuery{query3})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(silkworm::db::kv::api::DomainPointQuery{query3})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kAccountHistoryValue3};
@@ -2445,19 +2445,19 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_replayTransact
         EXPECT_CALL(transaction, first_txn_num_in_block(1'024'165)).Times(2).WillRepeatedly(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, domain_get(silkworm::db::kv::api::DomainPointQuery{query1})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(silkworm::db::kv::api::DomainPointQuery{query1})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kAccountHistoryValue1};
             co_return response;
         }));
-        EXPECT_CALL(transaction, domain_get(silkworm::db::kv::api::DomainPointQuery{query2})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(silkworm::db::kv::api::DomainPointQuery{query2})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = false,
                 .value = Bytes{}};
             co_return response;
         }));
-        EXPECT_CALL(transaction, domain_get(silkworm::db::kv::api::DomainPointQuery{query3})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(silkworm::db::kv::api::DomainPointQuery{query3})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kAccountHistoryValue3};
@@ -2497,19 +2497,19 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_replayTransact
         EXPECT_CALL(transaction, first_txn_num_in_block(1'024'165)).Times(2).WillRepeatedly(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, domain_get(silkworm::db::kv::api::DomainPointQuery{query1})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(silkworm::db::kv::api::DomainPointQuery{query1})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kAccountHistoryValue1};
             co_return response;
         }));
-        EXPECT_CALL(transaction, domain_get(silkworm::db::kv::api::DomainPointQuery{query2})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(silkworm::db::kv::api::DomainPointQuery{query2})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = false,
                 .value = Bytes{}};
             co_return response;
         }));
-        EXPECT_CALL(transaction, domain_get(silkworm::db::kv::api::DomainPointQuery{query3})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(silkworm::db::kv::api::DomainPointQuery{query3})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kAccountHistoryValue3};
@@ -2572,19 +2572,19 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_replayTransact
         EXPECT_CALL(transaction, first_txn_num_in_block(1'024'165)).Times(2).WillRepeatedly(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, domain_get(silkworm::db::kv::api::DomainPointQuery{query1})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(silkworm::db::kv::api::DomainPointQuery{query1})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kAccountHistoryValue1};
             co_return response;
         }));
-        EXPECT_CALL(transaction, domain_get(silkworm::db::kv::api::DomainPointQuery{query2})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(silkworm::db::kv::api::DomainPointQuery{query2})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = false,
                 .value = Bytes{}};
             co_return response;
         }));
-        EXPECT_CALL(transaction, domain_get(silkworm::db::kv::api::DomainPointQuery{query3})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_latest(silkworm::db::kv::api::DomainPointQuery{query3})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kAccountHistoryValue3};
@@ -3004,19 +3004,19 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_transaction") 
     EXPECT_CALL(transaction, first_txn_num_in_block(1'024'165)).Times(2).WillRepeatedly(Invoke([]() -> Task<TxnId> {
         co_return 244087591818873;
     }));
-    EXPECT_CALL(transaction, domain_get(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+    EXPECT_CALL(transaction, get_latest(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
         db::kv::api::DomainPointResult rsp1{
             .success = false,
             .value = Bytes{}};
         co_return rsp1;
     }));
-    EXPECT_CALL(transaction, domain_get(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+    EXPECT_CALL(transaction, get_latest(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
         db::kv::api::DomainPointResult rsp1{
             .success = true,
             .value = kAccountHistoryValue2};
         co_return rsp1;
     }));
-    EXPECT_CALL(transaction, domain_get(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+    EXPECT_CALL(transaction, get_latest(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
         db::kv::api::DomainPointResult rsp1{
             .success = true,
             .value = kAccountHistoryValue3};

--- a/silkworm/rpc/core/storage_walker.cpp
+++ b/silkworm/rpc/core/storage_walker.cpp
@@ -190,7 +190,7 @@ Task<void> StorageWalker::storage_range_at(
         .to_key = to,
         .timestamp = txn_number,
         .ascending_order = true};
-    auto paginated_result = co_await transaction_.domain_range(std::move(query));
+    auto paginated_result = co_await transaction_.range_as_of(std::move(query));
     auto it = co_await paginated_result.begin();
 
     while (const auto value = co_await it.next()) {

--- a/silkworm/rpc/core/storage_walker_test.cpp
+++ b/silkworm/rpc/core/storage_walker_test.cpp
@@ -210,7 +210,7 @@ class DummyTransaction : public BaseTransaction {
         co_return;
     }
 
-    Task<db::kv::api::DomainPointResult> domain_get(db::kv::api::DomainPointQuery /*query*/) override {
+    Task<db::kv::api::DomainPointResult> get_latest(db::kv::api::DomainPointQuery /*query*/) override {
         co_return db::kv::api::DomainPointResult{};
     }
 
@@ -226,7 +226,7 @@ class DummyTransaction : public BaseTransaction {
         co_return test::empty_paginated_keys_and_values();
     }
 
-    Task<db::kv::api::PaginatedKeysValues> domain_range(db::kv::api::DomainRangeQuery /*query*/) override {
+    Task<db::kv::api::PaginatedKeysValues> range_as_of(db::kv::api::DomainRangeQuery /*query*/) override {
         co_return test::empty_paginated_keys_and_values();
     }
 

--- a/silkworm/rpc/test_util/dummy_transaction.hpp
+++ b/silkworm/rpc/test_util/dummy_transaction.hpp
@@ -84,7 +84,7 @@ class DummyTransaction : public db::kv::api::BaseTransaction {
 
     Task<void> close() override { co_return; }
 
-    Task<db::kv::api::DomainPointResult> domain_get(db::kv::api::DomainPointQuery /*query*/) override {
+    Task<db::kv::api::DomainPointResult> get_latest(db::kv::api::DomainPointQuery /*query*/) override {
         co_return db::kv::api::DomainPointResult{};
     }
 
@@ -100,7 +100,7 @@ class DummyTransaction : public db::kv::api::BaseTransaction {
         co_return empty_paginated_keys_and_values();
     }
 
-    Task<db::kv::api::PaginatedKeysValues> domain_range(db::kv::api::DomainRangeQuery /*query*/) override {
+    Task<db::kv::api::PaginatedKeysValues> range_as_of(db::kv::api::DomainRangeQuery /*query*/) override {
         co_return test::empty_paginated_keys_and_values();
     }
 


### PR DESCRIPTION
Update `erigon-interface` to https://github.com/erigontech/interfaces/commit/f8b02083414eae92ade4d8ef768ed9473368b2d2, see also:

https://github.com/erigontech/erigon/pull/12621
https://github.com/erigontech/erigon/pull/12676
https://github.com/erigontech/erigon/pull/12740

*Extras*
- restore `debug_accountAt` integration tests