### PR TITLE
evm: remove unused TraceOp::precompiled_call_gas

### DIFF
--- a/silkworm/core/execution/evm.cpp
+++ b/silkworm/core/execution/evm.cpp
@@ -251,7 +251,7 @@ evmc::Result EVM::call(const evmc_message& message) noexcept {
         for (auto tracer : tracers_) {
             const ByteView empty_code{};  // Any precompile code is empty
             tracer.get().on_execution_start(rev, message, empty_code);
-            tracer.get().on_precompiled_run(res.raw(), message.gas, state_);
+            tracer.get().on_precompiled_run(res.raw(), state_);
             tracer.get().on_execution_end(res.raw(), state_);
         }
     } else {

--- a/silkworm/core/execution/evm.hpp
+++ b/silkworm/core/execution/evm.hpp
@@ -63,8 +63,7 @@ class EvmTracer {
     virtual void on_pre_check_failed(const evmc_result& /*result*/, const evmc_message& /*msg*/) noexcept {};
     virtual void on_creation_completed(const evmc_result& /*result*/, const IntraBlockState& /*intra_block_state*/) noexcept {}
 
-    virtual void on_precompiled_run(const evmc_result& /*result*/, int64_t /*gas*/,
-                                    const IntraBlockState& /*intra_block_state*/) noexcept {}
+    virtual void on_precompiled_run(const evmc_result& /*result*/, const IntraBlockState& /*intra_block_state*/) noexcept {}
 
     virtual void on_reward_granted(const CallResult& /*result*/, const IntraBlockState& /*intra_block_state*/) noexcept {}
 

--- a/silkworm/rpc/core/evm_debug.cpp
+++ b/silkworm/rpc/core/evm_debug.cpp
@@ -212,10 +212,9 @@ void DebugTracer::on_instruction_start(uint32_t pc, const intx::uint256* stack_t
     logs_.push_back(log);
 }
 
-void DebugTracer::on_precompiled_run(const evmc_result& result, int64_t gas, const silkworm::IntraBlockState& /*intra_block_state*/) noexcept {
+void DebugTracer::on_precompiled_run(const evmc_result& result, const silkworm::IntraBlockState& /*intra_block_state*/) noexcept {
     SILK_DEBUG << "DebugTracer::on_precompiled_run:"
-               << " status: " << result.status_code
-               << ", gas: " << std::dec << gas;
+               << " status: " << result.status_code;
 
     if (logs_.size() > 1) {
         flush_logs();

--- a/silkworm/rpc/core/evm_debug.hpp
+++ b/silkworm/rpc/core/evm_debug.hpp
@@ -85,8 +85,7 @@ class DebugTracer : public EvmTracer {
                               const evmone::ExecutionState& execution_state,
                               const silkworm::IntraBlockState& intra_block_state) noexcept override;
     void on_execution_end(const evmc_result& result, const silkworm::IntraBlockState& intra_block_state) noexcept override;
-    void on_precompiled_run(const evmc_result& result, int64_t gas,
-                            const silkworm::IntraBlockState& intra_block_state) noexcept override;
+    void on_precompiled_run(const evmc_result& result, const silkworm::IntraBlockState& intra_block_state) noexcept override;
 
     void flush_logs();
 

--- a/silkworm/rpc/core/evm_trace.cpp
+++ b/silkworm/rpc/core/evm_trace.cpp
@@ -686,15 +686,14 @@ void VmTraceTracer::on_instruction_start(uint32_t pc, const intx::uint256* stack
                << ",   msg.depth: " << std::dec << execution_state.msg->depth;
 }
 
-void VmTraceTracer::on_precompiled_run(const evmc_result& result, int64_t gas, const silkworm::IntraBlockState& /*intra_block_state*/) noexcept {
+void VmTraceTracer::on_precompiled_run(const evmc_result& result, const silkworm::IntraBlockState& /*intra_block_state*/) noexcept {
     SILK_DEBUG << "VmTraceTracer::on_precompiled_run:"
-               << " status: " << result.status_code << ", gas: " << std::dec << gas << "\n";
+               << " status: " << result.status_code << "\n";
 
     if (!traces_stack_.empty()) {
         auto& vm_trace = traces_stack_.top().get();
         if (!vm_trace.ops.empty()) {
             auto& op = vm_trace.ops[vm_trace.ops.size() - 1];
-            op.precompiled_call_gas = gas;
             op.sub = std::make_shared<VmTrace>();
             op.sub->code = "0x";
         }

--- a/silkworm/rpc/core/evm_trace.hpp
+++ b/silkworm/rpc/core/evm_trace.hpp
@@ -99,7 +99,6 @@ struct VmTrace;
 
 struct TraceOp {
     int64_t gas_cost{0};
-    std::optional<int64_t> precompiled_call_gas;
     std::optional<int64_t> call_gas_cap;
     std::optional<TraceEx> trace_ex;
     std::string idx;
@@ -150,7 +149,7 @@ class VmTraceTracer : public silkworm::EvmTracer {
                               const silkworm::IntraBlockState& intra_block_state) noexcept override;
     void on_execution_end(const evmc_result& result, const silkworm::IntraBlockState& intra_block_state) noexcept override;
     void on_pre_check_failed(const evmc_result& result, const evmc_message& msg) noexcept override;
-    void on_precompiled_run(const evmc_result& result, int64_t gas, const silkworm::IntraBlockState& intra_block_state) noexcept override;
+    void on_precompiled_run(const evmc_result& result, const silkworm::IntraBlockState& intra_block_state) noexcept override;
 
   private:
     VmTrace& vm_trace_;


### PR DESCRIPTION
The field `TraceOp::precompiled_call_gas` is registered during tracing but never used.