### PR TITLE
test: increase stack size for cmd/test/ethereum

### DIFF
--- a/cmd/test/ethereum.cpp
+++ b/cmd/test/ethereum.cpp
@@ -479,7 +479,7 @@ int main(int argc, char* argv[]) {
         }
     }
 
-    size_t stack_size{40 * kMebi};
+    size_t stack_size{50 * kMebi};
 #ifdef NDEBUG
     stack_size = 16 * kMebi;
 #endif


### PR DESCRIPTION
Now with evmone APIv2 execution even more stack space is needed for Debug+Asan builds.

evmone will try to optimize this aspect later.