### PR TITLE
rpcdaemon: remove useless Catch2 expectations

### DIFF
--- a/silkworm/db/kv/state_reader_test.cpp
+++ b/silkworm/db/kv/state_reader_test.cpp
@@ -50,10 +50,6 @@ class StateReaderTest : public silkworm::test_util::ContextTestBase {
 };
 
 TEST_CASE_METHOD(StateReaderTest, "StateReader::read_account") {
-    EXPECT_CALL(transaction_, first_txn_num_in_block(0)).WillOnce(Invoke([]() -> Task<TxnId> {
-        co_return 0;
-    }));
-
     SECTION("no account for history empty and current state empty") {
         EXPECT_CALL(transaction_, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
             db::kv::api::GetAsOfResult response{
@@ -110,10 +106,6 @@ TEST_CASE_METHOD(StateReaderTest, "StateReader::read_account") {
 }
 
 TEST_CASE_METHOD(StateReaderTest, "StateReader::read_storage") {
-    EXPECT_CALL(transaction_, first_txn_num_in_block(0)).WillOnce(Invoke([]() -> Task<TxnId> {
-        co_return 0;
-    }));
-
     SECTION("empty storage for history empty and current state empty") {
         EXPECT_CALL(transaction_, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
             db::kv::api::GetAsOfResult response{
@@ -165,10 +157,6 @@ TEST_CASE_METHOD(StateReaderTest, "StateReader::read_code") {
     }
 
     SECTION("empty code found for code hash") {
-        EXPECT_CALL(transaction_, first_txn_num_in_block(0)).WillOnce(Invoke([]() -> Task<TxnId> {
-            co_return 0;
-        }));
-
         EXPECT_CALL(transaction_, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
             db::kv::api::GetAsOfResult response{
                 .success = true,
@@ -186,10 +174,6 @@ TEST_CASE_METHOD(StateReaderTest, "StateReader::read_code") {
     }
 
     SECTION("non-empty code found for code hash") {
-        EXPECT_CALL(transaction_, first_txn_num_in_block(0)).WillOnce(Invoke([]() -> Task<TxnId> {
-            co_return 0;
-        }));
-
         EXPECT_CALL(transaction_, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
             db::kv::api::GetAsOfResult response{
                 .success = true,

--- a/silkworm/execution/remote_state_test.cpp
+++ b/silkworm/execution/remote_state_test.cpp
@@ -63,9 +63,6 @@ TEST_CASE_METHOD(RemoteStateTest, "async remote buffer", "[rpc][core][remote_buf
     SECTION("read_code for non-empty hash") {
         static const Bytes kCode{*from_hex("0x0608")};
 
-        EXPECT_CALL(transaction, first_txn_num_in_block(1'000'001)).WillOnce(Invoke([]() -> Task<TxnId> {
-            co_return 0;
-        }));
         EXPECT_CALL(transaction, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
             db::kv::api::GetAsOfResult response{
                 .success = true,
@@ -81,9 +78,6 @@ TEST_CASE_METHOD(RemoteStateTest, "async remote buffer", "[rpc][core][remote_buf
     }
 
     SECTION("read_code with empty response from db") {
-        EXPECT_CALL(transaction, first_txn_num_in_block(1'000'001)).WillOnce(Invoke([]() -> Task<TxnId> {
-            co_return 0;
-        }));
         EXPECT_CALL(transaction, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
             db::kv::api::GetAsOfResult response{
                 .success = true,
@@ -118,9 +112,6 @@ TEST_CASE_METHOD(RemoteStateTest, "async remote buffer", "[rpc][core][remote_buf
     }
 
     SECTION("read_account with empty response from db") {
-        EXPECT_CALL(transaction, first_txn_num_in_block(1'000'001)).WillOnce(Invoke([]() -> Task<TxnId> {
-            co_return 0;
-        }));
         EXPECT_CALL(transaction, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
             db::kv::api::GetAsOfResult response{
                 .success = false,
@@ -268,9 +259,6 @@ TEST_CASE_METHOD(RemoteStateTest, "async remote buffer", "[rpc][core][remote_buf
     */
 
     SECTION("AsyncRemoteState::read_account for empty response from db") {
-        EXPECT_CALL(transaction, first_txn_num_in_block(1'000'001)).WillOnce(Invoke([]() -> Task<TxnId> {
-            co_return 0;
-        }));
         EXPECT_CALL(transaction, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
             db::kv::api::GetAsOfResult response{
                 .success = false,
@@ -284,9 +272,6 @@ TEST_CASE_METHOD(RemoteStateTest, "async remote buffer", "[rpc][core][remote_buf
     }
 
     SECTION("AsyncRemoteState::read_code with empty response from db") {
-        EXPECT_CALL(transaction, first_txn_num_in_block(1'000'001)).WillOnce(Invoke([]() -> Task<TxnId> {
-            co_return 0;
-        }));
         EXPECT_CALL(transaction, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
             db::kv::api::GetAsOfResult response{
                 .success = true,
@@ -301,9 +286,6 @@ TEST_CASE_METHOD(RemoteStateTest, "async remote buffer", "[rpc][core][remote_buf
     }
 
     SECTION("AsyncRemoteState::read_storage with empty response from db") {
-        EXPECT_CALL(transaction, first_txn_num_in_block(1'000'001)).WillOnce(Invoke([]() -> Task<TxnId> {
-            co_return 0;
-        }));
         EXPECT_CALL(transaction, get_as_of(_)).WillOnce(Invoke([=](Unused) -> Task<db::kv::api::GetAsOfResult> {
             db::kv::api::GetAsOfResult response{
                 .success = true,


### PR DESCRIPTION
`silkworm_db_test` and `silkworm_execution_test` show some expectation failures, e.g.
```
Actual function call count doesn't match EXPECT_CALL(transaction, first_txn_num_in_block(1'000'001))...
Expected: to be called once
Actual: never called - unsatisfied and active
```