### PR TITLE
core: address error=array-bounds in gcc14

### DIFF
--- a/silkworm/core/common/assert.hpp
+++ b/silkworm/core/common/assert.hpp
@@ -17,7 +17,7 @@
 #pragma once
 
 namespace silkworm {
-void abort_due_to_assertion_failure(char const* expr, char const* file, int line);
+[[noreturn]] void abort_due_to_assertion_failure(char const* expr, char const* file, int line);
 }
 
 // SILKWORM_ASSERT always aborts program execution on assertion failure, even when NDEBUG is defined.

--- a/silkworm/core/common/small_map.hpp
+++ b/silkworm/core/common/small_map.hpp
@@ -29,7 +29,7 @@
 namespace silkworm {
 
 // SmallMap is a constexpr-friendly immutable map suitable for a small number of elements.
-template <std::totally_ordered Key, std::default_initializable T, size_t max_size = 8>
+template <std::totally_ordered Key, std::default_initializable T, size_t maximum_size = 8>
 class SmallMap {
   public:
     using ValueType = std::pair<Key, T>;
@@ -37,7 +37,7 @@ class SmallMap {
     constexpr SmallMap() noexcept = default;
 
     constexpr SmallMap(std::initializer_list<ValueType> init) : size_(init.size()) {
-        SILKWORM_ASSERT(size_ <= max_size);
+        SILKWORM_ASSERT(size_ <= maximum_size);
         for (size_t i{0}; i < size_; ++i) {
             data_[i] = *(std::data(init) + i);
         }
@@ -47,14 +47,14 @@ class SmallMap {
     template <std::input_iterator InputIt>
     constexpr SmallMap(InputIt first, InputIt last) {
         for (InputIt it{first}; it != last; ++it) {
-            SILKWORM_ASSERT(size_ < max_size);
+            SILKWORM_ASSERT(size_ < maximum_size);
             data_[size_++] = *it;
         }
         sort();
     }
 
     constexpr SmallMap(const SmallMap& other) : size_{other.size_} {
-        for (size_t i{0}; i < max_size; ++i) {
+        for (size_t i{0}; i < maximum_size; ++i) {
             data_[i] = other.data_[i];
         }
     }
@@ -63,7 +63,7 @@ class SmallMap {
             return *this;
         }
         size_ = other.size_;
-        for (size_t i{0}; i < max_size; ++i) {
+        for (size_t i{0}; i < maximum_size; ++i) {
             data_[i] = other.data_[i];
         }
         return *this;
@@ -75,6 +75,10 @@ class SmallMap {
 
     constexpr size_t size() const noexcept {
         return size_;
+    }
+
+    static constexpr size_t max_size() noexcept {
+        return maximum_size;
     }
 
     constexpr auto begin() const noexcept {
@@ -110,7 +114,7 @@ class SmallMap {
                   [](const ValueType& a, const ValueType& b) { return a.first < b.first; });
     }
 
-    std::array<ValueType, max_size> data_{};
+    std::array<ValueType, maximum_size> data_{};
     size_t size_{0};
 };
 

--- a/silkworm/core/protocol/bor/config.cpp
+++ b/silkworm/core/protocol/bor/config.cpp
@@ -65,7 +65,9 @@ std::optional<Config> Config::from_json(const nlohmann::json& json) noexcept {
         const BlockNum from{std::stoull(item.key(), nullptr, 0)};
         period.emplace_back(from, item.value().get<uint64_t>());
     }
-    SILKWORM_ASSERT(period.size() <= config.period.max_size());
+    if (period.size() > config.period.max_size()) {
+        return std::nullopt;
+    }
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"
     config.period = {period.begin(), period.end()};
@@ -76,7 +78,9 @@ std::optional<Config> Config::from_json(const nlohmann::json& json) noexcept {
         const BlockNum from{std::stoull(item.key(), nullptr, 0)};
         sprint.emplace_back(from, item.value().get<uint64_t>());
     }
-    SILKWORM_ASSERT(sprint.size() <= config.sprint.max_size());
+    if (sprint.size() > config.sprint.max_size()) {
+        return std::nullopt;
+    }
     config.sprint = {sprint.begin(), sprint.end()};
 
     config.validator_contract = hex_to_address(json["validatorContract"].get<std::string>(), /*return_zero_on_err=*/true);

--- a/silkworm/core/protocol/bor/config.cpp
+++ b/silkworm/core/protocol/bor/config.cpp
@@ -70,6 +70,7 @@ std::optional<Config> Config::from_json(const nlohmann::json& json) noexcept {
     }
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"
+    // silence misdiagnostics in gcc 14
     config.period = {period.begin(), period.end()};
 #pragma GCC diagnostic pop
 

--- a/silkworm/core/protocol/bor/config.cpp
+++ b/silkworm/core/protocol/bor/config.cpp
@@ -65,13 +65,18 @@ std::optional<Config> Config::from_json(const nlohmann::json& json) noexcept {
         const BlockNum from{std::stoull(item.key(), nullptr, 0)};
         period.emplace_back(from, item.value().get<uint64_t>());
     }
+    SILKWORM_ASSERT(period.size() <= config.period.max_size());
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
     config.period = {period.begin(), period.end()};
+#pragma GCC diagnostic pop
 
     std::vector<std::pair<BlockNum, uint64_t>> sprint;
     for (const auto& item : json["sprint"].items()) {
         const BlockNum from{std::stoull(item.key(), nullptr, 0)};
         sprint.emplace_back(from, item.value().get<uint64_t>());
     }
+    SILKWORM_ASSERT(sprint.size() <= config.sprint.max_size());
     config.sprint = {sprint.begin(), sprint.end()};
 
     config.validator_contract = hex_to_address(json["validatorContract"].get<std::string>(), /*return_zero_on_err=*/true);


### PR DESCRIPTION
Address the following error when compling with gcc 14.2:
```
at /home/andrew/silkworm/silkworm/core/common/small_map.hpp:48:15,
    inlined from ‘static std::optional<silkworm::protocol::bor::Config> silkworm::protocol::bor::Config::from_json(const nlohmann::json_abi_v3_11_3::json&)’ at /home/andrew/silkworm/silkworm/core/protocol/bor/config.cpp:71:50:
/usr/include/c++/14/bits/stl_pair.h:607:48: error: array subscript [15, 576460752303423485] is outside array bounds of ‘const silkworm::SmallMap<long unsigned int, long unsigned int> [1]’ [-Werror=array-bounds=]
  607 |         second = std::forward<second_type>(__p.second);
      |                                            ~~~~^~~~~~
/home/andrew/silkworm/silkworm/core/protocol/bor/config.cpp: In static member function ‘static std::optional<silkworm::protocol::bor::Config> silkworm::protocol::bor::Config::from_json(const nlohmann::json_abi_v3_11_3::json&)’:
/home/andrew/silkworm/silkworm/core/protocol/bor/config.cpp:71:50: note: at offset [240, 9223372036854775760] into object ‘<anonymous>’ of size 136
   71 |     config.period = {period.begin(), period.end()};
      |                                                  ^
```