### PR TITLE
rpcdaemon: use transaction-level state in trace API

### DIFF
--- a/.github/workflows/rpc-integration-tests.yml
+++ b/.github/workflows/rpc-integration-tests.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout RPC Tests Repository & Install Requirements
         run: |
           rm -rf ${{runner.workspace}}/rpc-tests
-          git -c advice.detachedHead=false clone --depth 1 --branch v1.21.0 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
+          git -c advice.detachedHead=false clone --depth 1 --branch v1.23.0 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
           cd ${{runner.workspace}}/rpc-tests
           pip3 install -r requirements.txt --break-system-packages
 

--- a/silkworm/db/kv/state_reader.cpp
+++ b/silkworm/db/kv/state_reader.cpp
@@ -26,11 +26,13 @@
 
 namespace silkworm::db::kv {
 
-StateReader::StateReader(kv::api::Transaction& tx, BlockNum block_num) : tx_(tx), block_num_(block_num) {}
+StateReader::StateReader(kv::api::Transaction& tx, std::optional<BlockNum> block_num, std::optional<TxnId> txn_id) : tx_(tx), block_num_(block_num), txn_number_(txn_id) {
+    SILKWORM_ASSERT((txn_id && !block_num) || (!txn_id && block_num));
+}
 
 Task<std::optional<Account>> StateReader::read_account(const evmc::address& address) const {
     if (!txn_number_) {
-        txn_number_ = co_await tx_.first_txn_num_in_block(block_num_);
+        txn_number_ = co_await tx_.first_txn_num_in_block(*block_num_);
     }
 
     db::kv::api::GetAsOfQuery query{
@@ -52,7 +54,7 @@ Task<evmc::bytes32> StateReader::read_storage(const evmc::address& address,
                                               uint64_t /* incarnation */,
                                               const evmc::bytes32& location_hash) const {
     if (!txn_number_) {
-        txn_number_ = co_await tx_.first_txn_num_in_block(block_num_);
+        txn_number_ = co_await tx_.first_txn_num_in_block(*block_num_);
     }
 
     db::kv::api::GetAsOfQuery query{
@@ -72,7 +74,7 @@ Task<std::optional<Bytes>> StateReader::read_code(const evmc::address& address, 
         co_return std::nullopt;
     }
     if (!txn_number_) {
-        txn_number_ = co_await tx_.first_txn_num_in_block(block_num_);
+        txn_number_ = co_await tx_.first_txn_num_in_block(*block_num_);
     }
 
     db::kv::api::GetAsOfQuery query{

--- a/silkworm/db/kv/state_reader.hpp
+++ b/silkworm/db/kv/state_reader.hpp
@@ -34,7 +34,7 @@ namespace silkworm::db::kv {
 
 class StateReader {
   public:
-    StateReader(kv::api::Transaction& tx, BlockNum block_num);
+    StateReader(kv::api::Transaction& tx, std::optional<BlockNum> block_num, std::optional<TxnId> txn_id = std::nullopt);
 
     StateReader(const StateReader&) = delete;
     StateReader& operator=(const StateReader&) = delete;
@@ -49,7 +49,7 @@ class StateReader {
 
   private:
     kv::api::Transaction& tx_;
-    BlockNum block_num_;
+    std::optional<BlockNum> block_num_;
     mutable std::optional<TxnId> txn_number_;
 };
 

--- a/silkworm/execution/local_state.cpp
+++ b/silkworm/execution/local_state.cpp
@@ -21,7 +21,12 @@
 namespace silkworm::execution {
 
 std::optional<Account> LocalState::read_account(const evmc::address& address) const noexcept {
-    return db::read_account(txn_, address, block_num_ + 1);
+    if (block_num_) {
+        return db::read_account(txn_, address, *block_num_ + 1);
+    } else {
+        // TODO read using txn_id
+        return std::nullopt;
+    }
 }
 
 ByteView LocalState::read_code(const evmc::address& /*address*/, const evmc::bytes32& code_hash) const noexcept {
@@ -33,7 +38,12 @@ ByteView LocalState::read_code(const evmc::address& /*address*/, const evmc::byt
 }
 
 evmc::bytes32 LocalState::read_storage(const evmc::address& address, uint64_t incarnation, const evmc::bytes32& location) const noexcept {
-    return db::read_storage(txn_, address, incarnation, location, block_num_ + 1);
+    if (block_num_) {
+        return db::read_storage(txn_, address, incarnation, location, *block_num_ + 1);
+    } else {
+        // TODO read using txn_id
+        return {};
+    }
 }
 
 uint64_t LocalState::previous_incarnation(const evmc::address& /*address*/) const noexcept {

--- a/silkworm/execution/local_state.hpp
+++ b/silkworm/execution/local_state.hpp
@@ -33,8 +33,9 @@ namespace silkworm::execution {
 
 class LocalState : public State {
   public:
-    explicit LocalState(BlockNum block_num, db::DataStoreRef data_store)
+    explicit LocalState(std::optional<BlockNum> block_num, std::optional<TxnId> txn_id, db::DataStoreRef data_store)
         : block_num_{block_num},
+          txnid_{txn_id},
           txn_{data_store.chaindata.start_ro_tx()},
           data_model_{txn_, data_store.blocks_repository} {}
 
@@ -91,7 +92,8 @@ class LocalState : public State {
     void unwind_state_changes(BlockNum /*block_num*/) override {}
 
   private:
-    BlockNum block_num_;
+    std::optional<BlockNum> block_num_;
+    std::optional<TxnId> txnid_;
     mutable datastore::kvdb::ROTxnManaged txn_;
     db::DataModel data_model_;
 };

--- a/silkworm/execution/remote_state.hpp
+++ b/silkworm/execution/remote_state.hpp
@@ -39,8 +39,9 @@ class AsyncRemoteState {
     explicit AsyncRemoteState(
         db::kv::api::Transaction& tx,
         const db::chain::ChainStorage& storage,
-        BlockNum block_num)
-        : storage_(storage), state_reader_(tx, block_num + 1) {}
+        std::optional<BlockNum> block_num,
+        std::optional<TxnId> txn_id = std::nullopt)
+        : storage_(storage), state_reader_(tx, block_num ? *block_num + 1 : block_num, txn_id) {}
 
     Task<std::optional<Account>> read_account(const evmc::address& address) const noexcept;
 
@@ -75,8 +76,8 @@ class RemoteState : public State {
         boost::asio::any_io_executor& executor,
         db::kv::api::Transaction& tx,
         const db::chain::ChainStorage& storage,
-        BlockNum block_num)
-        : executor_(executor), async_state_{tx, storage, block_num} {}
+        std::optional<BlockNum> block_num, std::optional<TxnId> txn_id = std::nullopt)
+        : executor_(executor), async_state_{tx, storage, block_num, txn_id} {}
 
     std::optional<Account> read_account(const evmc::address& address) const noexcept override;
 

--- a/silkworm/execution/remote_state_test.cpp
+++ b/silkworm/execution/remote_state_test.cpp
@@ -55,7 +55,7 @@ TEST_CASE_METHOD(RemoteStateTest, "async remote buffer", "[rpc][core][remote_buf
                 co_return Bytes{};
             }));
         const BlockNum block_num = 1'000'000;
-        AsyncRemoteState state{transaction, chain_storage, block_num};
+        AsyncRemoteState state{transaction, chain_storage, block_num, std::nullopt};
         const auto code_read{spawn_and_wait(state.read_code(address, kEmptyHash))};
         CHECK(code_read.empty());
     }

--- a/silkworm/execution/state_factory.cpp
+++ b/silkworm/execution/state_factory.cpp
@@ -30,9 +30,21 @@ std::shared_ptr<State> StateFactory::create_state(
     BlockNum block_num) {
     if (tx.is_local()) {
         auto& local_tx = dynamic_cast<db::kv::api::LocalTransaction&>(tx);
-        return std::make_shared<LocalState>(block_num, local_tx.data_store());
+        return std::make_shared<LocalState>(block_num, std::nullopt, local_tx.data_store());
     } else {  // NOLINT(readability-else-after-return)
-        return std::make_shared<RemoteState>(executor, tx, storage, block_num);
+        return std::make_shared<RemoteState>(executor, tx, storage, block_num, std::nullopt);
+    }
+}
+
+std::shared_ptr<State> StateFactory::create_state_txn(
+    boost::asio::any_io_executor& executor,
+    const db::chain::ChainStorage& storage,
+    TxnId txn_id) {
+    if (tx.is_local()) {
+        auto& local_tx = dynamic_cast<db::kv::api::LocalTransaction&>(tx);
+        return std::make_shared<LocalState>(std::nullopt, txn_id, local_tx.data_store());
+    } else {  // NOLINT(readability-else-after-return)
+        return std::make_shared<RemoteState>(executor, tx, storage, std::nullopt, txn_id);
     }
 }
 

--- a/silkworm/execution/state_factory.hpp
+++ b/silkworm/execution/state_factory.hpp
@@ -34,6 +34,11 @@ struct StateFactory {
         boost::asio::any_io_executor& executor,
         const db::chain::ChainStorage& storage,
         BlockNum block_num);
+
+    std::shared_ptr<State> create_state_txn(
+        boost::asio::any_io_executor& executor,
+        const db::chain::ChainStorage& storage,
+        TxnId txn_id);
 };
 
 }  // namespace silkworm::execution

--- a/silkworm/rpc/core/evm_trace_test.cpp
+++ b/silkworm/rpc/core/evm_trace_test.cpp
@@ -2013,17 +2013,17 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_replayTransact
     db::kv::api::GetAsOfQuery query1{
         .table = table::kAccountDomain,
         .key = db::account_domain_key(bytes_to_address(account_history_key1)),
-        .timestamp = 244087591818873,
+        .timestamp = 244087591818874,
     };
     db::kv::api::GetAsOfQuery query2{
         .table = table::kAccountDomain,
         .key = db::account_domain_key(bytes_to_address(account_history_key2)),
-        .timestamp = 244087591818873,
+        .timestamp = 244087591818874,
     };
     db::kv::api::GetAsOfQuery query3{
         .table = table::kAccountDomain,
         .key = db::account_domain_key(bytes_to_address(account_history_key3)),
-        .timestamp = 244087591818873,
+        .timestamp = 244087591818874,
     };
     EXPECT_CALL(backend, get_block_hash_from_block_num(_))
         .WillOnce(InvokeWithoutArgs([]() -> Task<std::optional<evmc::bytes32>> {
@@ -2399,7 +2399,7 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_replayTransact
     }
 
     SECTION("Call: only trace") {
-        EXPECT_CALL(transaction, first_txn_num_in_block(1'024'165)).Times(2).WillRepeatedly(Invoke([]() -> Task<TxnId> {
+        EXPECT_CALL(transaction, first_txn_num_in_block(1'024'165)).Times(1).WillRepeatedly(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
         EXPECT_CALL(transaction, get_as_of(silkworm::db::kv::api::GetAsOfQuery{query1})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
@@ -2451,7 +2451,7 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_replayTransact
         })"_json);
     }
     SECTION("Call: only stateDiff") {
-        EXPECT_CALL(transaction, first_txn_num_in_block(1'024'165)).Times(2).WillRepeatedly(Invoke([]() -> Task<TxnId> {
+        EXPECT_CALL(transaction, first_txn_num_in_block(1'024'165)).Times(1).WillRepeatedly(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
         EXPECT_CALL(transaction, get_as_of(silkworm::db::kv::api::GetAsOfQuery{query1})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
@@ -2526,7 +2526,7 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_replayTransact
         })"_json);
     }
     SECTION("Call: full output") {
-        EXPECT_CALL(transaction, first_txn_num_in_block(1'024'165)).Times(2).WillRepeatedly(Invoke([]() -> Task<TxnId> {
+        EXPECT_CALL(transaction, first_txn_num_in_block(1'024'165)).Times(1).WillRepeatedly(Invoke([]() -> Task<TxnId> {
             co_return 244087591818873;
         }));
         EXPECT_CALL(transaction, get_as_of(silkworm::db::kv::api::GetAsOfQuery{query1})).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
@@ -2933,17 +2933,17 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_transaction") 
     db::kv::api::GetAsOfQuery query1{
         .table = table::kAccountDomain,
         .key = db::account_domain_key(bytes_to_address(account_history_key1)),
-        .timestamp = 244087591818873,
+        .timestamp = 244087591818874,
     };
     db::kv::api::GetAsOfQuery query2{
         .table = table::kAccountDomain,
         .key = db::account_domain_key(bytes_to_address(account_history_key2)),
-        .timestamp = 244087591818873,
+        .timestamp = 244087591818874,
     };
     db::kv::api::GetAsOfQuery query3{
         .table = table::kAccountDomain,
         .key = db::account_domain_key(bytes_to_address(account_history_key3)),
-        .timestamp = 244087591818873,
+        .timestamp = 244087591818874,
     };
     EXPECT_CALL(backend, get_block_hash_from_block_num(_))
         .WillOnce(InvokeWithoutArgs([]() -> Task<std::optional<evmc::bytes32>> {
@@ -2953,7 +2953,7 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_transaction") 
         .WillOnce(InvokeWithoutArgs([]() -> Task<Bytes> {
             co_return kConfigValue;
         }));
-    EXPECT_CALL(transaction, first_txn_num_in_block(1'024'165)).Times(2).WillRepeatedly(Invoke([]() -> Task<TxnId> {
+    EXPECT_CALL(transaction, first_txn_num_in_block(1'024'165)).Times(1).WillRepeatedly(Invoke([]() -> Task<TxnId> {
         co_return 244087591818873;
     }));
     EXPECT_CALL(transaction, get_as_of(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {


### PR DESCRIPTION
This PR introduces:
- state management on TxnId for `TraceCallExecutor`
- update API `trace_replay_transaction`
- update API `trace_get`
- update API `trace_transaction`

This PR is connected to: https://github.com/erigontech/rpc-tests/pull/304
