### PR TITLE
core: use evmc::VM to own evmone's VM

### DIFF
--- a/silkworm/core/execution/evm.hpp
+++ b/silkworm/core/execution/evm.hpp
@@ -99,6 +99,15 @@ class EVM {
 
     ~EVM();
 
+    /// Returns the reference to the underlying evmone's VM object.
+    evmc::VM& vm() noexcept { return evm1_; }
+
+    /// Returns the reference to the evmone's internal interface for EVM.
+    evmone::VM& vm_impl() noexcept {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
+        return *static_cast<evmone::VM*>(evm1_.get_raw_pointer());
+    }
+
     const Block& block() const noexcept { return block_; }
 
     const ChainConfig& config() const noexcept { return config_; }
@@ -144,7 +153,7 @@ class EVM {
     std::vector<evmc::bytes32> block_hashes_{};
     EvmTracers tracers_;
 
-    evmone::VM* evm1_{nullptr};
+    evmc::VM evm1_;
 };
 
 class EvmHost : public evmc::Host {


### PR DESCRIPTION
Use the owned pointer to VM type from EVMC to manage the evmone's VM. This also prepares for evmone APIv2 usage where the `evmc::VM&` is needed.