### PR TITLE
node: replace incremental with full mode in InterHashes stage

### DIFF
--- a/silkworm/node/stagedsync/stages/stage_headers.cpp
+++ b/silkworm/node/stagedsync/stages/stage_headers.cpp
@@ -100,7 +100,7 @@ HeadersStage::HeadersStage(
     const auto stop_at_block = Environment::get_stop_at_block();
     if (stop_at_block.has_value()) {
         forced_target_block_ = stop_at_block;
-        log::Info(log_prefix_) << "env var STOP_AT_BLOCK set, target block=" << forced_target_block_.value();
+        SILK_DEBUG_M(log_prefix_, {"target=", std::to_string(*forced_target_block_)}) << " env var STOP_AT_BLOCK set";
     }
 }
 

--- a/silkworm/node/stagedsync/stages/stage_interhashes.hpp
+++ b/silkworm/node/stagedsync/stages/stage_interhashes.hpp
@@ -54,17 +54,17 @@ class InterHashes final : public Stage {
     trie::PrefixSet collect_storage_changes(db::RWTxn& txn, BlockNum from, BlockNum to,
                                             absl::btree_map<evmc::address, ethash_hash256>& hashed_addresses);
 
-    //! \brief Erigon's RegenerateIntermediateHashes
+    //! \brief Erigon RegenerateIntermediateHashes
     //! \remarks might throw WrongRoot
     //! \return the state root
     Stage::Result regenerate_intermediate_hashes(
         db::RWTxn& txn,
         const evmc::bytes32* expected_root = nullptr);
 
-    //! \brief Erigon's IncrementIntermediateHashes
+    //! \brief Erigon IncrementIntermediateHashes
     //! \remarks might throw
     //! \return the state root
-    Stage::Result increment_intermediate_hashes(
+    [[maybe_unused]] Stage::Result increment_intermediate_hashes(
         db::RWTxn& txn,
         BlockNum from,
         BlockNum to,


### PR DESCRIPTION
Fixes #2597 by replacing incremental mode with full-regeneration mode also for small block intervals.

This is the output of the `staged_pipeline debug_unwind` command:
```
  INFO [12-13|23:37:26.132 UTC] Debug unwind datadir: ~/silkworm
  INFO [12-13|23:37:32.558 UTC] Reopen snapshot repository folder: ~/silkworm/snapshots
  INFO [12-13|23:37:34.978 UTC] Total reopened bundles: 72 max block available: 20'474'999
  INFO [12-13|23:37:34.978 UTC] Debug unwind: forward to=1'000'000 START
  INFO [12-13|23:37:34.978 UTC] ExecutionPipeline                        Forward start
  INFO [12-13|23:37:34.978 UTC] [5/13 Execution]                         op=kForward from=0 to=1000000 span=1000000 
  INFO [12-13|23:38:04.979 UTC] [5/13 Execution]                         block=808598 blocks/s=26953 txns/s=37097 Mgas/s=1520 
  INFO [12-13|23:38:18.284 UTC] Flushed state                            size=41.53 MB in=597.098ms 
  INFO [12-13|23:38:18.558 UTC] [5/13 Execution] commit                  batch time=272.511ms 
  INFO [12-13|23:38:18.560 UTC] [5/13 Execution]                         op=Forward done=43.581s 
  INFO [12-13|23:38:18.560 UTC] [6/13 HashState]                         op=kForward from=0 to=1000000 span=1000000 
  INFO [12-13|23:38:18.560 UTC] [6/13 HashState]                         clearing=HashedAccount 
  INFO [12-13|23:38:18.560 UTC] [6/13 HashState]                         clearing=HashedStorage 
  INFO [12-13|23:38:18.560 UTC] [6/13 HashState]                         clearing=HashedCodeHash 
  INFO [12-13|23:38:19.250 UTC] [6/13 HashState]                         op=Forward done=690.790ms 
  INFO [12-13|23:38:19.250 UTC] [7/13 IntermediateHashes] begin          op=kForward from=0 to=1000000 span=1000000 
  INFO [12-13|23:38:19.250 UTC] [7/13 IntermediateHashes]                clearing=TrieAccount 
  INFO [12-13|23:38:19.250 UTC] [7/13 IntermediateHashes]                clearing=TrieStorage 
  INFO [12-13|23:38:19.769 UTC] [7/13 IntermediateHashes]                op=Forward done=518.718ms 
  WARN [12-13|23:38:19.769 UTC] Stopping ...                             STOP_BEFORE_STAGE=HistoryIndex hit=true 
  INFO [12-13|23:38:19.778 UTC] ExecutionPipeline                        Forward done
  INFO [12-13|23:38:19.778 UTC] Debug unwind: forward to=1'000'000 END
  INFO [12-13|23:38:19.778 UTC] Debug unwind: unwind down to block=999'900 START
  INFO [12-13|23:38:19.778 UTC] ExecutionPipeline                        Unwind start
  INFO [12-13|23:38:19.779 UTC] [7/13 HashState]                         op=kUnwind from=1000000 to=999900 span=100 
  INFO [12-13|23:38:19.790 UTC] [7/13 HashState]                         op=Unwind done=11.738ms 
  INFO [12-13|23:38:19.790 UTC] [8/13 IntermediateHashes] begin          op=kUnwind from=1000000 to=999900 span=100 
  INFO [12-13|23:38:19.790 UTC] [8/13 IntermediateHashes]                clearing=TrieAccount 
  INFO [12-13|23:38:19.790 UTC] [8/13 IntermediateHashes]                clearing=TrieStorage 
  INFO [12-13|23:38:20.311 UTC] [8/13 IntermediateHashes]                op=Unwind done=520.911ms 
  INFO [12-13|23:38:20.311 UTC] [9/13 Execution]                         op=kUnwind from=1000000 to=999900 span=100 
  INFO [12-13|23:38:20.314 UTC] Erased 1'160 records from AccountChangeSet
  INFO [12-13|23:38:20.314 UTC] Erased 116 records from StorageChangeSet
  INFO [12-13|23:38:20.314 UTC] Erased 100 records from Receipt
  INFO [12-13|23:38:20.314 UTC] Erased 52 records from TransactionLog
  INFO [12-13|23:38:20.314 UTC] Erased 1'171 records from CallTraceSet
  INFO [12-13|23:38:20.318 UTC] [10/13 Senders]                          op=kUnwind from=20474999 to=999900 span=19475099 
  INFO [12-13|23:38:20.318 UTC] [11/13 Bodies]                           op=kUnwind from=20474999 to=999900 span=19475099 
  INFO [12-13|23:38:20.319 UTC] [12/13 BlockHashes]                      op=kUnwind from=20474999 to=999900 span=19475099 
  INFO [12-13|23:38:20.319 UTC] [13/13 Headers]                          op=kUnwind from=20474999 to=999900 span=19475099 
  INFO [12-13|23:38:20.346 UTC] ExecutionPipeline                        Unwind done
  INFO [12-13|23:38:20.346 UTC] Debug unwind: unwind down to block=999'900 END
  INFO [12-13|23:38:20.346 UTC] Debug unwind: forward+unwind success up to block=1'000'000
```