### PR TITLE
db: split internal TKV get_latest method to match e3

### DIFF
--- a/cmake/run_unit_tests.sh
+++ b/cmake/run_unit_tests.sh
@@ -3,12 +3,12 @@
 set -e
 set -o pipefail
 
-if test `uname -s` = Linux
+if test "$(uname -s)" = Linux
 then
     ulimit -s unlimited
 fi
 
-script_dir=`dirname "$0"`
+script_dir=$(dirname "$0")
 
 cmake "-DSILKWORM_BUILD_DIR=$1" "-DSILKWORM_CLANG_COVERAGE=$2" -P "$script_dir/run_unit_tests.cmake" \
 	| grep -Ev '^(Randomness|RNG seed|============================)'

--- a/cmd/dev/grpc_toolbox.cpp
+++ b/cmd/dev/grpc_toolbox.cpp
@@ -849,7 +849,7 @@ int kv_seek() {
 }
 
 Task<void> kv_get_latest_query(const std::shared_ptr<Service>& kv_service,
-                               DomainPointQuery&& query,
+                               GetLatestQuery&& query,
                                const bool /*verbose*/) {
     try {
         auto tx = co_await kv_service->begin_transaction();
@@ -1057,7 +1057,7 @@ int kv_get_latest() {
         };
         return execute_temporal_kv_query(target, kv_get_as_of_query, std::move(query), verbose);
     }
-    DomainPointQuery query{
+    GetLatestQuery query{
         .table = table_name,
         .key = *key_bytes,
     };

--- a/cmd/dev/grpc_toolbox.cpp
+++ b/cmd/dev/grpc_toolbox.cpp
@@ -853,9 +853,23 @@ Task<void> kv_get_latest_query(const std::shared_ptr<Service>& kv_service,
                                const bool /*verbose*/) {
     try {
         auto tx = co_await kv_service->begin_transaction();
-        std::cout << "KV GetLatest -> " << query.table << " key=" << to_hex(query.key)
-                  << " ts=" << (query.timestamp ? *query.timestamp : -1) << " [latest: " << !query.timestamp.has_value() << "]\n";
+        std::cout << "KV GetLatest -> " << query.table << " key=" << to_hex(query.key) << " latest=true\n";
         const auto result = co_await tx->get_latest(std::move(query));
+        std::cout << "KV GetLatest <- success: " << result.success << " value=" << to_hex(result.value) << "\n";
+        co_await tx->close();
+    } catch (const std::exception& e) {
+        std::cout << "KV GetLatest <- error: " << e.what() << "\n";
+    }
+}
+
+Task<void> kv_get_as_of_query(const std::shared_ptr<Service>& kv_service,
+                              GetAsOfQuery&& query,
+                              const bool /*verbose*/) {
+    try {
+        auto tx = co_await kv_service->begin_transaction();
+        std::cout << "KV GetLatest -> " << query.table << " key=" << to_hex(query.key)
+                  << " ts=" << query.timestamp << " latest=false\n";
+        const auto result = co_await tx->get_as_of(std::move(query));
         std::cout << "KV GetLatest <- success: " << result.success << " value=" << to_hex(result.value) << "\n";
         co_await tx->close();
     } catch (const std::exception& e) {
@@ -1035,10 +1049,17 @@ int kv_get_latest() {
 
     const auto verbose{absl::GetFlag(FLAGS_verbose)};
 
+    if (timestamp > -1) {
+        GetAsOfQuery query{
+            .table = table_name,
+            .key = *key_bytes,
+            .timestamp = timestamp,
+        };
+        return execute_temporal_kv_query(target, kv_get_as_of_query, std::move(query), verbose);
+    }
     DomainPointQuery query{
         .table = table_name,
         .key = *key_bytes,
-        .timestamp = timestamp > -1 ? std::make_optional(timestamp) : std::nullopt,
     };
     return execute_temporal_kv_query(target, kv_get_latest_query, std::move(query), verbose);
 }

--- a/silkworm/db/kv/api/endpoint/temporal_point.hpp
+++ b/silkworm/db/kv/api/endpoint/temporal_point.hpp
@@ -41,7 +41,6 @@ struct DomainPointQuery {
     TxId tx_id{0};
     std::string table;
     Bytes key;
-    std::optional<Timestamp> timestamp;  // not present means 'latest state' (no history lookup)
     Bytes sub_key;
 
     // TODO(canepat) we need clang >= 17 to use spaceship operator instead of hand-made operator== below
@@ -52,10 +51,30 @@ inline bool operator==(const DomainPointQuery& lhs, const DomainPointQuery& rhs)
     return (lhs.tx_id == rhs.tx_id) &&
            (lhs.table == rhs.table) &&
            (lhs.key == rhs.key) &&
-           (lhs.timestamp == rhs.timestamp) &&
            (lhs.sub_key == rhs.sub_key);
 }
 
 using DomainPointResult = PointResult;
+
+struct GetAsOfQuery {
+    TxId tx_id{0};
+    std::string table;
+    Bytes key;
+    Bytes sub_key;
+    Timestamp timestamp;
+
+    // TODO(canepat) we need clang >= 17 to use spaceship operator instead of hand-made operator== below
+    // auto operator<=>(const GetAsOfQuery&) const = default;
+};
+
+inline bool operator==(const GetAsOfQuery& lhs, const GetAsOfQuery& rhs) {
+    return (lhs.tx_id == rhs.tx_id) &&
+           (lhs.table == rhs.table) &&
+           (lhs.key == rhs.key) &&
+           (lhs.sub_key == rhs.sub_key) &&
+           (lhs.timestamp == rhs.timestamp);
+}
+
+using GetAsOfResult = PointResult;
 
 }  // namespace silkworm::db::kv::api

--- a/silkworm/db/kv/api/endpoint/temporal_point.hpp
+++ b/silkworm/db/kv/api/endpoint/temporal_point.hpp
@@ -37,24 +37,24 @@ struct HistoryPointQuery {
 
 using HistoryPointResult = PointResult;
 
-struct DomainPointQuery {
+struct GetLatestQuery {
     TxId tx_id{0};
     std::string table;
     Bytes key;
     Bytes sub_key;
 
     // TODO(canepat) we need clang >= 17 to use spaceship operator instead of hand-made operator== below
-    // auto operator<=>(const DomainPointQuery&) const = default;
+    // auto operator<=>(const GetLatestQuery&) const = default;
 };
 
-inline bool operator==(const DomainPointQuery& lhs, const DomainPointQuery& rhs) {
+inline bool operator==(const GetLatestQuery& lhs, const GetLatestQuery& rhs) {
     return (lhs.tx_id == rhs.tx_id) &&
            (lhs.table == rhs.table) &&
            (lhs.key == rhs.key) &&
            (lhs.sub_key == rhs.sub_key);
 }
 
-using DomainPointResult = PointResult;
+using GetLatestResult = PointResult;
 
 struct GetAsOfQuery {
     TxId tx_id{0};

--- a/silkworm/db/kv/api/local_transaction.cpp
+++ b/silkworm/db/kv/api/local_transaction.cpp
@@ -74,9 +74,9 @@ Task<TxnId> LocalTransaction::first_txn_num_in_block(BlockNum /*block_num*/) {
     throw std::logic_error{"not yet implemented"};
 }
 
-Task<DomainPointResult> LocalTransaction::get_latest(DomainPointQuery /*query*/) {
+Task<GetLatestResult> LocalTransaction::get_latest(GetLatestQuery /*query*/) {
     // TODO(canepat) implement using E3-like aggregator abstraction [tx_id_ must be changed]
-    co_return DomainPointResult{};
+    co_return GetLatestResult{};
 }
 
 Task<GetAsOfResult> LocalTransaction::get_as_of(GetAsOfQuery /*query*/) {

--- a/silkworm/db/kv/api/local_transaction.cpp
+++ b/silkworm/db/kv/api/local_transaction.cpp
@@ -79,6 +79,11 @@ Task<DomainPointResult> LocalTransaction::get_latest(DomainPointQuery /*query*/)
     co_return DomainPointResult{};
 }
 
+Task<GetAsOfResult> LocalTransaction::get_as_of(GetAsOfQuery /*query*/) {
+    // TODO(canepat) implement using E3-like aggregator abstraction [tx_id_ must be changed]
+    co_return GetAsOfResult{};
+}
+
 Task<HistoryPointResult> LocalTransaction::history_seek(HistoryPointQuery /*query*/) {
     // TODO(canepat) implement using E3-like aggregator abstraction [tx_id_ must be changed]
     co_return HistoryPointResult{};

--- a/silkworm/db/kv/api/local_transaction.hpp
+++ b/silkworm/db/kv/api/local_transaction.hpp
@@ -62,7 +62,7 @@ class LocalTransaction : public BaseTransaction {
     Task<void> close() override;
 
     // rpc GetLatest(GetLatestReq) returns (GetLatestReply); w/ latest=true (ts ignored)
-    Task<DomainPointResult> get_latest(DomainPointQuery query) override;
+    Task<GetLatestResult> get_latest(GetLatestQuery query) override;
 
     // rpc GetLatest(GetLatestReq) returns (GetLatestReply); w/ latest=false (ts used)
     Task<GetAsOfResult> get_as_of(GetAsOfQuery query) override;

--- a/silkworm/db/kv/api/local_transaction.hpp
+++ b/silkworm/db/kv/api/local_transaction.hpp
@@ -61,8 +61,11 @@ class LocalTransaction : public BaseTransaction {
 
     Task<void> close() override;
 
-    // rpc GetLatest(GetLatestReq) returns (GetLatestReply);
+    // rpc GetLatest(GetLatestReq) returns (GetLatestReply); w/ latest=true (ts ignored)
     Task<DomainPointResult> get_latest(DomainPointQuery query) override;
+
+    // rpc GetLatest(GetLatestReq) returns (GetLatestReply); w/ latest=false (ts used)
+    Task<GetAsOfResult> get_as_of(GetAsOfQuery query) override;
 
     // rpc HistorySeek(HistorySeekReq) returns (HistorySeekReply);
     Task<HistoryPointResult> history_seek(HistoryPointQuery query) override;

--- a/silkworm/db/kv/api/transaction.hpp
+++ b/silkworm/db/kv/api/transaction.hpp
@@ -72,8 +72,11 @@ class Transaction {
 
     /** Temporal Point Queries **/
 
-    // rpc GetLatest(GetLatestReq) returns (GetLatestReply);
+    // rpc GetLatest(GetLatestReq) returns (GetLatestReply); w/ latest=true (ts ignored)
     virtual Task<DomainPointResult> get_latest(DomainPointQuery query) = 0;
+
+    // rpc GetLatest(GetLatestReq) returns (GetLatestReply); w/ latest=false (ts used)
+    virtual Task<GetAsOfResult> get_as_of(GetAsOfQuery query) = 0;
 
     // rpc HistorySeek(HistorySeekReq) returns (HistorySeekReply);
     virtual Task<HistoryPointResult> history_seek(HistoryPointQuery query) = 0;

--- a/silkworm/db/kv/api/transaction.hpp
+++ b/silkworm/db/kv/api/transaction.hpp
@@ -73,7 +73,7 @@ class Transaction {
     /** Temporal Point Queries **/
 
     // rpc GetLatest(GetLatestReq) returns (GetLatestReply); w/ latest=true (ts ignored)
-    virtual Task<DomainPointResult> get_latest(DomainPointQuery query) = 0;
+    virtual Task<GetLatestResult> get_latest(GetLatestQuery query) = 0;
 
     // rpc GetLatest(GetLatestReq) returns (GetLatestReply); w/ latest=false (ts used)
     virtual Task<GetAsOfResult> get_as_of(GetAsOfQuery query) = 0;

--- a/silkworm/db/kv/grpc/client/endpoint/temporal_point.cpp
+++ b/silkworm/db/kv/grpc/client/endpoint/temporal_point.cpp
@@ -38,7 +38,7 @@ api::HistoryPointResult history_seek_result_from_response(const proto::HistorySe
     return result;
 }
 
-proto::GetLatestReq get_latest_request_from_query(const api::DomainPointQuery& query) {
+proto::GetLatestReq get_latest_request_from_query(const api::GetLatestQuery& query) {
     proto::GetLatestReq request;
     request.set_tx_id(query.tx_id);
     request.set_table(query.table);
@@ -48,8 +48,8 @@ proto::GetLatestReq get_latest_request_from_query(const api::DomainPointQuery& q
     return request;
 }
 
-api::DomainPointResult get_latest_result_from_response(const proto::GetLatestReply& response) {
-    api::DomainPointResult result;
+api::GetLatestResult get_latest_result_from_response(const proto::GetLatestReply& response) {
+    api::GetLatestResult result;
     result.success = response.ok();
     result.value = string_to_bytes(response.v());
     return result;

--- a/silkworm/db/kv/grpc/client/endpoint/temporal_point.cpp
+++ b/silkworm/db/kv/grpc/client/endpoint/temporal_point.cpp
@@ -17,7 +17,6 @@
 #include "temporal_point.hpp"
 
 #include <silkworm/core/common/bytes_to_string.hpp>
-#include <silkworm/core/common/util.hpp>
 
 namespace silkworm::db::kv::grpc::client {
 
@@ -39,22 +38,35 @@ api::HistoryPointResult history_seek_result_from_response(const proto::HistorySe
     return result;
 }
 
-proto::GetLatestReq domain_get_request_from_query(const api::DomainPointQuery& query) {
+proto::GetLatestReq get_latest_request_from_query(const api::DomainPointQuery& query) {
     proto::GetLatestReq request;
     request.set_tx_id(query.tx_id);
     request.set_table(query.table);
     request.set_k(query.key.data(), query.key.size());
-    if (query.timestamp) {
-        request.set_ts(static_cast<uint64_t>(*query.timestamp));
-    } else {
-        request.set_latest(true);
-    }
+    request.set_latest(true);
     request.set_k2(query.sub_key.data(), query.sub_key.size());
     return request;
 }
 
-api::DomainPointResult domain_get_result_from_response(const proto::GetLatestReply& response) {
+api::DomainPointResult get_latest_result_from_response(const proto::GetLatestReply& response) {
     api::DomainPointResult result;
+    result.success = response.ok();
+    result.value = string_to_bytes(response.v());
+    return result;
+}
+
+::remote::GetLatestReq get_as_of_request_from_query(const api::GetAsOfQuery& query) {
+    proto::GetLatestReq request;
+    request.set_tx_id(query.tx_id);
+    request.set_table(query.table);
+    request.set_k(query.key.data(), query.key.size());
+    request.set_ts(static_cast<uint64_t>(query.timestamp));
+    request.set_k2(query.sub_key.data(), query.sub_key.size());
+    return request;
+}
+
+api::GetAsOfResult get_as_of_result_from_response(const ::remote::GetLatestReply& response) {
+    api::GetAsOfResult result;
     result.success = response.ok();
     result.value = string_to_bytes(response.v());
     return result;

--- a/silkworm/db/kv/grpc/client/endpoint/temporal_point.hpp
+++ b/silkworm/db/kv/grpc/client/endpoint/temporal_point.hpp
@@ -25,8 +25,8 @@ namespace silkworm::db::kv::grpc::client {
 ::remote::HistorySeekReq history_seek_request_from_query(const api::HistoryPointQuery&);
 api::HistoryPointResult history_seek_result_from_response(const ::remote::HistorySeekReply&);
 
-::remote::GetLatestReq get_latest_request_from_query(const api::DomainPointQuery&);
-api::DomainPointResult get_latest_result_from_response(const ::remote::GetLatestReply&);
+::remote::GetLatestReq get_latest_request_from_query(const api::GetLatestQuery&);
+api::GetLatestResult get_latest_result_from_response(const ::remote::GetLatestReply&);
 
 ::remote::GetLatestReq get_as_of_request_from_query(const api::GetAsOfQuery&);
 api::GetAsOfResult get_as_of_result_from_response(const ::remote::GetLatestReply&);

--- a/silkworm/db/kv/grpc/client/endpoint/temporal_point.hpp
+++ b/silkworm/db/kv/grpc/client/endpoint/temporal_point.hpp
@@ -25,7 +25,10 @@ namespace silkworm::db::kv::grpc::client {
 ::remote::HistorySeekReq history_seek_request_from_query(const api::HistoryPointQuery&);
 api::HistoryPointResult history_seek_result_from_response(const ::remote::HistorySeekReply&);
 
-::remote::GetLatestReq domain_get_request_from_query(const api::DomainPointQuery&);
-api::DomainPointResult domain_get_result_from_response(const ::remote::GetLatestReply&);
+::remote::GetLatestReq get_latest_request_from_query(const api::DomainPointQuery&);
+api::DomainPointResult get_latest_result_from_response(const ::remote::GetLatestReply&);
+
+::remote::GetLatestReq get_as_of_request_from_query(const api::GetAsOfQuery&);
+api::GetAsOfResult get_as_of_result_from_response(const ::remote::GetLatestReply&);
 
 }  // namespace silkworm::db::kv::grpc::client

--- a/silkworm/db/kv/grpc/client/endpoint/temporal_point_test.cpp
+++ b/silkworm/db/kv/grpc/client/endpoint/temporal_point_test.cpp
@@ -80,9 +80,9 @@ TEST_CASE("get_as_of_request_from_query", "[node][remote][kv][grpc]") {
 }
 
 TEST_CASE("get_as_of_result_from_response", "[node][remote][kv][grpc]") {
-    const Fixtures<proto::GetLatestReply, api::DomainPointResult> fixtures{
+    const Fixtures<proto::GetLatestReply, api::GetAsOfResult> fixtures{
         {{}, {}},
-        {sample_proto_get_as_of_response(), sample_domain_point_result()},
+        {sample_proto_get_as_of_response(), sample_get_as_of_result()},
     };
     for (const auto& [response, expected_point_result] : fixtures) {
         SECTION("ok: " + std::to_string(response.ok())) {

--- a/silkworm/db/kv/grpc/client/endpoint/temporal_point_test.cpp
+++ b/silkworm/db/kv/grpc/client/endpoint/temporal_point_test.cpp
@@ -61,13 +61,13 @@ TEST_CASE("history_get_result_from_response", "[node][remote][kv][grpc]") {
     }
 }
 
-TEST_CASE("domain_get_request_from_query", "[node][remote][kv][grpc]") {
-    const Fixtures<api::DomainPointQuery, proto::GetLatestReq> fixtures{
-        {sample_domain_point_query(), sample_proto_domain_point_request()},
+TEST_CASE("get_as_of_request_from_query", "[node][remote][kv][grpc]") {
+    const Fixtures<api::GetAsOfQuery, proto::GetLatestReq> fixtures{
+        {sample_get_as_of_query(), sample_proto_get_as_of_request()},
     };
     for (const auto& [query, expected_point_request] : fixtures) {
         SECTION("query: " + std::to_string(query.tx_id)) {
-            const auto& point_request{domain_get_request_from_query(query)};
+            const auto& point_request{get_as_of_request_from_query(query)};
             // CHECK(point_request == expected_point_request);  // requires operator== in gRPC
             CHECK(point_request.tx_id() == expected_point_request.tx_id());
             CHECK(point_request.table() == expected_point_request.table());
@@ -79,14 +79,14 @@ TEST_CASE("domain_get_request_from_query", "[node][remote][kv][grpc]") {
     }
 }
 
-TEST_CASE("domain_get_result_from_response", "[node][remote][kv][grpc]") {
+TEST_CASE("get_as_of_result_from_response", "[node][remote][kv][grpc]") {
     const Fixtures<proto::GetLatestReply, api::DomainPointResult> fixtures{
         {{}, {}},
-        {sample_proto_domain_get_response(), sample_domain_point_result()},
+        {sample_proto_get_as_of_response(), sample_domain_point_result()},
     };
     for (const auto& [response, expected_point_result] : fixtures) {
         SECTION("ok: " + std::to_string(response.ok())) {
-            const auto& point_result{domain_get_result_from_response(response)};
+            const auto& point_result{get_as_of_result_from_response(response)};
             // CHECK(point_result == expected_point_result);  // requires operator== in gRPC
             CHECK(point_result.success == expected_point_result.success);
             CHECK(point_result.value == expected_point_result.value);

--- a/silkworm/db/kv/grpc/client/remote_transaction.cpp
+++ b/silkworm/db/kv/grpc/client/remote_transaction.cpp
@@ -125,12 +125,25 @@ Task<TxnId> RemoteTransaction::first_txn_num_in_block(BlockNum block_num) {
 Task<api::DomainPointResult> RemoteTransaction::get_latest(api::DomainPointQuery query) {
     try {
         query.tx_id = tx_id_;
-        auto request = domain_get_request_from_query(query);
+        auto request = get_latest_request_from_query(query);
         const auto reply = co_await rpc::unary_rpc(&Stub::AsyncGetLatest, stub_, std::move(request), grpc_context_);
-        auto result = domain_get_result_from_response(reply);
+        auto result = get_latest_result_from_response(reply);
         co_return result;
     } catch (rpc::GrpcStatusError& gse) {
-        SILK_WARN << "KV::GetLatest RPC failed status=" << gse.status();
+        SILK_WARN << "KV::GetLatest (latest) RPC failed status=" << gse.status();
+        throw boost::system::system_error{rpc::to_system_code(gse.status().error_code())};
+    }
+}
+
+Task<api::GetAsOfResult> RemoteTransaction::get_as_of(api::GetAsOfQuery query) {
+    try {
+        query.tx_id = tx_id_;
+        auto request = get_as_of_request_from_query(query);
+        const auto reply = co_await rpc::unary_rpc(&Stub::AsyncGetLatest, stub_, std::move(request), grpc_context_);
+        auto result = get_as_of_result_from_response(reply);
+        co_return result;
+    } catch (rpc::GrpcStatusError& gse) {
+        SILK_WARN << "KV::GetLatest (as_of) RPC failed status=" << gse.status();
         throw boost::system::system_error{rpc::to_system_code(gse.status().error_code())};
     }
 }

--- a/silkworm/db/kv/grpc/client/remote_transaction.cpp
+++ b/silkworm/db/kv/grpc/client/remote_transaction.cpp
@@ -122,7 +122,7 @@ Task<TxnId> RemoteTransaction::first_txn_num_in_block(BlockNum block_num) {
     co_return min_txn_num + /*txn_index*/ 0;
 }
 
-Task<api::DomainPointResult> RemoteTransaction::get_latest(api::DomainPointQuery query) {
+Task<api::GetLatestResult> RemoteTransaction::get_latest(api::GetLatestQuery query) {
     try {
         query.tx_id = tx_id_;
         auto request = get_latest_request_from_query(query);

--- a/silkworm/db/kv/grpc/client/remote_transaction.hpp
+++ b/silkworm/db/kv/grpc/client/remote_transaction.hpp
@@ -63,7 +63,7 @@ class RemoteTransaction : public api::BaseTransaction {
     Task<void> close() override;
 
     // rpc GetLatest(GetLatestReq) returns (GetLatestReply); w/ latest=true (ts ignored)
-    Task<api::DomainPointResult> get_latest(api::DomainPointQuery query) override;
+    Task<api::GetLatestResult> get_latest(api::GetLatestQuery query) override;
 
     // rpc GetLatest(GetLatestReq) returns (GetLatestReply); w/ latest=false (ts used)
     Task<api::GetAsOfResult> get_as_of(api::GetAsOfQuery query) override;

--- a/silkworm/db/kv/grpc/client/remote_transaction.hpp
+++ b/silkworm/db/kv/grpc/client/remote_transaction.hpp
@@ -62,8 +62,11 @@ class RemoteTransaction : public api::BaseTransaction {
 
     Task<void> close() override;
 
-    // rpc GetLatest(GetLatestReq) returns (GetLatestReply);
+    // rpc GetLatest(GetLatestReq) returns (GetLatestReply); w/ latest=true (ts ignored)
     Task<api::DomainPointResult> get_latest(api::DomainPointQuery query) override;
+
+    // rpc GetLatest(GetLatestReq) returns (GetLatestReply); w/ latest=false (ts used)
+    Task<api::GetAsOfResult> get_as_of(api::GetAsOfQuery query) override;
 
     // rpc HistorySeek(HistorySeekReq) returns (HistorySeekReply);
     Task<api::HistoryPointResult> history_seek(api::HistoryPointQuery query) override;

--- a/silkworm/db/kv/grpc/client/remote_transaction_test.cpp
+++ b/silkworm/db/kv/grpc/client/remote_transaction_test.cpp
@@ -429,7 +429,7 @@ TEST_CASE_METHOD(RemoteTransactionTest, "RemoteTransaction::cursor_dup_sort", "[
 #endif  // SILKWORM_SANITIZE
 
 TEST_CASE_METHOD(RemoteTransactionTest, "RemoteTransaction::get_latest", "[db][kv][grpc][client][remote_transaction]") {
-    using db::kv::test_util::sample_proto_domain_get_response;
+    using db::kv::test_util::sample_proto_get_latest_response;
 
     auto get_latest = [&]() -> Task<api::DomainPointResult> {
 #if __GNUC__ < 13 && !defined(__clang__)  // Clang compiler defines __GNUC__ as well
@@ -450,7 +450,7 @@ TEST_CASE_METHOD(RemoteTransactionTest, "RemoteTransaction::get_latest", "[db][k
     api::DomainPointResult result;
 
     SECTION("call get_latest and get result") {
-        proto::GetLatestReply reply{sample_proto_domain_get_response()};
+        proto::GetLatestReply reply{sample_proto_get_latest_response()};
         EXPECT_CALL(reader, Finish).WillOnce(rpc::test::finish_with(grpc_context_, std::move(reply)));
 
         CHECK_NOTHROW((result = spawn_and_wait(get_latest)));

--- a/silkworm/db/kv/grpc/client/remote_transaction_test.cpp
+++ b/silkworm/db/kv/grpc/client/remote_transaction_test.cpp
@@ -431,15 +431,15 @@ TEST_CASE_METHOD(RemoteTransactionTest, "RemoteTransaction::cursor_dup_sort", "[
 TEST_CASE_METHOD(RemoteTransactionTest, "RemoteTransaction::get_latest", "[db][kv][grpc][client][remote_transaction]") {
     using db::kv::test_util::sample_proto_get_latest_response;
 
-    auto get_latest = [&]() -> Task<api::DomainPointResult> {
+    auto get_latest = [&]() -> Task<api::GetLatestResult> {
 #if __GNUC__ < 13 && !defined(__clang__)  // Clang compiler defines __GNUC__ as well
-        // Before GCC 13, we must avoid passing api::DomainPointQuery as temporary because co_await-ing expressions
+        // Before GCC 13, we must avoid passing api::GetLatestQuery as temporary because co_await-ing expressions
         // that involve compiler-generated constructors binding references to pr-values seems to trigger this bug:
         // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100611
-        api::DomainPointQuery query;
-        const api::DomainPointResult result = co_await remote_tx_.get_latest(std::move(query));
+        api::GetLatestQuery query;
+        const api::GetLatestResult result = co_await remote_tx_.get_latest(std::move(query));
 #else
-        const api::DomainPointResult result = co_await remote_tx_.get_latest(api::DomainPointQuery{});
+        const api::GetLatestResult result = co_await remote_tx_.get_latest(api::GetLatestQuery{});
 #endif  // #if __GNUC__ < 13 && !defined(__clang__)
         co_return result;
     };
@@ -447,7 +447,7 @@ TEST_CASE_METHOD(RemoteTransactionTest, "RemoteTransaction::get_latest", "[db][k
     rpc::test::StrictMockAsyncResponseReader<proto::GetLatestReply> reader;
     EXPECT_CALL(*stub_, AsyncGetLatestRaw).WillOnce(testing::Return(&reader));
 
-    api::DomainPointResult result;
+    api::GetLatestResult result;
 
     SECTION("call get_latest and get result") {
         proto::GetLatestReply reply{sample_proto_get_latest_response()};
@@ -468,6 +468,49 @@ TEST_CASE_METHOD(RemoteTransactionTest, "RemoteTransaction::get_latest", "[db][k
         EXPECT_CALL(reader, Finish).WillOnce(rpc::test::finish_cancelled(grpc_context_));
 
         CHECK_THROWS_AS(spawn_and_wait(get_latest), boost::system::system_error);
+    }
+}
+
+TEST_CASE_METHOD(RemoteTransactionTest, "RemoteTransaction::get_as_of", "[db][kv][grpc][client][remote_transaction]") {
+    using db::kv::test_util::sample_proto_get_as_of_response;
+
+    auto get_as_of = [&]() -> Task<api::GetAsOfResult> {
+#if __GNUC__ < 13 && !defined(__clang__)  // Clang compiler defines __GNUC__ as well
+        // Before GCC 13, we must avoid passing api::GetLatestQuery as temporary because co_await-ing expressions
+        // that involve compiler-generated constructors binding references to pr-values seems to trigger this bug:
+        // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100611
+        api::GetAsOfQuery query;
+        const api::GetAsOfResult result = co_await remote_tx_.get_as_of(std::move(query));
+#else
+        const api::GetAsOfResult result = co_await remote_tx_.get_as_of(api::GetAsOfQuery{});
+#endif  // #if __GNUC__ < 13 && !defined(__clang__)
+        co_return result;
+    };
+
+    rpc::test::StrictMockAsyncResponseReader<proto::GetLatestReply> reader;
+    EXPECT_CALL(*stub_, AsyncGetLatestRaw).WillOnce(testing::Return(&reader));
+
+    api::GetAsOfResult result;
+
+    SECTION("call get_as_of and get result") {
+        proto::GetLatestReply reply{sample_proto_get_as_of_response()};
+        EXPECT_CALL(reader, Finish).WillOnce(rpc::test::finish_with(grpc_context_, std::move(reply)));
+
+        CHECK_NOTHROW((result = spawn_and_wait(get_as_of)));
+        CHECK(result.success);
+        CHECK(result.value == from_hex("ff00ff00"));
+    }
+    SECTION("call get_as_of and get empty result") {
+        EXPECT_CALL(reader, Finish).WillOnce(rpc::test::finish_ok(grpc_context_));
+
+        CHECK_NOTHROW((result = spawn_and_wait(get_as_of)));
+        CHECK_FALSE(result.success);
+        CHECK(result.value.empty());
+    }
+    SECTION("call get_as_of and get error") {
+        EXPECT_CALL(reader, Finish).WillOnce(rpc::test::finish_cancelled(grpc_context_));
+
+        CHECK_THROWS_AS(spawn_and_wait(get_as_of), boost::system::system_error);
     }
 }
 

--- a/silkworm/db/kv/grpc/test_util/sample_protos.hpp
+++ b/silkworm/db/kv/grpc/test_util/sample_protos.hpp
@@ -65,17 +65,36 @@ inline api::HistoryPointResult sample_history_point_result() {
     };
 }
 
-inline api::DomainPointQuery sample_domain_point_query() {
+inline api::GetAsOfQuery sample_get_latest_query() {
     return {
         .tx_id = 1,
         .table = "AAA",
         .key = {0x00, 0x11, 0xff},
-        .timestamp = 1234567,
         .sub_key = {0x00, 0x11, 0x22},
     };
 }
 
-inline proto::GetLatestReq sample_proto_domain_point_request() {
+inline api::GetAsOfQuery sample_get_as_of_query() {
+    return {
+        .tx_id = 1,
+        .table = "AAA",
+        .key = {0x00, 0x11, 0xff},
+        .sub_key = {0x00, 0x11, 0x22},
+        .timestamp = 1234567,
+    };
+}
+
+inline proto::GetLatestReq sample_proto_get_latest_request() {
+    proto::GetLatestReq request;
+    request.set_tx_id(1);
+    request.set_table("AAA");
+    request.set_k(ascii_from_hex("0011ff"));
+    request.set_latest(true);
+    request.set_k2(ascii_from_hex("001122"));
+    return request;
+}
+
+inline proto::GetLatestReq sample_proto_get_as_of_request() {
     proto::GetLatestReq request;
     request.set_tx_id(1);
     request.set_table("AAA");
@@ -85,7 +104,14 @@ inline proto::GetLatestReq sample_proto_domain_point_request() {
     return request;
 }
 
-inline proto::GetLatestReply sample_proto_domain_get_response() {
+inline proto::GetLatestReply sample_proto_get_latest_response() {
+    proto::GetLatestReply response;
+    response.set_ok(true);
+    response.set_v(ascii_from_hex("ff00ff00"));
+    return response;
+}
+
+inline proto::GetLatestReply sample_proto_get_as_of_response() {
     proto::GetLatestReply response;
     response.set_ok(true);
     response.set_v(ascii_from_hex("ff00ff00"));

--- a/silkworm/db/kv/grpc/test_util/sample_protos.hpp
+++ b/silkworm/db/kv/grpc/test_util/sample_protos.hpp
@@ -118,7 +118,14 @@ inline proto::GetLatestReply sample_proto_get_as_of_response() {
     return response;
 }
 
-inline api::DomainPointResult sample_domain_point_result() {
+inline api::GetLatestResult sample_get_latest_result() {
+    return {
+        .success = true,
+        .value = {0xff, 0x00, 0xff, 0x00},
+    };
+}
+
+inline api::GetAsOfResult sample_get_as_of_result() {
     return {
         .success = true,
         .value = {0xff, 0x00, 0xff, 0x00},

--- a/silkworm/db/state/remote_state_test.cpp
+++ b/silkworm/db/state/remote_state_test.cpp
@@ -66,8 +66,8 @@ TEST_CASE_METHOD(RemoteStateTest, "async remote buffer", "[rpc][core][remote_buf
         EXPECT_CALL(transaction, first_txn_num_in_block(1'000'001)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 0;
         }));
-        EXPECT_CALL(transaction, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kCode};
             co_return response;
@@ -84,8 +84,8 @@ TEST_CASE_METHOD(RemoteStateTest, "async remote buffer", "[rpc][core][remote_buf
         EXPECT_CALL(transaction, first_txn_num_in_block(1'000'001)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 0;
         }));
-        EXPECT_CALL(transaction, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = Bytes{}};
             co_return response;
@@ -104,8 +104,8 @@ TEST_CASE_METHOD(RemoteStateTest, "async remote buffer", "[rpc][core][remote_buf
         EXPECT_CALL(transaction, first_txn_num_in_block(1'000'001)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 0;
         }));
-        EXPECT_CALL(transaction, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = Bytes{}};
             co_return response;
@@ -124,8 +124,8 @@ TEST_CASE_METHOD(RemoteStateTest, "async remote buffer", "[rpc][core][remote_buf
         EXPECT_CALL(transaction, first_txn_num_in_block(1'000'001)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 0;
         }));
-        EXPECT_CALL(transaction, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = false,
                 .value = Bytes{}};
             co_return response;
@@ -274,8 +274,8 @@ TEST_CASE_METHOD(RemoteStateTest, "async remote buffer", "[rpc][core][remote_buf
         EXPECT_CALL(transaction, first_txn_num_in_block(1'000'001)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 0;
         }));
-        EXPECT_CALL(transaction, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = false,
                 .value = Bytes{}};
             co_return response;
@@ -290,8 +290,8 @@ TEST_CASE_METHOD(RemoteStateTest, "async remote buffer", "[rpc][core][remote_buf
         EXPECT_CALL(transaction, first_txn_num_in_block(1'000'001)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 0;
         }));
-        EXPECT_CALL(transaction, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = Bytes{}};
             co_return response;
@@ -307,8 +307,8 @@ TEST_CASE_METHOD(RemoteStateTest, "async remote buffer", "[rpc][core][remote_buf
         EXPECT_CALL(transaction, first_txn_num_in_block(1'000'001)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 0;
         }));
-        EXPECT_CALL(transaction, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = Bytes{}};
             co_return response;

--- a/silkworm/db/state/remote_state_test.cpp
+++ b/silkworm/db/state/remote_state_test.cpp
@@ -66,7 +66,7 @@ TEST_CASE_METHOD(RemoteStateTest, "async remote buffer", "[rpc][core][remote_buf
         EXPECT_CALL(transaction, first_txn_num_in_block(1'000'001)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 0;
         }));
-        EXPECT_CALL(transaction, get_latest(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kCode};
@@ -84,7 +84,7 @@ TEST_CASE_METHOD(RemoteStateTest, "async remote buffer", "[rpc][core][remote_buf
         EXPECT_CALL(transaction, first_txn_num_in_block(1'000'001)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 0;
         }));
-        EXPECT_CALL(transaction, get_latest(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = Bytes{}};
@@ -104,7 +104,7 @@ TEST_CASE_METHOD(RemoteStateTest, "async remote buffer", "[rpc][core][remote_buf
         EXPECT_CALL(transaction, first_txn_num_in_block(1'000'001)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 0;
         }));
-        EXPECT_CALL(transaction, get_latest(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = Bytes{}};
@@ -124,7 +124,7 @@ TEST_CASE_METHOD(RemoteStateTest, "async remote buffer", "[rpc][core][remote_buf
         EXPECT_CALL(transaction, first_txn_num_in_block(1'000'001)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 0;
         }));
-        EXPECT_CALL(transaction, get_latest(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = false,
                 .value = Bytes{}};
@@ -274,7 +274,7 @@ TEST_CASE_METHOD(RemoteStateTest, "async remote buffer", "[rpc][core][remote_buf
         EXPECT_CALL(transaction, first_txn_num_in_block(1'000'001)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 0;
         }));
-        EXPECT_CALL(transaction, get_latest(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = false,
                 .value = Bytes{}};
@@ -290,7 +290,7 @@ TEST_CASE_METHOD(RemoteStateTest, "async remote buffer", "[rpc][core][remote_buf
         EXPECT_CALL(transaction, first_txn_num_in_block(1'000'001)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 0;
         }));
-        EXPECT_CALL(transaction, get_latest(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = Bytes{}};
@@ -307,7 +307,7 @@ TEST_CASE_METHOD(RemoteStateTest, "async remote buffer", "[rpc][core][remote_buf
         EXPECT_CALL(transaction, first_txn_num_in_block(1'000'001)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 0;
         }));
-        EXPECT_CALL(transaction, get_latest(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = Bytes{}};

--- a/silkworm/db/state/state_reader.cpp
+++ b/silkworm/db/state/state_reader.cpp
@@ -33,16 +33,17 @@ Task<std::optional<Account>> StateReader::read_account(const evmc::address& addr
         txn_number_ = co_await tx_.first_txn_num_in_block(block_number_);
     }
 
-    db::kv::api::DomainPointQuery query{
+    db::kv::api::GetAsOfQuery query{
         .table = table::kAccountDomain,
         .key = db::account_domain_key(address),
-        .timestamp = txn_number_,
+        .timestamp = static_cast<kv::api::Timestamp>(*txn_number_),
     };
-    const auto result = co_await tx_.get_latest(std::move(query));
+    const auto result = co_await tx_.get_as_of(std::move(query));
     if (!result.success) {
         co_return std::nullopt;
     }
-    auto account{Account::from_encoded_storage_v3(result.value)};
+
+    const auto account{Account::from_encoded_storage_v3(result.value)};
     success_or_throw(account);
     co_return *account;
 }
@@ -54,12 +55,12 @@ Task<evmc::bytes32> StateReader::read_storage(const evmc::address& address,
         txn_number_ = co_await tx_.first_txn_num_in_block(block_number_);
     }
 
-    db::kv::api::DomainPointQuery query{
+    db::kv::api::GetAsOfQuery query{
         .table = table::kStorageDomain,
         .key = db::storage_domain_key(address, location_hash),
-        .timestamp = txn_number_,
+        .timestamp = static_cast<kv::api::Timestamp>(*txn_number_),
     };
-    const auto result = co_await tx_.get_latest(std::move(query));
+    const auto result = co_await tx_.get_as_of(std::move(query));
     if (!result.success) {
         co_return evmc::bytes32{};
     }
@@ -74,12 +75,12 @@ Task<std::optional<Bytes>> StateReader::read_code(const evmc::address& address, 
         txn_number_ = co_await tx_.first_txn_num_in_block(block_number_);
     }
 
-    db::kv::api::DomainPointQuery query{
+    db::kv::api::GetAsOfQuery query{
         .table = table::kCodeDomain,
         .key = db::code_domain_key(address),
-        .timestamp = txn_number_,
+        .timestamp = static_cast<kv::api::Timestamp>(*txn_number_),
     };
-    const auto result = co_await tx_.get_latest(std::move(query));
+    const auto result = co_await tx_.get_as_of(std::move(query));
     if (!result.success) {
         co_return std::nullopt;
     }

--- a/silkworm/db/state/state_reader_test.cpp
+++ b/silkworm/db/state/state_reader_test.cpp
@@ -21,7 +21,6 @@
 #include <gmock/gmock.h>
 
 #include <silkworm/core/common/base.hpp>
-#include <silkworm/db/tables.hpp>
 #include <silkworm/db/test_util/mock_transaction.hpp>
 #include <silkworm/infra/test_util/context_test_base.hpp>
 #include <silkworm/rpc/common/util.hpp>
@@ -56,7 +55,7 @@ TEST_CASE_METHOD(StateReaderTest, "StateReader::read_account") {
     }));
 
     SECTION("no account for history empty and current state empty") {
-        EXPECT_CALL(transaction_, get_latest(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction_, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = false,
                 .value = Bytes{}};
@@ -70,7 +69,7 @@ TEST_CASE_METHOD(StateReaderTest, "StateReader::read_account") {
     }
 
     SECTION("account found in current state") {
-        EXPECT_CALL(transaction_, get_latest(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction_, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kEncodedAccount};
@@ -90,7 +89,7 @@ TEST_CASE_METHOD(StateReaderTest, "StateReader::read_account") {
     }
 
     SECTION("account found in history") {
-        EXPECT_CALL(transaction_, get_latest(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction_, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kEncodedAccount};
@@ -116,7 +115,7 @@ TEST_CASE_METHOD(StateReaderTest, "StateReader::read_storage") {
     }));
 
     SECTION("empty storage for history empty and current state empty") {
-        EXPECT_CALL(transaction_, get_latest(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction_, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = false,
                 .value = Bytes{}};
@@ -130,7 +129,7 @@ TEST_CASE_METHOD(StateReaderTest, "StateReader::read_storage") {
     }
 
     SECTION("storage found in current state") {
-        EXPECT_CALL(transaction_, get_latest(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction_, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kStorageLocation};
@@ -143,7 +142,7 @@ TEST_CASE_METHOD(StateReaderTest, "StateReader::read_storage") {
     }
 
     SECTION("storage found in history") {
-        EXPECT_CALL(transaction_, get_latest(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction_, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kStorageLocation};
@@ -170,7 +169,7 @@ TEST_CASE_METHOD(StateReaderTest, "StateReader::read_code") {
             co_return 0;
         }));
 
-        EXPECT_CALL(transaction_, get_latest(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction_, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = Bytes{}};
@@ -191,7 +190,7 @@ TEST_CASE_METHOD(StateReaderTest, "StateReader::read_code") {
             co_return 0;
         }));
 
-        EXPECT_CALL(transaction_, get_latest(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction_, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = kBinaryCode};

--- a/silkworm/db/state/state_reader_test.cpp
+++ b/silkworm/db/state/state_reader_test.cpp
@@ -55,8 +55,8 @@ TEST_CASE_METHOD(StateReaderTest, "StateReader::read_account") {
     }));
 
     SECTION("no account for history empty and current state empty") {
-        EXPECT_CALL(transaction_, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction_, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = false,
                 .value = Bytes{}};
             co_return response;
@@ -69,8 +69,8 @@ TEST_CASE_METHOD(StateReaderTest, "StateReader::read_account") {
     }
 
     SECTION("account found in current state") {
-        EXPECT_CALL(transaction_, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction_, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kEncodedAccount};
             co_return response;
@@ -89,8 +89,8 @@ TEST_CASE_METHOD(StateReaderTest, "StateReader::read_account") {
     }
 
     SECTION("account found in history") {
-        EXPECT_CALL(transaction_, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction_, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kEncodedAccount};
             co_return response;
@@ -115,8 +115,8 @@ TEST_CASE_METHOD(StateReaderTest, "StateReader::read_storage") {
     }));
 
     SECTION("empty storage for history empty and current state empty") {
-        EXPECT_CALL(transaction_, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction_, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = false,
                 .value = Bytes{}};
             co_return response;
@@ -129,8 +129,8 @@ TEST_CASE_METHOD(StateReaderTest, "StateReader::read_storage") {
     }
 
     SECTION("storage found in current state") {
-        EXPECT_CALL(transaction_, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction_, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kStorageLocation};
             co_return response;
@@ -142,8 +142,8 @@ TEST_CASE_METHOD(StateReaderTest, "StateReader::read_storage") {
     }
 
     SECTION("storage found in history") {
-        EXPECT_CALL(transaction_, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction_, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kStorageLocation};
             co_return response;
@@ -169,8 +169,8 @@ TEST_CASE_METHOD(StateReaderTest, "StateReader::read_code") {
             co_return 0;
         }));
 
-        EXPECT_CALL(transaction_, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction_, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = Bytes{}};
             co_return response;
@@ -190,8 +190,8 @@ TEST_CASE_METHOD(StateReaderTest, "StateReader::read_code") {
             co_return 0;
         }));
 
-        EXPECT_CALL(transaction_, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction_, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kBinaryCode};
             co_return response;

--- a/silkworm/db/test_util/mock_transaction.hpp
+++ b/silkworm/db/test_util/mock_transaction.hpp
@@ -48,6 +48,7 @@ class MockTransaction : public kv::api::Transaction {
     MOCK_METHOD((Task<std::optional<Bytes>>), get_both_range,
                 (const std::string&, ByteView, ByteView), (override));
     MOCK_METHOD((Task<kv::api::DomainPointResult>), get_latest, (kv::api::DomainPointQuery), (override));
+    MOCK_METHOD((Task<kv::api::GetAsOfResult>), get_as_of, (kv::api::GetAsOfQuery), (override));
     MOCK_METHOD((Task<kv::api::HistoryPointResult>), history_seek, (kv::api::HistoryPointQuery), (override));
     MOCK_METHOD((Task<kv::api::PaginatedTimestamps>), index_range, (kv::api::IndexRangeQuery), (override));
     MOCK_METHOD((Task<kv::api::PaginatedKeysValues>), history_range, (kv::api::HistoryRangeQuery), (override));

--- a/silkworm/db/test_util/mock_transaction.hpp
+++ b/silkworm/db/test_util/mock_transaction.hpp
@@ -47,7 +47,7 @@ class MockTransaction : public kv::api::Transaction {
     MOCK_METHOD((Task<Bytes>), get_one, (const std::string&, ByteView), (override));
     MOCK_METHOD((Task<std::optional<Bytes>>), get_both_range,
                 (const std::string&, ByteView, ByteView), (override));
-    MOCK_METHOD((Task<kv::api::DomainPointResult>), get_latest, (kv::api::DomainPointQuery), (override));
+    MOCK_METHOD((Task<kv::api::GetLatestResult>), get_latest, (kv::api::GetLatestQuery), (override));
     MOCK_METHOD((Task<kv::api::GetAsOfResult>), get_as_of, (kv::api::GetAsOfQuery), (override));
     MOCK_METHOD((Task<kv::api::HistoryPointResult>), history_seek, (kv::api::HistoryPointQuery), (override));
     MOCK_METHOD((Task<kv::api::PaginatedTimestamps>), index_range, (kv::api::IndexRangeQuery), (override));

--- a/silkworm/rpc/commands/debug_api_test.cpp
+++ b/silkworm/rpc/commands/debug_api_test.cpp
@@ -235,6 +235,10 @@ class DummyTransaction : public db::kv::api::BaseTransaction {
         co_return db::kv::api::DomainPointResult{};
     }
 
+    Task<db::kv::api::GetAsOfResult> get_as_of(db::kv::api::GetAsOfQuery /*query*/) override {
+        co_return db::kv::api::GetAsOfResult{};
+    }
+
     Task<db::kv::api::HistoryPointResult> history_seek(db::kv::api::HistoryPointQuery /*query*/) override {
         co_return db::kv::api::HistoryPointResult{};
     }

--- a/silkworm/rpc/commands/debug_api_test.cpp
+++ b/silkworm/rpc/commands/debug_api_test.cpp
@@ -231,8 +231,8 @@ class DummyTransaction : public db::kv::api::BaseTransaction {
         co_return;
     }
 
-    Task<db::kv::api::DomainPointResult> get_latest(db::kv::api::DomainPointQuery /*query*/) override {
-        co_return db::kv::api::DomainPointResult{};
+    Task<db::kv::api::GetLatestResult> get_latest(db::kv::api::GetLatestQuery /*query*/) override {
+        co_return db::kv::api::GetLatestResult{};
     }
 
     Task<db::kv::api::GetAsOfResult> get_as_of(db::kv::api::GetAsOfQuery /*query*/) override {

--- a/silkworm/rpc/core/account_dumper_test.cpp
+++ b/silkworm/rpc/core/account_dumper_test.cpp
@@ -214,6 +214,10 @@ class DummyTransaction : public BaseTransaction {
         co_return db::kv::api::DomainPointResult{};
     }
 
+    Task<db::kv::api::GetAsOfResult> get_as_of(db::kv::api::GetAsOfQuery /*query*/) override {
+        co_return db::kv::api::GetAsOfResult{};
+    }
+
     Task<db::kv::api::HistoryPointResult> history_seek(db::kv::api::HistoryPointQuery /*query*/) override {
         co_return db::kv::api::HistoryPointResult{};
     }

--- a/silkworm/rpc/core/account_dumper_test.cpp
+++ b/silkworm/rpc/core/account_dumper_test.cpp
@@ -210,8 +210,8 @@ class DummyTransaction : public BaseTransaction {
         co_return;
     }
 
-    Task<db::kv::api::DomainPointResult> get_latest(db::kv::api::DomainPointQuery /*query*/) override {
-        co_return db::kv::api::DomainPointResult{};
+    Task<db::kv::api::GetLatestResult> get_latest(db::kv::api::GetLatestQuery /*query*/) override {
+        co_return db::kv::api::GetLatestResult{};
     }
 
     Task<db::kv::api::GetAsOfResult> get_as_of(db::kv::api::GetAsOfQuery /*query*/) override {

--- a/silkworm/rpc/core/account_walker_test.cpp
+++ b/silkworm/rpc/core/account_walker_test.cpp
@@ -215,6 +215,10 @@ class DummyTransaction : public BaseTransaction {
         co_return db::kv::api::DomainPointResult{};
     }
 
+    Task<db::kv::api::GetAsOfResult> get_as_of(db::kv::api::GetAsOfQuery /*query*/) override {
+        co_return db::kv::api::GetAsOfResult{};
+    }
+
     Task<db::kv::api::HistoryPointResult> history_seek(db::kv::api::HistoryPointQuery /*query*/) override {
         co_return db::kv::api::HistoryPointResult{};
     }

--- a/silkworm/rpc/core/account_walker_test.cpp
+++ b/silkworm/rpc/core/account_walker_test.cpp
@@ -211,8 +211,8 @@ class DummyTransaction : public BaseTransaction {
         co_return;
     }
 
-    Task<db::kv::api::DomainPointResult> get_latest(db::kv::api::DomainPointQuery /*query*/) override {
-        co_return db::kv::api::DomainPointResult{};
+    Task<db::kv::api::GetLatestResult> get_latest(db::kv::api::GetLatestQuery /*query*/) override {
+        co_return db::kv::api::GetLatestResult{};
     }
 
     Task<db::kv::api::GetAsOfResult> get_as_of(db::kv::api::GetAsOfQuery /*query*/) override {

--- a/silkworm/rpc/core/evm_debug_test.cpp
+++ b/silkworm/rpc/core/evm_debug_test.cpp
@@ -93,17 +93,17 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute precompiled") {
         }));
 
     SECTION("precompiled contract failure") {
-        db::kv::api::DomainPointQuery query1{
+        db::kv::api::GetAsOfQuery query1{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey1)),
             .timestamp = 244087591818873,
         };
-        db::kv::api::DomainPointQuery query2{
+        db::kv::api::GetAsOfQuery query2{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey2)),
             .timestamp = 244087591818873,
         };
-        db::kv::api::DomainPointQuery query3{
+        db::kv::api::GetAsOfQuery query3{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey3)),
             .timestamp = 244087591818873,
@@ -119,20 +119,20 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute precompiled") {
         EXPECT_CALL(transaction, first_txn_num_in_block(10'336'007)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult rsp1{
+        EXPECT_CALL(transaction, get_as_of(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult rsp1{
                 .success = true,
                 .value = kAccountHistoryValue1};
             co_return rsp1;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult rsp1{
+        EXPECT_CALL(transaction, get_as_of(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult rsp1{
                 .success = true,
                 .value = Bytes{}};
             co_return rsp1;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query3))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult rsp1{
+        EXPECT_CALL(transaction, get_as_of(std::move(query3))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult rsp1{
                 .success = true,
                 .value = Bytes{}};
             co_return rsp1;
@@ -217,17 +217,17 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 1") {
     }
 
     SECTION("Call: full output") {
-        db::kv::api::DomainPointQuery query1{
+        db::kv::api::GetAsOfQuery query1{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey1)),
             .timestamp = 244087591818873,
         };
-        db::kv::api::DomainPointQuery query2{
+        db::kv::api::GetAsOfQuery query2{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey2)),
             .timestamp = 244087591818873,
         };
-        db::kv::api::DomainPointQuery query3{
+        db::kv::api::GetAsOfQuery query3{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey3)),
             .timestamp = 244087591818873,
@@ -244,20 +244,20 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 1") {
         EXPECT_CALL(transaction, first_txn_num_in_block(5'405'096)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kAccountHistoryValue1};
             co_return response;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = Bytes{}};
             co_return response;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kAccountHistoryValue3};
             co_return response;
@@ -336,17 +336,17 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 1") {
     }
 
     SECTION("Call: no stack") {
-        db::kv::api::DomainPointQuery query1{
+        db::kv::api::GetAsOfQuery query1{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey1)),
             .timestamp = 244087591818873,
         };
-        db::kv::api::DomainPointQuery query2{
+        db::kv::api::GetAsOfQuery query2{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey2)),
             .timestamp = 244087591818873,
         };
-        db::kv::api::DomainPointQuery query3{
+        db::kv::api::GetAsOfQuery query3{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey3)),
             .timestamp = 244087591818873,
@@ -362,20 +362,20 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 1") {
         EXPECT_CALL(transaction, first_txn_num_in_block(5'405'096)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kAccountHistoryValue1};
             co_return response;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = Bytes{}};
             co_return response;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kAccountHistoryValue3};
             co_return response;
@@ -446,17 +446,17 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 1") {
     }
 
     SECTION("Call: no memory") {
-        db::kv::api::DomainPointQuery query1{
+        db::kv::api::GetAsOfQuery query1{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey1)),
             .timestamp = 244087591818873,
         };
-        db::kv::api::DomainPointQuery query2{
+        db::kv::api::GetAsOfQuery query2{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey2)),
             .timestamp = 244087591818873,
         };
-        db::kv::api::DomainPointQuery query3{
+        db::kv::api::GetAsOfQuery query3{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey3)),
             .timestamp = 244087591818873,
@@ -472,20 +472,20 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 1") {
         EXPECT_CALL(transaction, first_txn_num_in_block(5'405'096)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kAccountHistoryValue1};
             co_return response;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = Bytes{}};
             co_return response;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kAccountHistoryValue3};
             co_return response;
@@ -561,17 +561,17 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 1") {
     }
 
     SECTION("Call: no storage") {
-        db::kv::api::DomainPointQuery query1{
+        db::kv::api::GetAsOfQuery query1{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey1)),
             .timestamp = 244087591818873,
         };
-        db::kv::api::DomainPointQuery query2{
+        db::kv::api::GetAsOfQuery query2{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey2)),
             .timestamp = 244087591818873,
         };
-        db::kv::api::DomainPointQuery query3{
+        db::kv::api::GetAsOfQuery query3{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey3)),
             .timestamp = 244087591818873,
@@ -587,20 +587,20 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 1") {
         EXPECT_CALL(transaction, first_txn_num_in_block(5'405'096)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kAccountHistoryValue1};
             co_return response;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = Bytes{}};
             co_return response;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kAccountHistoryValue3};
             co_return response;
@@ -677,17 +677,17 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 1") {
     }
 
     SECTION("Call: no stack, memory and storage") {
-        db::kv::api::DomainPointQuery query1{
+        db::kv::api::GetAsOfQuery query1{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey1)),
             .timestamp = 244087591818873,
         };
-        db::kv::api::DomainPointQuery query2{
+        db::kv::api::GetAsOfQuery query2{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey2)),
             .timestamp = 244087591818873,
         };
-        db::kv::api::DomainPointQuery query3{
+        db::kv::api::GetAsOfQuery query3{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey3)),
             .timestamp = 244087591818873,
@@ -703,20 +703,20 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 1") {
         EXPECT_CALL(transaction, first_txn_num_in_block(5'405'096)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kAccountHistoryValue1};
             co_return response;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = Bytes{}};
             co_return response;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kAccountHistoryValue3};
             co_return response;
@@ -780,17 +780,17 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 1") {
     }
 
     SECTION("Call with stream") {
-        db::kv::api::DomainPointQuery query1{
+        db::kv::api::GetAsOfQuery query1{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey1)),
             .timestamp = 244087591818873,
         };
-        db::kv::api::DomainPointQuery query2{
+        db::kv::api::GetAsOfQuery query2{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey2)),
             .timestamp = 244087591818873,
         };
-        db::kv::api::DomainPointQuery query3{
+        db::kv::api::GetAsOfQuery query3{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey3)),
             .timestamp = 244087591818873,
@@ -806,20 +806,20 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 1") {
         EXPECT_CALL(transaction, first_txn_num_in_block(5'405'096)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kAccountHistoryValue1};
             co_return response;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = Bytes{}};
             co_return response;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kAccountHistoryValue3};
             co_return response;
@@ -900,17 +900,17 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 2") {
         }));
 
     SECTION("Call: TO present") {
-        db::kv::api::DomainPointQuery query1{
+        db::kv::api::GetAsOfQuery query1{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey1)),
             .timestamp = 244087591818873,
         };
-        db::kv::api::DomainPointQuery query2{
+        db::kv::api::GetAsOfQuery query2{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey2)),
             .timestamp = 244087591818873,
         };
-        db::kv::api::DomainPointQuery query3{
+        db::kv::api::GetAsOfQuery query3{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey3)),
             .timestamp = 244087591818873,
@@ -926,20 +926,20 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 2") {
         EXPECT_CALL(transaction, first_txn_num_in_block(4'417'197)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kAccountHistoryValue1};
             co_return response;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kAccountHistoryValue2};
             co_return response;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query3))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(std::move(query3))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kAccountHistoryValue3};
             co_return response;
@@ -990,17 +990,17 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call with error") {
             return std::make_shared<RemoteState>(ioc, tx, storage, block_number);
         }));
 
-    db::kv::api::DomainPointQuery query1{
+    db::kv::api::GetAsOfQuery query1{
         .table = table::kAccountDomain,
         .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey1)),
         .timestamp = 244087591818873,
     };
-    db::kv::api::DomainPointQuery query2{
+    db::kv::api::GetAsOfQuery query2{
         .table = table::kAccountDomain,
         .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey2)),
         .timestamp = 244087591818873,
     };
-    db::kv::api::DomainPointQuery query3{
+    db::kv::api::GetAsOfQuery query3{
         .table = table::kAccountDomain,
         .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey3)),
         .timestamp = 244087591818873,
@@ -1016,20 +1016,20 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call with error") {
     EXPECT_CALL(transaction, first_txn_num_in_block(5'405'096)).WillOnce(Invoke([]() -> Task<TxnId> {
         co_return 244087591818873;
     }));
-    EXPECT_CALL(transaction, get_latest(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-        db::kv::api::DomainPointResult response{
+    EXPECT_CALL(transaction, get_as_of(std::move(query1))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+        db::kv::api::GetAsOfResult response{
             .success = true,
             .value = kAccountHistoryValue1};
         co_return response;
     }));
-    EXPECT_CALL(transaction, get_latest(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-        db::kv::api::DomainPointResult response{
+    EXPECT_CALL(transaction, get_as_of(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+        db::kv::api::GetAsOfResult response{
             .success = true,
             .value = Bytes{}};
         co_return response;
     }));
-    EXPECT_CALL(transaction, get_latest(std::move(query3))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-        db::kv::api::DomainPointResult response{
+    EXPECT_CALL(transaction, get_as_of(std::move(query3))).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+        db::kv::api::GetAsOfResult response{
             .success = true,
             .value = kAccountHistoryValue3};
         co_return response;

--- a/silkworm/rpc/core/evm_executor_test.cpp
+++ b/silkworm/rpc/core/evm_executor_test.cpp
@@ -112,8 +112,8 @@ TEST_CASE_METHOD(EVMExecutorTest, "EVMExecutor") {
         EXPECT_CALL(transaction, first_txn_num_in_block(6'000'001)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = Bytes{}};
             co_return response;
@@ -138,8 +138,8 @@ TEST_CASE_METHOD(EVMExecutorTest, "EVMExecutor") {
         EXPECT_CALL(transaction, first_txn_num_in_block(6'000'001)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, get_as_of(_)).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(_)).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = Bytes{}};
             co_return response;
@@ -173,8 +173,8 @@ TEST_CASE_METHOD(EVMExecutorTest, "EVMExecutor") {
         EXPECT_CALL(transaction, first_txn_num_in_block(6'000'001)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, get_as_of(_)).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(_)).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = Bytes{}};
             co_return response;

--- a/silkworm/rpc/core/evm_executor_test.cpp
+++ b/silkworm/rpc/core/evm_executor_test.cpp
@@ -112,7 +112,7 @@ TEST_CASE_METHOD(EVMExecutorTest, "EVMExecutor") {
         EXPECT_CALL(transaction, first_txn_num_in_block(6'000'001)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, get_latest(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = Bytes{}};
@@ -138,7 +138,7 @@ TEST_CASE_METHOD(EVMExecutorTest, "EVMExecutor") {
         EXPECT_CALL(transaction, first_txn_num_in_block(6'000'001)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, get_latest(_)).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_as_of(_)).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = Bytes{}};
@@ -173,7 +173,7 @@ TEST_CASE_METHOD(EVMExecutorTest, "EVMExecutor") {
         EXPECT_CALL(transaction, first_txn_num_in_block(6'000'001)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, get_latest(_)).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
+        EXPECT_CALL(transaction, get_as_of(_)).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
             db::kv::api::DomainPointResult response{
                 .success = true,
                 .value = Bytes{}};

--- a/silkworm/rpc/core/evm_trace_test.cpp
+++ b/silkworm/rpc/core/evm_trace_test.cpp
@@ -2106,7 +2106,7 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_replayTransact
         EXPECT_CALL(transaction, first_txn_num_in_block(1'024'165)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, get_as_of(silkworm::db::kv::api::GetAsOfQuery{query1})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult > {
+        EXPECT_CALL(transaction, get_as_of(silkworm::db::kv::api::GetAsOfQuery{query1})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
             db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kAccountHistoryValue1};
@@ -3015,7 +3015,7 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_transaction") 
             .value = kAccountHistoryValue2};
         co_return rsp1;
     }));
-    EXPECT_CALL(transaction, get_as_of(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult > {
+    EXPECT_CALL(transaction, get_as_of(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
         db::kv::api::GetAsOfResult rsp1{
             .success = true,
             .value = kAccountHistoryValue3};

--- a/silkworm/rpc/core/evm_trace_test.cpp
+++ b/silkworm/rpc/core/evm_trace_test.cpp
@@ -32,7 +32,6 @@
 #include <silkworm/db/tables.hpp>
 #include <silkworm/db/test_util/mock_transaction.hpp>
 #include <silkworm/infra/common/log.hpp>
-#include <silkworm/infra/test_util/log.hpp>
 #include <silkworm/rpc/ethdb/kv/backend_providers.hpp>
 #include <silkworm/rpc/test_util/mock_back_end.hpp>
 #include <silkworm/rpc/test_util/mock_block_cache.hpp>
@@ -76,17 +75,17 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_call precompil
     }));
 
     SECTION("precompiled contract failure") {
-        db::kv::api::DomainPointQuery query1{
+        db::kv::api::GetAsOfQuery query1{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey1)),
             .timestamp = 244087591818873,
         };
-        db::kv::api::DomainPointQuery query2{
+        db::kv::api::GetAsOfQuery query2{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey2)),
             .timestamp = 244087591818873,
         };
-        db::kv::api::DomainPointQuery query3{
+        db::kv::api::GetAsOfQuery query3{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey3)),
             .timestamp = 244087591818873,
@@ -102,20 +101,20 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_call precompil
         EXPECT_CALL(transaction, first_txn_num_in_block(10'336'007)).Times(2).WillRepeatedly(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult rsp1{
+        EXPECT_CALL(transaction, get_as_of(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult rsp1{
                 .success = false,
                 .value = Bytes{}};
             co_return rsp1;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult rsp1{
+        EXPECT_CALL(transaction, get_as_of(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult rsp1{
                 .success = false,
                 .value = Bytes{}};
             co_return rsp1;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult rsp1{
+        EXPECT_CALL(transaction, get_as_of(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult rsp1{
                 .success = false,
                 .value = Bytes{}};
             co_return rsp1;
@@ -217,17 +216,17 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_call 1") {
     }
 
     SECTION("Call: full output") {
-        db::kv::api::DomainPointQuery query1{
+        db::kv::api::GetAsOfQuery query1{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey1)),
             .timestamp = 244087591818873,
         };
-        db::kv::api::DomainPointQuery query2{
+        db::kv::api::GetAsOfQuery query2{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey2)),
             .timestamp = 244087591818873,
         };
-        db::kv::api::DomainPointQuery query3{
+        db::kv::api::GetAsOfQuery query3{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey3)),
             .timestamp = 244087591818873,
@@ -244,20 +243,20 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_call 1") {
         EXPECT_CALL(transaction, first_txn_num_in_block(5'405'096)).Times(2).WillRepeatedly(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kAccountHistoryValue1};
             co_return response;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = false,
                 .value = Bytes{}};
             co_return response;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kAccountHistoryValue3};
             co_return response;
@@ -406,17 +405,17 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_call 1") {
     }
 
     SECTION("Call: no vmTrace") {
-        db::kv::api::DomainPointQuery query1{
+        db::kv::api::GetAsOfQuery query1{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey1)),
             .timestamp = 244087591818873,
         };
-        db::kv::api::DomainPointQuery query2{
+        db::kv::api::GetAsOfQuery query2{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey2)),
             .timestamp = 244087591818873,
         };
-        db::kv::api::DomainPointQuery query3{
+        db::kv::api::GetAsOfQuery query3{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey3)),
             .timestamp = 244087591818873,
@@ -433,20 +432,20 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_call 1") {
         EXPECT_CALL(transaction, first_txn_num_in_block(5'405'096)).Times(2).WillRepeatedly(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kAccountHistoryValue1};
             co_return response;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = false,
                 .value = Bytes{}};
             co_return response;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kAccountHistoryValue3};
             co_return response;
@@ -532,17 +531,17 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_call 1") {
     }
 
     SECTION("Call: no trace") {
-        db::kv::api::DomainPointQuery query1{
+        db::kv::api::GetAsOfQuery query1{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey1)),
             .timestamp = 244087591818873,
         };
-        db::kv::api::DomainPointQuery query2{
+        db::kv::api::GetAsOfQuery query2{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey2)),
             .timestamp = 244087591818873,
         };
-        db::kv::api::DomainPointQuery query3{
+        db::kv::api::GetAsOfQuery query3{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey3)),
             .timestamp = 244087591818873,
@@ -559,20 +558,20 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_call 1") {
         EXPECT_CALL(transaction, first_txn_num_in_block(5'405'096)).Times(2).WillRepeatedly(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kAccountHistoryValue1};
             co_return response;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = false,
                 .value = Bytes{}};
             co_return response;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kAccountHistoryValue3};
             co_return response;
@@ -704,17 +703,17 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_call 1") {
     }
 
     SECTION("Call: no stateDiff") {
-        db::kv::api::DomainPointQuery query1{
+        db::kv::api::GetAsOfQuery query1{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey1)),
             .timestamp = 244087591818873,
         };
-        db::kv::api::DomainPointQuery query2{
+        db::kv::api::GetAsOfQuery query2{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey2)),
             .timestamp = 244087591818873,
         };
-        db::kv::api::DomainPointQuery query3{
+        db::kv::api::GetAsOfQuery query3{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey3)),
             .timestamp = 244087591818873,
@@ -731,20 +730,20 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_call 1") {
         EXPECT_CALL(transaction, first_txn_num_in_block(5'405'096)).Times(2).WillRepeatedly(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kAccountHistoryValue1};
             co_return response;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = false,
                 .value = Bytes{}};
             co_return response;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kAccountHistoryValue3};
             co_return response;
@@ -854,17 +853,17 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_call 1") {
     }
 
     SECTION("Call: no vmTrace, trace and stateDiff") {
-        db::kv::api::DomainPointQuery query1{
+        db::kv::api::GetAsOfQuery query1{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey1)),
             .timestamp = 244087591818873,
         };
-        db::kv::api::DomainPointQuery query2{
+        db::kv::api::GetAsOfQuery query2{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey2)),
             .timestamp = 244087591818873,
         };
-        db::kv::api::DomainPointQuery query3{
+        db::kv::api::GetAsOfQuery query3{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey3)),
             .timestamp = 244087591818873,
@@ -881,20 +880,20 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_call 1") {
         EXPECT_CALL(transaction, first_txn_num_in_block(5'405'096)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kAccountHistoryValue1};
             co_return response;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = false,
                 .value = Bytes{}};
             co_return response;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kAccountHistoryValue3};
             co_return response;
@@ -939,17 +938,17 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_call 2") {
     }));
 
     SECTION("Call: TO present") {
-        db::kv::api::DomainPointQuery query1{
+        db::kv::api::GetAsOfQuery query1{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey1)),
             .timestamp = 244087591818873,
         };
-        db::kv::api::DomainPointQuery query2{
+        db::kv::api::GetAsOfQuery query2{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey2)),
             .timestamp = 244087591818873,
         };
-        db::kv::api::DomainPointQuery query3{
+        db::kv::api::GetAsOfQuery query3{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey3)),
             .timestamp = 244087591818873,
@@ -965,20 +964,20 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_call 2") {
         EXPECT_CALL(transaction, first_txn_num_in_block(4'417'197)).Times(2).WillRepeatedly(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kAccountHistoryValue1};
             co_return response;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kAccountHistoryValue2};
             co_return response;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = false,
                 .value = Bytes{}};
             co_return response;
@@ -1087,17 +1086,17 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_call with erro
         return std::make_shared<RemoteState>(ioc, tx, storage, block_number);
     }));
 
-    db::kv::api::DomainPointQuery query1{
+    db::kv::api::GetAsOfQuery query1{
         .table = table::kAccountDomain,
         .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey1)),
         .timestamp = 244087591818873,
     };
-    db::kv::api::DomainPointQuery query2{
+    db::kv::api::GetAsOfQuery query2{
         .table = table::kAccountDomain,
         .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey2)),
         .timestamp = 244087591818873,
     };
-    db::kv::api::DomainPointQuery query3{
+    db::kv::api::GetAsOfQuery query3{
         .table = table::kAccountDomain,
         .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey3)),
         .timestamp = 244087591818873,
@@ -1113,20 +1112,20 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_call with erro
     EXPECT_CALL(transaction, first_txn_num_in_block(5'405'096)).Times(2).WillRepeatedly(Invoke([]() -> Task<TxnId> {
         co_return 244087591818873;
     }));
-    EXPECT_CALL(transaction, get_latest(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-        db::kv::api::DomainPointResult response{
+    EXPECT_CALL(transaction, get_as_of(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+        db::kv::api::GetAsOfResult response{
             .success = true,
             .value = kAccountHistoryValue1};
         co_return response;
     }));
-    EXPECT_CALL(transaction, get_latest(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-        db::kv::api::DomainPointResult response{
+    EXPECT_CALL(transaction, get_as_of(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+        db::kv::api::GetAsOfResult response{
             .success = true,
             .value = kAccountHistoryValue2};
         co_return response;
     }));
-    EXPECT_CALL(transaction, get_latest(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-        db::kv::api::DomainPointResult response{
+    EXPECT_CALL(transaction, get_as_of(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+        db::kv::api::GetAsOfResult response{
             .success = true,
             .value = kAccountHistoryValue3};
         co_return response;
@@ -1278,17 +1277,17 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_calls") {
     }
 
     SECTION("Call: full output") {
-        db::kv::api::DomainPointQuery query1{
+        db::kv::api::GetAsOfQuery query1{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey1)),
             .timestamp = 244087591818873,
         };
-        db::kv::api::DomainPointQuery query2{
+        db::kv::api::GetAsOfQuery query2{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey2)),
             .timestamp = 244087591818873,
         };
-        db::kv::api::DomainPointQuery query3{
+        db::kv::api::GetAsOfQuery query3{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey3)),
             .timestamp = 244087591818873,
@@ -1304,20 +1303,20 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_calls") {
         EXPECT_CALL(transaction, first_txn_num_in_block(5'405'096)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kAccountHistoryValue1};
             co_return response;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = false,
                 .value = Bytes{}};
             co_return response;
         }));
-        EXPECT_CALL(transaction, get_latest(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kAccountHistoryValue3};
             co_return response;
@@ -1486,17 +1485,17 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_block_transact
         return std::make_shared<RemoteState>(ioc, tx, storage, block_number);
     }));
 
-    db::kv::api::DomainPointQuery query1{
+    db::kv::api::GetAsOfQuery query1{
         .table = table::kAccountDomain,
         .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey1)),
         .timestamp = 244087591818873,
     };
-    db::kv::api::DomainPointQuery query2{
+    db::kv::api::GetAsOfQuery query2{
         .table = table::kAccountDomain,
         .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey2)),
         .timestamp = 244087591818873,
     };
-    db::kv::api::DomainPointQuery query3{
+    db::kv::api::GetAsOfQuery query3{
         .table = table::kAccountDomain,
         .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey3)),
         .timestamp = 244087591818873,
@@ -1512,20 +1511,20 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_block_transact
     EXPECT_CALL(transaction, first_txn_num_in_block(1'024'165)).Times(2).WillRepeatedly(Invoke([]() -> Task<TxnId> {
         co_return 244087591818873;
     }));
-    EXPECT_CALL(transaction, get_latest(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-        db::kv::api::DomainPointResult response{
+    EXPECT_CALL(transaction, get_as_of(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+        db::kv::api::GetAsOfResult response{
             .success = true,
             .value = kAccountHistoryValue1};
         co_return response;
     }));
-    EXPECT_CALL(transaction, get_latest(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-        db::kv::api::DomainPointResult response{
+    EXPECT_CALL(transaction, get_as_of(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+        db::kv::api::GetAsOfResult response{
             .success = false,
             .value = Bytes{}};
         co_return response;
     }));
-    EXPECT_CALL(transaction, get_latest(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-        db::kv::api::DomainPointResult response{
+    EXPECT_CALL(transaction, get_as_of(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+        db::kv::api::GetAsOfResult response{
             .success = true,
             .value = kAccountHistoryValue3};
         co_return response;
@@ -1938,17 +1937,17 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_block") {
 
     auto& tx = transaction;
 
-    db::kv::api::DomainPointQuery query1{
+    db::kv::api::GetAsOfQuery query1{
         .table = table::kAccountDomain,
         .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey1)),
         .timestamp = 244087591818873,
     };
-    db::kv::api::DomainPointQuery query2{
+    db::kv::api::GetAsOfQuery query2{
         .table = table::kAccountDomain,
         .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey2)),
         .timestamp = 244087591818873,
     };
-    db::kv::api::DomainPointQuery query3{
+    db::kv::api::GetAsOfQuery query3{
         .table = table::kAccountDomain,
         .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey3)),
         .timestamp = 244087591818873,
@@ -1968,20 +1967,20 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_block") {
     EXPECT_CALL(transaction, first_txn_num_in_block(1'024'165)).Times(2).WillRepeatedly(Invoke([]() -> Task<TxnId> {
         co_return 244087591818873;
     }));
-    EXPECT_CALL(transaction, get_latest(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-        db::kv::api::DomainPointResult response{
+    EXPECT_CALL(transaction, get_as_of(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+        db::kv::api::GetAsOfResult response{
             .success = false,
             .value = Bytes{}};
         co_return response;
     }));
-    EXPECT_CALL(transaction, get_latest(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-        db::kv::api::DomainPointResult response{
+    EXPECT_CALL(transaction, get_as_of(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+        db::kv::api::GetAsOfResult response{
             .success = true,
             .value = kAccountHistoryValue2};
         co_return response;
     }));
-    EXPECT_CALL(transaction, get_latest(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-        db::kv::api::DomainPointResult response{
+    EXPECT_CALL(transaction, get_as_of(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+        db::kv::api::GetAsOfResult response{
             .success = true,
             .value = kAccountHistoryValue3};
         co_return response;
@@ -2053,17 +2052,17 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_replayTransact
         return std::make_shared<RemoteState>(ioc, tx, storage, block_number);
     }));
 
-    db::kv::api::DomainPointQuery query1{
+    db::kv::api::GetAsOfQuery query1{
         .table = table::kAccountDomain,
         .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey1)),
         .timestamp = 244087591818873,
     };
-    db::kv::api::DomainPointQuery query2{
+    db::kv::api::GetAsOfQuery query2{
         .table = table::kAccountDomain,
         .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey2)),
         .timestamp = 244087591818873,
     };
-    db::kv::api::DomainPointQuery query3{
+    db::kv::api::GetAsOfQuery query3{
         .table = table::kAccountDomain,
         .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey3)),
         .timestamp = 244087591818873,
@@ -2107,20 +2106,20 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_replayTransact
         EXPECT_CALL(transaction, first_txn_num_in_block(1'024'165)).WillOnce(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, get_latest(silkworm::db::kv::api::DomainPointQuery{query1})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(silkworm::db::kv::api::GetAsOfQuery{query1})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult > {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kAccountHistoryValue1};
             co_return response;
         }));
-        EXPECT_CALL(transaction, get_latest(silkworm::db::kv::api::DomainPointQuery{query2})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(silkworm::db::kv::api::GetAsOfQuery{query2})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = false,
                 .value = Bytes{}};
             co_return response;
         }));
-        EXPECT_CALL(transaction, get_latest(silkworm::db::kv::api::DomainPointQuery{query3})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(silkworm::db::kv::api::GetAsOfQuery{query3})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kAccountHistoryValue3};
             co_return response;
@@ -2445,20 +2444,20 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_replayTransact
         EXPECT_CALL(transaction, first_txn_num_in_block(1'024'165)).Times(2).WillRepeatedly(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, get_latest(silkworm::db::kv::api::DomainPointQuery{query1})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(silkworm::db::kv::api::GetAsOfQuery{query1})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kAccountHistoryValue1};
             co_return response;
         }));
-        EXPECT_CALL(transaction, get_latest(silkworm::db::kv::api::DomainPointQuery{query2})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(silkworm::db::kv::api::GetAsOfQuery{query2})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = false,
                 .value = Bytes{}};
             co_return response;
         }));
-        EXPECT_CALL(transaction, get_latest(silkworm::db::kv::api::DomainPointQuery{query3})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(silkworm::db::kv::api::GetAsOfQuery{query3})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kAccountHistoryValue3};
             co_return response;
@@ -2497,20 +2496,20 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_replayTransact
         EXPECT_CALL(transaction, first_txn_num_in_block(1'024'165)).Times(2).WillRepeatedly(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, get_latest(silkworm::db::kv::api::DomainPointQuery{query1})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(silkworm::db::kv::api::GetAsOfQuery{query1})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kAccountHistoryValue1};
             co_return response;
         }));
-        EXPECT_CALL(transaction, get_latest(silkworm::db::kv::api::DomainPointQuery{query2})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(silkworm::db::kv::api::GetAsOfQuery{query2})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = false,
                 .value = Bytes{}};
             co_return response;
         }));
-        EXPECT_CALL(transaction, get_latest(silkworm::db::kv::api::DomainPointQuery{query3})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(silkworm::db::kv::api::GetAsOfQuery{query3})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kAccountHistoryValue3};
             co_return response;
@@ -2572,20 +2571,20 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_replayTransact
         EXPECT_CALL(transaction, first_txn_num_in_block(1'024'165)).Times(2).WillRepeatedly(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
-        EXPECT_CALL(transaction, get_latest(silkworm::db::kv::api::DomainPointQuery{query1})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(silkworm::db::kv::api::GetAsOfQuery{query1})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kAccountHistoryValue1};
             co_return response;
         }));
-        EXPECT_CALL(transaction, get_latest(silkworm::db::kv::api::DomainPointQuery{query2})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(silkworm::db::kv::api::GetAsOfQuery{query2})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = false,
                 .value = Bytes{}};
             co_return response;
         }));
