### PR TITLE
rpcdaemon: StateFactory rework

### DIFF
--- a/silkworm/db/kv/api/local_transaction.cpp
+++ b/silkworm/db/kv/api/local_transaction.cpp
@@ -65,8 +65,7 @@ std::shared_ptr<chain::ChainStorage> LocalTransaction::create_storage() {
 }
 
 Task<TxnId> LocalTransaction::first_txn_num_in_block(BlockNum /*block_num*/) {
-    // TO DO
-    co_return 0;
+    throw std::logic_error{"LocalTransaction::first_txn_num_in_block: not yet implemented"};
 }
 
 Task<GetLatestResult> LocalTransaction::get_latest(GetLatestQuery /*query*/) {

--- a/silkworm/db/kv/api/local_transaction.cpp
+++ b/silkworm/db/kv/api/local_transaction.cpp
@@ -65,7 +65,8 @@ std::shared_ptr<chain::ChainStorage> LocalTransaction::create_storage() {
 }
 
 Task<TxnId> LocalTransaction::first_txn_num_in_block(BlockNum /*block_num*/) {
-    throw std::logic_error{"not yet implemented"};
+    // TO DO
+    co_return 0;
 }
 
 Task<GetLatestResult> LocalTransaction::get_latest(GetLatestQuery /*query*/) {

--- a/silkworm/execution/state_factory.cpp
+++ b/silkworm/execution/state_factory.cpp
@@ -27,18 +27,6 @@ namespace silkworm::execution {
 std::shared_ptr<State> StateFactory::create_state(
     boost::asio::any_io_executor& executor,
     const db::chain::ChainStorage& storage,
-    BlockNum block_num) {
-    if (tx.is_local()) {
-        auto& local_tx = dynamic_cast<db::kv::api::LocalTransaction&>(tx);
-        return std::make_shared<LocalState>(block_num, std::nullopt, local_tx.data_store());
-    } else {  // NOLINT(readability-else-after-return)
-        return std::make_shared<RemoteState>(executor, tx, storage, block_num, std::nullopt);
-    }
-}
-
-std::shared_ptr<State> StateFactory::create_state_txn(
-    boost::asio::any_io_executor& executor,
-    const db::chain::ChainStorage& storage,
     TxnId txn_id) {
     if (tx.is_local()) {
         auto& local_tx = dynamic_cast<db::kv::api::LocalTransaction&>(tx);

--- a/silkworm/execution/state_factory.hpp
+++ b/silkworm/execution/state_factory.hpp
@@ -36,7 +36,7 @@ struct StateFactory {
         TxnId txn_id);
 
     Task<TxnId> get_txn_id(BlockNum block_num, uint32_t tx_id = 0) {
-        const auto base_txn_in_block = co_await tx.first_txn_num_in_block(block_num + 1);
+        const auto base_txn_in_block = co_await tx.first_txn_num_in_block(block_num);
         co_return base_txn_in_block + 1 + tx_id;  // + 1 for system txn in the beginning of block
     }
 };

--- a/silkworm/execution/state_factory.hpp
+++ b/silkworm/execution/state_factory.hpp
@@ -33,12 +33,12 @@ struct StateFactory {
     std::shared_ptr<State> create_state(
         boost::asio::any_io_executor& executor,
         const db::chain::ChainStorage& storage,
-        BlockNum block_num);
-
-    std::shared_ptr<State> create_state_txn(
-        boost::asio::any_io_executor& executor,
-        const db::chain::ChainStorage& storage,
         TxnId txn_id);
+
+    Task<TxnId> get_txn_id(BlockNum block_num, uint32_t tx_id = 0) {
+        const auto base_txn_in_block = co_await tx.first_txn_num_in_block(block_num + 1);
+        co_return base_txn_in_block + 1 + tx_id;  // + 1 for system txn in the beginning of block
+    }
 };
 
 }  // namespace silkworm::execution

--- a/silkworm/execution/state_factory.hpp
+++ b/silkworm/execution/state_factory.hpp
@@ -35,9 +35,9 @@ struct StateFactory {
         const db::chain::ChainStorage& storage,
         TxnId txn_id);
 
-    Task<TxnId> get_txn_id(BlockNum block_num, uint32_t tx_id = 0) {
+    Task<TxnId> user_txn_id_at(BlockNum block_num, uint32_t txn_index = 0) {
         const auto base_txn_in_block = co_await tx.first_txn_num_in_block(block_num);
-        co_return base_txn_in_block + 1 + tx_id;  // + 1 for system txn in the beginning of block
+        co_return base_txn_in_block + 1 + txn_index;  // + 1 for system txn in the beginning of block
     }
 };
 

--- a/silkworm/rpc/commands/eth_api.cpp
+++ b/silkworm/rpc/commands/eth_api.cpp
@@ -924,7 +924,7 @@ Task<void> EthereumRpcApi::handle_eth_estimate_gas(const nlohmann::json& request
         };
 
         execution::StateFactory state_factory{*tx};
-        auto txn_id = co_await state_factory.get_txn_id(latest_block.header.number);
+        const auto txn_id = co_await state_factory.user_txn_id_at(latest_block.header.number);
 
         rpc::EstimateGasOracle estimate_gas_oracle{block_header_provider, account_reader, chain_config, workers_, *tx, *chain_storage};
         const auto estimated_gas = co_await estimate_gas_oracle.estimate_gas(call, latest_block, txn_id, block_num_for_gas_limit);
@@ -1158,7 +1158,7 @@ Task<void> EthereumRpcApi::handle_eth_call(const nlohmann::json& request, std::s
         silkworm::Transaction txn{call.to_transaction()};
 
         execution::StateFactory state_factory{*tx};
-        auto txn_id = co_await state_factory.get_txn_id(block_num + 1);
+        const auto txn_id = co_await state_factory.user_txn_id_at(block_num + 1);
 
         const auto execution_result = co_await EVMExecutor::call(
             chain_config, *chain_storage, workers_, block_with_hash->block, txn, txn_id, [&state_factory](auto& io_executor, auto curr_txn_id, auto& storage) {
@@ -1348,7 +1348,7 @@ Task<void> EthereumRpcApi::handle_eth_create_access_list(const nlohmann::json& r
         AccessList saved_access_list = call.access_list;
 
         execution::StateFactory state_factory{*tx};
-        auto txn_id = co_await state_factory.get_txn_id(block_with_hash->block.header.number + 1);
+        const auto txn_id = co_await state_factory.user_txn_id_at(block_with_hash->block.header.number + 1);
 
         while (true) {
             const auto execution_result = co_await EVMExecutor::call(
@@ -1447,7 +1447,7 @@ Task<void> EthereumRpcApi::handle_eth_call_bundle(const nlohmann::json& request,
             }
 
             execution::StateFactory state_factory{*tx};
-            auto txn_id = co_await state_factory.get_txn_id(block_with_hash->block.header.number + 1);
+            const auto txn_id = co_await state_factory.user_txn_id_at(block_with_hash->block.header.number + 1);
 
             const auto execution_result = co_await EVMExecutor::call(
                 chain_config, *chain_storage, workers_, block_with_hash->block, tx_with_block->transaction, txn_id, [&](auto& io_executor, auto curr_txn_id, auto& storage) {

--- a/silkworm/rpc/commands/eth_api.cpp
+++ b/silkworm/rpc/commands/eth_api.cpp
@@ -1158,7 +1158,7 @@ Task<void> EthereumRpcApi::handle_eth_call(const nlohmann::json& request, std::s
         silkworm::Transaction txn{call.to_transaction()};
 
         execution::StateFactory state_factory{*tx};
-        auto txn_id = co_await state_factory.get_txn_id(block_num);
+        auto txn_id = co_await state_factory.get_txn_id(block_num + 1);
 
         const auto execution_result = co_await EVMExecutor::call(
             chain_config, *chain_storage, workers_, block_with_hash->block, txn, txn_id, [&state_factory](auto& io_executor, auto curr_txn_id, auto& storage) {
@@ -1348,7 +1348,7 @@ Task<void> EthereumRpcApi::handle_eth_create_access_list(const nlohmann::json& r
         AccessList saved_access_list = call.access_list;
 
         execution::StateFactory state_factory{*tx};
-        auto txn_id = co_await state_factory.get_txn_id(block_with_hash->block.header.number);
+        auto txn_id = co_await state_factory.get_txn_id(block_with_hash->block.header.number + 1);
 
         while (true) {
             const auto execution_result = co_await EVMExecutor::call(
@@ -1447,7 +1447,7 @@ Task<void> EthereumRpcApi::handle_eth_call_bundle(const nlohmann::json& request,
             }
 
             execution::StateFactory state_factory{*tx};
-            auto txn_id = co_await state_factory.get_txn_id(block_with_hash->block.header.number);
+            auto txn_id = co_await state_factory.get_txn_id(block_with_hash->block.header.number + 1);
 
             const auto execution_result = co_await EVMExecutor::call(
                 chain_config, *chain_storage, workers_, block_with_hash->block, tx_with_block->transaction, txn_id, [&](auto& io_executor, auto curr_txn_id, auto& storage) {

--- a/silkworm/rpc/commands/eth_api.cpp
+++ b/silkworm/rpc/commands/eth_api.cpp
@@ -923,8 +923,11 @@ Task<void> EthereumRpcApi::handle_eth_estimate_gas(const nlohmann::json& request
             co_return co_await state_reader.read_account(address);
         };
 
+        execution::StateFactory state_factory{*tx};
+        auto txn_id = co_await state_factory.get_txn_id(latest_block.header.number);
+
         rpc::EstimateGasOracle estimate_gas_oracle{block_header_provider, account_reader, chain_config, workers_, *tx, *chain_storage};
-        const auto estimated_gas = co_await estimate_gas_oracle.estimate_gas(call, latest_block, block_num_for_gas_limit);
+        const auto estimated_gas = co_await estimate_gas_oracle.estimate_gas(call, latest_block, txn_id, block_num_for_gas_limit);
 
         reply = make_json_content(request, to_quantity(estimated_gas));
     } catch (const std::invalid_argument& iv) {

--- a/silkworm/rpc/commands/eth_api_test.cpp
+++ b/silkworm/rpc/commands/eth_api_test.cpp
@@ -105,7 +105,7 @@ TEST_CASE_METHOD(test_util::RpcApiE2ETest, "unit: eth_feeHistory succeeds if req
     })"_json);
 }
 
-#ifdef notdef  // commented Temporary waiting implementaion local-transaction/
+#ifdef notdef  // temporarily commented out waiting for LocalTransaction implementation
 TEST_CASE_METHOD(test_util::RpcApiE2ETest, "eth_call without params on gas", "[rpc][api]") {
     const nlohmann::json request = R"({"jsonrpc":"2.0","id":1,"method":"eth_call","params":[{}, "latest"]})"_json;
     std::string reply;

--- a/silkworm/rpc/commands/eth_api_test.cpp
+++ b/silkworm/rpc/commands/eth_api_test.cpp
@@ -105,6 +105,7 @@ TEST_CASE_METHOD(test_util::RpcApiE2ETest, "unit: eth_feeHistory succeeds if req
     })"_json);
 }
 
+#ifdef notdef  // commented Temporary waiting implementaion local-transaction/
 TEST_CASE_METHOD(test_util::RpcApiE2ETest, "eth_call without params on gas", "[rpc][api]") {
     const nlohmann::json request = R"({"jsonrpc":"2.0","id":1,"method":"eth_call","params":[{}, "latest"]})"_json;
     std::string reply;
@@ -115,6 +116,7 @@ TEST_CASE_METHOD(test_util::RpcApiE2ETest, "eth_call without params on gas", "[r
         "result":"0x"
    })"_json);
 }
+#endif
 
 TEST_CASE_METHOD(test_util::RpcApiE2ETest, "fuzzy: eth_feeHistory sigsegv invalid input", "[rpc][api]") {
     const nlohmann::json request = R"({"jsonrpc":"2.0","id":1,"method":"eth_feeHistory","params":["5x1","0x2",[95,99]]})"_json;

--- a/silkworm/rpc/commands/rpc_api_test.cpp
+++ b/silkworm/rpc/commands/rpc_api_test.cpp
@@ -24,7 +24,7 @@
 
 namespace silkworm::rpc::commands {
 
-#ifdef notdef  // commented Temporary waiting implementaion local-transaction
+#ifdef notdef  // temporarily commented out waiting for LocalTransaction implementation
 using test_util::RequestHandlerForTest;
 using test_util::RpcApiTestBase;
 #endif
@@ -78,7 +78,7 @@ static const std::vector<std::string> kSubtestsToIgnore = {
     "call-simple-contract.io",      // eth_call: without gas paramters doesn't support base_fee_gas of block as default gas
 };
 
-#ifdef notdef  // commented Temporary waiting implementaion local-transaction
+#ifdef notdef  // temporarily commented out waiting for LocalTransaction implementation
 // Exclude tests from sanitizer builds due to ASAN/TSAN warnings inside gRPC library
 #ifndef SILKWORM_SANITIZE
 TEST_CASE("rpc_api io (all files)", "[rpc][rpc_api]") {

--- a/silkworm/rpc/commands/rpc_api_test.cpp
+++ b/silkworm/rpc/commands/rpc_api_test.cpp
@@ -24,7 +24,7 @@
 
 namespace silkworm::rpc::commands {
 
-#ifdef notdef  // commented Temporary wating implementaion local-transaction
+#ifdef notdef  // commented Temporary waiting implementaion local-transaction
 using test_util::RequestHandlerForTest;
 using test_util::RpcApiTestBase;
 #endif
@@ -78,7 +78,7 @@ static const std::vector<std::string> kSubtestsToIgnore = {
     "call-simple-contract.io",      // eth_call: without gas paramters doesn't support base_fee_gas of block as default gas
 };
 
-#ifdef notdef  // commented Temporary wating implementaion local-transaction
+#ifdef notdef  // commented Temporary waiting implementaion local-transaction
 // Exclude tests from sanitizer builds due to ASAN/TSAN warnings inside gRPC library
 #ifndef SILKWORM_SANITIZE
 TEST_CASE("rpc_api io (all files)", "[rpc][rpc_api]") {

--- a/silkworm/rpc/core/call_many.cpp
+++ b/silkworm/rpc/core/call_many.cpp
@@ -40,27 +40,16 @@ CallManyResult CallExecutor::executes_all_bundles(const silkworm::ChainConfig& c
                                                   const Bundles& bundles,
                                                   std::optional<std::uint64_t> opt_timeout,
                                                   const AccountsOverrides& accounts_overrides,
-                                                  int32_t transaction_index,
+                                                  TxnId txn_id,
                                                   boost::asio::any_io_executor& this_executor) {
     CallManyResult result;
     const auto& block = block_with_hash->block;
-    const auto& block_transactions = block.transactions;
-    auto state = execution::StateFactory{transaction_}.create_state(this_executor, storage, block.header.number);
+    auto state = execution::StateFactory{transaction_}.create_state_txn(this_executor, storage, txn_id);
     EVMExecutor executor{block, config, workers_, std::make_shared<state::OverrideState>(*state, accounts_overrides)};
 
     std::uint64_t timeout = opt_timeout.value_or(5000);
     const auto start_time = clock_time::now();
-    for (auto idx{0}; idx < transaction_index; ++idx) {
-        silkworm::Transaction txn{block_transactions[static_cast<size_t>(idx)]};
-        auto exec_result = executor.call(block, txn);
-        if ((clock_time::since(start_time) / 1000000) > timeout) {
-            std::ostringstream oss;
-            oss << "execution aborted (timeout = " << static_cast<double>(timeout) / 1000.0 << "s)";
-            result.error = oss.str();
-            return result;
-        }
-    }
-    executor.reset();
+
     // Don't call reserve here to preallocate result.results - since json value is dynamic it doesn't know yet how much it should allocate!
     // -> Don't uncomment this line result.results.reserve(bundles.size());
     for (const auto& bundle : bundles) {
@@ -168,6 +157,8 @@ Task<CallManyResult> CallExecutor::execute(
     }
 
     auto this_executor = co_await boost::asio::this_coro::executor;
+    const auto min_tx_num = co_await transaction_.first_txn_num_in_block(block_with_hash->block.header.number + 1);
+    const auto txn_id = min_tx_num + static_cast<long unsigned int>(transaction_index) + 1;  // for system txn in the beginning of block
     result = co_await async_task(workers_.executor(), [&]() -> CallManyResult {
         return executes_all_bundles(chain_config,
                                     *chain_storage,
@@ -175,7 +166,7 @@ Task<CallManyResult> CallExecutor::execute(
                                     bundles,
                                     timeout,
                                     accounts_overrides,
-                                    transaction_index,
+                                    txn_id,
                                     this_executor);
     });
 

--- a/silkworm/rpc/core/call_many.cpp
+++ b/silkworm/rpc/core/call_many.cpp
@@ -44,7 +44,7 @@ CallManyResult CallExecutor::executes_all_bundles(const silkworm::ChainConfig& c
                                                   boost::asio::any_io_executor& this_executor) {
     CallManyResult result;
     const auto& block = block_with_hash->block;
-    auto state = execution::StateFactory{transaction_}.create_state_txn(this_executor, storage, txn_id);
+    auto state = execution::StateFactory{transaction_}.create_state(this_executor, storage, txn_id);
     EVMExecutor executor{block, config, workers_, std::make_shared<state::OverrideState>(*state, accounts_overrides)};
 
     std::uint64_t timeout = opt_timeout.value_or(5000);

--- a/silkworm/rpc/core/call_many.hpp
+++ b/silkworm/rpc/core/call_many.hpp
@@ -64,7 +64,7 @@ class CallExecutor {
                                         const Bundles& bundles,
                                         std::optional<std::uint64_t> opt_timeout,
                                         const AccountsOverrides& accounts_overrides,
-                                        int32_t transaction_index,
+                                        TxnId txn_id,
                                         boost::asio::any_io_executor& executor);
 
   private:

--- a/silkworm/rpc/core/estimate_gas_oracle.cpp
+++ b/silkworm/rpc/core/estimate_gas_oracle.cpp
@@ -79,8 +79,12 @@ Task<intx::uint256> EstimateGasOracle::estimate_gas(const Call& call, const silk
     SILK_DEBUG << "hi: " << hi << ", lo: " << lo << ", cap: " << cap;
 
     auto this_executor = co_await boost::asio::this_coro::executor;
+
+    execution::StateFactory state_factory{transaction_};
+    auto txn_id = co_await state_factory.get_txn_id(block_num);
+
     auto exec_result = co_await async_task(workers_.executor(), [&]() -> ExecutionResult {
-        auto state = execution::StateFactory{transaction_}.create_state(this_executor, storage_, block_num);
+        auto state = execution::StateFactory{transaction_}.create_state(this_executor, storage_, txn_id);
 
         ExecutionResult result{evmc_status_code::EVMC_SUCCESS};
         silkworm::Transaction transaction{call.to_transaction()};

--- a/silkworm/rpc/core/estimate_gas_oracle.cpp
+++ b/silkworm/rpc/core/estimate_gas_oracle.cpp
@@ -25,7 +25,7 @@
 
 namespace silkworm::rpc {
 
-Task<intx::uint256> EstimateGasOracle::estimate_gas(const Call& call, const silkworm::Block& block, std::optional<BlockNum> block_num_for_gas_limit) {
+Task<intx::uint256> EstimateGasOracle::estimate_gas(const Call& call, const silkworm::Block& block, TxnId txn_id, std::optional<BlockNum> block_num_for_gas_limit) {
     SILK_DEBUG << "EstimateGasOracle::estimate_gas called";
 
     const auto block_num = block.header.number;
@@ -81,7 +81,6 @@ Task<intx::uint256> EstimateGasOracle::estimate_gas(const Call& call, const silk
     auto this_executor = co_await boost::asio::this_coro::executor;
 
     execution::StateFactory state_factory{transaction_};
-    auto txn_id = co_await state_factory.get_txn_id(block_num);
 
     auto exec_result = co_await async_task(workers_.executor(), [&]() -> ExecutionResult {
         auto state = state_factory.create_state(this_executor, storage_, txn_id);

--- a/silkworm/rpc/core/estimate_gas_oracle.cpp
+++ b/silkworm/rpc/core/estimate_gas_oracle.cpp
@@ -84,7 +84,7 @@ Task<intx::uint256> EstimateGasOracle::estimate_gas(const Call& call, const silk
     auto txn_id = co_await state_factory.get_txn_id(block_num);
 
     auto exec_result = co_await async_task(workers_.executor(), [&]() -> ExecutionResult {
-        auto state = execution::StateFactory{transaction_}.create_state(this_executor, storage_, txn_id);
+        auto state = state_factory.create_state(this_executor, storage_, txn_id);
 
         ExecutionResult result{evmc_status_code::EVMC_SUCCESS};
         silkworm::Transaction transaction{call.to_transaction()};

--- a/silkworm/rpc/core/estimate_gas_oracle.hpp
+++ b/silkworm/rpc/core/estimate_gas_oracle.hpp
@@ -90,7 +90,7 @@ class EstimateGasOracle {
     EstimateGasOracle(const EstimateGasOracle&) = delete;
     EstimateGasOracle& operator=(const EstimateGasOracle&) = delete;
 
-    Task<intx::uint256> estimate_gas(const Call& call, const silkworm::Block& latest_block, std::optional<BlockNum> block_num_for_gas_limit = {});
+    Task<intx::uint256> estimate_gas(const Call& call, const silkworm::Block& latest_block, TxnId txn_id, std::optional<BlockNum> block_num_for_gas_limit = {});
 
   protected:
     virtual ExecutionResult try_execution(EVMExecutor& executor, const silkworm::Block& _block, const silkworm::Transaction& transaction);

--- a/silkworm/rpc/core/estimate_gas_oracle_test.cpp
+++ b/silkworm/rpc/core/estimate_gas_oracle_test.cpp
@@ -122,7 +122,7 @@ TEST_CASE("estimate gas") {
             .WillOnce(Return(expect_result_fail))
             .WillOnce(Return(expect_result_fail))
             .WillRepeatedly(Return(expect_result_ok));
-        auto result = boost::asio::co_spawn(pool, estimate_gas_oracle.estimate_gas(call, block), boost::asio::use_future);
+        auto result = boost::asio::co_spawn(pool, estimate_gas_oracle.estimate_gas(call, block, 244087591818874), boost::asio::use_future);
         const intx::uint256& estimate_gas = result.get();
 
         CHECK(estimate_gas == kTxGas * 2);
@@ -131,7 +131,7 @@ TEST_CASE("estimate gas") {
     SECTION("Call empty, always succeeds") {
         ExecutionResult expect_result_ok{.error_code = evmc_status_code::EVMC_SUCCESS};
         EXPECT_CALL(estimate_gas_oracle, try_execution(_, _, _)).Times(14).WillRepeatedly(Return(expect_result_ok));
-        auto result = boost::asio::co_spawn(pool, estimate_gas_oracle.estimate_gas(call, block), boost::asio::use_future);
+        auto result = boost::asio::co_spawn(pool, estimate_gas_oracle.estimate_gas(call, block, 244087591818874), boost::asio::use_future);
         const intx::uint256& estimate_gas = result.get();
         CHECK(estimate_gas == kTxGas);
     }
@@ -155,7 +155,7 @@ TEST_CASE("estimate gas") {
             .WillOnce(Return(expect_result_ok))
             .WillOnce(Return(expect_result_fail))
             .WillRepeatedly(Return(expect_result_ok));
-        auto result = boost::asio::co_spawn(pool, estimate_gas_oracle.estimate_gas(call, block), boost::asio::use_future);
+        auto result = boost::asio::co_spawn(pool, estimate_gas_oracle.estimate_gas(call, block, 244087591818874), boost::asio::use_future);
         const intx::uint256& estimate_gas = result.get();
 
         CHECK(estimate_gas == 0x88b6);
@@ -180,7 +180,7 @@ TEST_CASE("estimate gas") {
             .WillOnce(Return(expect_result_fail))
             .WillOnce(Return(expect_result_ok))
             .WillRepeatedly(Return(expect_result_fail));
-        auto result = boost::asio::co_spawn(pool, estimate_gas_oracle.estimate_gas(call, block), boost::asio::use_future);
+        auto result = boost::asio::co_spawn(pool, estimate_gas_oracle.estimate_gas(call, block, 244087591818874), boost::asio::use_future);
         const intx::uint256& estimate_gas = result.get();
 
         CHECK(estimate_gas == 0x6d5e);
@@ -208,7 +208,7 @@ TEST_CASE("estimate gas") {
             .WillOnce(Return(expect_result_fail_pre_check))
             .WillOnce(Return(expect_result_ok))
             .WillRepeatedly(Return(expect_result_fail));
-        auto result = boost::asio::co_spawn(pool, estimate_gas_oracle.estimate_gas(call, block), boost::asio::use_future);
+        auto result = boost::asio::co_spawn(pool, estimate_gas_oracle.estimate_gas(call, block, 244087591818874), boost::asio::use_future);
         const intx::uint256& estimate_gas = result.get();
 
         CHECK(estimate_gas == 0x6d5e);
@@ -237,7 +237,7 @@ TEST_CASE("estimate gas") {
             .WillOnce(Return(expect_result_fail))
             .WillOnce(Return(expect_result_fail))
             .WillRepeatedly(Return(expect_result_ok));
-        auto result = boost::asio::co_spawn(pool, estimate_gas_oracle.estimate_gas(call, block), boost::asio::use_future);
+        auto result = boost::asio::co_spawn(pool, estimate_gas_oracle.estimate_gas(call, block, 244087591818874), boost::asio::use_future);
         const intx::uint256& estimate_gas = result.get();
 
         CHECK(estimate_gas == kTxGas * 4);
@@ -249,7 +249,7 @@ TEST_CASE("estimate gas") {
         EXPECT_CALL(estimate_gas_oracle, try_execution(_, _, _))
             .Times(15)
             .WillRepeatedly(Return(expect_result_ok));
-        auto result = boost::asio::co_spawn(pool, estimate_gas_oracle.estimate_gas(call, block), boost::asio::use_future);
+        auto result = boost::asio::co_spawn(pool, estimate_gas_oracle.estimate_gas(call, block, 244087591818874), boost::asio::use_future);
         const intx::uint256& estimate_gas = result.get();
 
         CHECK(estimate_gas == kTxGas);
@@ -279,7 +279,7 @@ TEST_CASE("estimate gas") {
             .WillOnce(Return(expect_result_fail))
             .WillOnce(Return(expect_result_fail))
             .WillRepeatedly(Return(expect_result_ok));
-        auto result = boost::asio::co_spawn(pool, estimate_gas_oracle.estimate_gas(call, block), boost::asio::use_future);
+        auto result = boost::asio::co_spawn(pool, estimate_gas_oracle.estimate_gas(call, block, 244087591818874), boost::asio::use_future);
         const intx::uint256& estimate_gas = result.get();
 
         CHECK(estimate_gas == kTxGas * 2);
@@ -306,7 +306,7 @@ TEST_CASE("estimate gas") {
             .WillOnce(Return(expect_result_fail))
             .WillOnce(Return(expect_result_fail))
             .WillRepeatedly(Return(expect_result_ok));
-        auto result = boost::asio::co_spawn(pool, estimate_gas_oracle.estimate_gas(call, block), boost::asio::use_future);
+        auto result = boost::asio::co_spawn(pool, estimate_gas_oracle.estimate_gas(call, block, 244087591818874), boost::asio::use_future);
         const intx::uint256& estimate_gas = result.get();
 
         CHECK(estimate_gas == 0x61a8);
@@ -337,7 +337,7 @@ TEST_CASE("estimate gas") {
             .WillOnce(Return(expect_result_fail))
             .WillOnce(Return(expect_result_fail))
             .WillRepeatedly(Return(expect_result_ok));
-        auto result = boost::asio::co_spawn(pool, estimate_gas_oracle.estimate_gas(call, block), boost::asio::use_future);
+        auto result = boost::asio::co_spawn(pool, estimate_gas_oracle.estimate_gas(call, block, 244087591818874), boost::asio::use_future);
         const intx::uint256& estimate_gas = result.get();
 
         CHECK(estimate_gas == kTxGas * 2);
@@ -365,7 +365,7 @@ TEST_CASE("estimate gas") {
             .WillOnce(Return(expect_result_fail))
             .WillOnce(Return(expect_result_fail))
             .WillRepeatedly(Return(expect_result_ok));
-        auto result = boost::asio::co_spawn(pool, estimate_gas_oracle.estimate_gas(call, block), boost::asio::use_future);
+        auto result = boost::asio::co_spawn(pool, estimate_gas_oracle.estimate_gas(call, block, 244087591818874), boost::asio::use_future);
         const intx::uint256& estimate_gas = result.get();
 
         CHECK(estimate_gas == 0x61a8);
@@ -375,7 +375,7 @@ TEST_CASE("estimate gas") {
         ExecutionResult expect_result_ok{.error_code = evmc_status_code::EVMC_SUCCESS};
         call.gas = kGasCap * 2;
         EXPECT_CALL(estimate_gas_oracle, try_execution(_, _, _)).Times(25).WillRepeatedly(Return(expect_result_ok));
-        auto result = boost::asio::co_spawn(pool, estimate_gas_oracle.estimate_gas(call, block), boost::asio::use_future);
+        auto result = boost::asio::co_spawn(pool, estimate_gas_oracle.estimate_gas(call, block, 244087591818874), boost::asio::use_future);
         const intx::uint256& estimate_gas = result.get();
 
         CHECK(estimate_gas == kTxGas);
@@ -386,7 +386,7 @@ TEST_CASE("estimate gas") {
         call.gas = kTxGas / 2;
 
         EXPECT_CALL(estimate_gas_oracle, try_execution(_, _, _)).Times(14).WillRepeatedly(Return(expect_result_ok));
-        auto result = boost::asio::co_spawn(pool, estimate_gas_oracle.estimate_gas(call, block), boost::asio::use_future);
+        auto result = boost::asio::co_spawn(pool, estimate_gas_oracle.estimate_gas(call, block, 244087591818874), boost::asio::use_future);
         const intx::uint256& estimate_gas = result.get();
 
         CHECK(estimate_gas == kTxGas);
@@ -398,7 +398,7 @@ TEST_CASE("estimate gas") {
 
         try {
             EXPECT_CALL(estimate_gas_oracle, try_execution(_, _, _)).Times(16).WillRepeatedly(Return(expect_result_fail));
-            auto result = boost::asio::co_spawn(pool, estimate_gas_oracle.estimate_gas(call, block), boost::asio::use_future);
+            auto result = boost::asio::co_spawn(pool, estimate_gas_oracle.estimate_gas(call, block, 244087591818874), boost::asio::use_future);
             result.get();
             CHECK(false);
         } catch (const silkworm::rpc::EstimateGasException&) {
@@ -424,7 +424,7 @@ TEST_CASE("estimate gas") {
                 .Times(2)
                 .WillOnce(Return(expect_result_fail))
                 .WillRepeatedly(Return(expect_result_fail_pre_check));
-            auto result = boost::asio::co_spawn(pool, estimate_gas_oracle.estimate_gas(call, block), boost::asio::use_future);
+            auto result = boost::asio::co_spawn(pool, estimate_gas_oracle.estimate_gas(call, block, 244087591818874), boost::asio::use_future);
             result.get();
             CHECK(false);
         } catch (const silkworm::rpc::EstimateGasException&) {
@@ -451,7 +451,7 @@ TEST_CASE("estimate gas") {
                 .Times(2)
                 .WillOnce(Return(expect_result_fail))
                 .WillRepeatedly(Return(expect_result_fail_pre_check));
-            auto result = boost::asio::co_spawn(pool, estimate_gas_oracle.estimate_gas(call, block), boost::asio::use_future);
+            auto result = boost::asio::co_spawn(pool, estimate_gas_oracle.estimate_gas(call, block, 244087591818874), boost::asio::use_future);
             result.get();
             CHECK(false);
         } catch (const silkworm::rpc::EstimateGasException&) {
@@ -477,7 +477,7 @@ TEST_CASE("estimate gas") {
                 .Times(2)
                 .WillOnce(Return(expect_result_fail))
                 .WillRepeatedly(Return(expect_result_fail_pre_check));
-            auto result = boost::asio::co_spawn(pool, estimate_gas_oracle.estimate_gas(call, block), boost::asio::use_future);
+            auto result = boost::asio::co_spawn(pool, estimate_gas_oracle.estimate_gas(call, block, 244087591818874), boost::asio::use_future);
             result.get();
             CHECK(false);
         } catch (const silkworm::rpc::EstimateGasException&) {

--- a/silkworm/rpc/core/evm_debug.cpp
+++ b/silkworm/rpc/core/evm_debug.cpp
@@ -438,7 +438,7 @@ Task<void> DebugExecutor::execute(json::Stream& stream, const ChainStorage& stor
     auto current_executor = co_await boost::asio::this_coro::executor;
 
     execution::StateFactory state_factory{tx_};
-    auto txn_id = co_await state_factory.get_txn_id(block_num);
+    const auto txn_id = co_await state_factory.user_txn_id_at(block_num);
 
     co_await async_task(workers_.executor(), [&]() -> void {
         auto state = state_factory.create_state(current_executor, storage, txn_id);
@@ -483,7 +483,7 @@ Task<void> DebugExecutor::execute(json::Stream& stream, const ChainStorage& stor
 
     auto transaction_index = static_cast<std::int32_t>(block.transactions.size());
 
-    co_await execute(stream, storage, block.header.number, block, transaction, transaction_index);
+    co_await execute(stream, storage, block.header.number + 1, block, transaction, transaction_index);
     co_return;
 }
 
@@ -506,7 +506,7 @@ Task<void> DebugExecutor::execute(
     // We must do the execution at the state after the txn identified by the given index within the given block
     // at the state after the block identified by the given block_num
     execution::StateFactory state_factory{tx_};
-    auto txn_id = co_await state_factory.get_txn_id(block_num, static_cast<uint32_t>(index));
+    const auto txn_id = co_await state_factory.user_txn_id_at(block_num, static_cast<uint32_t>(index));
 
     co_await async_task(workers_.executor(), [&]() {
         const auto state = state_factory.create_state(current_executor, storage, txn_id);
@@ -558,7 +558,7 @@ Task<void> DebugExecutor::execute(
     // We must do the execution at the state after the txn identified by transaction_with_block param in the same block
     // at the state of the block identified by the given block_num, i.e. at the start of the block (block_num)
     execution::StateFactory state_factory{tx_};
-    auto txn_id = co_await state_factory.get_txn_id(block.header.number, static_cast<uint32_t>(transaction_index));
+    const auto txn_id = co_await state_factory.user_txn_id_at(block.header.number, static_cast<uint32_t>(transaction_index));
 
     co_await async_task(workers_.executor(), [&]() {
         auto state = state_factory.create_state(current_executor, storage, txn_id);

--- a/silkworm/rpc/core/evm_debug.cpp
+++ b/silkworm/rpc/core/evm_debug.cpp
@@ -436,7 +436,7 @@ Task<void> DebugExecutor::execute(json::Stream& stream, const ChainStorage& stor
     auto current_executor = co_await boost::asio::this_coro::executor;
 
     execution::StateFactory state_factory{tx_};
-    auto txn_id = co_await state_factory.get_txn_id(block_num - 1);
+    auto txn_id = co_await state_factory.get_txn_id(block_num);
 
     co_await async_task(workers_.executor(), [&]() -> void {
         auto state = state_factory.create_state(current_executor, storage, txn_id);
@@ -504,7 +504,7 @@ Task<void> DebugExecutor::execute(
     // We must do the execution at the state after the txn identified by the given index within the given block
     // at the state after the block identified by the given block_num, i.e. at the start of the next block (block_num + 1)
     execution::StateFactory state_factory{tx_};
-    auto txn_id = co_await state_factory.get_txn_id(block_num, static_cast<uint32_t>(index));
+    auto txn_id = co_await state_factory.get_txn_id(block_num + 1, static_cast<uint32_t>(index));
 
     co_await async_task(workers_.executor(), [&]() {
         const auto state = state_factory.create_state(current_executor, storage, txn_id);

--- a/silkworm/rpc/core/evm_executor.cpp
+++ b/silkworm/rpc/core/evm_executor.cpp
@@ -292,13 +292,14 @@ Task<ExecutionResult> EVMExecutor::call(
     WorkerPool& workers,
     const silkworm::Block& block,
     const silkworm::Transaction& txn,
+    const TxnId txn_id,
     StateFactory state_factory,
     const Tracers& tracers,
     bool refund,
     bool gas_bailout) {
     auto this_executor = co_await boost::asio::this_coro::executor;
     const auto execution_result = co_await async_task(workers.executor(), [&]() -> ExecutionResult {
-        auto state = state_factory(this_executor, block.header.number, chain_storage);
+        auto state = state_factory(this_executor, txn_id, chain_storage);
         EVMExecutor executor{block, config, workers, state};
         return executor.call(block, txn, tracers, refund, gas_bailout);
     });

--- a/silkworm/rpc/core/evm_executor.hpp
+++ b/silkworm/rpc/core/evm_executor.hpp
@@ -92,6 +92,7 @@ class EVMExecutor {
         WorkerPool& workers,
         const silkworm::Block& block,
         const silkworm::Transaction& txn,
+        const TxnId txnId,
         StateFactory state_factory,
         const Tracers& tracers = {},
         bool refund = true,

--- a/silkworm/rpc/core/evm_trace.cpp
+++ b/silkworm/rpc/core/evm_trace.cpp
@@ -1618,7 +1618,7 @@ Task<TraceEntriesResult> TraceCallExecutor::trace_transaction_entries(const Tran
     // We must do the execution at the state after the txn identified by transaction_with_block param in the same block
     // at the state of the block identified by the given block_num, i.e. at the start of the block (block_num)
     execution::StateFactory state_factory{tx_};
-    auto txn_id = co_await state_factory.get_txn_id(block_num - 1, static_cast<uint32_t>(transaction_with_block.transaction.transaction_index));
+    auto txn_id = co_await state_factory.get_txn_id(block_num - 1, gsl::narrow<uint32_t>(transaction_with_block.transaction.transaction_index));
 
     const auto trace_result = co_await async_task(workers_.executor(), [&]() -> TraceEntriesResult {
         auto state = state_factory.create_state(current_executor, chain_storage_, txn_id);
@@ -1647,7 +1647,7 @@ Task<std::string> TraceCallExecutor::trace_transaction_error(const TransactionWi
     // We must do the execution at the state after the txn identified by transaction_with_block param in the same block
     // at the state of the block identified by the given block_num, i.e. at the start of the block (block_num)
     execution::StateFactory state_factory{tx_};
-    auto txn_id = co_await state_factory.get_txn_id(block_num, transaction_with_block.transaction.transaction_index);
+    auto txn_id = co_await state_factory.get_txn_id(block_num, gsl::narrow<uint32_t>(transaction_with_block.transaction.transaction_index));
 
     const auto trace_error = co_await async_task(workers_.executor(), [&]() -> std::string {
         auto state = state_factory.create_state(current_executor, chain_storage_, txn_id);
@@ -1680,7 +1680,7 @@ Task<TraceOperationsResult> TraceCallExecutor::trace_operations(const Transactio
     // We must do the execution at the state after the txn identified by transaction_with_block param in the same block
     // at the state of the block identified by the given block_num, i.e. at the start of the block (block_num)
     execution::StateFactory state_factory{tx_};
-    auto txn_id = co_await state_factory.get_txn_id(block_num - 1, static_cast<uint64_t>(transaction_with_block.transaction.transaction_index));
+    auto txn_id = co_await state_factory.get_txn_id(block_num - 1, gsl::narrow<uint32_t>(transaction_with_block.transaction.transaction_index));
 
     const auto trace_op_result = co_await async_task(workers_.executor(), [&]() -> TraceOperationsResult {
         auto state = execution::StateFactory{tx_}.create_state(current_executor, chain_storage_, txn_id);
@@ -1813,7 +1813,7 @@ Task<TraceCallResult> TraceCallExecutor::execute(
     // We must do the execution at the state after the txn identified by the given index within the given block
     // at the state after the block identified by the given block_num, i.e. at the start of the next block (block_num + 1)
     execution::StateFactory state_factory{tx_};
-    auto txn_id = co_await state_factory.get_txn_id(block_num, gsl::narrow<TxnId>(transaction.transaction_index));
+    auto txn_id = co_await state_factory.get_txn_id(block_num, gsl::narrow<uint32_t>(transaction.transaction_index));
     auto state = state_factory.create_state(current_executor, chain_storage_, txn_id);
     auto curr_state = state_factory.create_state(current_executor, chain_storage_, txn_id);
     const auto trace_call_result = co_await async_task(workers_.executor(), [&]() -> TraceCallResult {

--- a/silkworm/rpc/core/evm_trace.cpp
+++ b/silkworm/rpc/core/evm_trace.cpp
@@ -1813,7 +1813,7 @@ Task<TraceCallResult> TraceCallExecutor::execute(
     auto current_executor = co_await boost::asio::this_coro::executor;
 
     // We must do the execution at the state after the txn identified by the given index within the given block
-    // at the state after the block identified by the given block_num,
+    // at the state after the block identified by the given block_num
     execution::StateFactory state_factory{tx_};
     auto txn_id = co_await state_factory.get_txn_id(block_num, gsl::narrow<uint32_t>(transaction.transaction_index));
     auto state = state_factory.create_state(current_executor, chain_storage_, txn_id);

--- a/silkworm/rpc/core/evm_trace.cpp
+++ b/silkworm/rpc/core/evm_trace.cpp
@@ -1416,7 +1416,7 @@ Task<std::vector<TraceCallResult>> TraceCallExecutor::trace_block_transactions(c
 
     execution::StateFactory state_factory{tx_};
     // trace_block semantics: we must execute the call from the state at the current block
-    auto txn_id = co_await state_factory.get_txn_id(block_num);
+    const auto txn_id = co_await state_factory.user_txn_id_at(block_num);
 
     const auto call_result = co_await async_task(workers_.executor(), [&]() -> std::vector<TraceCallResult> {
         auto state = state_factory.create_state(current_executor, chain_storage_, txn_id);
@@ -1487,7 +1487,7 @@ Task<TraceManyCallResult> TraceCallExecutor::trace_calls(const silkworm::Block& 
 
     execution::StateFactory state_factory{tx_};
     // trace_calls semantics: we must execute the call from the state at the end of the given block, so we pass block.header.number + 1
-    auto txn_id = co_await state_factory.get_txn_id(block_num + 1);
+    const auto txn_id = co_await state_factory.user_txn_id_at(block_num + 1);
 
     const auto trace_calls_result = co_await async_task(workers_.executor(), [&]() -> TraceManyCallResult {
         auto state = state_factory.create_state(current_executor, chain_storage_, txn_id);
@@ -1552,7 +1552,7 @@ Task<TraceDeployResult> TraceCallExecutor::trace_deploy_transaction(const silkwo
     auto current_executor = co_await boost::asio::this_coro::executor;
 
     execution::StateFactory state_factory{tx_};
-    auto txn_id = co_await state_factory.get_txn_id(block_num);
+    const auto txn_id = co_await state_factory.user_txn_id_at(block_num);
 
     const auto deploy_result = co_await async_task(workers_.executor(), [&]() -> TraceDeployResult {
         auto state = state_factory.create_state(current_executor, chain_storage_, txn_id);
@@ -1620,7 +1620,7 @@ Task<TraceEntriesResult> TraceCallExecutor::trace_transaction_entries(const Tran
     // We must do the execution at the state after the txn identified by transaction_with_block param in the same block
     // at the state of the block identified by the given block_num, i.e. at the start of the block (block_num)
     execution::StateFactory state_factory{tx_};
-    auto txn_id = co_await state_factory.get_txn_id(block_num, gsl::narrow<uint32_t>(transaction_with_block.transaction.transaction_index));
+    const auto txn_id = co_await state_factory.user_txn_id_at(block_num, gsl::narrow<uint32_t>(transaction_with_block.transaction.transaction_index));
 
     const auto trace_result = co_await async_task(workers_.executor(), [&]() -> TraceEntriesResult {
         auto state = state_factory.create_state(current_executor, chain_storage_, txn_id);
@@ -1649,7 +1649,7 @@ Task<std::string> TraceCallExecutor::trace_transaction_error(const TransactionWi
     // We must do the execution at the state after the txn identified by transaction_with_block param in the same block
     // at the state of the block identified by the given block_num, i.e. at the start of the block (block_num)
     execution::StateFactory state_factory{tx_};
-    auto txn_id = co_await state_factory.get_txn_id(block_num, gsl::narrow<uint32_t>(transaction_with_block.transaction.transaction_index));
+    const auto txn_id = co_await state_factory.user_txn_id_at(block_num, gsl::narrow<uint32_t>(transaction_with_block.transaction.transaction_index));
 
     const auto trace_error = co_await async_task(workers_.executor(), [&]() -> std::string {
         auto state = state_factory.create_state(current_executor, chain_storage_, txn_id);
@@ -1682,7 +1682,7 @@ Task<TraceOperationsResult> TraceCallExecutor::trace_operations(const Transactio
     // We must do the execution at the state after the txn identified by transaction_with_block param in the same block
     // at the state of the block identified by the given block_num, i.e. at the start of the block (block_num)
     execution::StateFactory state_factory{tx_};
-    auto txn_id = co_await state_factory.get_txn_id(block_num, gsl::narrow<uint32_t>(transaction_with_block.transaction.transaction_index));
+    const auto txn_id = co_await state_factory.user_txn_id_at(block_num, gsl::narrow<uint32_t>(transaction_with_block.transaction.transaction_index));
 
     const auto trace_op_result = co_await async_task(workers_.executor(), [&]() -> TraceOperationsResult {
         auto state = execution::StateFactory{tx_}.create_state(current_executor, chain_storage_, txn_id);
@@ -1712,7 +1712,7 @@ Task<bool> TraceCallExecutor::trace_touch_block(const silkworm::BlockWithHash& b
     const auto chain_config = co_await chain_storage_.read_chain_config();
     auto current_executor = co_await boost::asio::this_coro::executor;
     execution::StateFactory state_factory{tx_};
-    auto txn_id = co_await state_factory.get_txn_id(block_num);
+    const auto txn_id = co_await state_factory.user_txn_id_at(block_num);
 
     const bool result = co_await async_task(workers_.executor(), [&]() -> bool {
         auto state = state_factory.create_state(current_executor, chain_storage_, txn_id);
@@ -1815,7 +1815,7 @@ Task<TraceCallResult> TraceCallExecutor::execute(
     // We must do the execution at the state after the txn identified by the given index within the given block
     // at the state after the block identified by the given block_num
     execution::StateFactory state_factory{tx_};
-    auto txn_id = co_await state_factory.get_txn_id(block_num, gsl::narrow<uint32_t>(transaction.transaction_index));
+    const auto txn_id = co_await state_factory.user_txn_id_at(block_num, gsl::narrow<uint32_t>(transaction.transaction_index));
     auto state = state_factory.create_state(current_executor, chain_storage_, txn_id);
     auto curr_state = state_factory.create_state(current_executor, chain_storage_, txn_id);
     const auto trace_call_result = co_await async_task(workers_.executor(), [&]() -> TraceCallResult {

--- a/silkworm/rpc/core/evm_trace.cpp
+++ b/silkworm/rpc/core/evm_trace.cpp
@@ -1415,7 +1415,7 @@ Task<std::vector<TraceCallResult>> TraceCallExecutor::trace_block_transactions(c
     auto current_executor = co_await boost::asio::this_coro::executor;
 
     execution::StateFactory state_factory{tx_};
-    auto txn_id = co_await state_factory.get_txn_id(block_num - 1);
+    auto txn_id = co_await state_factory.get_txn_id(block_num);
 
     const auto call_result = co_await async_task(workers_.executor(), [&]() -> std::vector<TraceCallResult> {
         auto state = state_factory.create_state(current_executor, chain_storage_, txn_id);
@@ -1485,7 +1485,8 @@ Task<TraceManyCallResult> TraceCallExecutor::trace_calls(const silkworm::Block& 
     auto current_executor = co_await boost::asio::this_coro::executor;
 
     execution::StateFactory state_factory{tx_};
-    auto txn_id = co_await state_factory.get_txn_id(block_num);
+    // trace_call semantics: we must execute the call from the state at the end of the given block, so we pass block.header.number + 1
+    auto txn_id = co_await state_factory.get_txn_id(block_num + 1);
 
     const auto trace_calls_result = co_await async_task(workers_.executor(), [&]() -> TraceManyCallResult {
         auto state = state_factory.create_state(current_executor, chain_storage_, txn_id);
@@ -1550,7 +1551,7 @@ Task<TraceDeployResult> TraceCallExecutor::trace_deploy_transaction(const silkwo
     auto current_executor = co_await boost::asio::this_coro::executor;
 
     execution::StateFactory state_factory{tx_};
-    auto txn_id = co_await state_factory.get_txn_id(block_num - 1);
+    auto txn_id = co_await state_factory.get_txn_id(block_num);
 
     const auto deploy_result = co_await async_task(workers_.executor(), [&]() -> TraceDeployResult {
         auto state = state_factory.create_state(current_executor, chain_storage_, txn_id);
@@ -1618,7 +1619,7 @@ Task<TraceEntriesResult> TraceCallExecutor::trace_transaction_entries(const Tran
     // We must do the execution at the state after the txn identified by transaction_with_block param in the same block
     // at the state of the block identified by the given block_num, i.e. at the start of the block (block_num)
     execution::StateFactory state_factory{tx_};
-    auto txn_id = co_await state_factory.get_txn_id(block_num - 1, gsl::narrow<uint32_t>(transaction_with_block.transaction.transaction_index));
+    auto txn_id = co_await state_factory.get_txn_id(block_num, gsl::narrow<uint32_t>(transaction_with_block.transaction.transaction_index));
 
     const auto trace_result = co_await async_task(workers_.executor(), [&]() -> TraceEntriesResult {
         auto state = state_factory.create_state(current_executor, chain_storage_, txn_id);
@@ -1680,7 +1681,7 @@ Task<TraceOperationsResult> TraceCallExecutor::trace_operations(const Transactio
     // We must do the execution at the state after the txn identified by transaction_with_block param in the same block
     // at the state of the block identified by the given block_num, i.e. at the start of the block (block_num)
     execution::StateFactory state_factory{tx_};
-    auto txn_id = co_await state_factory.get_txn_id(block_num - 1, gsl::narrow<uint32_t>(transaction_with_block.transaction.transaction_index));
+    auto txn_id = co_await state_factory.get_txn_id(block_num, gsl::narrow<uint32_t>(transaction_with_block.transaction.transaction_index));
 
     const auto trace_op_result = co_await async_task(workers_.executor(), [&]() -> TraceOperationsResult {
         auto state = execution::StateFactory{tx_}.create_state(current_executor, chain_storage_, txn_id);
@@ -1710,7 +1711,7 @@ Task<bool> TraceCallExecutor::trace_touch_block(const silkworm::BlockWithHash& b
     const auto chain_config = co_await chain_storage_.read_chain_config();
     auto current_executor = co_await boost::asio::this_coro::executor;
     execution::StateFactory state_factory{tx_};
-    auto txn_id = co_await state_factory.get_txn_id(block_num - 1);
+    auto txn_id = co_await state_factory.get_txn_id(block_num);
 
     const bool result = co_await async_task(workers_.executor(), [&]() -> bool {
         auto state = state_factory.create_state(current_executor, chain_storage_, txn_id);
@@ -1813,7 +1814,7 @@ Task<TraceCallResult> TraceCallExecutor::execute(
     // We must do the execution at the state after the txn identified by the given index within the given block
     // at the state after the block identified by the given block_num, i.e. at the start of the next block (block_num + 1)
     execution::StateFactory state_factory{tx_};
-    auto txn_id = co_await state_factory.get_txn_id(block_num, gsl::narrow<uint32_t>(transaction.transaction_index));
+    auto txn_id = co_await state_factory.get_txn_id(block_num + 1, gsl::narrow<uint32_t>(transaction.transaction_index));
     auto state = state_factory.create_state(current_executor, chain_storage_, txn_id);
     auto curr_state = state_factory.create_state(current_executor, chain_storage_, txn_id);
     const auto trace_call_result = co_await async_task(workers_.executor(), [&]() -> TraceCallResult {

--- a/silkworm/rpc/core/evm_trace_test.cpp
+++ b/silkworm/rpc/core/evm_trace_test.cpp
@@ -1222,8 +1222,8 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_calls") {
 
     SECTION("callMany: failed with intrinsic gas too low") {
         EXPECT_CALL(transaction, first_txn_num_in_block(5'405'096)).Times(1).WillRepeatedly(Invoke([]() -> Task<TxnId> {
-           co_return 244087591818873;
-         }));
+            co_return 244087591818873;
+        }));
         EXPECT_CALL(backend, get_block_hash_from_block_num(_))
             .WillOnce(InvokeWithoutArgs([]() -> Task<std::optional<evmc::bytes32>> {
                 co_return kZeroHeaderHash;

--- a/silkworm/rpc/core/evm_trace_test.cpp
+++ b/silkworm/rpc/core/evm_trace_test.cpp
@@ -1221,6 +1221,9 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_calls") {
     static Bytes account_history_value3{*silkworm::from_hex("000944ed67f28fd50bb8e90000")};
 
     SECTION("callMany: failed with intrinsic gas too low") {
+        EXPECT_CALL(transaction, first_txn_num_in_block(5'405'096)).Times(1).WillRepeatedly(Invoke([]() -> Task<TxnId> {
+           co_return 244087591818873;
+         }));
         EXPECT_CALL(backend, get_block_hash_from_block_num(_))
             .WillOnce(InvokeWithoutArgs([]() -> Task<std::optional<evmc::bytes32>> {
                 co_return kZeroHeaderHash;
@@ -1256,17 +1259,17 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_calls") {
         db::kv::api::GetAsOfQuery query1{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(account_history_key1)),
-            .timestamp = 244087591818873,
+            .timestamp = 244087591818874,
         };
         db::kv::api::GetAsOfQuery query2{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(account_history_key2)),
-            .timestamp = 244087591818873,
+            .timestamp = 244087591818874,
         };
         db::kv::api::GetAsOfQuery query3{
             .table = table::kAccountDomain,
             .key = db::account_domain_key(bytes_to_address(account_history_key3)),
-            .timestamp = 244087591818873,
+            .timestamp = 244087591818874,
         };
         EXPECT_CALL(backend, get_block_hash_from_block_num(_))
             .WillOnce(InvokeWithoutArgs([]() -> Task<std::optional<evmc::bytes32>> {
@@ -1459,17 +1462,17 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_block_transact
     db::kv::api::GetAsOfQuery query1{
         .table = table::kAccountDomain,
         .key = db::account_domain_key(bytes_to_address(account_history_key1)),
-        .timestamp = 244087591818873,
+        .timestamp = 244087591818874,
     };
     db::kv::api::GetAsOfQuery query2{
         .table = table::kAccountDomain,
         .key = db::account_domain_key(bytes_to_address(account_history_key2)),
-        .timestamp = 244087591818873,
+        .timestamp = 244087591818874,
     };
     db::kv::api::GetAsOfQuery query3{
         .table = table::kAccountDomain,
         .key = db::account_domain_key(bytes_to_address(account_history_key3)),
-        .timestamp = 244087591818873,
+        .timestamp = 244087591818874,
     };
     EXPECT_CALL(backend, get_block_hash_from_block_num(_))
         .WillOnce(InvokeWithoutArgs([]() -> Task<std::optional<evmc::bytes32>> {
@@ -1479,7 +1482,7 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_block_transact
         .WillOnce(InvokeWithoutArgs([]() -> Task<Bytes> {
             co_return kConfigValue;
         }));
-    EXPECT_CALL(transaction, first_txn_num_in_block(1'024'165)).Times(2).WillRepeatedly(Invoke([]() -> Task<TxnId> {
+    EXPECT_CALL(transaction, first_txn_num_in_block(1'024'165)).Times(1).WillRepeatedly(Invoke([]() -> Task<TxnId> {
         co_return 244087591818873;
     }));
     EXPECT_CALL(transaction, get_as_of(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
@@ -1909,17 +1912,17 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_block") {
     db::kv::api::GetAsOfQuery query1{
         .table = table::kAccountDomain,
         .key = db::account_domain_key(bytes_to_address(account_history_key1)),
-        .timestamp = 244087591818873,
+        .timestamp = 244087591818874,
     };
     db::kv::api::GetAsOfQuery query2{
         .table = table::kAccountDomain,
         .key = db::account_domain_key(bytes_to_address(account_history_key2)),
-        .timestamp = 244087591818873,
+        .timestamp = 244087591818874,
     };
     db::kv::api::GetAsOfQuery query3{
         .table = table::kAccountDomain,
         .key = db::account_domain_key(bytes_to_address(account_history_key3)),
-        .timestamp = 244087591818873,
+        .timestamp = 244087591818874,
     };
     EXPECT_CALL(backend, get_block_hash_from_block_num(_))
         .Times(2)
@@ -1930,7 +1933,7 @@ TEST_CASE_METHOD(TraceCallExecutorTest, "TraceCallExecutor::trace_block") {
         .WillRepeatedly(InvokeWithoutArgs([]() -> Task<Bytes> {
             co_return kConfigValue;
         }));
-    EXPECT_CALL(transaction, first_txn_num_in_block(1'024'165)).Times(2).WillRepeatedly(Invoke([]() -> Task<TxnId> {
+    EXPECT_CALL(transaction, first_txn_num_in_block(1'024'165)).Times(1).WillRepeatedly(Invoke([]() -> Task<TxnId> {
         co_return 244087591818873;
     }));
     EXPECT_CALL(transaction, get_as_of(std::move(query1))).WillRepeatedly(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {

--- a/silkworm/rpc/core/receipts.cpp
+++ b/silkworm/rpc/core/receipts.cpp
@@ -154,7 +154,7 @@ Task<std::optional<Receipts>> generate_receipts(db::kv::api::Transaction& tx, co
     auto current_executor = co_await boost::asio::this_coro::executor;
 
     execution::StateFactory state_factory{tx};
-    auto txn_id = co_await state_factory.get_txn_id(block_num);
+    const auto txn_id = co_await state_factory.user_txn_id_at(block_num);
 
     const auto receipts = co_await async_task(workers.executor(), [&]() -> Receipts {
         auto state = state_factory.create_state(current_executor, chain_storage, txn_id);

--- a/silkworm/rpc/core/receipts.cpp
+++ b/silkworm/rpc/core/receipts.cpp
@@ -154,7 +154,7 @@ Task<std::optional<Receipts>> generate_receipts(db::kv::api::Transaction& tx, co
     auto current_executor = co_await boost::asio::this_coro::executor;
 
     execution::StateFactory state_factory{tx};
-    auto txn_id = co_await state_factory.get_txn_id(block_num - 1);
+    auto txn_id = co_await state_factory.get_txn_id(block_num);
 
     const auto receipts = co_await async_task(workers.executor(), [&]() -> Receipts {
         auto state = state_factory.create_state(current_executor, chain_storage, txn_id);

--- a/silkworm/rpc/core/receipts.cpp
+++ b/silkworm/rpc/core/receipts.cpp
@@ -152,10 +152,14 @@ Task<std::optional<Receipts>> generate_receipts(db::kv::api::Transaction& tx, co
 
     const auto chain_config = co_await chain_storage.read_chain_config();
     auto current_executor = co_await boost::asio::this_coro::executor;
-    const auto receipts = co_await async_task(workers.executor(), [&]() -> Receipts {
-        auto state = execution::StateFactory{tx}.create_state(current_executor, chain_storage, block_num - 1);
 
-        auto curr_state = execution::StateFactory{tx}.create_state(current_executor, chain_storage, block_num - 1);
+    execution::StateFactory state_factory{tx};
+    auto txn_id = co_await state_factory.get_txn_id(block_num - 1);
+
+    const auto receipts = co_await async_task(workers.executor(), [&]() -> Receipts {
+        auto state = state_factory.create_state(current_executor, chain_storage, txn_id);
+
+        auto curr_state = state_factory.create_state(current_executor, chain_storage, txn_id);
         EVMExecutor executor{block, chain_config, workers, state};
 
         Receipts rpc_receipts;


### PR DESCRIPTION
This PR contains:
- removed StateFactory::create_state_txn()
- modified StateFactory::create_state() uses txn_id as input no more block_num
- StateFactory::user_txn_id_at() new method that return txn_id from block_num and txn_index
- modify APIs using new StateFactory interface