### PR TITLE
capi: fix capi_test with ASAN (#1881)

### DIFF
--- a/cmake/compiler_settings.cmake
+++ b/cmake/compiler_settings.cmake
@@ -16,7 +16,7 @@
 
 include(${CMAKE_CURRENT_LIST_DIR}/compiler_settings_sanitize.cmake)
 
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+if(MSVC)
 
   message("MSVC_VERSION = ${MSVC_VERSION}")
   message("MSVC_CXX_ARCHITECTURE_ID = ${MSVC_CXX_ARCHITECTURE_ID}")

--- a/cmd/capi/CMakeLists.txt
+++ b/cmd/capi/CMakeLists.txt
@@ -24,7 +24,7 @@ set(PRIVATE_LIBS
     silkworm_infra
     silkworm_db
     silkworm_rpcdaemon
-    silkworm_capi
+    silkworm_capi_static
     silkworm_infra_cli
 )
 

--- a/silkworm/capi/CMakeLists.txt
+++ b/silkworm/capi/CMakeLists.txt
@@ -31,35 +31,31 @@ set(PRIVATE_LIBS
     silkworm_rpcdaemon
 )
 
-# Temporarily skip unit test runner for silkworm_capi target in ASAN build (failures after PR #1879)
-if(SILKWORM_SANITIZE)
-  set(NO_TEST "NO_TEST")
-endif()
-
 # cmake-format: off
 silkworm_library(
   ${TARGET}
   PUBLIC ${PUBLIC_LIBS}
   PRIVATE ${PRIVATE_LIBS}
   TYPE SHARED
-  ${NO_TEST}
+  NO_TEST
 )
 # cmake-format: on
 
-if(NOT NO_TEST)
-  target_link_libraries(
-    silkworm_capi_test
-    PRIVATE silkworm_core
-            silkworm_db
-            silkworm_infra
-            silkworm_rpcdaemon
-            silkworm_node
-            silkworm_db_test_util
-  )
-endif()
+# cmake-format: off
+# unit tests and cmd will use a static library version
+# to avoid ODR violations when identical symbols are mixed into both .dll and .exe
+silkworm_library(
+  ${TARGET}_static
+  PUBLIC ${PUBLIC_LIBS}
+  PRIVATE ${PRIVATE_LIBS}
+  TYPE STATIC
+)
+# cmake-format: on
 
 # Remove custom stack_size linker option for this target
 get_target_property(LINK_OPTIONS ${TARGET} LINK_OPTIONS)
 list(REMOVE_ITEM LINK_OPTIONS "-Wl,-stack_size")
 list(REMOVE_ITEM LINK_OPTIONS "-Wl,${SILKWORM_STACK_SIZE}")
 set_target_properties(${TARGET} PROPERTIES LINK_OPTIONS "${LINK_OPTIONS}")
+
+target_link_libraries(silkworm_capi_static_test PRIVATE silkworm_db_test_util silkworm_node)

--- a/silkworm/capi/fork_validator.cpp
+++ b/silkworm/capi/fork_validator.cpp
@@ -17,6 +17,7 @@
 #include <silkworm/buildinfo.h>
 #include <silkworm/core/common/base.hpp>
 #include <silkworm/infra/common/environment.hpp>
+#include <silkworm/node/stagedsync/execution_engine.hpp>
 #include <silkworm/node/stagedsync/stages/stage_bodies.hpp>
 #include <silkworm/node/stagedsync/stages_factory_impl.hpp>
 

--- a/silkworm/capi/instance.hpp
+++ b/silkworm/capi/instance.hpp
@@ -22,11 +22,21 @@
 
 #include <boost/asio/cancellation_signal.hpp>
 
-#include <silkworm/db/datastore/snapshots/snapshot_repository.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/concurrency/context_pool_settings.hpp>
-#include <silkworm/node/stagedsync/execution_engine.hpp>
-#include <silkworm/rpc/daemon.hpp>
+#include <silkworm/node/common/node_settings.hpp>
+
+namespace silkworm::snapshots {
+class SnapshotRepository;
+}  // namespace silkworm::snapshots
+
+namespace silkworm::rpc {
+class Daemon;
+}  // namespace silkworm::rpc
+
+namespace silkworm::stagedsync {
+class ExecutionEngine;
+}  // namespace silkworm::stagedsync
 
 struct SilkwormInstance {
     silkworm::log::Settings log_settings;

--- a/silkworm/capi/rpcdaemon.cpp
+++ b/silkworm/capi/rpcdaemon.cpp
@@ -14,7 +14,9 @@
    limitations under the License.
 */
 
+#include <silkworm/db/data_store.hpp>
 #include <silkworm/infra/common/log.hpp>
+#include <silkworm/rpc/daemon.hpp>
 #include <silkworm/rpc/settings.hpp>
 
 #include "common.hpp"

--- a/silkworm/capi/silkworm.cpp
+++ b/silkworm/capi/silkworm.cpp
@@ -51,6 +51,8 @@
 #include <silkworm/infra/concurrency/signal_handler.hpp>
 #include <silkworm/infra/concurrency/thread_pool.hpp>
 #include <silkworm/node/execution/block/block_executor.hpp>
+#include <silkworm/node/stagedsync/execution_engine.hpp>
+#include <silkworm/rpc/daemon.hpp>
 
 #include "common.hpp"
 #include "instance.hpp"

--- a/silkworm/capi/silkworm_test.cpp
+++ b/silkworm/capi/silkworm_test.cpp
@@ -31,9 +31,10 @@
 #include <silkworm/db/datastore/snapshots/index_builder.hpp>
 #include <silkworm/db/datastore/snapshots/segment/segment_reader.hpp>
 #include <silkworm/db/test_util/temp_snapshots.hpp>
+#include <silkworm/db/test_util/test_database_context.hpp>
 #include <silkworm/infra/common/directories.hpp>
 #include <silkworm/infra/common/environment.hpp>
-#include <silkworm/rpc/test_util/api_test_database.hpp>
+#include <silkworm/node/stagedsync/execution_engine.hpp>
 
 #include "instance.hpp"
 


### PR DESCRIPTION
Problem:
Linking silkworm_node.lib to both silkworm_capi.dll and silkworm_capi_test.exe produces 2 sets of global data (identical symbols),
which is a conflict according to ASAN ODR:
https://github.com/google/sanitizers/wiki/AddressSanitizerOneDefinitionRuleViolation

Solution:
Build silkworm_capi_static.lib separately, and use it with silkworm_capi_static_test.exe and capi/execute.exe so
that the linker can resolve duplicate symbols.

fixes https://github.com/erigontech/silkworm/issues/1881
