### PR TITLE
core: unify transaction validation for execution and simulate paths

### DIFF
--- a/silkworm/core/protocol/validation.cpp
+++ b/silkworm/core/protocol/validation.cpp
@@ -207,11 +207,14 @@ ValidationResult validate_call_precheck(const Transaction& txn, const EVM& evm) 
         return ValidationResult::kInsufficientFunds;
     }
 
-    const bool contract_creation{!txn.to};
-
     // EIP-2681: Limit account nonce to 2^64-1
     if (txn.nonce >= UINT64_MAX) {
         return ValidationResult::kNonceTooHigh;
+    }
+
+    const bool contract_creation{!txn.to};
+    if (evm.revision() >= EVMC_SHANGHAI && contract_creation && txn.data.size() > kMaxInitCodeSize) {
+        return ValidationResult::kMaxInitCodeSizeExceeded;
     }
 
     if (evm.revision() >= EVMC_LONDON) {

--- a/silkworm/core/protocol/validation.cpp
+++ b/silkworm/core/protocol/validation.cpp
@@ -194,9 +194,9 @@ ValidationResult validate_call_precheck(const Transaction& txn, const EVM& evm) 
         return ValidationResult::kUnsupportedTransactionType;
     }
 
-    if (!is_valid_signature(txn.r, txn.s, evm.revision() >= EVMC_HOMESTEAD)) {
-        return ValidationResult::kInvalidSignature;
-    }
+    // if (!is_valid_signature(txn.r, txn.s, evm.revision() >= EVMC_HOMESTEAD)) {
+    //     return ValidationResult::kInvalidSignature;
+    // }
 
     const intx::uint128 g0{intrinsic_gas(txn, evm.revision())};
     if (txn.gas_limit < g0) {

--- a/silkworm/core/protocol/validation.cpp
+++ b/silkworm/core/protocol/validation.cpp
@@ -44,12 +44,12 @@ bool transaction_type_is_supported(TransactionType type, evmc_revision rev) {
 ValidationResult pre_validate_transaction(const Transaction& txn, const evmc_revision rev, const uint64_t chain_id,
                                           const std::optional<intx::uint256>& base_fee_per_gas,
                                           const std::optional<intx::uint256>& blob_gas_price) {
-    if (!is_valid_signature(txn.r, txn.s, rev >= EVMC_HOMESTEAD)) {
-        return ValidationResult::kInvalidSignature;
-    }
-
     if (const auto common_check = pre_validate_common_base(txn, rev, chain_id); common_check != ValidationResult::kOk) {
         return common_check;
+    }
+
+    if (!is_valid_signature(txn.r, txn.s, rev >= EVMC_HOMESTEAD)) {
+        return ValidationResult::kInvalidSignature;
     }
 
     if (rev >= EVMC_LONDON) {

--- a/silkworm/core/protocol/validation.cpp
+++ b/silkworm/core/protocol/validation.cpp
@@ -175,6 +175,16 @@ ValidationResult pre_validate_transactions(const Block& block, const ChainConfig
 }
 
 ValidationResult validate_call_precheck(const Transaction& txn, const EVM& evm) noexcept {
+    if (txn.chain_id.has_value()) {
+        if (evm.revision() < EVMC_SPURIOUS_DRAGON) {
+            // EIP-155 transaction before EIP-155 was activated
+            return ValidationResult::kUnsupportedTransactionType;
+        }
+        if (txn.chain_id.value() != evm.config().chain_id) {
+            return ValidationResult::kWrongChainId;
+        }
+    }
+
     const std::optional sender{txn.sender()};
     if (!sender) {
         return ValidationResult::kInvalidSignature;

--- a/silkworm/core/protocol/validation.hpp
+++ b/silkworm/core/protocol/validation.hpp
@@ -141,6 +141,10 @@ namespace protocol {
 
     ValidationResult validate_call_precheck(const Transaction& txn, const EVM& evm) noexcept;
 
+    ValidationResult pre_validate_common_base(const Transaction& txn, evmc_revision revision, uint64_t chain_id) noexcept;
+
+    ValidationResult pre_validate_common_forks(const Transaction& txn, const evmc_revision rev, const std::optional<intx::uint256>& blob_gas_price) noexcept;
+
     ValidationResult validate_call_funds(const Transaction& txn, const EVM& evm, const intx::uint256& owned_funds, bool bailout) noexcept;
 
     intx::uint256 compute_call_cost(const Transaction& txn, const intx::uint256& effective_gas_price, const EVM& evm);

--- a/silkworm/core/protocol/validation_test.cpp
+++ b/silkworm/core/protocol/validation_test.cpp
@@ -22,6 +22,8 @@
 #include <silkworm/core/common/test_util.hpp>
 #include <silkworm/core/state/in_memory_state.hpp>
 
+#include "silkworm/core/crypto/secp256k1n.hpp"
+
 namespace silkworm::protocol {
 
 TEST_CASE("Validate transaction types") {
@@ -68,6 +70,9 @@ TEST_CASE("Validate max_fee_per_gas") {
 
     Transaction txn;
     txn.type = TransactionType::kDynamicFee;
+    txn.gas_limit = 100'000;
+    txn.r = kSecp256k1n - 1;
+    txn.s = kSecp256k1Halfn - 1;
 
     txn.max_priority_fee_per_gas = 500'000'000;
     txn.max_fee_per_gas = 700'000'000;

--- a/silkworm/rpc/core/evm_executor_test.cpp
+++ b/silkworm/rpc/core/evm_executor_test.cpp
@@ -83,6 +83,7 @@ TEST_CASE_METHOD(EVMExecutorTest, "EVMExecutor") {
         block.header.base_fee_per_gas = 0x7;
         block.header.number = block_num;
         silkworm::Transaction txn{};
+        txn.gas_limit = 100'000;
         txn.max_fee_per_gas = 0x2;
         txn.set_sender(0xa872626373628737383927236382161739290870_address);
 
@@ -97,6 +98,7 @@ TEST_CASE_METHOD(EVMExecutorTest, "EVMExecutor") {
         block.header.base_fee_per_gas = 0x1;
         block.header.number = block_num;
         silkworm::Transaction txn{};
+        txn.gas_limit = 100'000;
         txn.max_fee_per_gas = 0x2;
         txn.set_sender(0xa872626373628737383927236382161739290870_address);
         txn.max_priority_fee_per_gas = 0x18;


### PR DESCRIPTION
This is an attempt to merge common code paths for both `pre_validate_transaction` and `call_pre_check`.