### PR TITLE
evm: add flag to execute in evmone APIv2

### DIFF
--- a/cmd/dev/check_changes.cpp
+++ b/cmd/dev/check_changes.cpp
@@ -131,7 +131,7 @@ int main(int argc, char* argv[]) {
             db::Buffer buffer{txn, std::make_unique<db::BufferFullDataModel>(access_layer)};
             buffer.set_historical_block(block_num);
 
-            ExecutionProcessor processor{block, *rule_set, buffer, *chain_config};
+            ExecutionProcessor processor{block, *rule_set, buffer, *chain_config, false};
             processor.evm().analysis_cache = &analysis_cache;
 
             if (const ValidationResult res = processor.execute_block(receipts); res != ValidationResult::kOk) {

--- a/cmd/dev/scan_txs.cpp
+++ b/cmd/dev/scan_txs.cpp
@@ -91,7 +91,7 @@ int main(int argc, char* argv[]) {
             db::Buffer buffer{txn, std::make_unique<db::BufferROTxDataModel>(txn)};
             buffer.set_historical_block(block_num);
 
-            ExecutionProcessor processor{block, *rule_set, buffer, *chain_config};
+            ExecutionProcessor processor{block, *rule_set, buffer, *chain_config, false};
             processor.evm().analysis_cache = &analysis_cache;
 
             // Execute the block and retrieve the receipts

--- a/cmd/state-transition/state_transition.cpp
+++ b/cmd/state-transition/state_transition.cpp
@@ -290,7 +290,7 @@ void StateTransition::run() {
             auto block = get_block(state, config);
             auto txn = get_transaction(expected_sub_state);
 
-            ExecutionProcessor processor{block, *rule_set, state, config};
+            ExecutionProcessor processor{block, *rule_set, state, config, false};
             Receipt receipt;
 
             const evmc_revision rev{config.revision(block.header.number, block.header.timestamp)};

--- a/silkworm/core/execution/execution.hpp
+++ b/silkworm/core/execution/execution.hpp
@@ -47,7 +47,7 @@ inline ValidationResult execute_block(
     if (!rule_set) {
         return ValidationResult::kUnknownProtocolRuleSet;
     }
-    ExecutionProcessor processor{block, *rule_set, state, chain_config};
+    ExecutionProcessor processor{block, *rule_set, state, chain_config, false};
 
     if (const ValidationResult res = processor.execute_block(receipts); res != ValidationResult::kOk) {
         return res;

--- a/silkworm/core/execution/execution_test.cpp
+++ b/silkworm/core/execution/execution_test.cpp
@@ -165,7 +165,7 @@ TEST_CASE("Execute block with tracing") {
     std::vector<Receipt> receipts;
     const auto rule_set{protocol::rule_set_factory(chain_config)};
     REQUIRE(rule_set);
-    ExecutionProcessor processor{block, *rule_set, state, chain_config};
+    ExecutionProcessor processor{block, *rule_set, state, chain_config, false};
 
     BlockTracer block_tracer{};
     processor.evm().add_tracer(block_tracer);

--- a/silkworm/core/execution/processor.cpp
+++ b/silkworm/core/execution/processor.cpp
@@ -105,8 +105,8 @@ namespace {
 }  // namespace
 
 ExecutionProcessor::ExecutionProcessor(const Block& block, protocol::RuleSet& rule_set, State& state,
-                                       const ChainConfig& config)
-    : state_{state}, rule_set_{rule_set}, evm_{block, state_, config} {
+                                       const ChainConfig& config, bool evm1_v2)
+    : state_{state}, rule_set_{rule_set}, evm_{block, state_, config}, evm1_v2_{evm1_v2} {
     evm_.beneficiary = rule_set.get_beneficiary(block.header);
     evm_.transfer = rule_set.transfer_func();
 

--- a/silkworm/core/execution/processor.hpp
+++ b/silkworm/core/execution/processor.hpp
@@ -35,7 +35,7 @@ class ExecutionProcessor {
     ExecutionProcessor(const ExecutionProcessor&) = delete;
     ExecutionProcessor& operator=(const ExecutionProcessor&) = delete;
 
-    ExecutionProcessor(const Block& block, protocol::RuleSet& rule_set, State& state, const ChainConfig& config);
+    ExecutionProcessor(const Block& block, protocol::RuleSet& rule_set, State& state, const ChainConfig& config, bool evm1_v2);
 
     /**
      * Execute a transaction, but do not write to the DB yet.
@@ -86,6 +86,10 @@ class ExecutionProcessor {
     protocol::RuleSet& rule_set_;
     EVM evm_;
     evmone::state::BlockInfo evm1_block_;
+
+    //! Execute transactions using evmone APIv2 only and apply the result state diff to the state.
+    //! TODO: This flag currently has no effect.
+    bool evm1_v2_ = false;
 };
 
 }  // namespace silkworm

--- a/silkworm/core/execution/processor_test.cpp
+++ b/silkworm/core/execution/processor_test.cpp
@@ -45,7 +45,7 @@ TEST_CASE("Zero gas price") {
 
     InMemoryState state;
     auto rule_set{protocol::rule_set_factory(kMainnetConfig)};
-    ExecutionProcessor processor{block, *rule_set, state, kMainnetConfig};
+    ExecutionProcessor processor{block, *rule_set, state, kMainnetConfig, false};
 
     Receipt receipt;
     processor.execute_transaction(txn, receipt);
@@ -85,7 +85,7 @@ TEST_CASE("No refund on error") {
 
     InMemoryState state;
     auto rule_set{protocol::rule_set_factory(kMainnetConfig)};
-    ExecutionProcessor processor{block, *rule_set, state, kMainnetConfig};
+    ExecutionProcessor processor{block, *rule_set, state, kMainnetConfig, false};
 
     Transaction txn{};
     txn.nonce = nonce;
@@ -179,7 +179,7 @@ TEST_CASE("Self-destruct") {
 
     InMemoryState state;
     auto rule_set{protocol::rule_set_factory(kMainnetConfig)};
-    ExecutionProcessor processor{block, *rule_set, state, kMainnetConfig};
+    ExecutionProcessor processor{block, *rule_set, state, kMainnetConfig, false};
 
     processor.evm().state().add_to_balance(originator, kEther);
     processor.evm().state().set_code(caller_address, caller_code);
@@ -327,7 +327,7 @@ TEST_CASE("Out of Gas during account re-creation") {
     txn.set_sender(caller);
 
     auto rule_set{protocol::rule_set_factory(kMainnetConfig)};
-    ExecutionProcessor processor{block, *rule_set, state, kMainnetConfig};
+    ExecutionProcessor processor{block, *rule_set, state, kMainnetConfig, false};
     processor.evm().state().add_to_balance(caller, kEther);
 
     Receipt receipt;
@@ -370,7 +370,7 @@ TEST_CASE("Empty suicide beneficiary") {
     InMemoryState state;
 
     auto rule_set{protocol::rule_set_factory(kMainnetConfig)};
-    ExecutionProcessor processor{block, *rule_set, state, kMainnetConfig};
+    ExecutionProcessor processor{block, *rule_set, state, kMainnetConfig, false};
     processor.evm().state().add_to_balance(caller, kEther);
 
     Receipt receipt;

--- a/silkworm/core/protocol/blockchain.cpp
+++ b/silkworm/core/protocol/blockchain.cpp
@@ -89,7 +89,7 @@ ValidationResult Blockchain::insert_block(Block& block, bool check_state_root) {
 }
 
 ValidationResult Blockchain::execute_block(const Block& block, bool check_state_root) {
-    ExecutionProcessor processor{block, *rule_set_, state_, config_};
+    ExecutionProcessor processor{block, *rule_set_, state_, config_, false};
     processor.evm().exo_evm = exo_evm;
 
     if (const ValidationResult res = processor.execute_block(receipts_); res != ValidationResult::kOk) {

--- a/silkworm/db/test_util/test_database_context.cpp
+++ b/silkworm/db/test_util/test_database_context.cpp
@@ -128,7 +128,7 @@ void populate_blocks(RWTxn& txn, const std::filesystem::path& tests_dir, InMemor
 
         // FIX 4b: populate receipts and logs table
         std::vector<silkworm::Receipt> receipts;
-        ExecutionProcessor processor{block, *rule_set, state_buffer, *chain_config};
+        ExecutionProcessor processor{block, *rule_set, state_buffer, *chain_config, false};
         Buffer db_buffer{txn, std::make_unique<BufferROTxDataModel>(txn)};
         for (auto& block_txn : block.transactions) {
             silkworm::Receipt receipt{};

--- a/silkworm/node/execution/block/block_executor.cpp
+++ b/silkworm/node/execution/block/block_executor.cpp
@@ -32,7 +32,7 @@ BlockExecutor::BlockExecutor(const ChainConfig* chain_config, bool write_receipt
       write_change_sets_{write_change_sets} {}
 
 ValidationResult BlockExecutor::execute_single(const Block& block, db::Buffer& state_buffer, AnalysisCache& analysis_cache) {
-    ExecutionProcessor processor{block, *protocol_rule_set_, state_buffer, *chain_config_};
+    ExecutionProcessor processor{block, *protocol_rule_set_, state_buffer, *chain_config_, false};
     processor.evm().analysis_cache = &analysis_cache;
 
     CallTraces traces;

--- a/silkworm/rpc/core/evm_executor.hpp
+++ b/silkworm/rpc/core/evm_executor.hpp
@@ -103,7 +103,7 @@ class EVMExecutor {
           workers_{workers},
           state_{std::move(state)},
           rule_set_{protocol::rule_set_factory(config)},
-          execution_processor_{block, *rule_set_, *state_, config} {
+          execution_processor_{block, *rule_set_, *state_, config, false} {
         SILKWORM_ASSERT(rule_set_);
         if (!has_service<AnalysisCacheService>(workers_)) {
             make_service<AnalysisCacheService>(workers_);


### PR DESCRIPTION
Add a flag to ExecutionProcesser to indicate the transaction execution should happen in evmone APIv2 only. This flag is off by default and setting it to on has no effect for now.