### PR TITLE
db: move LocalState/RemoteState to execution, StateReader to kv

### DIFF
--- a/silkworm/db/kv/api/base_transaction.hpp
+++ b/silkworm/db/kv/api/base_transaction.hpp
@@ -27,6 +27,7 @@ class BaseTransaction : public Transaction {
   public:
     explicit BaseTransaction(StateCache* state_cache) : state_cache_{state_cache} {}
 
+    bool is_local() const override { return false; }
     void set_state_cache_enabled(bool cache_enabled) override;
 
     Task<KeyValue> get(const std::string& table, ByteView key) override;

--- a/silkworm/db/kv/api/local_transaction.cpp
+++ b/silkworm/db/kv/api/local_transaction.cpp
@@ -17,7 +17,6 @@
 #include "local_transaction.hpp"
 
 #include <silkworm/db/chain/local_chain_storage.hpp>
-#include <silkworm/db/state/local_state.hpp>
 
 namespace silkworm::db::kv::api {
 
@@ -58,11 +57,6 @@ Task<std::shared_ptr<CursorDupSort>> LocalTransaction::get_cursor(const std::str
         cursors_[table] = cursor;
     }
     co_return cursor;
-}
-
-std::shared_ptr<State> LocalTransaction::create_state(boost::asio::any_io_executor&, const chain::ChainStorage&, BlockNum block_num) {
-    // The calling thread *must* be *different* from the one which created this LocalTransaction instance
-    return std::make_shared<state::LocalState>(block_num, data_store_);
 }
 
 std::shared_ptr<chain::ChainStorage> LocalTransaction::create_storage() {

--- a/silkworm/db/kv/api/local_transaction.hpp
+++ b/silkworm/db/kv/api/local_transaction.hpp
@@ -53,7 +53,8 @@ class LocalTransaction : public BaseTransaction {
 
     Task<std::shared_ptr<CursorDupSort>> cursor_dup_sort(const std::string& table) override;
 
-    std::shared_ptr<State> create_state(boost::asio::any_io_executor& executor, const chain::ChainStorage& storage, BlockNum block_num) override;
+    bool is_local() const override { return true; }
+    DataStoreRef data_store() const { return data_store_; }
 
     std::shared_ptr<chain::ChainStorage> create_storage() override;
 

--- a/silkworm/db/kv/api/transaction.hpp
+++ b/silkworm/db/kv/api/transaction.hpp
@@ -23,7 +23,6 @@
 
 #include <silkworm/core/common/base.hpp>
 #include <silkworm/core/common/util.hpp>
-#include <silkworm/core/state/state.hpp>
 #include <silkworm/db/chain/chain_storage.hpp>
 
 #include "cursor.hpp"
@@ -55,7 +54,7 @@ class Transaction {
 
     virtual Task<std::shared_ptr<CursorDupSort>> cursor_dup_sort(const std::string& table) = 0;
 
-    virtual std::shared_ptr<State> create_state(boost::asio::any_io_executor& executor, const chain::ChainStorage& storage, BlockNum block_num) = 0;
+    virtual bool is_local() const = 0;
 
     virtual std::shared_ptr<chain::ChainStorage> create_storage() = 0;
 

--- a/silkworm/db/kv/grpc/client/remote_transaction.cpp
+++ b/silkworm/db/kv/grpc/client/remote_transaction.cpp
@@ -18,7 +18,6 @@
 
 #include <silkworm/db/chain/remote_chain_storage.hpp>
 #include <silkworm/db/kv/txn_num.hpp>
-#include <silkworm/db/state/remote_state.hpp>
 #include <silkworm/infra/grpc/client/call.hpp>
 #include <silkworm/infra/grpc/common/errors.hpp>
 #include <silkworm/infra/grpc/common/util.hpp>
@@ -107,10 +106,6 @@ Task<std::shared_ptr<api::CursorDupSort>> RemoteTransaction::get_cursor(const st
         cursors_[table] = cursor;
     }
     co_return cursor;
-}
-
-std::shared_ptr<silkworm::State> RemoteTransaction::create_state(boost::asio::any_io_executor& executor, const chain::ChainStorage& storage, BlockNum block_num) {
-    return std::make_shared<db::state::RemoteState>(executor, *this, storage, block_num);
 }
 
 std::shared_ptr<chain::ChainStorage> RemoteTransaction::create_storage() {

--- a/silkworm/db/kv/grpc/client/remote_transaction.hpp
+++ b/silkworm/db/kv/grpc/client/remote_transaction.hpp
@@ -54,8 +54,6 @@ class RemoteTransaction : public api::BaseTransaction {
 
     Task<std::shared_ptr<api::CursorDupSort>> cursor_dup_sort(const std::string& table) override;
 
-    std::shared_ptr<silkworm::State> create_state(boost::asio::any_io_executor& executor, const chain::ChainStorage& storage, BlockNum block_num) override;
-
     std::shared_ptr<chain::ChainStorage> create_storage() override;
 
     Task<TxnId> first_txn_num_in_block(BlockNum block_num) override;

--- a/silkworm/db/kv/state_reader.cpp
+++ b/silkworm/db/kv/state_reader.cpp
@@ -24,7 +24,7 @@
 #include <silkworm/db/util.hpp>
 #include <silkworm/infra/common/decoding_exception.hpp>
 
-namespace silkworm::db::state {
+namespace silkworm::db::kv {
 
 StateReader::StateReader(kv::api::Transaction& tx, BlockNum block_num) : tx_(tx), block_num_(block_num) {}
 
@@ -87,4 +87,4 @@ Task<std::optional<Bytes>> StateReader::read_code(const evmc::address& address, 
     co_return result.value;
 }
 
-}  // namespace silkworm::db::state
+}  // namespace silkworm::db::kv

--- a/silkworm/db/kv/state_reader.hpp
+++ b/silkworm/db/kv/state_reader.hpp
@@ -30,7 +30,7 @@
 
 #include "version.hpp"
 
-namespace silkworm::db::state {
+namespace silkworm::db::kv {
 
 class StateReader {
   public:
@@ -53,4 +53,4 @@ class StateReader {
     mutable std::optional<TxnId> txn_number_;
 };
 
-}  // namespace silkworm::db::state
+}  // namespace silkworm::db::kv

--- a/silkworm/db/kv/state_reader_test.cpp
+++ b/silkworm/db/kv/state_reader_test.cpp
@@ -25,7 +25,7 @@
 #include <silkworm/infra/test_util/context_test_base.hpp>
 #include <silkworm/rpc/common/util.hpp>
 
-namespace silkworm::db::state {
+namespace silkworm::db::kv {
 
 using testing::_;
 using testing::Invoke;
@@ -208,4 +208,4 @@ TEST_CASE_METHOD(StateReaderTest, "StateReader::read_code") {
 }
 #endif  // SILKWORM_SANITIZE
 
-}  // namespace silkworm::db::state
+}  // namespace silkworm::db::kv

--- a/silkworm/db/state/remote_state.hpp
+++ b/silkworm/db/state/remote_state.hpp
@@ -30,7 +30,7 @@
 #include <silkworm/db/chain/chain_storage.hpp>
 #include <silkworm/db/chain/providers.hpp>
 #include <silkworm/db/kv/api/transaction.hpp>
-#include <silkworm/db/state/state_reader.hpp>
+#include <silkworm/db/kv/state_reader.hpp>
 
 namespace silkworm::db::state {
 
@@ -63,7 +63,7 @@ class AsyncRemoteState {
     static std::unordered_map<evmc::bytes32, Bytes> code_;
 
     const chain::ChainStorage& storage_;
-    StateReader state_reader_;
+    kv::StateReader state_reader_;
 };
 
 class RemoteState : public State {

--- a/silkworm/db/test_util/mock_transaction.hpp
+++ b/silkworm/db/test_util/mock_transaction.hpp
@@ -38,8 +38,7 @@ class MockTransaction : public kv::api::Transaction {
     MOCK_METHOD((Task<void>), open, (), (override));
     MOCK_METHOD((Task<std::shared_ptr<kv::api::Cursor>>), cursor, (const std::string&), (override));
     MOCK_METHOD((Task<std::shared_ptr<kv::api::CursorDupSort>>), cursor_dup_sort, (const std::string&), (override));
-    MOCK_METHOD((std::shared_ptr<State>), create_state,
-                (boost::asio::any_io_executor&, const chain::ChainStorage&, BlockNum), (override));
+    bool is_local() const override { return false; }
     MOCK_METHOD((std::shared_ptr<chain::ChainStorage>), create_storage, (), (override));
     MOCK_METHOD((Task<TxnId>), first_txn_num_in_block, (BlockNum), (override));
     MOCK_METHOD((Task<void>), close, (), (override));

--- a/silkworm/execution/local_state.cpp
+++ b/silkworm/execution/local_state.cpp
@@ -18,7 +18,7 @@
 
 #include <silkworm/core/common/util.hpp>
 
-namespace silkworm::db::state {
+namespace silkworm::execution {
 
 std::optional<Account> LocalState::read_account(const evmc::address& address) const noexcept {
     return db::read_account(txn_, address, block_num_ + 1);
@@ -66,4 +66,4 @@ std::optional<evmc::bytes32> LocalState::canonical_hash(BlockNum block_num) cons
     return data_model_.read_canonical_header_hash(block_num);
 }
 
-}  // namespace silkworm::db::state
+}  // namespace silkworm::execution

--- a/silkworm/execution/remote_state.cpp
+++ b/silkworm/execution/remote_state.cpp
@@ -28,7 +28,7 @@
 #include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/infra/common/log.hpp>
 
-namespace silkworm::db::state {
+namespace silkworm::execution {
 
 std::unordered_map<evmc::bytes32, Bytes> AsyncRemoteState::code_;
 
@@ -172,4 +172,4 @@ std::optional<evmc::bytes32> RemoteState::canonical_hash(BlockNum /*block_num*/)
     throw std::logic_error{"RemoteState::canonical_hash not yet implemented"};
 }
 
-}  // namespace silkworm::db::state
+}  // namespace silkworm::execution

--- a/silkworm/execution/remote_state.hpp
+++ b/silkworm/execution/remote_state.hpp
@@ -16,28 +16,67 @@
 
 #pragma once
 
-#include <iostream>
 #include <optional>
 #include <string>
 #include <vector>
 
+#include <silkworm/infra/concurrency/task.hpp>
+
+#include <boost/asio/io_context.hpp>
 #include <evmc/evmc.hpp>
 
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/core/state/state.hpp>
-#include <silkworm/db/access_layer.hpp>
-#include <silkworm/db/datastore/mdbx/mdbx.hpp>
+#include <silkworm/db/chain/chain_storage.hpp>
+#include <silkworm/db/chain/providers.hpp>
+#include <silkworm/db/kv/api/transaction.hpp>
+#include <silkworm/db/kv/state_reader.hpp>
 
-#include "../data_store.hpp"
+namespace silkworm::execution {
 
-namespace silkworm::db::state {
-
-class LocalState : public State {
+class AsyncRemoteState {
   public:
-    explicit LocalState(BlockNum block_num, DataStoreRef data_store)
-        : block_num_{block_num},
-          txn_{data_store.chaindata.start_ro_tx()},
-          data_model_{txn_, data_store.blocks_repository} {}
+    explicit AsyncRemoteState(
+        db::kv::api::Transaction& tx,
+        const db::chain::ChainStorage& storage,
+        BlockNum block_num)
+        : storage_(storage), state_reader_(tx, block_num + 1) {}
+
+    Task<std::optional<Account>> read_account(const evmc::address& address) const noexcept;
+
+    Task<ByteView> read_code(const evmc::address& address, const evmc::bytes32& code_hash) const noexcept;
+
+    Task<evmc::bytes32> read_storage(const evmc::address& address, uint64_t incarnation, const evmc::bytes32& location) const noexcept;
+
+    Task<uint64_t> previous_incarnation(const evmc::address& address) const noexcept;
+
+    Task<std::optional<BlockHeader>> read_header(BlockNum block_num, const evmc::bytes32& block_hash) const noexcept;
+
+    Task<bool> read_body(BlockNum block_num, const evmc::bytes32& block_hash, BlockBody& filled_body) const noexcept;
+
+    Task<std::optional<intx::uint256>> total_difficulty(BlockNum block_num, const evmc::bytes32& block_hash) const noexcept;
+
+    Task<evmc::bytes32> state_root_hash() const;
+
+    Task<BlockNum> current_canonical_block() const;
+
+    Task<std::optional<evmc::bytes32>> canonical_hash(BlockNum block_num) const;
+
+  private:
+    static std::unordered_map<evmc::bytes32, Bytes> code_;
+
+    const db::chain::ChainStorage& storage_;
+    db::kv::StateReader state_reader_;
+};
+
+class RemoteState : public State {
+  public:
+    explicit RemoteState(
+        boost::asio::any_io_executor& executor,
+        db::kv::api::Transaction& tx,
+        const db::chain::ChainStorage& storage,
+        BlockNum block_num)
+        : executor_(executor), async_state_{tx, storage, block_num} {}
 
     std::optional<Account> read_account(const evmc::address& address) const noexcept override;
 
@@ -92,9 +131,10 @@ class LocalState : public State {
     void unwind_state_changes(BlockNum /*block_num*/) override {}
 
   private:
-    BlockNum block_num_;
-    mutable db::ROTxnManaged txn_;
-    db::DataModel data_model_;
+    boost::asio::any_io_executor executor_;
+    AsyncRemoteState async_state_;
 };
 
-}  // namespace silkworm::db::state
+std::ostream& operator<<(std::ostream& out, const RemoteState& s);
+
+}  // namespace silkworm::execution

--- a/silkworm/execution/remote_state_test.cpp
+++ b/silkworm/execution/remote_state_test.cpp
@@ -32,7 +32,7 @@
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/test_util/context_test_base.hpp>
 
-namespace silkworm::db::state {
+namespace silkworm::execution {
 
 using testing::_;
 using testing::Invoke;
@@ -50,7 +50,7 @@ TEST_CASE_METHOD(RemoteStateTest, "async remote buffer", "[rpc][core][remote_buf
     const evmc::address address{0x0715a7794a1dc8e42615f059dd6e406a6594651a_address};
 
     SECTION("read_code for empty hash") {
-        EXPECT_CALL(transaction, get_one(table::kCodeName, _))
+        EXPECT_CALL(transaction, get_one(db::table::kCodeName, _))
             .WillRepeatedly(InvokeWithoutArgs([]() -> Task<Bytes> {
                 co_return Bytes{};
             }));
@@ -374,7 +374,7 @@ TEST_CASE_METHOD(RemoteStateTest, "async remote buffer", "[rpc][core][remote_buf
     }
 
     SECTION("AsyncRemoteState::canonical_hash for empty response from chain storage") {
-        EXPECT_CALL(transaction, get_one(table::kCanonicalHashesName, _))
+        EXPECT_CALL(transaction, get_one(db::table::kCanonicalHashesName, _))
             .WillRepeatedly(InvokeWithoutArgs([=]() -> Task<Bytes> {
                 co_return Bytes{};
             }));
@@ -406,4 +406,4 @@ TEST_CASE_METHOD(RemoteStateTest, "RemoteState") {
 }
 #endif  // SILKWORM_SANITIZE
 
-}  // namespace silkworm::db::state
+}  // namespace silkworm::execution

--- a/silkworm/execution/state_factory.cpp
+++ b/silkworm/execution/state_factory.cpp
@@ -1,0 +1,39 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "state_factory.hpp"
+
+#include <silkworm/db/kv/api/local_transaction.hpp>
+#include <silkworm/db/kv/grpc/client/remote_transaction.hpp>
+
+#include "local_state.hpp"
+#include "remote_state.hpp"
+
+namespace silkworm::execution {
+
+std::shared_ptr<State> StateFactory::create_state(
+    boost::asio::any_io_executor& executor,
+    const db::chain::ChainStorage& storage,
+    BlockNum block_num) {
+    if (tx.is_local()) {
+        auto& local_tx = dynamic_cast<db::kv::api::LocalTransaction&>(tx);
+        return std::make_shared<LocalState>(block_num, local_tx.data_store());
+    } else {
+        return std::make_shared<RemoteState>(executor, tx, storage, block_num);
+    }
+}
+
+}  // namespace silkworm::execution

--- a/silkworm/execution/state_factory.hpp
+++ b/silkworm/execution/state_factory.hpp
@@ -1,4 +1,4 @@
-#[[
+/*
    Copyright 2024 The Silkworm Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,34 +12,28 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-]]
+*/
 
-include("${SILKWORM_MAIN_DIR}/cmake/common/targets.cmake")
+#pragma once
 
-find_package(asio-grpc REQUIRED)
-find_package(gRPC REQUIRED)
-find_package(GTest REQUIRED)
+#include <memory>
 
-# cmake-format: off
-set(LIBS_PRIVATE
-    gRPC::grpc++
-    silkworm_interfaces
-)
-# cmake-format: on
+#include <boost/asio/any_io_executor.hpp>
 
-# cmake-format: off
-set(LIBS_PUBLIC
-    asio-grpc::asio-grpc
-    silkworm_core
-    silkworm_infra
-    silkworm_db
-)
-# cmake-format: on
+#include <silkworm/core/common/base.hpp>
+#include <silkworm/core/state/state.hpp>
+#include <silkworm/db/chain/chain_storage.hpp>
+#include <silkworm/db/kv/api/transaction.hpp>
 
-silkworm_library(
-  silkworm_execution
-  PUBLIC ${LIBS_PUBLIC}
-  PRIVATE ${LIBS_PRIVATE}
-)
+namespace silkworm::execution {
 
-target_link_libraries(silkworm_execution_test PRIVATE GTest::gmock silkworm_infra_test_util)
+struct StateFactory {
+    db::kv::api::Transaction& tx;
+
+    std::shared_ptr<State> create_state(
+        boost::asio::any_io_executor& executor,
+        const db::chain::ChainStorage& storage,
+        BlockNum block_num);
+};
+
+}  // namespace silkworm::execution

--- a/silkworm/rpc/commands/debug_api_test.cpp
+++ b/silkworm/rpc/commands/debug_api_test.cpp
@@ -215,10 +215,6 @@ class DummyTransaction : public db::kv::api::BaseTransaction {
         co_return cursor;
     }
 
-    std::shared_ptr<silkworm::State> create_state(boost::asio::any_io_executor&, const ChainStorage&, BlockNum) override {
-        return nullptr;
-    }
-
     std::shared_ptr<ChainStorage> create_storage() override {
         return nullptr;
     }

--- a/silkworm/rpc/commands/eth_api.cpp
+++ b/silkworm/rpc/commands/eth_api.cpp
@@ -32,7 +32,7 @@
 #include <silkworm/core/types/block.hpp>
 #include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/core/types/transaction.hpp>
-#include <silkworm/db/state/state_reader.hpp>
+#include <silkworm/db/kv/state_reader.hpp>
 #include <silkworm/db/util.hpp>
 #include <silkworm/infra/common/clock_time.hpp>
 #include <silkworm/infra/common/log.hpp>
@@ -52,7 +52,7 @@
 
 namespace silkworm::rpc::commands {
 
-using db::state::StateReader;
+using db::kv::StateReader;
 
 // https://eth.wiki/json-rpc/API#eth_blocknumber
 Task<void> EthereumRpcApi::handle_eth_block_num(const nlohmann::json& request, nlohmann::json& reply) {

--- a/silkworm/rpc/commands/ots_api.cpp
+++ b/silkworm/rpc/commands/ots_api.cpp
@@ -25,8 +25,8 @@
 #include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/db/datastore/mdbx/bitmap.hpp>
 #include <silkworm/db/kv/api/endpoint/key_value.hpp>
+#include <silkworm/db/kv/state_reader.hpp>
 #include <silkworm/db/kv/txn_num.hpp>
-#include <silkworm/db/state/state_reader.hpp>
 #include <silkworm/db/tables.hpp>
 #include <silkworm/infra/common/async_binary_search.hpp>
 #include <silkworm/infra/common/log.hpp>
@@ -41,7 +41,7 @@
 namespace silkworm::rpc::commands {
 
 using namespace silkworm::db;
-using db::state::StateReader;
+using db::kv::StateReader;
 
 static constexpr int kCurrentApiLevel{8};
 

--- a/silkworm/rpc/commands/parity_api.cpp
+++ b/silkworm/rpc/commands/parity_api.cpp
@@ -23,8 +23,8 @@
 
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/core/types/address.hpp>
+#include <silkworm/db/kv/state_reader.hpp>
 #include <silkworm/db/kv/txn_num.hpp>
-#include <silkworm/db/state/state_reader.hpp>
 #include <silkworm/db/tables.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/rpc/common/util.hpp>
@@ -34,7 +34,7 @@
 
 namespace silkworm::rpc::commands {
 
-using db::state::StateReader;
+using db::kv::StateReader;
 
 Task<void> ParityRpcApi::handle_parity_list_storage_keys(const nlohmann::json& request, nlohmann::json& reply) {
     const auto& params = request["params"];

--- a/silkworm/rpc/core/account_dumper.cpp
+++ b/silkworm/rpc/core/account_dumper.cpp
@@ -23,7 +23,7 @@
 #include <silkworm/core/trie/nibbles.hpp>
 #include <silkworm/core/types/account.hpp>
 #include <silkworm/core/types/address.hpp>
-#include <silkworm/db/state/state_reader.hpp>
+#include <silkworm/db/kv/state_reader.hpp>
 #include <silkworm/db/tables.hpp>
 #include <silkworm/db/util.hpp>
 #include <silkworm/infra/common/decoding_exception.hpp>
@@ -35,7 +35,7 @@
 
 namespace silkworm::rpc::core {
 
-using db::state::StateReader;
+using db::kv::StateReader;
 
 Task<DumpAccounts> AccountDumper::dump_accounts(
     BlockCache& cache,

--- a/silkworm/rpc/core/account_dumper_test.cpp
+++ b/silkworm/rpc/core/account_dumper_test.cpp
@@ -194,10 +194,6 @@ class DummyTransaction : public BaseTransaction {
         co_return cursor;
     }
 
-    std::shared_ptr<silkworm::State> create_state(boost::asio::any_io_executor&, const ChainStorage&, BlockNum) override {
-        return nullptr;
-    }
-
     std::shared_ptr<ChainStorage> create_storage() override {
         return nullptr;
     }

--- a/silkworm/rpc/core/block_reader.cpp
+++ b/silkworm/rpc/core/block_reader.cpp
@@ -20,7 +20,7 @@
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/core/types/account.hpp>
 #include <silkworm/core/types/address.hpp>
-#include <silkworm/db/state/state_reader.hpp>
+#include <silkworm/db/kv/state_reader.hpp>
 #include <silkworm/db/tables.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/rpc/common/util.hpp>
@@ -30,7 +30,7 @@
 
 namespace silkworm::rpc {
 
-using db::state::StateReader;
+using db::kv::StateReader;
 using namespace silkworm::db;
 using namespace silkworm::db::chain;
 

--- a/silkworm/rpc/core/call_many.cpp
+++ b/silkworm/rpc/core/call_many.cpp
@@ -22,6 +22,7 @@
 
 #include <evmc/instructions.h>
 
+#include <silkworm/execution/state_factory.hpp>
 #include <silkworm/infra/common/clock_time.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/rpc/common/async_task.hpp>
@@ -44,7 +45,7 @@ CallManyResult CallExecutor::executes_all_bundles(const silkworm::ChainConfig& c
     CallManyResult result;
     const auto& block = block_with_hash->block;
     const auto& block_transactions = block.transactions;
-    auto state = transaction_.create_state(this_executor, storage, block.header.number);
+    auto state = execution::StateFactory{transaction_}.create_state(this_executor, storage, block.header.number);
     EVMExecutor executor{block, config, workers_, std::make_shared<state::OverrideState>(*state, accounts_overrides)};
 
     std::uint64_t timeout = opt_timeout.value_or(5000);

--- a/silkworm/rpc/core/estimate_gas_oracle.cpp
+++ b/silkworm/rpc/core/estimate_gas_oracle.cpp
@@ -18,6 +18,7 @@
 
 #include <string>
 
+#include <silkworm/execution/state_factory.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/rpc/common/async_task.hpp>
 #include <silkworm/rpc/core/block_reader.hpp>
@@ -79,7 +80,7 @@ Task<intx::uint256> EstimateGasOracle::estimate_gas(const Call& call, const silk
 
     auto this_executor = co_await boost::asio::this_coro::executor;
     auto exec_result = co_await async_task(workers_.executor(), [&]() -> ExecutionResult {
-        auto state = transaction_.create_state(this_executor, storage_, block_num);
+        auto state = execution::StateFactory{transaction_}.create_state(this_executor, storage_, block_num);
 
         ExecutionResult result{evmc_status_code::EVMC_SUCCESS};
         silkworm::Transaction transaction{call.to_transaction()};

--- a/silkworm/rpc/core/evm_debug.cpp
+++ b/silkworm/rpc/core/evm_debug.cpp
@@ -25,6 +25,7 @@
 
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/core/types/evmc_bytes32.hpp>
+#include <silkworm/execution/state_factory.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/rpc/common/async_task.hpp>
 #include <silkworm/rpc/common/util.hpp>
@@ -434,7 +435,7 @@ Task<void> DebugExecutor::execute(json::Stream& stream, const ChainStorage& stor
     const auto chain_config = co_await storage.read_chain_config();
     auto current_executor = co_await boost::asio::this_coro::executor;
     co_await async_task(workers_.executor(), [&]() -> void {
-        auto state = tx_.create_state(current_executor, storage, block_num - 1);
+        auto state = execution::StateFactory{tx_}.create_state(current_executor, storage, block_num - 1);
         EVMExecutor executor{block, chain_config, workers_, state};
 
         for (std::uint64_t idx = 0; idx < transactions.size(); ++idx) {
@@ -492,7 +493,7 @@ Task<void> DebugExecutor::execute(
     const auto chain_config = co_await storage.read_chain_config();
     auto current_executor = co_await boost::asio::this_coro::executor;
     co_await async_task(workers_.executor(), [&]() {
-        auto state = tx_.create_state(current_executor, storage, block_num);
+        auto state = execution::StateFactory{tx_}.create_state(current_executor, storage, block_num);
         EVMExecutor executor{block, chain_config, workers_, state};
 
         for (auto idx{0}; idx < index; ++idx) {
@@ -543,7 +544,7 @@ Task<void> DebugExecutor::execute(
     const auto chain_config = co_await storage.read_chain_config();
     auto current_executor = co_await boost::asio::this_coro::executor;
     co_await async_task(workers_.executor(), [&]() {
-        auto state = tx_.create_state(current_executor, storage, block.header.number);
+        auto state = execution::StateFactory{tx_}.create_state(current_executor, storage, block.header.number);
         EVMExecutor executor{block, chain_config, workers_, state};
 
         for (auto idx{0}; idx < transaction_index; ++idx) {

--- a/silkworm/rpc/core/evm_debug_test.cpp
+++ b/silkworm/rpc/core/evm_debug_test.cpp
@@ -26,7 +26,6 @@
 #include <silkworm/core/common/bytes_to_string.hpp>
 #include <silkworm/db/chain/remote_chain_storage.hpp>
 #include <silkworm/db/kv/api/transaction.hpp>
-#include <silkworm/db/state/remote_state.hpp>
 #include <silkworm/db/tables.hpp>
 #include <silkworm/db/test_util/mock_transaction.hpp>
 #include <silkworm/rpc/ethdb/kv/backend_providers.hpp>
@@ -68,7 +67,6 @@ class TestDebugExecutor : DebugExecutor {
 };
 
 #ifndef SILKWORM_SANITIZE
-using silkworm::db::state::RemoteState;
 using testing::_;
 using testing::Invoke;
 using testing::InvokeWithoutArgs;
@@ -85,12 +83,6 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute precompiled") {
     static Bytes account_history_key3{*silkworm::from_hex("0000000000000000000000000000000000000000")};
 
     static Bytes account_history_value1{*silkworm::from_hex("010203ed03e820f1885eda54b7a053318cd41e2093220dab15d65381b1157a3633a83bfd5c92390105")};
-
-    auto& tx = transaction;
-    EXPECT_CALL(transaction, create_state(_, _, _))
-        .WillOnce(Invoke([&tx](auto& ioc, const auto& storage, auto block_num) -> std::shared_ptr<State> {
-            return std::make_shared<RemoteState>(ioc, tx, storage, block_num);
-        }));
 
     SECTION("precompiled contract failure") {
         db::kv::api::GetAsOfQuery query1{
@@ -175,12 +167,6 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 1") {
 
     static Bytes account_history_key3{*silkworm::from_hex("0x0000000000000000000000000000000000000000")};
     static Bytes account_history_value3{*silkworm::from_hex("000944ed67f28fd50bb8e90000")};
-
-    auto& tx = transaction;
-    EXPECT_CALL(transaction, create_state(_, _, _))
-        .WillOnce(Invoke([&tx](auto& ioc, const auto& storage, auto block_num) -> std::shared_ptr<State> {
-            return std::make_shared<RemoteState>(ioc, tx, storage, block_num);
-        }));
 
     SECTION("Call: failed with intrinsic gas too low") {
         EXPECT_CALL(backend, get_block_hash_from_block_num(_))
@@ -893,12 +879,6 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call 2") {
     static Bytes account_history_key3{*silkworm::from_hex("0000000000000000000000000000000000000000")};
     static Bytes account_history_value3{*silkworm::from_hex("00094165832d46fa1082db0000")};
 
-    auto& tx = transaction;
-    EXPECT_CALL(transaction, create_state(_, _, _))
-        .WillOnce(Invoke([&tx](auto& ioc, const auto& storage, auto block_num) -> std::shared_ptr<State> {
-            return std::make_shared<RemoteState>(ioc, tx, storage, block_num);
-        }));
-
     SECTION("Call: TO present") {
         db::kv::api::GetAsOfQuery query1{
             .table = table::kAccountDomain,
@@ -983,12 +963,6 @@ TEST_CASE_METHOD(DebugExecutorTest, "DebugExecutor::execute call with error") {
 
     static Bytes account_history_key3{*silkworm::from_hex("0000000000000000000000000000000000000000")};
     static Bytes account_history_value3{*silkworm::from_hex("000944ed67f28fd50bb8e90000")};
-
-    auto& tx = transaction;
-    EXPECT_CALL(transaction, create_state(_, _, _))
-        .WillOnce(Invoke([&tx](auto& ioc, const auto& storage, auto block_num) -> std::shared_ptr<State> {
-            return std::make_shared<RemoteState>(ioc, tx, storage, block_num);
-        }));
 
     db::kv::api::GetAsOfQuery query1{
         .table = table::kAccountDomain,

--- a/silkworm/rpc/core/evm_executor_test.cpp
+++ b/silkworm/rpc/core/evm_executor_test.cpp
@@ -27,9 +27,9 @@
 
 #include <silkworm/db/chain/remote_chain_storage.hpp>
 #include <silkworm/db/kv/api/transaction.hpp>
-#include <silkworm/db/state/remote_state.hpp>
 #include <silkworm/db/test_util/mock_cursor.hpp>
 #include <silkworm/db/test_util/mock_transaction.hpp>
+#include <silkworm/execution/remote_state.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/grpc/client/client_context_pool.hpp>
 #include <silkworm/infra/test_util/log.hpp>
@@ -57,7 +57,7 @@ struct EVMExecutorTest : public test_util::ServiceContextTestBase {
     const uint64_t chain_id{11155111};
     const ChainConfig* chain_config_ptr{lookup_chain_config(chain_id)};
     BlockNum block_num{6'000'000};
-    std::shared_ptr<State> state{std::make_shared<db::state::RemoteState>(io_executor, transaction, storage, block_num)};
+    std::shared_ptr<State> state{std::make_shared<execution::RemoteState>(io_executor, transaction, storage, block_num)};
 };
 
 #ifndef SILKWORM_SANITIZE

--- a/silkworm/rpc/core/evm_trace.cpp
+++ b/silkworm/rpc/core/evm_trace.cpp
@@ -33,6 +33,7 @@
 #include <silkworm/core/protocol/ethash_rule_set.hpp>
 #include <silkworm/core/types/address.hpp>
 #include <silkworm/core/types/evmc_bytes32.hpp>
+#include <silkworm/execution/state_factory.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/rpc/common/async_task.hpp>
 #include <silkworm/rpc/common/util.hpp>
@@ -1414,13 +1415,13 @@ Task<std::vector<TraceCallResult>> TraceCallExecutor::trace_block_transactions(c
     const auto chain_config = co_await chain_storage_.read_chain_config();
     auto current_executor = co_await boost::asio::this_coro::executor;
     const auto call_result = co_await async_task(workers_.executor(), [&]() -> std::vector<TraceCallResult> {
-        auto state = tx_.create_state(current_executor, chain_storage_, block_num - 1);
+        auto state = execution::StateFactory{tx_}.create_state(current_executor, chain_storage_, block_num - 1);
         IntraBlockState initial_ibs{*state};
 
         StateAddresses state_addresses(initial_ibs);
         std::shared_ptr<EvmTracer> ibs_tracer = std::make_shared<trace::IntraBlockStateTracer>(state_addresses);
 
-        auto curr_state = tx_.create_state(current_executor, chain_storage_, block_num - 1);
+        auto curr_state = execution::StateFactory{tx_}.create_state(current_executor, chain_storage_, block_num - 1);
         EVMExecutor executor{block, chain_config, workers_, curr_state};
 
         std::vector<TraceCallResult> trace_call_result(transactions.size());
@@ -1479,11 +1480,11 @@ Task<TraceManyCallResult> TraceCallExecutor::trace_calls(const silkworm::Block& 
     const auto chain_config = co_await chain_storage_.read_chain_config();
     auto current_executor = co_await boost::asio::this_coro::executor;
     const auto trace_calls_result = co_await async_task(workers_.executor(), [&]() -> TraceManyCallResult {
-        auto state = tx_.create_state(current_executor, chain_storage_, block_num);
+        auto state = execution::StateFactory{tx_}.create_state(current_executor, chain_storage_, block_num);
         silkworm::IntraBlockState initial_ibs{*state};
         StateAddresses state_addresses(initial_ibs);
 
-        auto curr_state = tx_.create_state(current_executor, chain_storage_, block_num);
+        auto curr_state = execution::StateFactory{tx_}.create_state(current_executor, chain_storage_, block_num);
         EVMExecutor executor{block, chain_config, workers_, state};
 
         std::shared_ptr<silkworm::EvmTracer> ibs_tracer = std::make_shared<trace::IntraBlockStateTracer>(state_addresses);
@@ -1540,10 +1541,10 @@ Task<TraceDeployResult> TraceCallExecutor::trace_deploy_transaction(const silkwo
     const auto chain_config = co_await chain_storage_.read_chain_config();
     auto current_executor = co_await boost::asio::this_coro::executor;
     const auto deploy_result = co_await async_task(workers_.executor(), [&]() -> TraceDeployResult {
-        auto state = tx_.create_state(current_executor, chain_storage_, block_num - 1);
+        auto state = execution::StateFactory{tx_}.create_state(current_executor, chain_storage_, block_num - 1);
         silkworm::IntraBlockState initial_ibs{*state};
 
-        auto curr_state = tx_.create_state(current_executor, chain_storage_, block_num - 1);
+        auto curr_state = execution::StateFactory{tx_}.create_state(current_executor, chain_storage_, block_num - 1);
         EVMExecutor executor{block, chain_config, workers_, curr_state};
 
         TraceDeployResult result;
@@ -1600,9 +1601,9 @@ Task<TraceEntriesResult> TraceCallExecutor::trace_transaction_entries(const Tran
     const auto chain_config = co_await chain_storage_.read_chain_config();
     auto current_executor = co_await boost::asio::this_coro::executor;
     const auto trace_result = co_await async_task(workers_.executor(), [&]() -> TraceEntriesResult {
-        auto state = tx_.create_state(current_executor, chain_storage_, block_num - 1);
+        auto state = execution::StateFactory{tx_}.create_state(current_executor, chain_storage_, block_num - 1);
         silkworm::IntraBlockState initial_ibs{*state};
-        auto curr_state = tx_.create_state(current_executor, chain_storage_, block_num - 1);
+        auto curr_state = execution::StateFactory{tx_}.create_state(current_executor, chain_storage_, block_num - 1);
         EVMExecutor executor{block, chain_config, workers_, curr_state};
 
         executor.call_first_n(block, transaction_with_block.transaction.transaction_index);
@@ -1625,10 +1626,10 @@ Task<std::string> TraceCallExecutor::trace_transaction_error(const TransactionWi
     const auto chain_config = co_await chain_storage_.read_chain_config();
     auto current_executor = co_await boost::asio::this_coro::executor;
     const auto trace_error = co_await async_task(workers_.executor(), [&]() -> std::string {
-        auto state = tx_.create_state(current_executor, chain_storage_, block_num - 1);
+        auto state = execution::StateFactory{tx_}.create_state(current_executor, chain_storage_, block_num - 1);
         silkworm::IntraBlockState initial_ibs{*state};
 
-        auto curr_state = tx_.create_state(current_executor, chain_storage_, block_num - 1);
+        auto curr_state = execution::StateFactory{tx_}.create_state(current_executor, chain_storage_, block_num - 1);
         EVMExecutor executor{block, chain_config, workers_, curr_state};
 
         executor.call_first_n(block, transaction_with_block.transaction.transaction_index);
@@ -1653,10 +1654,10 @@ Task<TraceOperationsResult> TraceCallExecutor::trace_operations(const Transactio
     const auto chain_config = co_await chain_storage_.read_chain_config();
     auto current_executor = co_await boost::asio::this_coro::executor;
     const auto trace_op_result = co_await async_task(workers_.executor(), [&]() -> TraceOperationsResult {
-        auto state = tx_.create_state(current_executor, chain_storage_, block_num - 1);
+        auto state = execution::StateFactory{tx_}.create_state(current_executor, chain_storage_, block_num - 1);
         silkworm::IntraBlockState initial_ibs{*state};
 
-        auto curr_state = tx_.create_state(current_executor, chain_storage_, block_num - 1);
+        auto curr_state = execution::StateFactory{tx_}.create_state(current_executor, chain_storage_, block_num - 1);
         EVMExecutor executor{block, chain_config, workers_, curr_state};
 
         executor.call_first_n(block, transaction_with_block.transaction.transaction_index);
@@ -1682,10 +1683,10 @@ Task<bool> TraceCallExecutor::trace_touch_block(const silkworm::BlockWithHash& b
     const auto chain_config = co_await chain_storage_.read_chain_config();
     auto current_executor = co_await boost::asio::this_coro::executor;
     const bool result = co_await async_task(workers_.executor(), [&]() -> bool {
-        auto state = tx_.create_state(current_executor, chain_storage_, block_num - 1);
+        auto state = execution::StateFactory{tx_}.create_state(current_executor, chain_storage_, block_num - 1);
         silkworm::IntraBlockState initial_ibs{*state};
 
-        auto curr_state = tx_.create_state(current_executor, chain_storage_, block_num - 1);
+        auto curr_state = execution::StateFactory{tx_}.create_state(current_executor, chain_storage_, block_num - 1);
         EVMExecutor executor{block, chain_config, workers_, curr_state};
 
         for (size_t i = 0; i < block.transactions.size(); ++i) {
@@ -1779,7 +1780,7 @@ Task<TraceCallResult> TraceCallExecutor::execute(
     const auto chain_config = co_await chain_storage_.read_chain_config();
     auto current_executor = co_await boost::asio::this_coro::executor;
     const auto trace_call_result = co_await async_task(workers_.executor(), [&]() -> TraceCallResult {
-        auto state = tx_.create_state(current_executor, chain_storage_, block_num);
+        auto state = execution::StateFactory{tx_}.create_state(current_executor, chain_storage_, block_num);
         silkworm::IntraBlockState initial_ibs{*state};
 
         Tracers tracers;
@@ -1787,7 +1788,7 @@ Task<TraceCallResult> TraceCallExecutor::execute(
         std::shared_ptr<silkworm::EvmTracer> tracer = std::make_shared<trace::IntraBlockStateTracer>(state_addresses);
         tracers.push_back(tracer);
 
-        auto curr_state = tx_.create_state(current_executor, chain_storage_, block_num);
+        auto curr_state = execution::StateFactory{tx_}.create_state(current_executor, chain_storage_, block_num);
         EVMExecutor executor{block, chain_config, workers_, curr_state};
         for (size_t idx{0}; idx < transaction.transaction_index; ++idx) {
             silkworm::Transaction txn{block.transactions[idx]};

--- a/silkworm/rpc/core/evm_trace_test.cpp
+++ b/silkworm/rpc/core/evm_trace_test.cpp
@@ -28,7 +28,6 @@
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/db/chain/remote_chain_storage.hpp>
 #include <silkworm/db/kv/api/endpoint/key_value.hpp>
-#include <silkworm/db/state/remote_state.hpp>
 #include <silkworm/db/tables.hpp>
 #include <silkworm/db/test_util/mock_transaction.hpp>
 #include <silkworm/infra/common/log.hpp>
@@ -54,7 +53,6 @@ struct TraceCallExecutorTest : public test_util::ServiceContextTestBase {
 };
 
 #ifndef SILKWORM_SANITIZE
-using silkworm::db::state::RemoteState;
 using testing::_;
 using testing::Invoke;
 using testing::InvokeWithoutArgs;
@@ -68,11 +66,6 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_call precompil
     static Bytes account_history_key1{*silkworm::from_hex("0a6bb546b9208cfab9e8fa2b9b2c042b18df7030")};
     static Bytes account_history_key2{*silkworm::from_hex("0000000000000000000000000000000000000009")};
     static Bytes account_history_key3{*silkworm::from_hex("0000000000000000000000000000000000000000")};
-
-    auto& tx = transaction;
-    EXPECT_CALL(transaction, create_state(_, _, _)).Times(2).WillRepeatedly(Invoke([&tx](auto& ioc, const auto& storage, auto block_num) -> std::shared_ptr<State> {
-        return std::make_shared<RemoteState>(ioc, tx, storage, block_num);
-    }));
 
     SECTION("precompiled contract failure") {
         db::kv::api::GetAsOfQuery query1{
@@ -181,11 +174,6 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_call 1") {
 
     static Bytes account_history_key3{*silkworm::from_hex("0000000000000000000000000000000000000000")};
     static Bytes account_history_value3{*silkworm::from_hex("000944ed67f28fd50bb8e90000")};
-
-    auto& tx = transaction;
-    EXPECT_CALL(transaction, create_state(_, _, _)).Times(2).WillRepeatedly(Invoke([&tx](auto& ioc, const auto& storage, auto block_num) -> std::shared_ptr<State> {
-        return std::make_shared<RemoteState>(ioc, tx, storage, block_num);
-    }));
 
     SECTION("Call: failed with intrinsic gas too low") {
         EXPECT_CALL(backend, get_block_hash_from_block_num(_))
@@ -932,11 +920,6 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_call 2") {
 
     static Bytes account_history_key3{*silkworm::from_hex("0000000000000000000000000000000000000000")};
 
-    auto& tx = transaction;
-    EXPECT_CALL(transaction, create_state(_, _, _)).Times(2).WillRepeatedly(Invoke([&tx](auto& ioc, const auto& storage, auto block_num) -> std::shared_ptr<State> {
-        return std::make_shared<RemoteState>(ioc, tx, storage, block_num);
-    }));
-
     SECTION("Call: TO present") {
         db::kv::api::GetAsOfQuery query1{
             .table = table::kAccountDomain,
@@ -1080,11 +1063,6 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_call with erro
 
     static Bytes account_history_key3{*silkworm::from_hex("0000000000000000000000000000000000000000")};
     static Bytes account_history_value3{*silkworm::from_hex("000944ed67f28fd50bb8e90000")};
-
-    auto& tx = transaction;
-    EXPECT_CALL(transaction, create_state(_, _, _)).Times(2).WillRepeatedly(Invoke([&tx](auto& ioc, const auto& storage, auto block_num) -> std::shared_ptr<State> {
-        return std::make_shared<RemoteState>(ioc, tx, storage, block_num);
-    }));
 
     db::kv::api::GetAsOfQuery query1{
         .table = table::kAccountDomain,
@@ -1238,11 +1216,6 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_calls") {
 
     static Bytes account_history_key3{*silkworm::from_hex("000000000000000000000000000000000000000000000000005279a8")};
     static Bytes account_history_value3{*silkworm::from_hex("000944ed67f28fd50bb8e90000")};
-
-    auto& tx = transaction;
-    EXPECT_CALL(transaction, create_state(_, _, _)).Times(2).WillRepeatedly(Invoke([&tx](auto& ioc, const auto& storage, auto block_num) -> std::shared_ptr<State> {
-        return std::make_shared<RemoteState>(ioc, tx, storage, block_num);
-    }));
 
     SECTION("callMany: failed with intrinsic gas too low") {
         EXPECT_CALL(backend, get_block_hash_from_block_num(_))
@@ -1479,11 +1452,6 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_block_transact
 
     static Bytes account_history_key3{*silkworm::from_hex("0000000000000000000000000000000000000000")};
     static Bytes account_history_value3{*silkworm::from_hex("0008028ded68c33d14010000")};
-
-    auto& tx = transaction;
-    EXPECT_CALL(transaction, create_state(_, _, _)).Times(2).WillRepeatedly(Invoke([&tx](auto& ioc, const auto& storage, auto block_num) -> std::shared_ptr<State> {
-        return std::make_shared<RemoteState>(ioc, tx, storage, block_num);
-    }));
 
     db::kv::api::GetAsOfQuery query1{
         .table = table::kAccountDomain,
@@ -1935,8 +1903,6 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_block") {
     static Bytes account_history_key3{*silkworm::from_hex("daae090d53f9ed9e2e1fd25258c01bac4dd6d1c5")};
     static Bytes account_history_value3{*silkworm::from_hex("0127080334e1d62a9e34400000")};
 
-    auto& tx = transaction;
-
     db::kv::api::GetAsOfQuery query1{
         .table = table::kAccountDomain,
         .key = db::account_domain_key(bytes_to_address(account_history_key1)),
@@ -1952,9 +1918,6 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_block") {
         .key = db::account_domain_key(bytes_to_address(account_history_key3)),
         .timestamp = 244087591818873,
     };
-    EXPECT_CALL(transaction, create_state(_, _, _)).Times(2).WillRepeatedly(Invoke([&tx](auto& ioc, const auto& storage, auto block_num) -> std::shared_ptr<State> {
-        return std::make_shared<RemoteState>(ioc, tx, storage, block_num);
-    }));
     EXPECT_CALL(backend, get_block_hash_from_block_num(_))
         .Times(2)
         .WillRepeatedly(InvokeWithoutArgs([]() -> Task<std::optional<evmc::bytes32>> {
@@ -2046,11 +2009,6 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_replayTransact
 
     static Bytes account_history_key3{*silkworm::from_hex("0000000000000000000000000000000000000000")};
     static Bytes account_history_value3{*silkworm::from_hex("0008028ded68c33d14010000")};
-
-    auto& tx = transaction;
-    EXPECT_CALL(transaction, create_state(_, _, _)).Times(2).WillRepeatedly(Invoke([&tx](auto& ioc, const auto& storage, auto block_num) -> std::shared_ptr<State> {
-        return std::make_shared<RemoteState>(ioc, tx, storage, block_num);
-    }));
 
     db::kv::api::GetAsOfQuery query1{
         .table = table::kAccountDomain,
@@ -2971,11 +2929,6 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_transaction") 
 
     static Bytes account_history_key3{*silkworm::from_hex("daae090d53f9ed9e2e1fd25258c01bac4dd6d1c5")};
     static Bytes account_history_value3{*silkworm::from_hex("0127080334e1d62a9e34400000")};
-
-    auto& tx = transaction;
-    EXPECT_CALL(transaction, create_state(_, _, _)).Times(2).WillRepeatedly(Invoke([&tx](auto& ioc, const auto& storage, auto block_num) -> std::shared_ptr<State> {
-        return std::make_shared<RemoteState>(ioc, tx, storage, block_num);
-    }));
 
     db::kv::api::GetAsOfQuery query1{
         .table = table::kAccountDomain,

--- a/silkworm/rpc/core/receipts.cpp
+++ b/silkworm/rpc/core/receipts.cpp
@@ -20,6 +20,7 @@
 #include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/db/tables.hpp>
 #include <silkworm/db/util.hpp>
+#include <silkworm/execution/state_factory.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/rpc/common/async_task.hpp>
 #include <silkworm/rpc/core/evm_executor.hpp>
@@ -152,9 +153,9 @@ Task<std::optional<Receipts>> generate_receipts(db::kv::api::Transaction& tx, co
     const auto chain_config = co_await chain_storage.read_chain_config();
     auto current_executor = co_await boost::asio::this_coro::executor;
     const auto receipts = co_await async_task(workers.executor(), [&]() -> Receipts {
-        auto state = tx.create_state(current_executor, chain_storage, block_num - 1);
+        auto state = execution::StateFactory{tx}.create_state(current_executor, chain_storage, block_num - 1);
 
-        auto curr_state = tx.create_state(current_executor, chain_storage, block_num - 1);
+        auto curr_state = execution::StateFactory{tx}.create_state(current_executor, chain_storage, block_num - 1);
         EVMExecutor executor{block, chain_config, workers, state};
 
         Receipts rpc_receipts;

--- a/silkworm/rpc/core/storage_walker_test.cpp
+++ b/silkworm/rpc/core/storage_walker_test.cpp
@@ -194,10 +194,6 @@ class DummyTransaction : public BaseTransaction {
         co_return cursor;
     }
 
-    std::shared_ptr<silkworm::State> create_state(boost::asio::any_io_executor&, const ChainStorage&, BlockNum) override {
-        return nullptr;
-    }
-
     std::shared_ptr<ChainStorage> create_storage() override {
         return nullptr;
     }

--- a/silkworm/rpc/test_util/dummy_transaction.hpp
+++ b/silkworm/rpc/test_util/dummy_transaction.hpp
@@ -25,7 +25,6 @@
 #include <silkworm/db/chain/remote_chain_storage.hpp>
 #include <silkworm/db/kv/api/base_transaction.hpp>
 #include <silkworm/db/kv/api/cursor.hpp>
-#include <silkworm/db/state/remote_state.hpp>
 #include <silkworm/rpc/ethdb/kv/backend_providers.hpp>
 #include <silkworm/rpc/test_util/mock_back_end.hpp>
 
@@ -68,10 +67,6 @@ class DummyTransaction : public db::kv::api::BaseTransaction {
 
     Task<std::shared_ptr<db::kv::api::CursorDupSort>> cursor_dup_sort(const std::string& /*table*/) override {
         co_return cursor_dup_sort_;
-    }
-
-    std::shared_ptr<silkworm::State> create_state(boost::asio::any_io_executor& executor, const db::chain::ChainStorage& storage, BlockNum block_num) override {
-        return std::make_shared<db::state::RemoteState>(executor, *this, storage, block_num);
     }
 
     std::shared_ptr<db::chain::ChainStorage> create_storage() override {


### PR DESCRIPTION
db/state module is being repurposed for the low level e3 state implementation. It contains the eth state implementation that is not generic enough to be in db/datastore (akin SharedDomains vs Aggregator split in erigon). "low level" means that db/state must not depend on db/kv API.

In relation to this 2 refactorings are made:
1. move StateReader from db/state to db/kv. Rationale: StateReader is a client on top of the kv API exposing a particular facet the kv API (similar to what db/kv/StateChangesStream is doing as well).
2. move LocalState/RemoteState to execution. Rationale: LocalState/RemoteState are also clients on top of the kv API (or a lower level direct API) that adapt it to the core State interface abstraction used in relation to the EVM execution. The `db::kv::api::Transaction::create_state` method is replaced with execution::StateFactory. Now kv::api::Transaction is more decoupled from the EVM execution needs, and more closely represents the temporal KV API.

As a result, db/state does not depend on db/kv anymore. On the contrary, it is now possible to put code in db/kv that depends on db/state as needed.
