### PR TITLE
evm: enable evmone APIv2 in tool/test utils

### DIFF
--- a/cmd/dev/check_changes.cpp
+++ b/cmd/dev/check_changes.cpp
@@ -131,7 +131,7 @@ int main(int argc, char* argv[]) {
             db::Buffer buffer{txn, std::make_unique<db::BufferFullDataModel>(access_layer)};
             buffer.set_historical_block(block_num);
 
-            ExecutionProcessor processor{block, *rule_set, buffer, *chain_config, false};
+            ExecutionProcessor processor{block, *rule_set, buffer, *chain_config, true};
             processor.evm().analysis_cache = &analysis_cache;
 
             if (const ValidationResult res = processor.execute_block(receipts); res != ValidationResult::kOk) {

--- a/cmd/dev/scan_txs.cpp
+++ b/cmd/dev/scan_txs.cpp
@@ -91,7 +91,7 @@ int main(int argc, char* argv[]) {
             db::Buffer buffer{txn, std::make_unique<db::BufferROTxDataModel>(txn)};
             buffer.set_historical_block(block_num);
 
-            ExecutionProcessor processor{block, *rule_set, buffer, *chain_config, false};
+            ExecutionProcessor processor{block, *rule_set, buffer, *chain_config, true};
             processor.evm().analysis_cache = &analysis_cache;
 
             // Execute the block and retrieve the receipts

--- a/cmd/state-transition/state_transition.cpp
+++ b/cmd/state-transition/state_transition.cpp
@@ -290,7 +290,7 @@ void StateTransition::run() {
             auto block = get_block(state, config);
             auto txn = get_transaction(expected_sub_state);
 
-            ExecutionProcessor processor{block, *rule_set, state, config, false};
+            ExecutionProcessor processor{block, *rule_set, state, config, true};
             Receipt receipt;
 
             const evmc_revision rev{config.revision(block.header.number, block.header.timestamp)};

--- a/silkworm/core/execution/execution.hpp
+++ b/silkworm/core/execution/execution.hpp
@@ -47,7 +47,7 @@ inline ValidationResult execute_block(
     if (!rule_set) {
         return ValidationResult::kUnknownProtocolRuleSet;
     }
-    ExecutionProcessor processor{block, *rule_set, state, chain_config, false};
+    ExecutionProcessor processor{block, *rule_set, state, chain_config, true};
 
     if (const ValidationResult res = processor.execute_block(receipts); res != ValidationResult::kOk) {
         return res;

--- a/silkworm/db/test_util/test_database_context.cpp
+++ b/silkworm/db/test_util/test_database_context.cpp
@@ -128,7 +128,7 @@ void populate_blocks(RWTxn& txn, const std::filesystem::path& tests_dir, InMemor
 
         // FIX 4b: populate receipts and logs table
         std::vector<silkworm::Receipt> receipts;
-        ExecutionProcessor processor{block, *rule_set, state_buffer, *chain_config, false};
+        ExecutionProcessor processor{block, *rule_set, state_buffer, *chain_config, true};
         Buffer db_buffer{txn, std::make_unique<BufferROTxDataModel>(txn)};
         for (auto& block_txn : block.transactions) {
             silkworm::Receipt receipt{};


### PR DESCRIPTION
Enable evmone APIv2 by the flag in the ExecutionProcessor in:
- cmd/dev/check_changes
- cmd/dev/scan_tx
- cmd/state_transition
- db unit tests
- execution unit tests via `execute_block()`