### PR TITLE
core: move get_block_hash() from EvmHost to EVM

### DIFF
--- a/silkworm/core/execution/evm.cpp
+++ b/silkworm/core/execution/evm.cpp
@@ -479,17 +479,17 @@ evmc_tx_context EvmHost::get_tx_context() const noexcept {
     return context;
 }
 
-evmc::bytes32 EvmHost::get_block_hash(int64_t block_num) const noexcept {
+evmc::bytes32 EVM::get_block_hash(int64_t block_num) noexcept {
     SILKWORM_ASSERT(block_num >= 0);
-    const uint64_t current_block_num{evm_.block_.header.number};
+    const uint64_t current_block_num{block_.header.number};
     SILKWORM_ASSERT(static_cast<uint64_t>(block_num) < current_block_num);
     const uint64_t new_size_u64{current_block_num - static_cast<uint64_t>(block_num)};
     SILKWORM_ASSERT(std::in_range<size_t>(new_size_u64));
     const size_t new_size{static_cast<size_t>(new_size_u64)};
 
-    std::vector<evmc::bytes32>& hashes{evm_.block_hashes_};
+    std::vector<evmc::bytes32>& hashes{block_hashes_};
     if (hashes.empty()) {
-        hashes.push_back(evm_.block_.header.parent_hash);
+        hashes.push_back(block_.header.parent_hash);
     }
 
     const size_t old_size{hashes.size()};
@@ -498,7 +498,7 @@ evmc::bytes32 EvmHost::get_block_hash(int64_t block_num) const noexcept {
     }
 
     for (size_t i{old_size}; i < new_size; ++i) {
-        std::optional<BlockHeader> header{evm_.state().db().read_header(current_block_num - i, hashes[i - 1])};
+        std::optional<BlockHeader> header{state().db().read_header(current_block_num - i, hashes[i - 1])};
         if (!header) {
             break;
         }
@@ -506,6 +506,10 @@ evmc::bytes32 EvmHost::get_block_hash(int64_t block_num) const noexcept {
     }
 
     return hashes[new_size - 1];
+}
+
+evmc::bytes32 EvmHost::get_block_hash(int64_t block_num) const noexcept {
+    return evm_.get_block_hash(block_num);
 }
 
 void EvmHost::emit_log(const evmc::address& address, const uint8_t* data, size_t data_size,

--- a/silkworm/core/execution/evm.hpp
+++ b/silkworm/core/execution/evm.hpp
@@ -125,6 +125,8 @@ class EVM {
 
     bool bailout{false};
 
+    [[nodiscard]] evmc::bytes32 get_block_hash(int64_t block_num) noexcept;
+
   private:
     friend class EvmHost;
 


### PR DESCRIPTION
Move the implementation of the get_block_hash() from EvmHost to EVM where it is cached. This is in preparation for evmone APIv2 where this method is used.