### PR TITLE
Use evmone APIv2 on the side

### DIFF
--- a/cmd/test/ethereum.cpp
+++ b/cmd/test/ethereum.cpp
@@ -55,12 +55,27 @@ static const fs::path kBlockchainDir{"BlockchainTests"};
 
 static const fs::path kTransactionDir{"TransactionTests"};
 
-static const std::vector<fs::path> kSlowTests{
+static const std::array kSlowTests{
     kBlockchainDir / "GeneralStateTests" / "stTimeConsuming",
     kBlockchainDir / "GeneralStateTests" / "VMTests" / "vmPerformance",
 };
 
-static const std::vector<fs::path> kFailingTests{};
+static const std::array kFailingTests{
+    // Tests related to create address collision. Silkworm and evmone implement this scenario
+    // differently:
+    // Silkworm follows the older EIP-684 and clears the created account storage if not empty,
+    // evmone tries to follow the newer EIP-7610 to revert the creation, however Silkworm
+    // is not able to provide enough information to evmone to identify non-empty storage,
+    // in the result the non-empty storage remains unchanged.
+    // This scenarion don't happen in real networks. The desired behavior for implementations
+    // is still being discussed.
+    kBlockchainDir / "GeneralStateTests" / "stCreate2" / "RevertInCreateInInitCreate2.json",
+    kBlockchainDir / "GeneralStateTests" / "stCreate2" / "RevertInCreateInInitCreate2Paris.json",
+    kBlockchainDir / "GeneralStateTests" / "stRevertTest" / "RevertInCreateInInit.json",
+    kBlockchainDir / "GeneralStateTests" / "stRevertTest" / "RevertInCreateInInit_Paris.json",
+    kBlockchainDir / "GeneralStateTests" / "stSStoreTest" / "InitCollision.json",
+    kBlockchainDir / "GeneralStateTests" / "stSStoreTest" / "InitCollisionParis.json",
+};
 
 static constexpr size_t kColumnWidth{80};
 

--- a/silkworm/core/execution/processor.cpp
+++ b/silkworm/core/execution/processor.cpp
@@ -16,12 +16,47 @@
 
 #include "processor.hpp"
 
+#include <evmone/test/state/state.hpp>
+
 #include <silkworm/core/common/assert.hpp>
 #include <silkworm/core/protocol/intrinsic_gas.hpp>
 #include <silkworm/core/protocol/param.hpp>
 #include <silkworm/core/trie/vector_root.hpp>
 
 namespace silkworm {
+class StateView final : public evmone::state::StateView {
+    IntraBlockState& state_;
+
+  public:
+    explicit StateView(IntraBlockState& state) noexcept : state_{state} {}
+
+    std::optional<Account> get_account(const evmc::address& addr) const noexcept override {
+        const auto* obj = state_.get_object(addr);
+        if (obj == nullptr || !obj->current.has_value())
+            return std::nullopt;
+
+        const auto& cur = *obj->current;
+        return Account{
+            .nonce = cur.nonce,
+            .balance = cur.balance,
+            .code_hash = cur.code_hash,
+
+            // This information is only needed to implement EIP-7610 (create address collision).
+            // Proper way of doing so is to inspect the account's storage root hash,
+            // but this information is currently unavailable to EVM.
+            // The false value is safe "do nothing" option.
+            .has_storage = false,
+        };
+    }
+
+    evmone::bytes get_account_code(const evmc::address& addr) const noexcept override {
+        return evmone::bytes{state_.get_code(addr)};
+    }
+
+    evmc::bytes32 get_storage(const evmc::address& addr, const evmc::bytes32& key) const noexcept override {
+        return state_.get_original_storage(addr, key);
+    }
+};
 
 ExecutionProcessor::ExecutionProcessor(const Block& block, protocol::RuleSet& rule_set, State& state,
                                        const ChainConfig& config)

--- a/silkworm/core/execution/processor.cpp
+++ b/silkworm/core/execution/processor.cpp
@@ -58,6 +58,18 @@ class StateView final : public evmone::state::StateView {
     }
 };
 
+namespace {
+    class BlockHashes final : public evmone::state::BlockHashes {
+        EVM& evm_;
+
+      public:
+        explicit BlockHashes(EVM& evm) noexcept : evm_{evm} {}
+        evmc::bytes32 get_block_hash(int64_t block_number) const noexcept override {
+            return evm_.get_block_hash(block_number);
+        }
+    };
+}  // namespace
+
 ExecutionProcessor::ExecutionProcessor(const Block& block, protocol::RuleSet& rule_set, State& state,
                                        const ChainConfig& config)
     : state_{state}, rule_set_{rule_set}, evm_{block, state_, config} {

--- a/silkworm/core/execution/processor.hpp
+++ b/silkworm/core/execution/processor.hpp
@@ -19,6 +19,8 @@
 #include <cstdint>
 #include <vector>
 
+#include <evmone/test/state/block.hpp>
+
 #include <silkworm/core/execution/evm.hpp>
 #include <silkworm/core/protocol/rule_set.hpp>
 #include <silkworm/core/state/state.hpp>
@@ -83,6 +85,7 @@ class ExecutionProcessor {
     IntraBlockState state_;
     protocol::RuleSet& rule_set_;
     EVM evm_;
+    evmone::state::BlockInfo evm1_block_;
 };
 
 }  // namespace silkworm

--- a/silkworm/core/state/intra_block_state.hpp
+++ b/silkworm/core/state/intra_block_state.hpp
@@ -132,6 +132,7 @@ class IntraBlockState {
     friend class state::StorageAccessDelta;
     friend class state::AccountAccessDelta;
     friend class state::TransientStorageChangeDelta;
+    friend class StateView;
 
     evmc::bytes32 get_storage(const evmc::address& address, const evmc::bytes32& key, bool original) const noexcept;
 

--- a/third_party/evmone/CMakeLists.txt
+++ b/third_party/evmone/CMakeLists.txt
@@ -49,9 +49,20 @@ add_library(
   evmone/lib/evmone_precompiles/ripemd160.cpp
   evmone/lib/evmone_precompiles/sha256.cpp
   evmone/lib/evmone_precompiles/kzg.cpp
+  evmone/lib/evmone_precompiles/bn254.cpp
+  evmone/lib/evmone_precompiles/secp256k1.cpp
+  evmone/lib/evmone_precompiles/bls.cpp
+  evmone/test/state/host.cpp
+  evmone/test/state/precompiles.cpp
+  evmone/test/state/state.cpp
 )
-set_source_files_properties(evmone/lib/evmone/vm.cpp PROPERTIES COMPILE_DEFINITIONS PROJECT_VERSION="0.12.0")
-target_include_directories(evmone PUBLIC evmone/include evmone/lib)
+set_source_files_properties(evmone/lib/evmone/vm.cpp PROPERTIES COMPILE_DEFINITIONS PROJECT_VERSION="0.11.0")
+target_include_directories(
+  evmone
+  PUBLIC evmone/include evmone/lib
+  INTERFACE .
+  PRIVATE ../..
+)
 target_link_libraries(
   evmone
   PUBLIC evmc intx::intx blst::blst
@@ -69,4 +80,11 @@ else()
             $<$<CXX_COMPILER_ID:GNU>:-Wno-attributes>
             $<$<CXX_COMPILER_ID:Clang,AppleClang>:-Wno-unknown-attributes>
   )
+endif()
+
+if(SILKWORM_CORE_USE_ABSEIL)
+  # Propagate SILKWORM_CORE_USE_ABSEIL to allow using Silkworm's preferred FlatHashMap.
+  find_package(absl REQUIRED)
+  target_compile_definitions(evmone PRIVATE SILKWORM_CORE_USE_ABSEIL)
+  target_link_libraries(evmone PRIVATE absl::flat_hash_map)
 endif()


### PR DESCRIPTION
This is the part of the full replacement of the evmone API proposed in #2480.

Here we translate structures representing blocks/transactions and implement required interfaces (StateView and BlockHashes). Transactions are also executed in evmone APIv2 but effects of the execution (StateDiff) are not applied to the state. The state transitions are still handled by Silkworm in the old way (IntraBlockState + evmone/EVMC).
The results of both executions are compared against each other to verify the evmone APIv2 works correctly.

In summary, we execute every transaction twice, but this allows us to verify the correctness of the new API and its integration. Moreover, the unit tests and RPC are unaffected by the change. We plan to incrementally move the EVM execution to the new API.