### PR TITLE
cmake: TSAN suppression for MDBX false-positives in unit tests

### DIFF
--- a/cmake/run_unit_tests.cmake
+++ b/cmake/run_unit_tests.cmake
@@ -52,6 +52,10 @@ foreach(TEST_COMMAND IN LISTS TEST_COMMANDS)
     set(ENV{LLVM_PROFILE_FILE} "${TEST_COMMAND_NAME}.profraw")
   endif()
 
+  if("${SILKWORM_SANITIZE}" STREQUAL "thread")
+    set(ENV{TSAN_OPTIONS} "suppressions=tsan_suppressions.txt")
+  endif()
+
   execute_process(COMMAND "${TEST_COMMAND}" "--rng-seed=${TIME}" "--min-duration=2" RESULT_VARIABLE EXIT_CODE)
   if(NOT (EXIT_CODE EQUAL 0))
     message(FATAL_ERROR "${TEST_COMMAND_REL_PATH} has failed: ${EXIT_CODE}")

--- a/cmake/run_unit_tests.sh
+++ b/cmake/run_unit_tests.sh
@@ -10,5 +10,5 @@ fi
 
 script_dir=$(dirname "$0")
 
-cmake "-DSILKWORM_BUILD_DIR=$1" "-DSILKWORM_CLANG_COVERAGE=$2" -P "$script_dir/run_unit_tests.cmake" \
+cmake "-DSILKWORM_BUILD_DIR=$1" "-DSILKWORM_CLANG_COVERAGE=$2" "-DSILKWORM_SANITIZE=$3" -P "$script_dir/run_unit_tests.cmake" \
 	| grep -Ev '^(Randomness|RNG seed|============================)'

--- a/tsan_suppressions.txt
+++ b/tsan_suppressions.txt
@@ -1,0 +1,5 @@
+# ThreadSanitizer suppressions file for project Silkworm.
+
+# MDBX is not compatible with ThreadSanitizer, see warning in mdbx.c:861
+# "libmdbx don't compatible with ThreadSanitizer, you will get a lot of false-positive issues."
+race:mdbx


### PR DESCRIPTION
After #1881 re-enabled C-API unit tests, we're experiencing intermittent failures related to MDBX in TSAN build, e.g. [here](https://app.circleci.com/pipelines/github/erigontech/silkworm/14921/workflows/c5f9e071-66e6-4862-853a-dabcd0e4b7d9/jobs/65928).

The root cause is that MDBX is [not compatible with Thread Sanitiser](https://github.com/erigontech/mdbx-go/blob/839cb7b1a9a5e6f8cff751ec1b25814d24a7ab38/mdbxdist/mdbx.c#L861), so we must suppress MDBX data races for unit tests in TSAN build.