### PR TITLE
snapshots: state snapshot files decoders

### DIFF
--- a/silkworm/db/datastore/snapshots/btree/btree_index.cpp
+++ b/silkworm/db/datastore/snapshots/btree/btree_index.cpp
@@ -50,7 +50,7 @@ BTreeIndex::BTreeIndex(
     const auto memory_mapped_range = memory_file_->region();
 
     // Read encoded Elias-Fano 32-bit list of integers representing data offsets
-    data_offsets_ = EliasFanoList32::from_encoded_data(memory_mapped_range);
+    data_offsets_ = std::make_shared<EliasFanoList32>(EliasFanoList32::from_encoded_data(memory_mapped_range));
     ensure(data_offsets_->sequence_length() > 0, "BTreeIndex: invalid zero-length data offsets");
 
     const auto encoded_nodes = memory_mapped_range.subspan(data_offsets_->encoded_data_size());

--- a/silkworm/db/datastore/snapshots/elias_fano/elias_fano_decoder.hpp
+++ b/silkworm/db/datastore/snapshots/elias_fano/elias_fano_decoder.hpp
@@ -16,20 +16,23 @@
 
 #pragma once
 
-#include "elias_fano/elias_fano_decoder.hpp"
-#include "rec_split/accessor_index.hpp"
-#include "segment/kv_segment_reader.hpp"
+#include <optional>
 
-namespace silkworm::snapshots {
+#include "../common/codec.hpp"
+#include "elias_fano.hpp"
 
-struct InvertedIndex {
-    const segment::KVSegmentFileReader& kv_segment;
-    const rec_split::AccessorIndex& accessor_index;
+namespace silkworm::snapshots::elias_fano {
 
-    template <DecoderConcept TKeyDecoder>
-    segment::KVSegmentReader<TKeyDecoder, elias_fano::EliasFanoDecoder> kv_segment_reader() {
-        return {kv_segment};
+struct EliasFanoDecoder : public snapshots::Decoder {
+    std::optional<EliasFanoList32> value;
+
+    ~EliasFanoDecoder() override = default;
+
+    void decode_word(ByteView word) override {
+        value = EliasFanoList32::from_encoded_data(std::span<const uint8_t>{word.data(), word.size()});
     }
 };
 
-}  // namespace silkworm::snapshots
+static_assert(snapshots::DecoderConcept<EliasFanoDecoder>);
+
+}  // namespace silkworm::snapshots::elias_fano

--- a/silkworm/db/datastore/snapshots/elias_fano/elias_fano_decoder_test.cpp
+++ b/silkworm/db/datastore/snapshots/elias_fano/elias_fano_decoder_test.cpp
@@ -1,0 +1,43 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "elias_fano_decoder.hpp"
+
+#include <sstream>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <silkworm/core/common/bytes_to_string.hpp>
+
+namespace silkworm::snapshots::elias_fano {
+
+TEST_CASE("EliasFanoDecoder") {
+    EliasFanoList32 expected_list{3, 3};
+    expected_list.add_offset(1);
+    expected_list.add_offset(2);
+    expected_list.add_offset(3);
+    expected_list.build();
+    std::stringstream expected_list_stream;
+    expected_list_stream << expected_list;
+    auto expected_list_str = expected_list_stream.str();
+
+    EliasFanoDecoder decoder;
+    decoder.decode_word(string_view_to_byte_view(expected_list_str));
+    REQUIRE(decoder.value.has_value());
+    CHECK(decoder.value == expected_list);
+}
+
+}  // namespace silkworm::snapshots::elias_fano

--- a/silkworm/db/datastore/snapshots/history.hpp
+++ b/silkworm/db/datastore/snapshots/history.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "history_accessor_index.hpp"
 #include "inverted_index.hpp"
 #include "rec_split/accessor_index.hpp"
 #include "segment/segment_reader.hpp"
@@ -26,6 +27,11 @@ struct History {
     const segment::SegmentFileReader& segment;
     const rec_split::AccessorIndex& accessor_index;
     InvertedIndex inverted_index;
+
+    template <EncoderConcept TIIKeyEncoder>
+    static HistoryAccessorIndexKeyEncoder<TIIKeyEncoder> make_accessor_index_key_encoder() {
+        return HistoryAccessorIndexKeyEncoder<TIIKeyEncoder>{};
+    }
 };
 
 }  // namespace silkworm::snapshots

--- a/silkworm/db/state/address_decoder.hpp
+++ b/silkworm/db/state/address_decoder.hpp
@@ -1,0 +1,39 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <algorithm>
+
+#include <evmc/evmc.hpp>
+
+#include <silkworm/db/datastore/snapshots/common/codec.hpp>
+
+namespace silkworm::db::state {
+
+struct AddressDecoder : public snapshots::Decoder {
+    evmc::address value;
+
+    ~AddressDecoder() override = default;
+
+    void decode_word(ByteView word) override {
+        std::copy_n(word.data(), kAddressLength, value.bytes);
+    }
+};
+
+static_assert(snapshots::DecoderConcept<AddressDecoder>);
+
+}  // namespace silkworm::db::state

--- a/silkworm/db/state/address_decoder.hpp
+++ b/silkworm/db/state/address_decoder.hpp
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <algorithm>
+#include <stdexcept>
 
 #include <evmc/evmc.hpp>
 
@@ -30,7 +30,9 @@ struct AddressDecoder : public snapshots::Decoder {
     ~AddressDecoder() override = default;
 
     void decode_word(ByteView word) override {
-        std::copy_n(word.data(), kAddressLength, value.bytes);
+        if (word.size() < kAddressLength)
+            throw std::runtime_error{"AddressDecoder failed to decode"};
+        std::memcpy(value.bytes, word.data(), kAddressLength);
     }
 };
 

--- a/silkworm/db/state/address_decoder_test.cpp
+++ b/silkworm/db/state/address_decoder_test.cpp
@@ -1,0 +1,32 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "address_decoder.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <silkworm/core/common/util.hpp>
+
+namespace silkworm::db::state {
+
+TEST_CASE("AddressDecoder") {
+    using evmc::literals::operator""_address;
+    AddressDecoder decoder;
+    decoder.decode_word(*from_hex("0x000000000000000000636f6e736f6c652e6c6f67"));
+    CHECK(decoder.value == 0x000000000000000000636f6e736f6c652e6c6f67_address);
+}
+
+}  // namespace silkworm::db::state

--- a/silkworm/db/state/code_domain.hpp
+++ b/silkworm/db/state/code_domain.hpp
@@ -14,21 +14,15 @@
    limitations under the License.
 */
 
+#pragma once
+
+#include <silkworm/db/datastore/snapshots/common/raw_codec.hpp>
+#include <silkworm/db/datastore/snapshots/segment/kv_segment_reader.hpp>
+
 #include "address_decoder.hpp"
-
-#include <catch2/catch_test_macros.hpp>
-
-#include <silkworm/core/common/util.hpp>
 
 namespace silkworm::db::state {
 
-TEST_CASE("AddressDecoder") {
-    using evmc::literals::operator""_address;
-    AddressDecoder decoder;
-    decoder.decode_word(*from_hex("0x000000000000000000636f6e736f6c652e6c6f67"));
-    CHECK(decoder.value == 0x000000000000000000636f6e736f6c652e6c6f67_address);
-
-    CHECK_THROWS_AS(decoder.decode_word({}), std::runtime_error);
-}
+using CodeDomainKVSegmentReader = snapshots::segment::KVSegmentReader<AddressDecoder, snapshots::RawDecoder<Bytes>>;
 
 }  // namespace silkworm::db::state

--- a/silkworm/db/state/commitment_domain.hpp
+++ b/silkworm/db/state/commitment_domain.hpp
@@ -14,21 +14,13 @@
    limitations under the License.
 */
 
-#include "address_decoder.hpp"
+#pragma once
 
-#include <catch2/catch_test_macros.hpp>
-
-#include <silkworm/core/common/util.hpp>
+#include <silkworm/db/datastore/snapshots/common/raw_codec.hpp>
+#include <silkworm/db/datastore/snapshots/segment/kv_segment_reader.hpp>
 
 namespace silkworm::db::state {
 
-TEST_CASE("AddressDecoder") {
-    using evmc::literals::operator""_address;
-    AddressDecoder decoder;
-    decoder.decode_word(*from_hex("0x000000000000000000636f6e736f6c652e6c6f67"));
-    CHECK(decoder.value == 0x000000000000000000636f6e736f6c652e6c6f67_address);
-
-    CHECK_THROWS_AS(decoder.decode_word({}), std::runtime_error);
-}
+using CommitmentDomainKVSegmentReader = snapshots::segment::KVSegmentReader<snapshots::RawDecoder<Bytes>, snapshots::RawDecoder<Bytes>>;
 
 }  // namespace silkworm::db::state

--- a/silkworm/db/state/hash_decoder.hpp
+++ b/silkworm/db/state/hash_decoder.hpp
@@ -1,0 +1,38 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <algorithm>
+
+#include <silkworm/core/types/hash.hpp>
+#include <silkworm/db/datastore/snapshots/common/codec.hpp>
+
+namespace silkworm::db::state {
+
+struct HashDecoder : public snapshots::Decoder {
+    Hash value;
+
+    ~HashDecoder() override = default;
+
+    void decode_word(ByteView word) override {
+        value = Hash{word};
+    }
+};
+
+static_assert(snapshots::DecoderConcept<HashDecoder>);
+
+}  // namespace silkworm::db::state

--- a/silkworm/db/state/hash_decoder_test.cpp
+++ b/silkworm/db/state/hash_decoder_test.cpp
@@ -1,0 +1,32 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "hash_decoder.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <silkworm/core/common/util.hpp>
+
+namespace silkworm::db::state {
+
+TEST_CASE("HashDecoder") {
+    using evmc::literals::operator""_bytes32;
+    HashDecoder decoder;
+    decoder.decode_word(*from_hex("0xb397a22bb95bf14753ec174f02f99df3f0bdf70d1851cdff813ebf745f5aeb55"));
+    CHECK(decoder.value == 0xb397a22bb95bf14753ec174f02f99df3f0bdf70d1851cdff813ebf745f5aeb55_bytes32);
+}
+
+}  // namespace silkworm::db::state

--- a/silkworm/db/state/hash_decoder_test.cpp
+++ b/silkworm/db/state/hash_decoder_test.cpp
@@ -27,6 +27,8 @@ TEST_CASE("HashDecoder") {
     HashDecoder decoder;
     decoder.decode_word(*from_hex("0xb397a22bb95bf14753ec174f02f99df3f0bdf70d1851cdff813ebf745f5aeb55"));
     CHECK(decoder.value == 0xb397a22bb95bf14753ec174f02f99df3f0bdf70d1851cdff813ebf745f5aeb55_bytes32);
+
+    CHECK_THROWS_AS(decoder.decode_word({}), std::runtime_error);
 }
 
 }  // namespace silkworm::db::state

--- a/silkworm/db/state/log_address_inverted_index.hpp
+++ b/silkworm/db/state/log_address_inverted_index.hpp
@@ -1,0 +1,28 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <silkworm/db/datastore/snapshots/common/raw_codec.hpp>
+#include <silkworm/db/datastore/snapshots/segment/kv_segment_reader.hpp>
+
+#include "address_decoder.hpp"
+
+namespace silkworm::db::state {
+
+using LogAddressInvertedIndexKVSegmentReader = snapshots::segment::KVSegmentReader<AddressDecoder, snapshots::RawDecoder<Bytes>>;
+
+}  // namespace silkworm::db::state

--- a/silkworm/db/state/log_topics_inverted_index.hpp
+++ b/silkworm/db/state/log_topics_inverted_index.hpp
@@ -1,0 +1,28 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <silkworm/db/datastore/snapshots/common/raw_codec.hpp>
+#include <silkworm/db/datastore/snapshots/segment/kv_segment_reader.hpp>
+
+#include "hash_decoder.hpp"
+
+namespace silkworm::db::state {
+
+using LogTopicsInvertedIndexKVSegmentReader = snapshots::segment::KVSegmentReader<HashDecoder, snapshots::RawDecoder<Bytes>>;
+
+}  // namespace silkworm::db::state

--- a/silkworm/db/state/receipts_domain.hpp
+++ b/silkworm/db/state/receipts_domain.hpp
@@ -1,0 +1,59 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <stdexcept>
+
+#include <silkworm/db/datastore/snapshots/segment/kv_segment_reader.hpp>
+#include <silkworm/db/datastore/snapshots/segment/seg/common/varint.hpp>
+
+namespace silkworm::db::state {
+
+enum class ReceiptsDomainKey : uint8_t {
+    kCumulativeGasUsedInBlockKey = 0,
+    kCumulativeBlobGasUsedInBlockKey = 1,
+    kFirstLogIndexKey = 2,
+};
+
+struct ReceiptsDomainKeyDecoder : public snapshots::Decoder {
+    ReceiptsDomainKey value;
+    ~ReceiptsDomainKeyDecoder() override = default;
+    void decode_word(ByteView word) override {
+        if (word.empty())
+            throw std::runtime_error{"ReceiptsDomainKeyDecoder failed to decode an empty word"};
+        value = static_cast<ReceiptsDomainKey>(word[0]);
+    }
+};
+
+static_assert(snapshots::DecoderConcept<ReceiptsDomainKeyDecoder>);
+
+struct VarintDecoder : public snapshots::Decoder {
+    uint64_t value;
+    ~VarintDecoder() override = default;
+    void decode_word(ByteView word) override {
+        auto value_opt = snapshots::seg::varint::decode(word);
+        if (!value_opt)
+            throw std::runtime_error{"VarintDecoder failed to decode"};
+        value = *value_opt;
+    }
+};
+
+static_assert(snapshots::DecoderConcept<VarintDecoder>);
+
+using ReceiptsDomainKVSegmentReader = snapshots::segment::KVSegmentReader<ReceiptsDomainKeyDecoder, VarintDecoder>;
+
+}  // namespace silkworm::db::state

--- a/silkworm/db/state/receipts_domain_test.cpp
+++ b/silkworm/db/state/receipts_domain_test.cpp
@@ -14,19 +14,16 @@
    limitations under the License.
 */
 
-#include "address_decoder.hpp"
+#include "receipts_domain.hpp"
 
 #include <catch2/catch_test_macros.hpp>
 
-#include <silkworm/core/common/util.hpp>
-
 namespace silkworm::db::state {
 
-TEST_CASE("AddressDecoder") {
-    using evmc::literals::operator""_address;
-    AddressDecoder decoder;
-    decoder.decode_word(*from_hex("0x000000000000000000636f6e736f6c652e6c6f67"));
-    CHECK(decoder.value == 0x000000000000000000636f6e736f6c652e6c6f67_address);
+TEST_CASE("ReceiptsDomainKeyDecoder") {
+    ReceiptsDomainKeyDecoder decoder;
+    decoder.decode_word(Bytes{1});
+    CHECK(decoder.value == ReceiptsDomainKey::kCumulativeBlobGasUsedInBlockKey);
 
     CHECK_THROWS_AS(decoder.decode_word({}), std::runtime_error);
 }

--- a/silkworm/db/state/storage_domain.hpp
+++ b/silkworm/db/state/storage_domain.hpp
@@ -1,0 +1,57 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <stdexcept>
+
+#include <silkworm/db/datastore/snapshots/segment/kv_segment_reader.hpp>
+
+#include "address_decoder.hpp"
+
+namespace silkworm::db::state {
+
+struct Bytes32Decoder : public snapshots::Decoder {
+    evmc::bytes32 value;
+    ~Bytes32Decoder() override = default;
+    void decode_word(ByteView word) override {
+        if (word.size() < sizeof(value.bytes))
+            throw std::runtime_error{"Bytes32Decoder failed to decode"};
+        std::memcpy(value.bytes, word.data(), sizeof(value.bytes));
+    }
+};
+
+static_assert(snapshots::DecoderConcept<Bytes32Decoder>);
+
+struct StorageAddressAndLocationDecoder : public snapshots::Decoder {
+    struct {
+        AddressDecoder address;
+        Bytes32Decoder location_hash;
+    } value;
+
+    ~StorageAddressAndLocationDecoder() override = default;
+
+    void decode_word(ByteView word) override {
+        value.address.decode_word(word);
+        value.location_hash.decode_word(word.substr(kAddressLength));
+    }
+};
+
+static_assert(snapshots::DecoderConcept<StorageAddressAndLocationDecoder>);
+
+using StorageDomainKVSegmentReader = snapshots::segment::KVSegmentReader<StorageAddressAndLocationDecoder, Bytes32Decoder>;
+
+}  // namespace silkworm::db::state

--- a/silkworm/db/state/storage_domain_test.cpp
+++ b/silkworm/db/state/storage_domain_test.cpp
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-#include "address_decoder.hpp"
+#include "storage_domain.hpp"
 
 #include <catch2/catch_test_macros.hpp>
 
@@ -22,11 +22,17 @@
 
 namespace silkworm::db::state {
 
-TEST_CASE("AddressDecoder") {
+TEST_CASE("StorageAddressAndLocationDecoder") {
     using evmc::literals::operator""_address;
-    AddressDecoder decoder;
-    decoder.decode_word(*from_hex("0x000000000000000000636f6e736f6c652e6c6f67"));
-    CHECK(decoder.value == 0x000000000000000000636f6e736f6c652e6c6f67_address);
+    using evmc::literals::operator""_bytes32;
+    StorageAddressAndLocationDecoder decoder;
+
+    decoder.decode_word(
+        *from_hex(
+            "000000000000000000636f6e736f6c652e6c6f67"
+            "000000000000000000000000000000000000000000005666856076ebaf477f07"));
+    CHECK(decoder.value.address.value == 0x000000000000000000636f6e736f6c652e6c6f67_address);
+    CHECK(decoder.value.location_hash.value == 0x000000000000000000000000000000000000000000005666856076ebaf477f07_bytes32);
 
     CHECK_THROWS_AS(decoder.decode_word({}), std::runtime_error);
 }

--- a/silkworm/db/state/traces_from_inverted_index.hpp
+++ b/silkworm/db/state/traces_from_inverted_index.hpp
@@ -1,0 +1,28 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <silkworm/db/datastore/snapshots/common/raw_codec.hpp>
+#include <silkworm/db/datastore/snapshots/segment/kv_segment_reader.hpp>
+
+#include "address_decoder.hpp"
+
+namespace silkworm::db::state {
+
+using TracesFromInvertedIndexKVSegmentReader = snapshots::segment::KVSegmentReader<AddressDecoder, snapshots::RawDecoder<Bytes>>;
+
+}  // namespace silkworm::db::state

--- a/silkworm/db/state/traces_to_inverted_index.hpp
+++ b/silkworm/db/state/traces_to_inverted_index.hpp
@@ -1,0 +1,28 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <silkworm/db/datastore/snapshots/common/raw_codec.hpp>
+#include <silkworm/db/datastore/snapshots/segment/kv_segment_reader.hpp>
+
+#include "address_decoder.hpp"
+
+namespace silkworm::db::state {
+
+using TracesToInvertedIndexKVSegmentReader = snapshots::segment::KVSegmentReader<AddressDecoder, snapshots::RawDecoder<Bytes>>;
+
+}  // namespace silkworm::db::state


### PR DESCRIPTION
* generic decoder for reading II .ef values
* generic encoder for doing lookups on history .vi keys
* entity-specific decoders for reading domains and IIs

