### PR TITLE
evm: drop bailout option from validate_call_funds()

### DIFF
--- a/silkworm/core/execution/processor.cpp
+++ b/silkworm/core/execution/processor.cpp
@@ -263,7 +263,10 @@ CallResult ExecutionProcessor::call(const Transaction& txn, const std::vector<st
     SILKWORM_ASSERT(sender);
 
     SILKWORM_ASSERT(protocol::validate_call_precheck(txn, evm_) == ValidationResult::kOk);
-    SILKWORM_ASSERT(protocol::validate_call_funds(txn, evm_, state_.get_balance(*txn.sender()), bailout) == ValidationResult::kOk);
+
+    if (!bailout) {
+        SILKWORM_ASSERT(protocol::validate_call_funds(txn, evm_, state_.get_balance(*txn.sender())) == ValidationResult::kOk);
+    }
 
     const BlockHeader& header{evm_.block().header};
     const intx::uint256 base_fee_per_gas{header.base_fee_per_gas.value_or(0)};

--- a/silkworm/core/protocol/validation.cpp
+++ b/silkworm/core/protocol/validation.cpp
@@ -222,20 +222,18 @@ ValidationResult pre_validate_common_forks(const Transaction& txn, const evmc_re
     return ValidationResult::kOk;
 }
 
-ValidationResult validate_call_funds(const Transaction& txn, const EVM& evm, const intx::uint256& owned_funds, bool bailout) noexcept {
-    if (!bailout) {
-        const intx::uint256 base_fee{evm.block().header.base_fee_per_gas.value_or(0)};
-        const intx::uint256 effective_gas_price{txn.max_fee_per_gas >= evm.block().header.base_fee_per_gas ? txn.effective_gas_price(base_fee)
-                                                                                                           : txn.max_priority_fee_per_gas};
+ValidationResult validate_call_funds(const Transaction& txn, const EVM& evm, const intx::uint256& owned_funds) noexcept {
+    const intx::uint256 base_fee{evm.block().header.base_fee_per_gas.value_or(0)};
+    const intx::uint256 effective_gas_price{txn.max_fee_per_gas >= evm.block().header.base_fee_per_gas ? txn.effective_gas_price(base_fee)
+                                                                                                       : txn.max_priority_fee_per_gas};
 
-        const auto required_funds = compute_call_cost(txn, effective_gas_price, evm);
-        intx::uint512 maximum_cost = required_funds;
-        if (txn.type != TransactionType::kLegacy && txn.type != TransactionType::kAccessList) {
-            maximum_cost = txn.maximum_gas_cost();
-        }
-        if (owned_funds < maximum_cost + txn.value) {
-            return ValidationResult::kInsufficientFunds;
-        }
+    const auto required_funds = compute_call_cost(txn, effective_gas_price, evm);
+    intx::uint512 maximum_cost = required_funds;
+    if (txn.type != TransactionType::kLegacy && txn.type != TransactionType::kAccessList) {
+        maximum_cost = txn.maximum_gas_cost();
+    }
+    if (owned_funds < maximum_cost + txn.value) {
+        return ValidationResult::kInsufficientFunds;
     }
     return ValidationResult::kOk;
 }

--- a/silkworm/core/protocol/validation.hpp
+++ b/silkworm/core/protocol/validation.hpp
@@ -145,7 +145,7 @@ namespace protocol {
 
     ValidationResult pre_validate_common_forks(const Transaction& txn, evmc_revision rev, const std::optional<intx::uint256>& blob_gas_price) noexcept;
 
-    ValidationResult validate_call_funds(const Transaction& txn, const EVM& evm, const intx::uint256& owned_funds, bool bailout) noexcept;
+    ValidationResult validate_call_funds(const Transaction& txn, const EVM& evm, const intx::uint256& owned_funds) noexcept;
 
     intx::uint256 compute_call_cost(const Transaction& txn, const intx::uint256& effective_gas_price, const EVM& evm);
 

--- a/silkworm/rpc/core/evm_executor.cpp
+++ b/silkworm/rpc/core/evm_executor.cpp
@@ -240,8 +240,8 @@ ExecutionResult EVMExecutor::call(
 
     const auto owned_funds = execution_processor_.intra_block_state().get_balance(*txn.sender());
 
-    if (const auto result = protocol::validate_call_funds(txn, evm, owned_funds, bailout);
-        result != ValidationResult::kOk) {
+    if (const auto result = protocol::validate_call_funds(txn, evm, owned_funds);
+        !bailout && result != ValidationResult::kOk) {
         return convert_validated_funds(block, txn, evm, owned_funds);
     }
 


### PR DESCRIPTION
The bailout option to validate_call_funds() makes it no-op function. Drop this option from the function so that the transaction validation code is not aware of the bailout semantic. Instead, ignore the validation result in the single place where it matters.