### PR TITLE
snapshots: queries refactoring

### DIFF
--- a/silkworm/db/access_layer.cpp
+++ b/silkworm/db/access_layer.cpp
@@ -1266,25 +1266,11 @@ bool DataModel::read_block_from_snapshot(BlockNum block_num, Block& block) const
 }
 
 std::optional<BlockHeader> DataModel::read_header_from_snapshot(BlockNum block_num) const {
-    std::optional<BlockHeader> block_header;
-    // We know the header snapshot in advance: find it based on target block number
-    const auto [segment_and_index, _] = repository_.find_segment(blocks::kHeaderSegmentAndIdxNames, block_num);
-    if (segment_and_index) {
-        block_header = HeaderFindByBlockNumSegmentQuery{*segment_and_index}.exec(block_num);
-    }
-    return block_header;
+    return HeaderFindByBlockNumQuery{repository_}.exec(block_num);
 }
 
 std::optional<BlockHeader> DataModel::read_header_from_snapshot(const Hash& hash) const {
-    std::optional<BlockHeader> block_header;
-    // We don't know the header snapshot in advance: search for block hash in each header snapshot in reverse order
-    for (const auto& bundle_ptr : repository_.view_bundles_reverse()) {
-        const auto& bundle = *bundle_ptr;
-        auto segment_and_index = bundle.segment_and_accessor_index(blocks::kHeaderSegmentAndIdxNames);
-        block_header = HeaderFindByHashSegmentQuery{segment_and_index}.exec(hash);
-        if (block_header) break;
-    }
-    return block_header;
+    return HeaderFindByHashQuery{repository_}.exec(hash);
 }
 
 std::optional<BlockBodyForStorage> DataModel::read_body_for_storage_from_snapshot(BlockNum block_num) const {
@@ -1310,14 +1296,7 @@ bool DataModel::read_body_from_snapshot(BlockNum block_num, BlockBody& body) con
 }
 
 bool DataModel::is_body_in_snapshot(BlockNum block_num) const {
-    // We know the body snapshot in advance: find it based on target block number
-    const auto [segment_and_index, _] = repository_.find_segment(blocks::kBodySegmentAndIdxNames, block_num);
-    if (segment_and_index) {
-        const auto stored_body = BodyFindByBlockNumSegmentQuery{*segment_and_index}.exec(block_num);
-        return stored_body.has_value();
-    }
-
-    return false;
+    return BodyFindByBlockNumQuery{repository_}.exec(block_num).has_value();
 }
 
 bool DataModel::read_transactions_from_snapshot(BlockNum block_num, uint64_t base_txn_id, uint64_t txn_count, std::vector<Transaction>& txs) const {
@@ -1325,31 +1304,27 @@ bool DataModel::read_transactions_from_snapshot(BlockNum block_num, uint64_t bas
         return true;
     }
 
-    const auto [segment_and_index, _] = repository_.find_segment(blocks::kTxnSegmentAndIdxNames, block_num);
-    if (!segment_and_index) return false;
+    auto txs_opt = TransactionRangeFromIdQuery{repository_}.exec(block_num, base_txn_id, txn_count);
+    if (!txs_opt) return false;
 
-    txs = TransactionRangeFromIdSegmentQuery{*segment_and_index}.exec_into_vector(base_txn_id, txn_count);
-
+    txs = std::move(*txs_opt);
     return true;
 }
 
 bool DataModel::read_rlp_transactions_from_snapshot(BlockNum block_num, std::vector<Bytes>& rlp_txs) const {
-    const auto [body_segment_and_index, _] = repository_.find_segment(blocks::kBodySegmentAndIdxNames, block_num);
-    if (body_segment_and_index) {
-        auto stored_body = BodyFindByBlockNumSegmentQuery{*body_segment_and_index}.exec(block_num);
-        if (!stored_body) return false;
+    auto stored_body = BodyFindByBlockNumQuery{repository_}.exec(block_num);
+    if (!stored_body) return false;
 
+    {
         // Skip first and last *system transactions* in block body
         const auto base_txn_id{stored_body->base_txn_id + 1};
         const auto txn_count{stored_body->txn_count >= 2 ? stored_body->txn_count - 2 : stored_body->txn_count};
-
         if (txn_count == 0) return true;
 
-        const auto [tx_segment_and_index, _2] = repository_.find_segment(blocks::kTxnSegmentAndIdxNames, block_num);
-        if (!tx_segment_and_index) return false;
+        auto txs_opt = TransactionPayloadRlpRangeFromIdQuery{repository_}.exec(block_num, base_txn_id, txn_count);
+        if (!txs_opt) return false;
 
-        rlp_txs = TransactionPayloadRlpRangeFromIdSegmentQuery{*tx_segment_and_index}.exec_into_vector(base_txn_id, txn_count);
-
+        rlp_txs = std::move(*txs_opt);
         return true;
     }
 

--- a/silkworm/db/access_layer.cpp
+++ b/silkworm/db/access_layer.cpp
@@ -1382,7 +1382,7 @@ std::optional<BlockNum> DataModel::read_tx_lookup_from_db(const evmc::bytes32& t
 }
 
 std::optional<BlockNum> DataModel::read_tx_lookup_from_snapshot(const evmc::bytes32& tx_hash) const {
-    TransactionBlockNumByTxnHashQuery query{repository_.view_bundles_reverse()};
+    TransactionBlockNumByTxnHashQuery query{repository_};
     return query.exec(tx_hash);
 }
 

--- a/silkworm/db/access_layer.hpp
+++ b/silkworm/db/access_layer.hpp
@@ -290,7 +290,7 @@ class DataModel {
   public:
     DataModel(
         ROTxn& txn,
-        snapshots::SnapshotRepository& repository)
+        const snapshots::SnapshotRepositoryROAccess& repository)
         : txn_{txn},
           repository_{repository} {}
 
@@ -381,7 +381,7 @@ class DataModel {
     std::optional<BlockNum> read_tx_lookup_from_snapshot(const evmc::bytes32& tx_hash) const;
 
     ROTxn& txn_;
-    snapshots::SnapshotRepository& repository_;
+    const snapshots::SnapshotRepositoryROAccess& repository_;
 };
 
 class DataModelFactory {

--- a/silkworm/db/blocks/bodies/body_queries.hpp
+++ b/silkworm/db/blocks/bodies/body_queries.hpp
@@ -17,7 +17,7 @@
 #pragma once
 
 #include <silkworm/db/datastore/snapshots/basic_queries.hpp>
-#include <silkworm/db/datastore/snapshots/snapshot_repository.hpp>
+#include <silkworm/db/datastore/snapshots/snapshot_repository_ro_access.hpp>
 
 #include "../schema_config.hpp"
 #include "body_segment.hpp"
@@ -28,8 +28,7 @@ using BodyFindByBlockNumSegmentQuery = FindByIdSegmentQuery<BodySegmentReader>;
 
 class BodyFindByBlockNumQuery {
   public:
-    // TODO: use a sub-interface of SnapshotRepository
-    explicit BodyFindByBlockNumQuery(SnapshotRepository& repository)
+    explicit BodyFindByBlockNumQuery(const SnapshotRepositoryROAccess& repository)
         : repository_{repository} {}
 
     std::optional<BlockBodyForStorage> exec(BlockNum block_num) {
@@ -39,7 +38,7 @@ class BodyFindByBlockNumQuery {
     }
 
   private:
-    SnapshotRepository& repository_;
+    const SnapshotRepositoryROAccess& repository_;
 };
 
 }  // namespace silkworm::snapshots

--- a/silkworm/db/blocks/bodies/body_queries.hpp
+++ b/silkworm/db/blocks/bodies/body_queries.hpp
@@ -24,21 +24,13 @@
 
 namespace silkworm::snapshots {
 
-using BodyFindByBlockNumSegmentQuery = FindByIdSegmentQuery<BodySegmentReader>;
+using BodyFindByBlockNumSegmentQuery = FindByIdSegmentQuery<BodySegmentReader, &db::blocks::kBodySegmentAndIdxNames>;
 
-class BodyFindByBlockNumQuery {
-  public:
-    explicit BodyFindByBlockNumQuery(const SnapshotRepositoryROAccess& repository)
-        : repository_{repository} {}
-
+struct BodyFindByBlockNumQuery : public FindByTimestampMapQuery<BodyFindByBlockNumSegmentQuery> {
+    using FindByTimestampMapQuery::FindByTimestampMapQuery;
     std::optional<BlockBodyForStorage> exec(BlockNum block_num) {
-        const auto [segment_and_index, _] = repository_.find_segment(db::blocks::kBodySegmentAndIdxNames, block_num);
-        if (!segment_and_index) return std::nullopt;
-        return BodyFindByBlockNumSegmentQuery{*segment_and_index}.exec(block_num);
+        return FindByTimestampMapQuery::exec(block_num, block_num);
     }
-
-  private:
-    const SnapshotRepositoryROAccess& repository_;
 };
 
 }  // namespace silkworm::snapshots

--- a/silkworm/db/blocks/bodies/body_queries.hpp
+++ b/silkworm/db/blocks/bodies/body_queries.hpp
@@ -24,18 +24,18 @@
 
 namespace silkworm::snapshots {
 
-using BodyFindByBlockNumQuery = FindByIdQuery<BodySegmentReader>;
+using BodyFindByBlockNumSegmentQuery = FindByIdSegmentQuery<BodySegmentReader>;
 
-class BodyFindByBlockNumMultiQuery {
+class BodyFindByBlockNumQuery {
   public:
     // TODO: use a sub-interface of SnapshotRepository
-    explicit BodyFindByBlockNumMultiQuery(SnapshotRepository& repository)
+    explicit BodyFindByBlockNumQuery(SnapshotRepository& repository)
         : repository_{repository} {}
 
     std::optional<BlockBodyForStorage> exec(BlockNum block_num) {
         const auto [segment_and_index, _] = repository_.find_segment(db::blocks::kBodySegmentAndIdxNames, block_num);
         if (!segment_and_index) return std::nullopt;
-        return BodyFindByBlockNumQuery{*segment_and_index}.exec(block_num);
+        return BodyFindByBlockNumSegmentQuery{*segment_and_index}.exec(block_num);
     }
 
   private:

--- a/silkworm/db/blocks/bodies/body_txs_amount_query.cpp
+++ b/silkworm/db/blocks/bodies/body_txs_amount_query.cpp
@@ -22,10 +22,10 @@
 
 namespace silkworm::snapshots {
 
-BodyTxsAmountQuery::Result BodyTxsAmountQuery::exec() {
+BodyTxsAmountSegmentQuery::Result BodyTxsAmountSegmentQuery::exec() {
     size_t body_count = segment_.item_count();
     if (body_count == 0) {
-        throw std::runtime_error("BodyTxsAmountQuery empty body snapshot: " + segment_.path().path().string());
+        throw std::runtime_error("BodyTxsAmountSegmentQuery empty body snapshot: " + segment_.path().path().string());
     }
 
     BodySegmentReader reader{segment_};

--- a/silkworm/db/blocks/bodies/body_txs_amount_query.hpp
+++ b/silkworm/db/blocks/bodies/body_txs_amount_query.hpp
@@ -22,14 +22,14 @@
 
 namespace silkworm::snapshots {
 
-class BodyTxsAmountQuery {
+class BodyTxsAmountSegmentQuery {
   public:
     struct Result {
         uint64_t first_tx_id{};
         uint64_t count{};
     };
 
-    explicit BodyTxsAmountQuery(const segment::SegmentFileReader& segment) : segment_(segment) {}
+    explicit BodyTxsAmountSegmentQuery(const segment::SegmentFileReader& segment) : segment_(segment) {}
 
     Result exec();
 

--- a/silkworm/db/blocks/bodies/body_txs_amount_query_test.cpp
+++ b/silkworm/db/blocks/bodies/body_txs_amount_query_test.cpp
@@ -25,12 +25,12 @@
 
 namespace silkworm::snapshots {
 
-TEST_CASE("BodyTxsAmountQuery") {
+TEST_CASE("BodyTxsAmountSegmentQuery") {
     TemporaryDirectory tmp_dir;
     test_util::SampleBodySnapshotFile snapshot_file{tmp_dir.path()};
     segment::SegmentFileReader snapshot{snapshot_file.path()};
 
-    BodyTxsAmountQuery query{snapshot};
+    BodyTxsAmountSegmentQuery query{snapshot};
     auto result = query.exec();
 
     CHECK(result.first_tx_id == 7'341'262);

--- a/silkworm/db/blocks/headers/header_queries.hpp
+++ b/silkworm/db/blocks/headers/header_queries.hpp
@@ -22,7 +22,7 @@
 
 namespace silkworm::snapshots {
 
-using HeaderFindByBlockNumQuery = FindByIdQuery<HeaderSegmentReader>;
-using HeaderFindByHashQuery = FindByHashQuery<HeaderSegmentReader>;
+using HeaderFindByBlockNumSegmentQuery = FindByIdSegmentQuery<HeaderSegmentReader>;
+using HeaderFindByHashSegmentQuery = FindByHashSegmentQuery<HeaderSegmentReader>;
 
 }  // namespace silkworm::snapshots

--- a/silkworm/db/blocks/headers/header_queries.hpp
+++ b/silkworm/db/blocks/headers/header_queries.hpp
@@ -18,11 +18,21 @@
 
 #include <silkworm/db/datastore/snapshots/basic_queries.hpp>
 
+#include "../schema_config.hpp"
 #include "header_segment.hpp"
 
 namespace silkworm::snapshots {
 
-using HeaderFindByBlockNumSegmentQuery = FindByIdSegmentQuery<HeaderSegmentReader>;
-using HeaderFindByHashSegmentQuery = FindByHashSegmentQuery<HeaderSegmentReader>;
+using HeaderFindByBlockNumSegmentQuery = FindByIdSegmentQuery<HeaderSegmentReader, &db::blocks::kHeaderSegmentAndIdxNames>;
+
+struct HeaderFindByBlockNumQuery : public FindByTimestampMapQuery<HeaderFindByBlockNumSegmentQuery> {
+    using FindByTimestampMapQuery::FindByTimestampMapQuery;
+    std::optional<BlockHeader> exec(BlockNum block_num) {
+        return FindByTimestampMapQuery::exec(block_num, block_num);
+    }
+};
+
+using HeaderFindByHashSegmentQuery = FindByHashSegmentQuery<HeaderSegmentReader, &db::blocks::kHeaderSegmentAndIdxNames>;
+using HeaderFindByHashQuery = FindMapQuery<HeaderFindByHashSegmentQuery>;
 
 }  // namespace silkworm::snapshots

--- a/silkworm/db/blocks/schema_config.hpp
+++ b/silkworm/db/blocks/schema_config.hpp
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <array>
 #include <memory>
 
 #include "../datastore/common/entity_name.hpp"
@@ -44,7 +43,7 @@ inline constexpr std::string_view kHeaderSegmentTag = kHeaderSegmentName.name;
 //! Index header_hash -> block_num -> headers_segment_offset
 inline constexpr datastore::EntityName kIdxHeaderHashName{"headers.idx"};
 inline constexpr std::string_view kIdxHeaderHashTag = kHeaderSegmentTag;
-inline constexpr std::array<datastore::EntityName, 3> kHeaderSegmentAndIdxNames{
+inline constexpr snapshots::SegmentAndAccessorIndexNames kHeaderSegmentAndIdxNames{
     snapshots::Schema::kDefaultEntityName,
     kHeaderSegmentName,
     kIdxHeaderHashName,
@@ -55,7 +54,7 @@ inline constexpr std::string_view kBodySegmentTag = kBodySegmentName.name;
 //! Index block_num -> bodies_segment_offset
 inline constexpr datastore::EntityName kIdxBodyNumberName{"bodies.idx"};
 inline constexpr std::string_view kIdxBodyNumberTag = kBodySegmentTag;
-inline constexpr std::array<datastore::EntityName, 3> kBodySegmentAndIdxNames{
+inline constexpr snapshots::SegmentAndAccessorIndexNames kBodySegmentAndIdxNames{
     snapshots::Schema::kDefaultEntityName,
     kBodySegmentName,
     kIdxBodyNumberName,
@@ -66,7 +65,7 @@ inline constexpr std::string_view kTxnSegmentTag = kTxnSegmentName.name;
 //! Index transaction_hash -> txn_id -> transactions_segment_offset
 inline constexpr datastore::EntityName kIdxTxnHashName{"transactions.idx"};
 inline constexpr std::string_view kIdxTxnHashTag = kTxnSegmentTag;
-inline constexpr std::array<datastore::EntityName, 3> kTxnSegmentAndIdxNames{
+inline constexpr snapshots::SegmentAndAccessorIndexNames kTxnSegmentAndIdxNames{
     snapshots::Schema::kDefaultEntityName,
     kTxnSegmentName,
     kIdxTxnHashName,

--- a/silkworm/db/blocks/transactions/txn_index.cpp
+++ b/silkworm/db/blocks/transactions/txn_index.cpp
@@ -31,7 +31,7 @@ std::pair<uint64_t, uint64_t> TransactionIndex::compute_txs_amount(
     SnapshotPath bodies_segment_path,
     std::optional<MemoryMappedRegion> bodies_segment_region) {
     segment::SegmentFileReader body_segment{std::move(bodies_segment_path), bodies_segment_region};
-    auto result = BodyTxsAmountQuery{body_segment}.exec();
+    auto result = BodyTxsAmountSegmentQuery{body_segment}.exec();
     return {result.first_tx_id, result.count};
 }
 

--- a/silkworm/db/blocks/transactions/txn_queries.hpp
+++ b/silkworm/db/blocks/transactions/txn_queries.hpp
@@ -21,6 +21,7 @@
 #include <silkworm/core/common/bytes.hpp>
 #include <silkworm/core/types/hash.hpp>
 #include <silkworm/db/datastore/snapshots/basic_queries.hpp>
+#include <silkworm/db/datastore/snapshots/snapshot_repository_ro_access.hpp>
 
 #include "../schema_config.hpp"
 #include "txn_segment.hpp"
@@ -69,8 +70,7 @@ class TransactionBlockNumByTxnHashSegmentQuery {
 
 class TransactionBlockNumByTxnHashQuery {
   public:
-    // TODO: use a sub-interface of SnapshotRepository
-    explicit TransactionBlockNumByTxnHashQuery(SnapshotRepository& repository)
+    explicit TransactionBlockNumByTxnHashQuery(const SnapshotRepositoryROAccess& repository)
         : repository_{repository} {}
 
     std::optional<BlockNum> exec(const Hash& hash) {
@@ -85,7 +85,7 @@ class TransactionBlockNumByTxnHashQuery {
     }
 
   private:
-    SnapshotRepository& repository_;
+    const SnapshotRepositoryROAccess& repository_;
 };
 
 }  // namespace silkworm::snapshots

--- a/silkworm/db/blocks/transactions/txn_queries.hpp
+++ b/silkworm/db/blocks/transactions/txn_queries.hpp
@@ -28,10 +28,14 @@
 
 namespace silkworm::snapshots {
 
-using TransactionFindByIdSegmentQuery = FindByIdSegmentQuery<TransactionSegmentReader>;
-using TransactionFindByHashSegmentQuery = FindByHashSegmentQuery<TransactionSegmentReader>;
-using TransactionRangeFromIdSegmentQuery = RangeFromIdSegmentQuery<TransactionSegmentReader>;
-using TransactionPayloadRlpRangeFromIdSegmentQuery = RangeFromIdSegmentQuery<TransactionSegmentPayloadRlpReader<Bytes>>;
+using TransactionFindByIdSegmentQuery = FindByIdSegmentQuery<TransactionSegmentReader, &db::blocks::kTxnSegmentAndIdxNames>;
+using TransactionFindByHashSegmentQuery = FindByHashSegmentQuery<TransactionSegmentReader, &db::blocks::kTxnSegmentAndIdxNames>;
+
+using TransactionRangeFromIdSegmentQuery = RangeFromIdSegmentQuery<TransactionSegmentReader, &db::blocks::kTxnSegmentAndIdxNames>;
+using TransactionRangeFromIdQuery = FindByTimestampMapQuery<TransactionRangeFromIdSegmentQuery>;
+
+using TransactionPayloadRlpRangeFromIdSegmentQuery = RangeFromIdSegmentQuery<TransactionSegmentPayloadRlpReader<Bytes>, &db::blocks::kTxnSegmentAndIdxNames>;
+using TransactionPayloadRlpRangeFromIdQuery = FindByTimestampMapQuery<TransactionPayloadRlpRangeFromIdSegmentQuery>;
 
 class TransactionBlockNumByTxnHashSegmentQuery {
   public:

--- a/silkworm/db/blocks/transactions/txn_queries.hpp
+++ b/silkworm/db/blocks/transactions/txn_queries.hpp
@@ -68,24 +68,6 @@ class TransactionBlockNumByTxnHashSegmentQuery {
     TransactionFindByHashSegmentQuery cross_check_query_;
 };
 
-class TransactionBlockNumByTxnHashQuery {
-  public:
-    explicit TransactionBlockNumByTxnHashQuery(const SnapshotRepositoryROAccess& repository)
-        : repository_{repository} {}
-
-    std::optional<BlockNum> exec(const Hash& hash) {
-        for (const auto& bundle_ptr : repository_.view_bundles_reverse()) {
-            TransactionBlockNumByTxnHashSegmentQuery query{*bundle_ptr};
-            auto block_num = query.exec(hash);
-            if (block_num) {
-                return block_num;
-            }
-        }
-        return std::nullopt;
-    }
-
-  private:
-    const SnapshotRepositoryROAccess& repository_;
-};
+using TransactionBlockNumByTxnHashQuery = FindMapQuery<TransactionBlockNumByTxnHashSegmentQuery>;
 
 }  // namespace silkworm::snapshots

--- a/silkworm/db/blocks/transactions/txn_queries.hpp
+++ b/silkworm/db/blocks/transactions/txn_queries.hpp
@@ -53,7 +53,7 @@ class TransactionBlockNumByTxnHashSegmentQuery {
     std::optional<BlockNum> exec(const Hash& hash) {
         // Lookup the entire txn to check that the retrieved txn hash matches (no way to know if key exists in MPHF)
         const auto transaction = cross_check_query_.exec(hash);
-        auto result = transaction ? index_.lookup_ordinal_by_hash(hash) : std::nullopt;
+        auto result = transaction ? index_.lookup_by_key(hash) : std::nullopt;
         return result;
     }
 

--- a/silkworm/db/blocks/transactions/txn_queries.hpp
+++ b/silkworm/db/blocks/transactions/txn_queries.hpp
@@ -27,16 +27,16 @@
 
 namespace silkworm::snapshots {
 
-using TransactionFindByIdQuery = FindByIdQuery<TransactionSegmentReader>;
-using TransactionFindByHashQuery = FindByHashQuery<TransactionSegmentReader>;
-using TransactionRangeFromIdQuery = RangeFromIdQuery<TransactionSegmentReader>;
-using TransactionPayloadRlpRangeFromIdQuery = RangeFromIdQuery<TransactionSegmentPayloadRlpReader<Bytes>>;
+using TransactionFindByIdSegmentQuery = FindByIdSegmentQuery<TransactionSegmentReader>;
+using TransactionFindByHashSegmentQuery = FindByHashSegmentQuery<TransactionSegmentReader>;
+using TransactionRangeFromIdSegmentQuery = RangeFromIdSegmentQuery<TransactionSegmentReader>;
+using TransactionPayloadRlpRangeFromIdSegmentQuery = RangeFromIdSegmentQuery<TransactionSegmentPayloadRlpReader<Bytes>>;
 
-class TransactionBlockNumByTxnHashQuery {
+class TransactionBlockNumByTxnHashSegmentQuery {
   public:
-    TransactionBlockNumByTxnHashQuery(
+    TransactionBlockNumByTxnHashSegmentQuery(
         const rec_split::AccessorIndex& index,
-        TransactionFindByHashQuery cross_check_query)
+        TransactionFindByHashSegmentQuery cross_check_query)
         : index_(index),
           cross_check_query_(cross_check_query) {}
 
@@ -49,13 +49,13 @@ class TransactionBlockNumByTxnHashQuery {
 
   private:
     const rec_split::AccessorIndex& index_;
-    TransactionFindByHashQuery cross_check_query_;
+    TransactionFindByHashSegmentQuery cross_check_query_;
 };
 
 template <std::ranges::view TBundlesView, class TBundle = typename std::ranges::iterator_t<TBundlesView>::value_type>
-class TransactionBlockNumByTxnHashMultiQuery {
+class TransactionBlockNumByTxnHashQuery {
   public:
-    explicit TransactionBlockNumByTxnHashMultiQuery(TBundlesView bundles)
+    explicit TransactionBlockNumByTxnHashQuery(TBundlesView bundles)
         : bundles_(std::move(bundles)) {}
 
     std::optional<BlockNum> exec(const Hash& hash) {
@@ -65,8 +65,8 @@ class TransactionBlockNumByTxnHashMultiQuery {
             const rec_split::AccessorIndex& idx_txn_hash = bundle.idx_txn_hash();
             const rec_split::AccessorIndex& idx_txn_hash_2_block = bundle.idx_txn_hash_2_block();
 
-            TransactionFindByHashQuery cross_check_query{{segment, idx_txn_hash}};
-            TransactionBlockNumByTxnHashQuery query{idx_txn_hash_2_block, cross_check_query};
+            TransactionFindByHashSegmentQuery cross_check_query{{segment, idx_txn_hash}};
+            TransactionBlockNumByTxnHashSegmentQuery query{idx_txn_hash_2_block, cross_check_query};
             auto block_num = query.exec(hash);
             if (block_num) {
                 return block_num;

--- a/silkworm/db/blocks/transactions/txn_to_block_index.cpp
+++ b/silkworm/db/blocks/transactions/txn_to_block_index.cpp
@@ -20,7 +20,7 @@
 
 namespace silkworm::snapshots {
 
-static IndexInputDataQuery::Iterator::value_type query_entry(TxsAndBodiesQuery::Iterator& it) {
+static IndexInputDataQuery::Iterator::value_type query_entry(TxsAndBodiesSegmentQuery::Iterator& it) {
     return {
         .key_data = it->tx_buffer,
         .value = it->block_num,
@@ -28,12 +28,12 @@ static IndexInputDataQuery::Iterator::value_type query_entry(TxsAndBodiesQuery::
 }
 
 IndexInputDataQuery::Iterator TransactionToBlockIndexInputDataQuery::begin() {
-    auto impl_it = std::make_shared<TxsAndBodiesQuery::Iterator>(query_.begin());
+    auto impl_it = std::make_shared<TxsAndBodiesSegmentQuery::Iterator>(query_.begin());
     return IndexInputDataQuery::Iterator{this, impl_it, query_entry(*impl_it)};
 }
 
 IndexInputDataQuery::Iterator TransactionToBlockIndexInputDataQuery::end() {
-    auto impl_it = std::make_shared<TxsAndBodiesQuery::Iterator>(query_.end());
+    auto impl_it = std::make_shared<TxsAndBodiesSegmentQuery::Iterator>(query_.end());
     return IndexInputDataQuery::Iterator{this, impl_it, query_entry(*impl_it)};
 }
 
@@ -43,7 +43,7 @@ size_t TransactionToBlockIndexInputDataQuery::keys_count() {
 
 std::pair<std::shared_ptr<void>, IndexInputDataQuery::Iterator::value_type>
 TransactionToBlockIndexInputDataQuery::next_iterator(std::shared_ptr<void> it_impl) {
-    auto& it_impl_ref = *reinterpret_cast<TxsAndBodiesQuery::Iterator*>(it_impl.get());
+    auto& it_impl_ref = *reinterpret_cast<TxsAndBodiesSegmentQuery::Iterator*>(it_impl.get());
     ++it_impl_ref;
     return {it_impl, query_entry(it_impl_ref)};
 }
@@ -51,8 +51,8 @@ TransactionToBlockIndexInputDataQuery::next_iterator(std::shared_ptr<void> it_im
 bool TransactionToBlockIndexInputDataQuery::equal_iterators(
     std::shared_ptr<void> lhs_it_impl,
     std::shared_ptr<void> rhs_it_impl) const {
-    auto lhs = reinterpret_cast<TxsAndBodiesQuery::Iterator*>(lhs_it_impl.get());
-    auto rhs = reinterpret_cast<TxsAndBodiesQuery::Iterator*>(rhs_it_impl.get());
+    auto lhs = reinterpret_cast<TxsAndBodiesSegmentQuery::Iterator*>(lhs_it_impl.get());
+    auto rhs = reinterpret_cast<TxsAndBodiesSegmentQuery::Iterator*>(rhs_it_impl.get());
     return (*lhs == *rhs);
 }
 
@@ -68,7 +68,7 @@ IndexBuilder TransactionToBlockIndex::make(
 
     auto descriptor = make_descriptor(segment_path, first_block_num, first_tx_id);
 
-    TxsAndBodiesQuery data_query{
+    TxsAndBodiesSegmentQuery data_query{
         std::move(segment_path),
         segment_region,
         std::move(bodies_segment_path),

--- a/silkworm/db/blocks/transactions/txn_to_block_index.hpp
+++ b/silkworm/db/blocks/transactions/txn_to_block_index.hpp
@@ -33,7 +33,7 @@ namespace silkworm::snapshots {
 
 class TransactionToBlockIndexInputDataQuery : public IndexInputDataQuery {
   public:
-    explicit TransactionToBlockIndexInputDataQuery(TxsAndBodiesQuery query)
+    explicit TransactionToBlockIndexInputDataQuery(TxsAndBodiesSegmentQuery query)
         : query_(std::move(query)) {}
 
     Iterator begin() override;
@@ -43,7 +43,7 @@ class TransactionToBlockIndexInputDataQuery : public IndexInputDataQuery {
     bool equal_iterators(std::shared_ptr<void> lhs_it_impl, std::shared_ptr<void> rhs_it_impl) const override;
 
   private:
-    TxsAndBodiesQuery query_;
+    TxsAndBodiesSegmentQuery query_;
 };
 
 class TransactionToBlockIndex {

--- a/silkworm/db/blocks/transactions/txs_and_bodies_query.cpp
+++ b/silkworm/db/blocks/transactions/txs_and_bodies_query.cpp
@@ -24,7 +24,7 @@
 
 namespace silkworm::snapshots {
 
-TxsAndBodiesQuery::Iterator::Iterator(
+TxsAndBodiesSegmentQuery::Iterator::Iterator(
     std::shared_ptr<seg::Decompressor> txs_decoder,
     seg::Decompressor::Iterator tx_it,
     std::shared_ptr<seg::Decompressor> bodies_decoder,
@@ -48,7 +48,7 @@ TxsAndBodiesQuery::Iterator::Iterator(
     value_.tx_buffer = *tx_it_;
 }
 
-void TxsAndBodiesQuery::Iterator::skip_bodies_until_tx_id(uint64_t tx_id) {
+void TxsAndBodiesSegmentQuery::Iterator::skip_bodies_until_tx_id(uint64_t tx_id) {
     while (!(tx_id < value_.body.base_txn_id + value_.body.txn_count)) {
         ++body_it_;
         if (body_it_ == bodies_decoder_->end()) {
@@ -60,7 +60,7 @@ void TxsAndBodiesQuery::Iterator::skip_bodies_until_tx_id(uint64_t tx_id) {
     }
 }
 
-TxsAndBodiesQuery::Iterator& TxsAndBodiesQuery::Iterator::operator++() {
+TxsAndBodiesSegmentQuery::Iterator& TxsAndBodiesSegmentQuery::Iterator::operator++() {
     // check if already at the end
     if (!txs_decoder_) {
         return *this;
@@ -92,14 +92,14 @@ TxsAndBodiesQuery::Iterator& TxsAndBodiesQuery::Iterator::operator++() {
     return *this;
 }
 
-bool operator==(const TxsAndBodiesQuery::Iterator& lhs, const TxsAndBodiesQuery::Iterator& rhs) {
+bool operator==(const TxsAndBodiesSegmentQuery::Iterator& lhs, const TxsAndBodiesSegmentQuery::Iterator& rhs) {
     return (lhs.txs_decoder_ == rhs.txs_decoder_) &&
            (!lhs.txs_decoder_ || (lhs.tx_it_ == rhs.tx_it_)) &&
            (lhs.bodies_decoder_ == rhs.bodies_decoder_) &&
            (!lhs.bodies_decoder_ || (lhs.body_it_ == rhs.body_it_));
 }
 
-void TxsAndBodiesQuery::Iterator::decode_body_rlp(ByteView body_rlp, BlockBodyForStorage& body) {
+void TxsAndBodiesSegmentQuery::Iterator::decode_body_rlp(ByteView body_rlp, BlockBodyForStorage& body) {
     auto decode_result = decode_stored_block_body(body_rlp, body);
     if (!decode_result) {
         std::stringstream error;
@@ -112,8 +112,8 @@ void TxsAndBodiesQuery::Iterator::decode_body_rlp(ByteView body_rlp, BlockBodyFo
     }
 }
 
-TxsAndBodiesQuery::Iterator TxsAndBodiesQuery::begin() const {
-    std::string log_title = "TxsAndBodiesQuery for: " + txs_segment_path_.path().string();
+TxsAndBodiesSegmentQuery::Iterator TxsAndBodiesSegmentQuery::begin() const {
+    std::string log_title = "TxsAndBodiesSegmentQuery for: " + txs_segment_path_.path().string();
 
     auto txs_decoder = std::make_shared<seg::Decompressor>(txs_segment_path_.path(), txs_segment_region_);
 
@@ -128,7 +128,7 @@ TxsAndBodiesQuery::Iterator TxsAndBodiesQuery::begin() const {
 
     auto bodies_decoder = std::make_shared<seg::Decompressor>(bodies_segment_path_.path(), bodies_segment_region_);
 
-    TxsAndBodiesQuery::Iterator it{
+    TxsAndBodiesSegmentQuery::Iterator it{
         txs_decoder,
         txs_decoder->begin(),
         bodies_decoder,
@@ -146,7 +146,7 @@ TxsAndBodiesQuery::Iterator TxsAndBodiesQuery::begin() const {
     return it;
 }
 
-TxsAndBodiesQuery::Iterator TxsAndBodiesQuery::end() const {
+TxsAndBodiesSegmentQuery::Iterator TxsAndBodiesSegmentQuery::end() const {
     return Iterator{
         {},
         seg::Decompressor::Iterator::make_end(),
@@ -155,7 +155,7 @@ TxsAndBodiesQuery::Iterator TxsAndBodiesQuery::end() const {
         std::numeric_limits<uint64_t>::max(),
         first_tx_id_,
         expected_tx_count_,
-        "TxsAndBodiesQuery::end",
+        "TxsAndBodiesSegmentQuery::end",
     };
 }
 

--- a/silkworm/db/blocks/transactions/txs_and_bodies_query.hpp
+++ b/silkworm/db/blocks/transactions/txs_and_bodies_query.hpp
@@ -32,7 +32,7 @@
 
 namespace silkworm::snapshots {
 
-class TxsAndBodiesQuery {
+class TxsAndBodiesSegmentQuery {
   public:
     class Iterator {
       public:
@@ -85,7 +85,7 @@ class TxsAndBodiesQuery {
 
     static_assert(std::input_or_output_iterator<Iterator>);
 
-    TxsAndBodiesQuery(
+    TxsAndBodiesSegmentQuery(
         SnapshotPath txs_segment_path,
         std::optional<MemoryMappedRegion> txs_segment_region,
         SnapshotPath bodies_segment_path,

--- a/silkworm/db/cli/snapshots.cpp
+++ b/silkworm/db/cli/snapshots.cpp
@@ -431,16 +431,16 @@ void open_index(const SnapshotSubcommandSettings& settings) {
     if (idx.double_enum_index()) {
         if (settings.lookup_block_num) {
             const uint64_t data_id{*settings.lookup_block_num};
-            const uint64_t enumeration{data_id - idx.base_data_id()};
-            if (enumeration < idx.key_count()) {
-                SILK_INFO << "Offset by ordinal lookup for " << data_id << ": " << idx.lookup_by_ordinal(enumeration);
+            auto offset = idx.lookup_by_data_id(data_id);
+            if (offset) {
+                SILK_INFO << "Offset by data id lookup for " << data_id << ": " << *offset;
             } else {
-                SILK_WARN << "Invalid absolute data number " << data_id << " for ordinal lookup";
+                SILK_WARN << "Invalid data id " << data_id;
             }
         } else {
             for (size_t i{0}; i < idx.key_count(); ++i) {
                 if (i % (idx.key_count() / 10) == 0) {
-                    SILK_INFO << "Offset by ordinal lookup for " << i << ": " << idx.lookup_by_ordinal(i)
+                    SILK_INFO << "Offset by ordinal lookup for " << i << ": " << idx.lookup_by_ordinal({i})
                               << " [existence filter: " << int{idx.existence_filter()[i]} << "]";
                 }
             }

--- a/silkworm/db/cli/snapshots.cpp
+++ b/silkworm/db/cli/snapshots.cpp
@@ -686,7 +686,7 @@ void lookup_header_by_hash(const SnapshotSubcommandSettings& settings) {
     for (const auto& bundle_ptr : repository.view_bundles_reverse()) {
         const auto& bundle = *bundle_ptr;
         auto segment_and_index = bundle.segment_and_accessor_index(db::blocks::kHeaderSegmentAndIdxNames);
-        const auto header = HeaderFindByHashQuery{segment_and_index}.exec(*hash);
+        const auto header = HeaderFindByHashSegmentQuery{segment_and_index}.exec(*hash);
         if (header) {
             matching_header = header;
             matching_snapshot_path = segment_and_index.segment.path();
@@ -714,7 +714,7 @@ void lookup_header_by_number(const SnapshotSubcommandSettings& settings) {
     auto repository = make_repository(settings.settings);
     const auto [segment_and_index, _] = repository.find_segment(db::blocks::kHeaderSegmentAndIdxNames, block_num);
     if (segment_and_index) {
-        const auto header = HeaderFindByBlockNumQuery{*segment_and_index}.exec(block_num);
+        const auto header = HeaderFindByBlockNumSegmentQuery{*segment_and_index}.exec(block_num);
         ensure(header.has_value(),
                [&]() { return "lookup_header_by_number: " + std::to_string(block_num) + " NOT found in " + segment_and_index->segment.path().filename(); });
         SILK_INFO << "Lookup header number: " << block_num << " found in: " << segment_and_index->segment.path().filename();
@@ -754,7 +754,7 @@ void lookup_body_in_one(const SnapshotSubcommandSettings& settings, BlockNum blo
 
     rec_split::AccessorIndex idx_body_number{snapshot_path->related_path_ext(db::blocks::kIdxExtension)};
 
-    const auto body = BodyFindByBlockNumQuery{{body_segment, idx_body_number}}.exec(block_num);
+    const auto body = BodyFindByBlockNumSegmentQuery{{body_segment, idx_body_number}}.exec(block_num);
     if (body) {
         SILK_INFO << "Lookup body number: " << block_num << " found in: " << body_segment.path().filename();
         if (settings.verbose) {
@@ -773,7 +773,7 @@ void lookup_body_in_all(const SnapshotSubcommandSettings& settings, BlockNum blo
     std::chrono::time_point start{std::chrono::steady_clock::now()};
     const auto [segment_and_index, _] = repository.find_segment(db::blocks::kBodySegmentAndIdxNames, block_num);
     if (segment_and_index) {
-        const auto body = BodyFindByBlockNumQuery{*segment_and_index}.exec(block_num);
+        const auto body = BodyFindByBlockNumSegmentQuery{*segment_and_index}.exec(block_num);
         ensure(body.has_value(),
                [&]() { return "lookup_body: " + std::to_string(block_num) + " NOT found in " + segment_and_index->segment.path().filename(); });
         SILK_INFO << "Lookup body number: " << block_num << " found in: " << segment_and_index->segment.path().filename();
@@ -873,7 +873,7 @@ void lookup_txn_by_hash_in_one(const SnapshotSubcommandSettings& settings, const
     {
         rec_split::AccessorIndex idx_txn_hash{snapshot_path->related_path_ext(db::blocks::kIdxExtension)};
 
-        const auto transaction = TransactionFindByHashQuery{{txn_segment, idx_txn_hash}}.exec(hash);
+        const auto transaction = TransactionFindByHashSegmentQuery{{txn_segment, idx_txn_hash}}.exec(hash);
         if (transaction) {
             SILK_INFO << "Lookup txn hash: " << hash.to_hex() << " found in: " << txn_segment.path().filename();
             if (settings.verbose) {
@@ -895,7 +895,7 @@ void lookup_txn_by_hash_in_all(const SnapshotSubcommandSettings& settings, const
     for (const auto& bundle_ptr : repository.view_bundles_reverse()) {
         const auto& bundle = *bundle_ptr;
         auto segment_and_index = bundle.segment_and_accessor_index(db::blocks::kTxnSegmentAndIdxNames);
-        const auto transaction = TransactionFindByHashQuery{segment_and_index}.exec(hash);
+        const auto transaction = TransactionFindByHashSegmentQuery{segment_and_index}.exec(hash);
         if (transaction) {
             matching_snapshot_path = segment_and_index.segment.path();
             if (settings.verbose) {
@@ -935,7 +935,7 @@ void lookup_txn_by_id_in_one(const SnapshotSubcommandSettings& settings, uint64_
     {
         rec_split::AccessorIndex idx_txn_hash{snapshot_path->related_path_ext(db::blocks::kIdxExtension)};
 
-        const auto transaction = TransactionFindByIdQuery{{txn_segment, idx_txn_hash}}.exec(txn_id);
+        const auto transaction = TransactionFindByIdSegmentQuery{{txn_segment, idx_txn_hash}}.exec(txn_id);
         if (transaction) {
             SILK_INFO << "Lookup txn ID: " << txn_id << " found in: " << txn_segment.path().filename();
             if (settings.verbose) {
@@ -957,7 +957,7 @@ void lookup_txn_by_id_in_all(const SnapshotSubcommandSettings& settings, uint64_
     for (const auto& bundle_ptr : repository.view_bundles_reverse()) {
         const auto& bundle = *bundle_ptr;
         auto segment_and_index = bundle.segment_and_accessor_index(db::blocks::kTxnSegmentAndIdxNames);
-        const auto transaction = TransactionFindByIdQuery{segment_and_index}.exec(txn_id);
+        const auto transaction = TransactionFindByIdSegmentQuery{segment_and_index}.exec(txn_id);
         if (transaction) {
             matching_snapshot_path = segment_and_index.segment.path();
             if (settings.verbose) {

--- a/silkworm/db/datastore/snapshots/basic_queries.hpp
+++ b/silkworm/db/datastore/snapshots/basic_queries.hpp
@@ -69,7 +69,7 @@ struct FindByHashSegmentQuery : public BasicSegmentQuery<TSegmentReader, segment
     using BasicSegmentQuery<TSegmentReader, segment_names>::BasicSegmentQuery;
 
     std::optional<typename TSegmentReader::Iterator::value_type> exec(const Hash& hash) {
-        auto offset = this->index_.lookup_by_hash(hash);
+        auto offset = this->index_.lookup_by_key(hash);
         if (!offset) {
             return std::nullopt;
         }

--- a/silkworm/db/datastore/snapshots/basic_queries.hpp
+++ b/silkworm/db/datastore/snapshots/basic_queries.hpp
@@ -18,15 +18,19 @@
 
 #include <cstdint>
 #include <optional>
+#include <utility>
 
 #include <silkworm/core/types/hash.hpp>
 
 #include "segment/segment_reader.hpp"
 #include "segment_and_accessor_index.hpp"
+#include "snapshot_repository_ro_access.hpp"
 
 namespace silkworm::snapshots {
 
-template <segment::SegmentReaderConcept TSegmentReader>
+template <
+    segment::SegmentReaderConcept TSegmentReader,
+    const SegmentAndAccessorIndexNames* segment_names = nullptr>
 class BasicSegmentQuery {
   public:
     explicit BasicSegmentQuery(
@@ -34,14 +38,19 @@ class BasicSegmentQuery {
         : reader_{segment_and_index.segment},
           index_{segment_and_index.index} {}
 
+    explicit BasicSegmentQuery(const SegmentAndAccessorIndexProvider& bundle)
+        : BasicSegmentQuery{bundle.segment_and_accessor_index(*segment_names)} {}
+
   protected:
     TSegmentReader reader_;
     const rec_split::AccessorIndex& index_;
 };
 
-template <segment::SegmentReaderConcept TSegmentReader>
-struct FindByIdSegmentQuery : public BasicSegmentQuery<TSegmentReader> {
-    using BasicSegmentQuery<TSegmentReader>::BasicSegmentQuery;
+template <
+    segment::SegmentReaderConcept TSegmentReader,
+    const SegmentAndAccessorIndexNames* segment_names = nullptr>
+struct FindByIdSegmentQuery : public BasicSegmentQuery<TSegmentReader, segment_names> {
+    using BasicSegmentQuery<TSegmentReader, segment_names>::BasicSegmentQuery;
 
     std::optional<typename TSegmentReader::Iterator::value_type> exec(uint64_t id) {
         auto offset = this->index_.lookup_by_data_id(id);
@@ -53,9 +62,11 @@ struct FindByIdSegmentQuery : public BasicSegmentQuery<TSegmentReader> {
     }
 };
 
-template <segment::SegmentReaderConcept TSegmentReader>
-struct FindByHashSegmentQuery : public BasicSegmentQuery<TSegmentReader> {
-    using BasicSegmentQuery<TSegmentReader>::BasicSegmentQuery;
+template <
+    segment::SegmentReaderConcept TSegmentReader,
+    const SegmentAndAccessorIndexNames* segment_names = nullptr>
+struct FindByHashSegmentQuery : public BasicSegmentQuery<TSegmentReader, segment_names> {
+    using BasicSegmentQuery<TSegmentReader, segment_names>::BasicSegmentQuery;
 
     std::optional<typename TSegmentReader::Iterator::value_type> exec(const Hash& hash) {
         auto offset = this->index_.lookup_by_hash(hash);
@@ -74,9 +85,11 @@ struct FindByHashSegmentQuery : public BasicSegmentQuery<TSegmentReader> {
     }
 };
 
-template <segment::SegmentReaderConcept TSegmentReader>
-struct RangeFromIdSegmentQuery : public BasicSegmentQuery<TSegmentReader> {
-    using BasicSegmentQuery<TSegmentReader>::BasicSegmentQuery;
+template <
+    segment::SegmentReaderConcept TSegmentReader,
+    const SegmentAndAccessorIndexNames* segment_names = nullptr>
+struct RangeFromIdSegmentQuery : public BasicSegmentQuery<TSegmentReader, segment_names> {
+    using BasicSegmentQuery<TSegmentReader, segment_names>::BasicSegmentQuery;
 
     std::vector<typename TSegmentReader::Iterator::value_type> exec_into_vector(uint64_t first_id, uint64_t count) {
         auto offset = this->index_.lookup_by_data_id(first_id);
@@ -86,6 +99,49 @@ struct RangeFromIdSegmentQuery : public BasicSegmentQuery<TSegmentReader> {
 
         return this->reader_.read_into_vector(*offset, count);
     }
+};
+
+//! Given a TSegmentQuery that returns an optional value, runs it for all bundles and returns the last non-null result.
+//! Iterating backwards by default is an optimization assuming that results are often found in the most recent snapshots.
+template <class TSegmentQuery>
+struct FindMapQuery {
+    explicit FindMapQuery(const SnapshotRepositoryROAccess& repository)
+        : repository_{repository} {}
+
+    auto exec(auto&&... args) {
+        for (const auto& bundle_ptr : repository_.view_bundles_reverse()) {
+            TSegmentQuery query{*bundle_ptr};
+            auto result = query.exec(args...);
+            if (result) {
+                return result;
+            }
+        }
+        // std::nullopt<ResultType>
+        return decltype(std::declval<TSegmentQuery>().exec(args...)){};
+    }
+
+  protected:
+    const SnapshotRepositoryROAccess& repository_;
+};
+
+//! Given a timestamp and a TSegmentQuery, runs it for a bundle located by that timestamp.
+template <class TSegmentQuery>
+struct FindByTimestampMapQuery {
+    explicit FindByTimestampMapQuery(const SnapshotRepositoryROAccess& repository)
+        : repository_{repository} {}
+
+    auto exec(SnapshotRepositoryROAccess::Timestamp t, auto&&... args) {
+        auto bundle_ptr = repository_.find_bundle(t);
+        if (bundle_ptr) {
+            TSegmentQuery query{*bundle_ptr};
+            return query.exec(args...);
+        }
+        // std::nullopt<ResultType>
+        return decltype(std::declval<TSegmentQuery>().exec(args...)){};
+    }
+
+  protected:
+    const SnapshotRepositoryROAccess& repository_;
 };
 
 }  // namespace silkworm::snapshots

--- a/silkworm/db/datastore/snapshots/basic_queries.hpp
+++ b/silkworm/db/datastore/snapshots/basic_queries.hpp
@@ -30,7 +30,7 @@ namespace silkworm::snapshots {
 
 template <
     segment::SegmentReaderConcept TSegmentReader,
-    const SegmentAndAccessorIndexNames* segment_names = nullptr>
+    const SegmentAndAccessorIndexNames* segment_names>
 class BasicSegmentQuery {
   public:
     explicit BasicSegmentQuery(
@@ -48,7 +48,7 @@ class BasicSegmentQuery {
 
 template <
     segment::SegmentReaderConcept TSegmentReader,
-    const SegmentAndAccessorIndexNames* segment_names = nullptr>
+    const SegmentAndAccessorIndexNames* segment_names>
 struct FindByIdSegmentQuery : public BasicSegmentQuery<TSegmentReader, segment_names> {
     using BasicSegmentQuery<TSegmentReader, segment_names>::BasicSegmentQuery;
 
@@ -64,7 +64,7 @@ struct FindByIdSegmentQuery : public BasicSegmentQuery<TSegmentReader, segment_n
 
 template <
     segment::SegmentReaderConcept TSegmentReader,
-    const SegmentAndAccessorIndexNames* segment_names = nullptr>
+    const SegmentAndAccessorIndexNames* segment_names>
 struct FindByHashSegmentQuery : public BasicSegmentQuery<TSegmentReader, segment_names> {
     using BasicSegmentQuery<TSegmentReader, segment_names>::BasicSegmentQuery;
 
@@ -87,14 +87,14 @@ struct FindByHashSegmentQuery : public BasicSegmentQuery<TSegmentReader, segment
 
 template <
     segment::SegmentReaderConcept TSegmentReader,
-    const SegmentAndAccessorIndexNames* segment_names = nullptr>
+    const SegmentAndAccessorIndexNames* segment_names>
 struct RangeFromIdSegmentQuery : public BasicSegmentQuery<TSegmentReader, segment_names> {
     using BasicSegmentQuery<TSegmentReader, segment_names>::BasicSegmentQuery;
 
-    std::vector<typename TSegmentReader::Iterator::value_type> exec_into_vector(uint64_t first_id, uint64_t count) {
+    std::optional<std::vector<typename TSegmentReader::Iterator::value_type>> exec(uint64_t first_id, uint64_t count) {
         auto offset = this->index_.lookup_by_data_id(first_id);
         if (!offset) {
-            return {};
+            return std::nullopt;
         }
 
         return this->reader_.read_into_vector(*offset, count);

--- a/silkworm/db/datastore/snapshots/basic_queries.hpp
+++ b/silkworm/db/datastore/snapshots/basic_queries.hpp
@@ -27,9 +27,9 @@
 namespace silkworm::snapshots {
 
 template <segment::SegmentReaderConcept TSegmentReader>
-class BasicQuery {
+class BasicSegmentQuery {
   public:
-    explicit BasicQuery(
+    explicit BasicSegmentQuery(
         const SegmentAndAccessorIndex segment_and_index)
         : reader_{segment_and_index.segment},
           index_{segment_and_index.index} {}
@@ -40,8 +40,8 @@ class BasicQuery {
 };
 
 template <segment::SegmentReaderConcept TSegmentReader>
-struct FindByIdQuery : public BasicQuery<TSegmentReader> {
-    using BasicQuery<TSegmentReader>::BasicQuery;
+struct FindByIdSegmentQuery : public BasicSegmentQuery<TSegmentReader> {
+    using BasicSegmentQuery<TSegmentReader>::BasicSegmentQuery;
 
     std::optional<typename TSegmentReader::Iterator::value_type> exec(uint64_t id) {
         auto offset = this->index_.lookup_by_data_id(id);
@@ -54,8 +54,8 @@ struct FindByIdQuery : public BasicQuery<TSegmentReader> {
 };
 
 template <segment::SegmentReaderConcept TSegmentReader>
-struct FindByHashQuery : public BasicQuery<TSegmentReader> {
-    using BasicQuery<TSegmentReader>::BasicQuery;
+struct FindByHashSegmentQuery : public BasicSegmentQuery<TSegmentReader> {
+    using BasicSegmentQuery<TSegmentReader>::BasicSegmentQuery;
 
     std::optional<typename TSegmentReader::Iterator::value_type> exec(const Hash& hash) {
         auto offset = this->index_.lookup_by_hash(hash);
@@ -75,8 +75,8 @@ struct FindByHashQuery : public BasicQuery<TSegmentReader> {
 };
 
 template <segment::SegmentReaderConcept TSegmentReader>
-struct RangeFromIdQuery : public BasicQuery<TSegmentReader> {
-    using BasicQuery<TSegmentReader>::BasicQuery;
+struct RangeFromIdSegmentQuery : public BasicSegmentQuery<TSegmentReader> {
+    using BasicSegmentQuery<TSegmentReader>::BasicSegmentQuery;
 
     std::vector<typename TSegmentReader::Iterator::value_type> exec_into_vector(uint64_t first_id, uint64_t count) {
         auto offset = this->index_.lookup_by_data_id(first_id);

--- a/silkworm/db/datastore/snapshots/common/util/iterator/map_values_view.hpp
+++ b/silkworm/db/datastore/snapshots/common/util/iterator/map_values_view.hpp
@@ -21,7 +21,7 @@
 #include <ranges>
 #include <utility>
 
-namespace silkworm {
+namespace silkworm::map_values_view::fallback {
 
 template <typename TMapKey, typename TMapValue>
 class MapValuesView : std::ranges::view_interface<MapValuesView<TMapKey, TMapValue>> {
@@ -75,16 +75,44 @@ class MapValuesView : std::ranges::view_interface<MapValuesView<TMapKey, TMapVal
     Iterator end_;
 };
 
+}  // namespace silkworm::map_values_view::fallback
+
+namespace silkworm::map_values_view::builtin {
+
 template <typename TMapKey, typename TMapValue>
-auto make_map_values_view(const std::map<TMapKey, TMapValue>& map) {
-    // std::views::values is not present on clang 15
+class MapValuesView : public std::ranges::view_interface<MapValuesView<TMapKey, TMapValue>> {
+  public:
+    using Map = std::map<TMapKey, TMapValue>;
+
+    explicit MapValuesView(const Map& map)
+        : base_view_{std::views::values(map)} {}
+
+    auto begin() const { return base_view_.begin(); }
+    auto end() const { return base_view_.end(); }
+
+  private:
+    decltype(std::views::values([]() -> const Map& { throw 1; }())) base_view_;
+};
+
+}  // namespace silkworm::map_values_view::builtin
+
+namespace silkworm {
+
+// std::views::values is not present on clang 15
 #if defined(__clang__) && (__clang_major__ <= 15) && !defined(__apple_build_version__)
-    return MapValuesView<TMapKey, TMapValue>{map};
+using silkworm::map_values_view::fallback::MapValuesView;
 #elif defined(__clang__) && (__clang_major__ <= 14) && defined(__apple_build_version__)  // clang 15 == Apple clang 14
-    return MapValuesView<TMapKey, TMapValue>{map};
+using silkworm::map_values_view::fallback::MapValuesView;
 #else
-    return std::views::values(map);
+using silkworm::map_values_view::builtin::MapValuesView;
 #endif
+
+template <typename TMapKey, typename TMapValue>
+MapValuesView<TMapKey, TMapValue> make_map_values_view(const std::map<TMapKey, TMapValue>& map) {
+    return MapValuesView<TMapKey, TMapValue>{map};
 }
+
+template <typename TMapKey, typename TMapValue>
+using MapValuesViewReverse = decltype(std::ranges::reverse_view([]() -> MapValuesView<TMapKey, TMapValue>&& { throw 1; }()));
 
 }  // namespace silkworm

--- a/silkworm/db/datastore/snapshots/elias_fano/elias_fano.hpp
+++ b/silkworm/db/datastore/snapshots/elias_fano/elias_fano.hpp
@@ -148,7 +148,10 @@ class EliasFanoList32 {
         std::copy(data.begin(), data.end(), reinterpret_cast<uint8_t*>(data_.data()));
     }
 
-    size_t sequence_length() const { return count_ + 1; }
+    size_t sequence_length() const {
+        if (u_ == 0) return 0;
+        return count_ + 1;
+    }
 
     size_t count() const { return count_; }
 
@@ -254,7 +257,13 @@ class EliasFanoList32 {
                (data_ == other.data_);
     }
 
+    static EliasFanoList32 empty_list() {
+        return EliasFanoList32{};
+    }
+
   private:
+    EliasFanoList32() {}
+
     uint64_t derive_fields() {
         l_ = u_ / (count_ + 1) == 0 ? 0 : 63 ^ static_cast<uint64_t>(std::countl_zero(u_ / (count_ + 1)));
         lower_bits_mask_ = (uint64_t{1} << l_) - 1;

--- a/silkworm/db/datastore/snapshots/elias_fano/elias_fano_decoder.hpp
+++ b/silkworm/db/datastore/snapshots/elias_fano/elias_fano_decoder.hpp
@@ -24,7 +24,7 @@
 namespace silkworm::snapshots::elias_fano {
 
 struct EliasFanoDecoder : public snapshots::Decoder {
-    std::optional<EliasFanoList32> value;
+    EliasFanoList32 value{EliasFanoList32::empty_list()};
 
     ~EliasFanoDecoder() override = default;
 

--- a/silkworm/db/datastore/snapshots/elias_fano/elias_fano_decoder_test.cpp
+++ b/silkworm/db/datastore/snapshots/elias_fano/elias_fano_decoder_test.cpp
@@ -36,7 +36,6 @@ TEST_CASE("EliasFanoDecoder") {
 
     EliasFanoDecoder decoder;
     decoder.decode_word(string_view_to_byte_view(expected_list_str));
-    REQUIRE(decoder.value.has_value());
     CHECK(decoder.value == expected_list);
 }
 

--- a/silkworm/db/datastore/snapshots/index_builders_factory.hpp
+++ b/silkworm/db/datastore/snapshots/index_builders_factory.hpp
@@ -16,14 +16,11 @@
 
 #pragma once
 
-#include <filesystem>
-#include <functional>
 #include <memory>
 #include <vector>
 
 #include "common/snapshot_path.hpp"
 #include "index_builder.hpp"
-#include "snapshot_bundle.hpp"
 
 namespace silkworm::snapshots {
 

--- a/silkworm/db/datastore/snapshots/rec_split/accessor_index.hpp
+++ b/silkworm/db/datastore/snapshots/rec_split/accessor_index.hpp
@@ -16,54 +16,33 @@
 
 #pragma once
 
-#include <cstdint>
-#include <memory>
 #include <optional>
-
-#include <silkworm/core/common/assert.hpp>
-#include <silkworm/core/types/hash.hpp>
 
 #include "../common/snapshot_path.hpp"
 #include "rec_split.hpp"
 
 namespace silkworm::snapshots::rec_split {
 
-class AccessorIndex {
+class AccessorIndex : private RecSplitIndex {
   public:
     explicit AccessorIndex(
         SnapshotPath path,
         std::optional<MemoryMappedRegion> region = std::nullopt)
-        : path_{std::move(path)},
-          index_{path_.path(), region} {
+        : RecSplitIndex{path.path(), region},
+          path_{std::move(path)} {
     }
 
-    std::optional<size_t> lookup_by_data_id(uint64_t id) const {
-        return index_.lookup_by_data_id(id);
-    }
+    using RecSplitIndex::lookup_by_data_id;
+    using RecSplitIndex::lookup_by_key;
 
-    std::optional<size_t> lookup_by_hash(const Hash& hash) const {
-        return index_.lookup_by_key(hash);
-    }
-
-    std::optional<size_t> lookup_ordinal_by_hash(const Hash& hash) const {
-        auto [result, found] = index_.lookup(hash);
-        return found ? std::optional{result} : std::nullopt;
-    }
+    using RecSplitIndex::base_data_id;
+    using RecSplitIndex::memory_file_region;
 
     const SnapshotPath& path() const { return path_; }
     const std::filesystem::path& fs_path() const { return path_.path(); }
 
-    MemoryMappedRegion memory_file_region() const {
-        return index_.memory_file_region();
-    }
-
-    uint64_t base_data_id() const {
-        return index_.base_data_id();
-    }
-
   private:
     SnapshotPath path_;
-    rec_split::RecSplitIndex index_;
 };
 
 }  // namespace silkworm::snapshots::rec_split

--- a/silkworm/db/datastore/snapshots/rec_split/rec_split_par_test.cpp
+++ b/silkworm/db/datastore/snapshots/rec_split/rec_split_par_test.cpp
@@ -254,9 +254,9 @@ TEST_CASE("RecSplit8-Par: double index lookup", "[silkworm][node][recsplit]") {
 
     RecSplit8 rs2{settings.index_path};
     for (size_t i{0}; i < settings.keys_count; ++i) {
-        const auto [enumeration_index, found] = rs2.lookup("key " + std::to_string(i));
+        const auto enumeration_index = rs2.lookup_ordinal_by_key("key " + std::to_string(i));
+        REQUIRE(enumeration_index);
         CHECK(enumeration_index == i);
-        CHECK(found);
         CHECK(rs2.lookup_by_ordinal(enumeration_index) == i * 17);
     }
 }

--- a/silkworm/db/datastore/snapshots/rec_split/rec_split_seq_test.cpp
+++ b/silkworm/db/datastore/snapshots/rec_split/rec_split_seq_test.cpp
@@ -249,9 +249,9 @@ TEST_CASE("RecSplit8: double index lookup", "[silkworm][snapshots][recsplit]") {
 
     RecSplit8 rs2{settings.index_path};
     for (size_t i{0}; i < settings.keys_count; ++i) {
-        const auto [enumeration_index, found] = rs2.lookup("key " + std::to_string(i));
+        const auto enumeration_index = rs2.lookup_ordinal_by_key("key " + std::to_string(i));
+        REQUIRE(enumeration_index);
         CHECK(enumeration_index == i);
-        CHECK(found);
         CHECK(rs2.lookup_by_ordinal(enumeration_index) == i * 17);
     }
 }

--- a/silkworm/db/datastore/snapshots/segment_and_accessor_index.hpp
+++ b/silkworm/db/datastore/snapshots/segment_and_accessor_index.hpp
@@ -16,6 +16,9 @@
 
 #pragma once
 
+#include <array>
+
+#include "../common/entity_name.hpp"
 #include "rec_split/accessor_index.hpp"
 #include "segment/segment_reader.hpp"
 
@@ -24,6 +27,14 @@ namespace silkworm::snapshots {
 struct SegmentAndAccessorIndex {
     const segment::SegmentFileReader& segment;
     const rec_split::AccessorIndex& index;
+};
+
+using SegmentAndAccessorIndexNames = std::array<datastore::EntityName, 3>;
+
+struct SegmentAndAccessorIndexProvider {
+    virtual ~SegmentAndAccessorIndexProvider() = default;
+    virtual SegmentAndAccessorIndex segment_and_accessor_index(
+        const SegmentAndAccessorIndexNames& names) const = 0;
 };
 
 }  // namespace silkworm::snapshots

--- a/silkworm/db/datastore/snapshots/snapshot_bundle.hpp
+++ b/silkworm/db/datastore/snapshots/snapshot_bundle.hpp
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <array>
 #include <filesystem>
 #include <functional>
 #include <vector>
@@ -75,7 +74,7 @@ struct SnapshotBundlePaths {
     StepRange step_range_;
 };
 
-struct SnapshotBundle {
+struct SnapshotBundle : public SegmentAndAccessorIndexProvider {
     using StepRange = datastore::StepRange;
 
     SnapshotBundle(StepRange step_range, SnapshotBundleData data)
@@ -90,7 +89,7 @@ struct SnapshotBundle {
               range,
               open_bundle_data(schema, dir_path, range),
           } {}
-    virtual ~SnapshotBundle();
+    ~SnapshotBundle() override;
 
     SnapshotBundle(SnapshotBundle&&) = default;
     SnapshotBundle& operator=(SnapshotBundle&&) noexcept = default;
@@ -105,7 +104,7 @@ struct SnapshotBundle {
         datastore::EntityName entity_name,
         datastore::EntityName index_name) const;
     SegmentAndAccessorIndex segment_and_accessor_index(
-        std::array<datastore::EntityName, 3> names) const {
+        const SegmentAndAccessorIndexNames& names) const override {
         return {
             segment(names[0], names[1]),
             accessor_index(names[0], names[2]),

--- a/silkworm/db/datastore/snapshots/snapshot_repository.cpp
+++ b/silkworm/db/datastore/snapshots/snapshot_repository.cpp
@@ -23,6 +23,8 @@
 #include <silkworm/infra/common/ensure.hpp>
 #include <silkworm/infra/common/log.hpp>
 
+#include "index_builders_factory.hpp"
+
 namespace silkworm::snapshots {
 
 namespace fs = std::filesystem;

--- a/silkworm/db/datastore/snapshots/snapshot_repository.cpp
+++ b/silkworm/db/datastore/snapshots/snapshot_repository.cpp
@@ -93,9 +93,9 @@ Step SnapshotRepository::max_end_step() const {
 }
 
 std::pair<std::optional<SegmentAndAccessorIndex>, std::shared_ptr<SnapshotBundle>> SnapshotRepository::find_segment(
-    std::array<datastore::EntityName, 3> names,
+    const SegmentAndAccessorIndexNames& names,
     Timestamp t) const {
-    auto bundle = find_bundle(step_converter_->step_from_timestamp(t));
+    auto bundle = find_bundle(t);
     if (bundle) {
         return {bundle->segment_and_accessor_index(names), bundle};
     }
@@ -154,6 +154,10 @@ void SnapshotRepository::reopen_folder() {
 
     SILK_INFO << "Total reopened bundles: " << bundles_count()
               << " max block available: " << max_block_available();
+}
+
+std::shared_ptr<SnapshotBundle> SnapshotRepository::find_bundle(Timestamp t) const {
+    return find_bundle(step_converter_->step_from_timestamp(t));
 }
 
 std::shared_ptr<SnapshotBundle> SnapshotRepository::find_bundle(Step step) const {

--- a/silkworm/db/datastore/snapshots/snapshot_repository.hpp
+++ b/silkworm/db/datastore/snapshots/snapshot_repository.hpp
@@ -90,8 +90,9 @@ class SnapshotRepository : public SnapshotRepositoryROAccess {
     }
 
     std::pair<std::optional<SegmentAndAccessorIndex>, std::shared_ptr<SnapshotBundle>> find_segment(
-        std::array<datastore::EntityName, 3> names,
+        const SegmentAndAccessorIndexNames& names,
         Timestamp t) const override;
+    std::shared_ptr<SnapshotBundle> find_bundle(Timestamp t) const override;
     std::shared_ptr<SnapshotBundle> find_bundle(Step step) const override;
 
     std::vector<std::shared_ptr<SnapshotBundle>> bundles_in_range(StepRange range) const override;

--- a/silkworm/db/datastore/snapshots/snapshot_repository.hpp
+++ b/silkworm/db/datastore/snapshots/snapshot_repository.hpp
@@ -29,22 +29,21 @@
 
 #include "../common/entity_name.hpp"
 #include "common/snapshot_path.hpp"
-#include "common/util/iterator/map_values_view.hpp"
-#include "index_builder.hpp"
-#include "index_builders_factory.hpp"
 #include "segment_and_accessor_index.hpp"
 #include "snapshot_bundle.hpp"
+#include "snapshot_repository_ro_access.hpp"
 
 namespace silkworm::snapshots {
 
 struct IndexBuilder;
+struct IndexBuildersFactory;
 
 //! Read-only repository for all snapshot files.
 //! @details Some simplifications are currently in place:
 //! - all snapshots of given blocks range must exist (to make such range available)
 //! - gaps in blocks range are not allowed
 //! - segments have [from:to) semantic
-class SnapshotRepository {
+class SnapshotRepository : public SnapshotRepositoryROAccess {
   public:
     using Timestamp = datastore::Timestamp;
     using Step = datastore::Step;
@@ -60,6 +59,8 @@ class SnapshotRepository {
     SnapshotRepository(SnapshotRepository&&) = default;
     SnapshotRepository& operator=(SnapshotRepository&&) noexcept = default;
 
+    ~SnapshotRepository() override = default;
+
     const std::filesystem::path& path() const { return dir_path_; }
     const Schema::RepositoryDef& schema() const { return schema_; };
 
@@ -70,51 +71,30 @@ class SnapshotRepository {
     //! Replace bundles whose ranges are contained within the given bundle
     void replace_snapshot_bundles(SnapshotBundle bundle);
 
-    size_t bundles_count() const;
+    size_t bundles_count() const override;
 
-    //! All types of .seg and .idx files are available up to this block number
-    BlockNum max_block_available() const;
-    Timestamp max_timestamp_available() const;
+    BlockNum max_block_available() const override;
+    Timestamp max_timestamp_available() const override;
 
     std::vector<std::shared_ptr<IndexBuilder>> missing_indexes() const;
     void remove_stale_indexes() const;
     void build_indexes(const SnapshotBundlePaths& bundle) const;
 
-    using Bundles = std::map<Step, std::shared_ptr<SnapshotBundle>>;
-
-    template <class TBaseView>
-    class BundlesView : public std::ranges::view_interface<BundlesView<TBaseView>> {
-      public:
-        BundlesView(
-            TBaseView base_view,
-            std::shared_ptr<Bundles> bundles)
-            : base_view_(std::move(base_view)),
-              bundles_(std::move(bundles)) {}
-
-        auto begin() const { return base_view_.begin(); }
-        auto end() const { return base_view_.end(); }
-
-      private:
-        TBaseView base_view_;
-        std::shared_ptr<Bundles> bundles_{};
-    };
-
-    auto view_bundles() const {
+    BundlesView<MapValuesView<Bundles::key_type, Bundles::mapped_type>> view_bundles() const override {
         std::scoped_lock lock(*bundles_mutex_);
         return BundlesView{make_map_values_view(*bundles_), bundles_};
     }
-
-    auto view_bundles_reverse() const {
+    BundlesView<MapValuesViewReverse<Bundles::key_type, Bundles::mapped_type>> view_bundles_reverse() const override {
         std::scoped_lock lock(*bundles_mutex_);
         return BundlesView{std::ranges::reverse_view(make_map_values_view(*bundles_)), bundles_};
     }
 
     std::pair<std::optional<SegmentAndAccessorIndex>, std::shared_ptr<SnapshotBundle>> find_segment(
         std::array<datastore::EntityName, 3> names,
-        Timestamp t) const;
-    std::shared_ptr<SnapshotBundle> find_bundle(Step step) const;
+        Timestamp t) const override;
+    std::shared_ptr<SnapshotBundle> find_bundle(Step step) const override;
 
-    std::vector<std::shared_ptr<SnapshotBundle>> bundles_in_range(StepRange range) const;
+    std::vector<std::shared_ptr<SnapshotBundle>> bundles_in_range(StepRange range) const override;
 
   private:
     Step max_end_step() const;

--- a/silkworm/db/datastore/snapshots/snapshot_repository_ro_access.hpp
+++ b/silkworm/db/datastore/snapshots/snapshot_repository_ro_access.hpp
@@ -1,0 +1,79 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <array>
+#include <map>
+#include <memory>
+#include <optional>
+#include <ranges>
+#include <utility>
+#include <vector>
+
+#include "../common/entity_name.hpp"
+#include "../common/step.hpp"
+#include "common/util/iterator/map_values_view.hpp"
+#include "segment_and_accessor_index.hpp"
+
+namespace silkworm::snapshots {
+
+struct SnapshotBundle;
+
+struct SnapshotRepositoryROAccess {
+    using Timestamp = datastore::Timestamp;
+    using Step = datastore::Step;
+    using StepRange = datastore::StepRange;
+    using Bundles = std::map<Step, std::shared_ptr<SnapshotBundle>>;
+
+    template <class TBaseView>
+    class BundlesView : public std::ranges::view_interface<BundlesView<TBaseView>> {
+      public:
+        BundlesView(
+            TBaseView base_view,
+            std::shared_ptr<Bundles> bundles)
+            : base_view_(std::move(base_view)),
+              bundles_(std::move(bundles)) {}
+
+        auto begin() const { return base_view_.begin(); }
+        auto end() const { return base_view_.end(); }
+
+      private:
+        TBaseView base_view_;
+        std::shared_ptr<Bundles> bundles_{};
+    };
+
+    virtual ~SnapshotRepositoryROAccess() = default;
+
+    virtual size_t bundles_count() const = 0;
+
+    //! All types of .seg and .idx files are available up to this block number
+    virtual BlockNum max_block_available() const = 0;
+    //! All types of .seg and .idx files are available up to this timestamp
+    virtual Timestamp max_timestamp_available() const = 0;
+
+    virtual BundlesView<MapValuesView<Bundles::key_type, Bundles::mapped_type>> view_bundles() const = 0;
+    virtual BundlesView<MapValuesViewReverse<Bundles::key_type, Bundles::mapped_type>> view_bundles_reverse() const = 0;
+
+    virtual std::pair<std::optional<SegmentAndAccessorIndex>, std::shared_ptr<SnapshotBundle>> find_segment(
+        std::array<datastore::EntityName, 3> names,
+        Timestamp t) const = 0;
+    virtual std::shared_ptr<SnapshotBundle> find_bundle(Step step) const = 0;
+
+    virtual std::vector<std::shared_ptr<SnapshotBundle>> bundles_in_range(StepRange range) const = 0;
+};
+
+}  // namespace silkworm::snapshots

--- a/silkworm/db/datastore/snapshots/snapshot_repository_ro_access.hpp
+++ b/silkworm/db/datastore/snapshots/snapshot_repository_ro_access.hpp
@@ -69,8 +69,9 @@ struct SnapshotRepositoryROAccess {
     virtual BundlesView<MapValuesViewReverse<Bundles::key_type, Bundles::mapped_type>> view_bundles_reverse() const = 0;
 
     virtual std::pair<std::optional<SegmentAndAccessorIndex>, std::shared_ptr<SnapshotBundle>> find_segment(
-        std::array<datastore::EntityName, 3> names,
+        const SegmentAndAccessorIndexNames& names,
         Timestamp t) const = 0;
+    virtual std::shared_ptr<SnapshotBundle> find_bundle(Timestamp t) const = 0;
     virtual std::shared_ptr<SnapshotBundle> find_bundle(Step step) const = 0;
 
     virtual std::vector<std::shared_ptr<SnapshotBundle>> bundles_in_range(StepRange range) const = 0;

--- a/silkworm/db/freezer.cpp
+++ b/silkworm/db/freezer.cpp
@@ -61,7 +61,7 @@ static BlockNum get_first_stored_header_num(ROTxn& txn) {
 }
 
 static std::optional<uint64_t> get_next_base_txn_id(SnapshotRepository& repository, BlockNum block_num) {
-    auto body = BodyFindByBlockNumMultiQuery{repository}.exec(block_num);
+    auto body = BodyFindByBlockNumQuery{repository}.exec(block_num);
     if (!body) return std::nullopt;
     return body->base_txn_id + body->txn_count;
 }

--- a/silkworm/db/snapshot_repository_test.cpp
+++ b/silkworm/db/snapshot_repository_test.cpp
@@ -229,7 +229,7 @@ TEST_CASE("SnapshotRepository::find_block_num", "[silkworm][node][snapshot]") {
 
     auto repository = make_repository(tmp_dir.path());
 
-    TransactionBlockNumByTxnHashMultiQuery query{repository.view_bundles_reverse()};
+    TransactionBlockNumByTxnHashQuery query{repository.view_bundles_reverse()};
 
     // known block 1'500'012 txn hash
     auto block_num = query.exec(silkworm::Hash{from_hex("0x2224c39c930355233f11414e9f216f381c1f6b0c32fc77b192128571c2dc9eb9").value()});

--- a/silkworm/db/snapshot_repository_test.cpp
+++ b/silkworm/db/snapshot_repository_test.cpp
@@ -229,7 +229,7 @@ TEST_CASE("SnapshotRepository::find_block_num", "[silkworm][node][snapshot]") {
 
     auto repository = make_repository(tmp_dir.path());
 
-    TransactionBlockNumByTxnHashQuery query{repository.view_bundles_reverse()};
+    TransactionBlockNumByTxnHashQuery query{repository};
 
     // known block 1'500'012 txn hash
     auto block_num = query.exec(silkworm::Hash{from_hex("0x2224c39c930355233f11414e9f216f381c1f6b0c32fc77b192128571c2dc9eb9").value()});

--- a/silkworm/db/snapshot_test.cpp
+++ b/silkworm/db/snapshot_test.cpp
@@ -211,18 +211,18 @@ TEST_CASE("TransactionSnapshot::txn_range OK", "[silkworm][node][snapshot][index
     TransactionRangeFromIdSegmentQuery query{{txn_segment, idx_txn_hash}};
 
     // block 1'500'012: base_txn_id is 7'341'263, txn_count is 7
-    CHECK(query.exec_into_vector(7'341'263, 0).empty());
-    CHECK(query.exec_into_vector(7'341'263, 7).size() == 7);
+    CHECK(query.exec(7'341'263, 0)->empty());
+    CHECK(query.exec(7'341'263, 7)->size() == 7);
 
     // block 1'500'013: base_txn_id is 7'341'272, txn_count is 1
-    CHECK(query.exec_into_vector(7'341'272, 0).empty());
-    CHECK(query.exec_into_vector(7'341'272, 1).size() == 1);
+    CHECK(query.exec(7'341'272, 0)->empty());
+    CHECK(query.exec(7'341'272, 1)->size() == 1);
 
     // invalid base_txn_id returns empty
-    CHECK(query.exec_into_vector(0, 1).empty());
-    CHECK(query.exec_into_vector(10'000'000, 1).empty());
-    CHECK(query.exec_into_vector(7'341'261, 1).empty());  // before the first system tx
-    CHECK(query.exec_into_vector(7'341'274, 1).empty());  // after the last system tx
+    CHECK_FALSE(query.exec(0, 1));
+    CHECK_FALSE(query.exec(10'000'000, 1));
+    CHECK_FALSE(query.exec(7'341'261, 1));  // before the first system tx
+    CHECK_FALSE(query.exec(7'341'274, 1));  // after the last system tx
 }
 
 TEST_CASE("TransactionSnapshot::txn_rlp_range OK", "[silkworm][node][snapshot][index]") {
@@ -240,18 +240,18 @@ TEST_CASE("TransactionSnapshot::txn_rlp_range OK", "[silkworm][node][snapshot][i
     TransactionPayloadRlpRangeFromIdSegmentQuery query{{txn_segment, idx_txn_hash}};
 
     // block 1'500'012: base_txn_id is 7'341'263, txn_count is 7
-    CHECK(query.exec_into_vector(7'341'263, 0).empty());
-    CHECK(query.exec_into_vector(7'341'263, 7).size() == 7);
+    CHECK(query.exec(7'341'263, 0)->empty());
+    CHECK(query.exec(7'341'263, 7)->size() == 7);
 
     // block 1'500'013: base_txn_id is 7'341'272, txn_count is 1
-    CHECK(query.exec_into_vector(7'341'272, 0).empty());
-    CHECK(query.exec_into_vector(7'341'272, 1).size() == 1);
+    CHECK(query.exec(7'341'272, 0)->empty());
+    CHECK(query.exec(7'341'272, 1)->size() == 1);
 
     // invalid base_txn_id returns empty
-    CHECK(query.exec_into_vector(0, 1).empty());
-    CHECK(query.exec_into_vector(10'000'000, 1).empty());
-    CHECK(query.exec_into_vector(7'341'261, 1).empty());  // before the first system tx
-    CHECK(query.exec_into_vector(7'341'274, 1).empty());  // after the last system tx
+    CHECK_FALSE(query.exec(0, 1));
+    CHECK_FALSE(query.exec(10'000'000, 1));
+    CHECK_FALSE(query.exec(7'341'261, 1));  // before the first system tx
+    CHECK_FALSE(query.exec(7'341'274, 1));  // after the last system tx
 }
 
 TEST_CASE("slice_tx_payload", "[silkworm][node][snapshot]") {

--- a/silkworm/db/snapshot_test.cpp
+++ b/silkworm/db/snapshot_test.cpp
@@ -78,7 +78,7 @@ TEST_CASE("HeaderSnapshot::header_by_number OK", "[silkworm][node][snapshot][ind
     SegmentFileReader header_segment{header_segment_path};
 
     AccessorIndex idx_header_hash{header_segment_path.related_path_ext(db::blocks::kIdxExtension)};
-    HeaderFindByBlockNumQuery header_by_number{{header_segment, idx_header_hash}};
+    HeaderFindByBlockNumSegmentQuery header_by_number{{header_segment, idx_header_hash}};
 
     CHECK(!header_by_number.exec(1'500'011));
     CHECK(header_by_number.exec(1'500'012));
@@ -118,7 +118,7 @@ TEST_CASE("BodySnapshot::body_by_number OK", "[silkworm][node][snapshot][index]"
     SegmentFileReader body_segment{body_segment_path};
 
     AccessorIndex idx_body_number{body_segment_path.related_path_ext(db::blocks::kIdxExtension)};
-    BodyFindByBlockNumQuery body_by_number{{body_segment, idx_body_number}};
+    BodyFindByBlockNumSegmentQuery body_by_number{{body_segment, idx_body_number}};
 
     CHECK(!body_by_number.exec(1'500'011));
     CHECK(body_by_number.exec(1'500'012));
@@ -144,7 +144,7 @@ TEST_CASE("TransactionSnapshot::txn_by_id OK", "[silkworm][node][snapshot][index
     SegmentFileReader txn_segment{txn_segment_path};
 
     AccessorIndex idx_txn_hash{txn_segment_path.related_path_ext(db::blocks::kIdxExtension)};
-    TransactionFindByIdQuery txn_by_id{{txn_segment, idx_txn_hash}};
+    TransactionFindByIdSegmentQuery txn_by_id{{txn_segment, idx_txn_hash}};
 
     const auto transaction = txn_by_id.exec(7'341'272);
     CHECK(transaction.has_value());
@@ -170,10 +170,10 @@ TEST_CASE("TransactionSnapshot::block_num_by_txn_hash OK", "[silkworm][node][sna
     SegmentFileReader txn_segment{txn_segment_path};
 
     AccessorIndex idx_txn_hash{txn_segment_path.related_path_ext(db::blocks::kIdxExtension)};
-    TransactionFindByIdQuery txn_by_id{{txn_segment, idx_txn_hash}};
+    TransactionFindByIdSegmentQuery txn_by_id{{txn_segment, idx_txn_hash}};
 
     AccessorIndex idx_txn_hash_2_block{txn_segment_path.related_path(std::string{db::blocks::kIdxTxnHash2BlockTag}, db::blocks::kIdxExtension)};
-    TransactionBlockNumByTxnHashQuery block_num_by_txn_hash{idx_txn_hash_2_block, TransactionFindByHashQuery{{txn_segment, idx_txn_hash}}};
+    TransactionBlockNumByTxnHashSegmentQuery block_num_by_txn_hash{idx_txn_hash_2_block, TransactionFindByHashSegmentQuery{{txn_segment, idx_txn_hash}}};
 
     // block 1'500'012: base_txn_id is 7'341'263, txn_count is 7
     auto transaction = txn_by_id.exec(7'341'269);  // known txn id in block 1'500'012
@@ -208,7 +208,7 @@ TEST_CASE("TransactionSnapshot::txn_range OK", "[silkworm][node][snapshot][index
     SegmentFileReader txn_segment{txn_segment_path};
 
     AccessorIndex idx_txn_hash{txn_segment_path.related_path_ext(db::blocks::kIdxExtension)};
-    TransactionRangeFromIdQuery query{{txn_segment, idx_txn_hash}};
+    TransactionRangeFromIdSegmentQuery query{{txn_segment, idx_txn_hash}};
 
     // block 1'500'012: base_txn_id is 7'341'263, txn_count is 7
     CHECK(query.exec_into_vector(7'341'263, 0).empty());
@@ -237,7 +237,7 @@ TEST_CASE("TransactionSnapshot::txn_rlp_range OK", "[silkworm][node][snapshot][i
     SegmentFileReader txn_segment{txn_segment_path};
 
     AccessorIndex idx_txn_hash{txn_segment_path.related_path_ext(db::blocks::kIdxExtension)};
-    TransactionPayloadRlpRangeFromIdQuery query{{txn_segment, idx_txn_hash}};
+    TransactionPayloadRlpRangeFromIdSegmentQuery query{{txn_segment, idx_txn_hash}};
 
     // block 1'500'012: base_txn_id is 7'341'263, txn_count is 7
     CHECK(query.exec_into_vector(7'341'263, 0).empty());


### PR DESCRIPTION
* switch names: Query -> SegmentQuery, MultiQuery -> Query
* simplify TransactionBlockNumByTxnHashMultiQuery to follow a "multi-bundle query" pattern
* SnapshotRepository read-only interface for queries
* multi-bundle queries: FindMapQuery, FindByTimestampMapQuery
* access_layer DataModel refactoring to use multi-bundle queries
* refactor RecSplitIndex ordinal lookup: improve type safety and naming
* non-null EliasFanoDecoder value
* KVSegmentValuesReader
