### PR TITLE
Don't compute hashes of empty requests

### DIFF
--- a/silkworm/core/types/eip_7685_requests.cpp
+++ b/silkworm/core/types/eip_7685_requests.cpp
@@ -77,10 +77,13 @@ Hash FlatRequests::calculate_sha256() const {
 
     for (const auto enum_type : magic_enum::enum_values<FlatRequestType>()) {
         const auto request_type = magic_enum::enum_integer(enum_type);
-        Bytes to_sha;
-        to_sha.push_back(request_type);
-        to_sha.append(requests_[request_type]);
-        intermediate.append(precompile::sha256_run(ByteView{to_sha}).value());
+        // Include intermediate hashes of non-empty requests only
+        if (!std::empty(requests_[request_type])) {
+            Bytes to_sha;
+            to_sha.push_back(request_type);
+            to_sha.append(requests_[request_type]);
+            intermediate.append(precompile::sha256_run(ByteView{to_sha}).value());
+        }
     }
     const auto final_bytes = precompile::sha256_run(intermediate).value();
     return Hash{final_bytes};

--- a/silkworm/core/types/eip_7685_requests_test.cpp
+++ b/silkworm/core/types/eip_7685_requests_test.cpp
@@ -58,6 +58,13 @@ TEST_CASE("EIP-7585 tests") {
         const auto hash = requests.calculate_sha256();
         CHECK(hash == Hash{from_hex("fb11d3d094091e34794c99218a862850a4a85dc1e128ce8c85f2a2bcbcc899ef").value()});
     }
+
+    SECTION("Calculate sha256 of empty requests") {
+        FlatRequests requests;
+
+        const auto hash = requests.calculate_sha256();
+        CHECK(hash == Hash{from_hex("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855").value()});
+    }
 }
 
 }  // namespace silkworm


### PR DESCRIPTION
Intermediate hashes of empty requests shouldn't be used for computing final signature. See: https://github.com/ethereum/EIPs/pull/8989