-        EXPECT_CALL(transaction, get_latest(silkworm::db::kv::api::DomainPointQuery{query3})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-            db::kv::api::DomainPointResult response{
+        EXPECT_CALL(transaction, get_as_of(silkworm::db::kv::api::GetAsOfQuery{query3})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+            db::kv::api::GetAsOfResult response{
                 .success = true,
                 .value = kAccountHistoryValue3};
             co_return response;
@@ -2978,17 +2977,17 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_transaction") 
         return std::make_shared<RemoteState>(ioc, tx, storage, block_number);
     }));
 
-    db::kv::api::DomainPointQuery query1{
+    db::kv::api::GetAsOfQuery query1{
         .table = table::kAccountDomain,
         .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey1)),
         .timestamp = 244087591818873,
     };
-    db::kv::api::DomainPointQuery query2{
+    db::kv::api::GetAsOfQuery query2{
         .table = table::kAccountDomain,
         .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey2)),
         .timestamp = 244087591818873,
     };
-    db::kv::api::DomainPointQuery query3{
+    db::kv::api::GetAsOfQuery query3{
         .table = table::kAccountDomain,
         .key = db::account_domain_key(bytes_to_address(kAccountHistoryKey3)),
         .timestamp = 244087591818873,
@@ -3004,20 +3003,20 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_transaction") 
     EXPECT_CALL(transaction, first_txn_num_in_block(1'024'165)).Times(2).WillRepeatedly(Invoke([]() -> Task<TxnId> {
         co_return 244087591818873;
     }));
-    EXPECT_CALL(transaction, get_latest(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-        db::kv::api::DomainPointResult rsp1{
+    EXPECT_CALL(transaction, get_as_of(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+        db::kv::api::GetAsOfResult rsp1{
             .success = false,
             .value = Bytes{}};
         co_return rsp1;
     }));
-    EXPECT_CALL(transaction, get_latest(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-        db::kv::api::DomainPointResult rsp1{
+    EXPECT_CALL(transaction, get_as_of(std::move(query2))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
+        db::kv::api::GetAsOfResult rsp1{
             .success = true,
             .value = kAccountHistoryValue2};
         co_return rsp1;
     }));
-    EXPECT_CALL(transaction, get_latest(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::DomainPointResult> {
-        db::kv::api::DomainPointResult rsp1{
+    EXPECT_CALL(transaction, get_as_of(std::move(query3))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult > {
+        db::kv::api::GetAsOfResult rsp1{
             .success = true,
             .value = kAccountHistoryValue3};
         co_return rsp1;

--- a/silkworm/rpc/core/storage_walker_test.cpp
+++ b/silkworm/rpc/core/storage_walker_test.cpp
@@ -214,6 +214,10 @@ class DummyTransaction : public BaseTransaction {
         co_return db::kv::api::DomainPointResult{};
     }
 
+    Task<db::kv::api::GetAsOfResult > get_as_of(db::kv::api::GetAsOfQuery /*query*/) override {
+        co_return db::kv::api::GetAsOfResult{};
+    }
+
     Task<db::kv::api::HistoryPointResult> history_seek(db::kv::api::HistoryPointQuery /*query*/) override {
         co_return db::kv::api::HistoryPointResult{};
     }

--- a/silkworm/rpc/core/storage_walker_test.cpp
+++ b/silkworm/rpc/core/storage_walker_test.cpp
@@ -214,7 +214,7 @@ class DummyTransaction : public BaseTransaction {
         co_return db::kv::api::DomainPointResult{};
     }
 
-    Task<db::kv::api::GetAsOfResult > get_as_of(db::kv::api::GetAsOfQuery /*query*/) override {
+    Task<db::kv::api::GetAsOfResult> get_as_of(db::kv::api::GetAsOfQuery /*query*/) override {
         co_return db::kv::api::GetAsOfResult{};
     }
 

--- a/silkworm/rpc/core/storage_walker_test.cpp
+++ b/silkworm/rpc/core/storage_walker_test.cpp
@@ -210,8 +210,8 @@ class DummyTransaction : public BaseTransaction {
         co_return;
     }
 
-    Task<db::kv::api::DomainPointResult> get_latest(db::kv::api::DomainPointQuery /*query*/) override {
-        co_return db::kv::api::DomainPointResult{};
+    Task<db::kv::api::GetLatestResult> get_latest(db::kv::api::GetLatestQuery /*query*/) override {
+        co_return db::kv::api::GetLatestResult{};
     }
 
     Task<db::kv::api::GetAsOfResult> get_as_of(db::kv::api::GetAsOfQuery /*query*/) override {

--- a/silkworm/rpc/test_util/dummy_transaction.hpp
+++ b/silkworm/rpc/test_util/dummy_transaction.hpp
@@ -84,8 +84,8 @@ class DummyTransaction : public db::kv::api::BaseTransaction {
 
     Task<void> close() override { co_return; }
 
-    Task<db::kv::api::DomainPointResult> get_latest(db::kv::api::DomainPointQuery /*query*/) override {
-        co_return db::kv::api::DomainPointResult{};
+    Task<db::kv::api::GetLatestResult> get_latest(db::kv::api::GetLatestQuery /*query*/) override {
+        co_return db::kv::api::GetLatestResult{};
     }
 
     Task<db::kv::api::GetAsOfResult> get_as_of(db::kv::api::GetAsOfQuery /*query*/) override {

--- a/silkworm/rpc/test_util/dummy_transaction.hpp
+++ b/silkworm/rpc/test_util/dummy_transaction.hpp
@@ -88,6 +88,10 @@ class DummyTransaction : public db::kv::api::BaseTransaction {
         co_return db::kv::api::DomainPointResult{};
     }
 
+    Task<db::kv::api::GetAsOfResult> get_as_of(db::kv::api::GetAsOfQuery /*query*/) override {
+        co_return db::kv::api::GetAsOfResult{};
+    }
+
     Task<db::kv::api::HistoryPointResult> history_seek(db::kv::api::HistoryPointQuery /*query*/) override {
         co_return db::kv::api::HistoryPointResult{};
     }


### PR DESCRIPTION
This PR splits `db::kv::api::Transaction::get_latest` (renamed as such in #2530, formerly known as `domain_get`) into two different methods both mapped into the same gRPC call `rpc GetLatest(GetLatestReq) returns (GetLatestReply);` in `kv.proto`:

- `get_latest`: corresponds to `GetLatest` with latest=true, i.e. timestamp `ts` ignored
- `get_as_of`: corresponds to `GetLatest` with latest=false, i.e. timestamp `ts` used

This refactoring matches the way E3 captures the different semantics internally.

It would be cleaner to split the responsibilities also at the gRPC interface level e.g. having both `GetLatest` and `GetAsOf` also there or alternatively rename `GetLatest` as `Get`.