### PR TITLE
rpcdaemon: debug_traceBlockByNumber support for block tags

### DIFF
--- a/.github/workflows/rpc-integration-tests.yml
+++ b/.github/workflows/rpc-integration-tests.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout RPC Tests Repository & Install Requirements
         run: |
           rm -rf ${{runner.workspace}}/rpc-tests
-          git -c advice.detachedHead=false clone --depth 1 --branch v1.32.0 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
+          git -c advice.detachedHead=false clone --depth 1 --branch v1.33.0 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
           cd ${{runner.workspace}}/rpc-tests
           pip3 install -r requirements.txt --break-system-packages
 

--- a/.github/workflows/run_integration_tests.sh
+++ b/.github/workflows/run_integration_tests.sh
@@ -28,7 +28,7 @@ debug_traceBlockByNumber/test_09,\
 debug_traceBlockByNumber/test_10,\
 debug_traceBlockByNumber/test_11,\
 debug_traceBlockByNumber/test_12,\
-debug_traceBlockByNumber/test_21,\
+debug_traceBlockByNumber/test_29,\
 debug_traceTransaction/test_25.json,\
 debug_traceTransaction/test_36.json,\
 debug_traceTransaction/test_43.json,\


### PR DESCRIPTION
Add support for block number provided using tags in debug_traceBlockByNumber
Fixes #1802 