### PR TITLE
CI - gcc 11 on PR workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -447,9 +447,9 @@ workflows:
       - lint
       - linux-clang-tidy-diff
       - linux-release:
-          name: linux-gcc-12-release
+          name: linux-gcc-<<pipeline.parameters.gcc_version_min>>-release
           compiler_id: gcc
-          compiler_version: 12
+          compiler_version: <<pipeline.parameters.gcc_version_min>>
           ethereum_tests: false
           requires:
             - lint
@@ -468,9 +468,9 @@ workflows:
         - matches: { pattern: "^ci\\/.+$", value: <<pipeline.git.branch>> }
     jobs:
       - linux-release:
-          name: linux-gcc-<<pipeline.parameters.gcc_version_min>>-release
+          name: linux-gcc-12-release
           compiler_id: gcc
-          compiler_version: <<pipeline.parameters.gcc_version_min>>
+          compiler_version: 12
       - linux-gcc-thread-sanitizer
       - linux-clang-coverage
       - linux-clang-address-sanitizer


### PR DESCRIPTION
Extra compilers find 2 types of problems:
1. "lint" - warnings, style, adherence to standard C++ etc. These type of problems are typically found more by the latest compiler versions. They are usually not critical and easy to fix, so can be postponed to the master integration workflow.
2. Usage of newer language and library features that are not available on old compiler versions. These type of problems are critical for GCC, because we make our releases (via silkworm-go) using the minimal GCC version. Such problems are not easy to fix as they might require reimplementing parts of the code without relying on the new features.

We shouldn't postpone critical and potentially hard work to the master integration workflow, therefore I suggest to use minimal compiler versions on the "light" PR workflow, and use other versions on "integration".

