### PR TITLE
node: fix reached block num in BlockHashes for existing blocks

### DIFF
--- a/cmd/dev/staged_pipeline.cpp
+++ b/cmd/dev/staged_pipeline.cpp
@@ -484,6 +484,7 @@ void forward(datastore::kvdb::EnvConfig& config, BlockNum forward_point, const b
 
     config.readonly = false;
 
+    Environment::set_stop_at_block(forward_point);
     Environment::set_start_at_stage(start_at_stage);
     Environment::set_stop_before_stage(stop_before_stage);
 

--- a/silkworm/node/stagedsync/stages/stage_blockhashes.cpp
+++ b/silkworm/node/stagedsync/stages/stage_blockhashes.cpp
@@ -72,20 +72,16 @@ Stage::Result BlockHashes::forward(db::RWTxn& txn) {
         txn.commit_and_renew();
 
     } catch (const mdbx::exception& ex) {
-        log::Error(log_prefix_,
-                   {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
+        SILK_ERROR_M(log_prefix_, {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
         ret = Stage::Result::kDbError;
     } catch (const StageError& ex) {
-        log::Error(log_prefix_,
-                   {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
+        SILK_ERROR_M(log_prefix_, {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
         ret = static_cast<Stage::Result>(ex.err());
     } catch (const std::exception& ex) {
-        log::Error(log_prefix_,
-                   {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
+        SILK_ERROR_M(log_prefix_, {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
         ret = Stage::Result::kUnexpectedError;
     } catch (...) {
-        log::Error(log_prefix_,
-                   {"function", std::string(__FUNCTION__), "exception", "undefined"});
+        SILK_ERROR_M(log_prefix_, {"function", std::string(__FUNCTION__), "exception", "undefined"});
         ret = Stage::Result::kUnexpectedError;
     }
 
@@ -122,20 +118,16 @@ Stage::Result BlockHashes::unwind(db::RWTxn& txn) {
         txn.commit_and_renew();
 
     } catch (const mdbx::exception& ex) {
-        log::Error(log_prefix_,
-                   {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
+        SILK_ERROR_M(log_prefix_, {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
         ret = Stage::Result::kDbError;
     } catch (const StageError& ex) {
-        log::Error(log_prefix_,
-                   {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
+        SILK_ERROR_M(log_prefix_, {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
         ret = static_cast<Stage::Result>(ex.err());
     } catch (const std::exception& ex) {
-        log::Error(log_prefix_,
-                   {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
+        SILK_ERROR_M(log_prefix_, {"function", std::string(__FUNCTION__), "exception", std::string(ex.what())});
         ret = Stage::Result::kUnexpectedError;
     } catch (...) {
-        log::Error(log_prefix_,
-                   {"function", std::string(__FUNCTION__), "exception", "undefined"});
+        SILK_ERROR_M(log_prefix_, {"function", std::string(__FUNCTION__), "exception", "undefined"});
         ret = Stage::Result::kUnexpectedError;
     }
 
@@ -171,10 +163,11 @@ void BlockHashes::collect_and_load(db::RWTxn& txn, const BlockNum from, const Bl
     auto expected_block_num{from + 1};
     auto header_key{db::block_key(expected_block_num)};
     auto canon_hashes_cursor = txn.rw_cursor(db::table::kCanonicalHashes);
-    auto data{canon_hashes_cursor->find(datastore::kvdb::to_slice(header_key), /*throw_notfound=*/false)};
+    auto data = canon_hashes_cursor->find(datastore::kvdb::to_slice(header_key), /*throw_notfound=*/false);
     while (data.done) {
         reached_block_num_ = endian::load_big_u64(static_cast<uint8_t*>(data.key.data()));
         if (reached_block_num_ > to) {
+            --reached_block_num_;
             break;
         }
 


### PR DESCRIPTION
Fixes #2593 

Note: the off-by-one error in reached block number reported back by BlockHashes only happens if the target block does _not_ correspond to the highest saved block (hence, more blocks exist in the canonical chain after the target one).

*Extras*
- improve error logs
- avoid CLion warning
- add missing `STOP_AT_BLOCK` set in `forward` subcommand of `staged_pipeline`