### PR TITLE
evm: de-duplicate bailout flag

### DIFF
--- a/silkworm/core/execution/processor.cpp
+++ b/silkworm/core/execution/processor.cpp
@@ -258,13 +258,13 @@ void ExecutionProcessor::execute_transaction(const Transaction& txn, Receipt& re
     check_evm1_execution_result(evm1_receipt.state_diff, state_);
 }
 
-CallResult ExecutionProcessor::call(const Transaction& txn, const std::vector<std::shared_ptr<EvmTracer>>& tracers, bool bailout, bool refund) noexcept {
+CallResult ExecutionProcessor::call(const Transaction& txn, const std::vector<std::shared_ptr<EvmTracer>>& tracers, bool refund) noexcept {
     const std::optional<evmc::address> sender{txn.sender()};
     SILKWORM_ASSERT(sender);
 
     SILKWORM_ASSERT(protocol::validate_call_precheck(txn, evm_) == ValidationResult::kOk);
 
-    if (!bailout) {
+    if (!evm().bailout) {
         SILKWORM_ASSERT(protocol::validate_call_funds(txn, evm_, state_.get_balance(*txn.sender())) == ValidationResult::kOk);
     }
 
@@ -284,7 +284,7 @@ CallResult ExecutionProcessor::call(const Transaction& txn, const std::vector<st
         state_.set_nonce(*sender, state_.get_nonce(*txn.sender()) + 1);
     }
 
-    if (!bailout) {
+    if (!evm().bailout) {
         const intx::uint256 required_funds = protocol::compute_call_cost(txn, effective_gas_price, evm_);
         state_.subtract_from_balance(*txn.sender(), required_funds);
     }
@@ -294,7 +294,7 @@ CallResult ExecutionProcessor::call(const Transaction& txn, const std::vector<st
     uint64_t gas_left{result.gas_left};
     uint64_t gas_used{txn.gas_limit - result.gas_left};
 
-    if (refund && !bailout) {
+    if (refund && !evm().bailout) {
         gas_used = txn.gas_limit - refund_gas(txn, effective_gas_price, result.gas_left, result.gas_refund);
         gas_left = txn.gas_limit - gas_used;
     }

--- a/silkworm/core/execution/processor.hpp
+++ b/silkworm/core/execution/processor.hpp
@@ -43,7 +43,7 @@ class ExecutionProcessor {
      */
     void execute_transaction(const Transaction& txn, Receipt& receipt) noexcept;
 
-    CallResult call(const Transaction& txn, const std::vector<std::shared_ptr<EvmTracer>>& tracers, bool bailout, bool refund) noexcept;
+    CallResult call(const Transaction& txn, const std::vector<std::shared_ptr<EvmTracer>>& tracers, bool refund) noexcept;
 
     //! \brief Execute the block.
     //! \remarks Warning: This method does not verify state root; pre-Byzantium receipt root isn't validated either.

--- a/silkworm/rpc/core/evm_executor.cpp
+++ b/silkworm/rpc/core/evm_executor.cpp
@@ -245,7 +245,7 @@ ExecutionResult EVMExecutor::call(
         return convert_validated_funds(block, txn, evm, owned_funds);
     }
 
-    const auto result = execution_processor_.call(txn, tracers, bailout, refund);
+    const auto result = execution_processor_.call(txn, tracers, refund);
 
     ExecutionResult exec_result{result.status, result.gas_left, result.data};
 


### PR DESCRIPTION
In the `ExecutionProcessor::call()` the bailout flag is passed by parameter but is also accessible as `evm().bailout`. It would be wrong if these flags are out of sync. Therefore, drop the bailout parameter and only use `evm().bailout` in the implementation.