### PR TITLE
Fix typo Update README.md

### DIFF
--- a/tests/docker/README.md
+++ b/tests/docker/README.md
@@ -17,7 +17,7 @@ From time to time it is necessary to rebuild the whole docker image and refresh 
 ```bash
 ./run-docker.sh -r master
 ```
-Inside the Dockefile you can find a certain variations:
+Inside the Dockerfile you can find a certain variations:
 - build using different clang versions
 - build using local changes
 - run tests


### PR DESCRIPTION
I fixed a typo in the README.md file located in the tests/docker directory by correcting the word "Dockefile" to "Dockerfile".

Specific Change:
Before:
Inside the Dockefile you can find a certain variations:
After:
Inside the Dockerfile you can find a certain variations:
This update ensures the correct spelling of "Dockerfile," improving the accuracy and professionalism of the documentation.