### PR TITLE
evm: clean up empty accounts after system contracts

### DIFF
--- a/silkworm/core/protocol/merge_rule_set.cpp
+++ b/silkworm/core/protocol/merge_rule_set.cpp
@@ -97,6 +97,7 @@ void MergeRuleSet::initialize(EVM& evm) {
         system_txn.data = Bytes{ByteView{*header.parent_beacon_block_root}};
         system_txn.set_sender(kSystemAddress);
         evm.execute(system_txn, kSystemCallGasLimit);
+        evm.state().destruct_touched_dead();
     }
 
     if (evm.revision() >= EVMC_PRAGUE) {
@@ -107,6 +108,7 @@ void MergeRuleSet::initialize(EVM& evm) {
         system_txn.data = Bytes{ByteView{header.parent_hash}};
         system_txn.set_sender(kSystemAddress);
         evm.execute(system_txn, kSystemCallGasLimit);
+        evm.state().destruct_touched_dead();
     }
 }
 
@@ -122,6 +124,7 @@ ValidationResult MergeRuleSet::finalize(IntraBlockState& state, const Block& blo
         for (const Withdrawal& w : *block.withdrawals) {
             const auto amount_in_wei{intx::uint256{w.amount} * intx::uint256{kGiga}};
             state.add_to_balance(w.address, amount_in_wei);
+            state.destruct_touched_dead();
         }
     }
 

--- a/silkworm/core/protocol/validation.cpp
+++ b/silkworm/core/protocol/validation.cpp
@@ -343,6 +343,7 @@ ValidationResult validate_requests_root(const BlockHeader& header, const std::ve
         system_txn.data = Bytes{};
         system_txn.set_sender(kSystemAddress);
         const auto withdrawals = evm.execute(system_txn, kSystemCallGasLimit);
+        evm.state().destruct_touched_dead();
         requests.add_request(FlatRequestType::kWithdrawalRequest, withdrawals.data);
     }
 
@@ -354,6 +355,7 @@ ValidationResult validate_requests_root(const BlockHeader& header, const std::ve
         system_txn.data = Bytes{};
         system_txn.set_sender(kSystemAddress);
         const auto consolidations = evm.execute(system_txn, kSystemCallGasLimit);
+        evm.state().destruct_touched_dead();
         requests.add_request(FlatRequestType::kConsolidationRequest, consolidations.data);
     }
 


### PR DESCRIPTION
Destruct empty accounts created during interaction with system accounts, requests or operations. This leaves the intra block state in sanity.

This helps to partially switch to EVM execution via evmone APIv2.