### PR TITLE
evm: apply state diff from evmone APIv2 if enabled

### DIFF
--- a/silkworm/core/execution/execution_test.cpp
+++ b/silkworm/core/execution/execution_test.cpp
@@ -165,7 +165,7 @@ TEST_CASE("Execute block with tracing") {
     std::vector<Receipt> receipts;
     const auto rule_set{protocol::rule_set_factory(chain_config)};
     REQUIRE(rule_set);
-    ExecutionProcessor processor{block, *rule_set, state, chain_config, false};
+    ExecutionProcessor processor{block, *rule_set, state, chain_config, true};
 
     BlockTracer block_tracer{};
     processor.evm().add_tracer(block_tracer);

--- a/silkworm/core/execution/processor_test.cpp
+++ b/silkworm/core/execution/processor_test.cpp
@@ -45,7 +45,7 @@ TEST_CASE("Zero gas price") {
 
     InMemoryState state;
     auto rule_set{protocol::rule_set_factory(kMainnetConfig)};
-    ExecutionProcessor processor{block, *rule_set, state, kMainnetConfig, false};
+    ExecutionProcessor processor{block, *rule_set, state, kMainnetConfig, true};
 
     Receipt receipt;
     processor.execute_transaction(txn, receipt);
@@ -85,7 +85,7 @@ TEST_CASE("No refund on error") {
 
     InMemoryState state;
     auto rule_set{protocol::rule_set_factory(kMainnetConfig)};
-    ExecutionProcessor processor{block, *rule_set, state, kMainnetConfig, false};
+    ExecutionProcessor processor{block, *rule_set, state, kMainnetConfig, true};
 
     Transaction txn{};
     txn.nonce = nonce;
@@ -179,7 +179,7 @@ TEST_CASE("Self-destruct") {
 
     InMemoryState state;
     auto rule_set{protocol::rule_set_factory(kMainnetConfig)};
-    ExecutionProcessor processor{block, *rule_set, state, kMainnetConfig, false};
+    ExecutionProcessor processor{block, *rule_set, state, kMainnetConfig, true};
 
     processor.evm().state().add_to_balance(originator, kEther);
     processor.evm().state().set_code(caller_address, caller_code);
@@ -327,7 +327,7 @@ TEST_CASE("Out of Gas during account re-creation") {
     txn.set_sender(caller);
 
     auto rule_set{protocol::rule_set_factory(kMainnetConfig)};
-    ExecutionProcessor processor{block, *rule_set, state, kMainnetConfig, false};
+    ExecutionProcessor processor{block, *rule_set, state, kMainnetConfig, true};
     processor.evm().state().add_to_balance(caller, kEther);
 
     Receipt receipt;
@@ -370,7 +370,7 @@ TEST_CASE("Empty suicide beneficiary") {
     InMemoryState state;
 
     auto rule_set{protocol::rule_set_factory(kMainnetConfig)};
-    ExecutionProcessor processor{block, *rule_set, state, kMainnetConfig, false};
+    ExecutionProcessor processor{block, *rule_set, state, kMainnetConfig, true};
     processor.evm().state().add_to_balance(caller, kEther);
 
     Receipt receipt;

--- a/silkworm/core/state/intra_block_state.hpp
+++ b/silkworm/core/state/intra_block_state.hpp
@@ -133,6 +133,7 @@ class IntraBlockState {
     friend class state::AccountAccessDelta;
     friend class state::TransientStorageChangeDelta;
     friend class StateView;
+    friend class ExecutionProcessor;
 
     evmc::bytes32 get_storage(const evmc::address& address, const evmc::bytes32& key, bool original) const noexcept;
 


### PR DESCRIPTION
Implement handling of evmone's StateDiff and apply it to the IntraBlockState after each transaction
if evmone APIv2 is abled in ExecutionProcessor.

Also enable evmone APIv2 in direct unit tests for ExecutionProcessor.