### PR TITLE
datastore: DomainGetLatestQuery for snapshots and datastore

### DIFF
--- a/silkworm/capi/silkworm.cpp
+++ b/silkworm/capi/silkworm.cpp
@@ -228,8 +228,14 @@ SILKWORM_EXPORT int silkworm_init(SilkwormHandle* handle, const struct SilkwormS
 
     auto data_dir_path = parse_path(settings->data_dir_path);
     auto snapshots_dir_path = DataDirectory{data_dir_path}.snapshots().path();
-    auto blocks_repository = db::blocks::make_blocks_repository(snapshots_dir_path, /* open = */ false);
-    auto state_repository = db::state::make_state_repository(snapshots_dir_path, /* open = */ false);
+    auto blocks_repository = db::blocks::make_blocks_repository(
+        snapshots_dir_path,
+        /* open = */ false,
+        /* index_salt = */ 0);  // TODO: pass from erigon
+    auto state_repository = db::state::make_state_repository(
+        snapshots_dir_path,
+        /* open = */ false,
+        /* index_salt = */ 0);  // TODO: pass from erigon
 
     // NOLINTNEXTLINE(bugprone-unhandled-exception-at-new)
     *handle = new SilkwormInstance{

--- a/silkworm/db/blocks/schema_config.cpp
+++ b/silkworm/db/blocks/schema_config.cpp
@@ -22,6 +22,7 @@ namespace silkworm::db::blocks {
 
 snapshots::Schema::RepositoryDef make_blocks_repository_schema() {
     snapshots::Schema::RepositoryDef repository_schema;
+    repository_schema.index_salt_file_name("salt-blocks.txt");
     snapshots::Schema::EntityDef& schema = repository_schema.default_entity();
 
     schema.segment(kHeaderSegmentName)
@@ -55,12 +56,16 @@ std::unique_ptr<snapshots::IndexBuildersFactory> make_blocks_index_builders_fact
     return std::make_unique<BlocksIndexBuildersFactory>(make_blocks_repository_schema());
 }
 
-snapshots::SnapshotRepository make_blocks_repository(std::filesystem::path dir_path, bool open) {
+snapshots::SnapshotRepository make_blocks_repository(
+    std::filesystem::path dir_path,
+    bool open,
+    std::optional<uint32_t> index_salt) {
     return snapshots::SnapshotRepository{
         std::move(dir_path),
         open,
         make_blocks_repository_schema(),
         std::make_unique<datastore::StepToBlockNumConverter>(),
+        std::move(index_salt),
         make_blocks_index_builders_factory(),
     };
 }

--- a/silkworm/db/blocks/schema_config.hpp
+++ b/silkworm/db/blocks/schema_config.hpp
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 
 #include "../datastore/common/entity_name.hpp"
 #include "../datastore/snapshots/index_builders_factory.hpp"
@@ -36,7 +37,8 @@ std::unique_ptr<snapshots::IndexBuildersFactory> make_blocks_index_builders_fact
 
 snapshots::SnapshotRepository make_blocks_repository(
     std::filesystem::path dir_path,
-    bool open = true);
+    bool open = true,
+    std::optional<uint32_t> index_salt = std::nullopt);
 
 inline constexpr datastore::EntityName kHeaderSegmentName{"headers"};
 inline constexpr std::string_view kHeaderSegmentTag = kHeaderSegmentName.name;

--- a/silkworm/db/datastore/domain_get_latest_query.hpp
+++ b/silkworm/db/datastore/domain_get_latest_query.hpp
@@ -1,0 +1,75 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include "kvdb/database.hpp"
+#include "kvdb/domain_get_latest_query.hpp"
+#include "snapshots/domain_get_latest_query.hpp"
+
+namespace silkworm::datastore {
+
+template <
+    kvdb::EncoderConcept TKeyEncoder1, snapshots::EncoderConcept TKeyEncoder2,
+    kvdb::DecoderConcept TValueDecoder1, snapshots::DecoderConcept TValueDecoder2>
+struct DomainGetLatestQuery {
+    DomainGetLatestQuery(
+        datastore::EntityName entity_name,
+        kvdb::Domain kvdb_entity,
+        kvdb::ROTxn& tx,
+        const snapshots::SnapshotRepositoryROAccess& repository)
+        : query1_{tx, kvdb_entity},
+          query2_{repository, entity_name} {}
+
+    DomainGetLatestQuery(
+        datastore::EntityName entity_name,
+        kvdb::DatabaseRef database,
+        kvdb::ROTxn& tx,
+        const snapshots::SnapshotRepositoryROAccess& repository)
+        : DomainGetLatestQuery{
+              entity_name,
+              database.domain(entity_name),
+              tx,
+              repository,
+          } {}
+
+    using Key1 = decltype(TKeyEncoder1::value);
+    using Key2 = decltype(TKeyEncoder2::value);
+    static_assert(std::same_as<Key1, Key2>);
+    using Key = Key1;
+
+    using Result1 = typename kvdb::DomainGetLatestQuery<TKeyEncoder1, TValueDecoder1>::Result;
+    using Result2 = typename snapshots::DomainGetLatestQuery<TKeyEncoder2, TValueDecoder2>::Result;
+    using Result = Result1;
+
+    std::optional<Result> exec(const Key& key) {
+        auto result1 = query1_.exec(key);
+        if (result1) {
+            return result1;
+        }
+        auto result2 = query2_.exec(key);
+        if (result2) {
+            return Result{std::move(result2->value), result2->step};
+        }
+        return std::nullopt;
+    }
+
+  private:
+    kvdb::DomainGetLatestQuery<TKeyEncoder1, TValueDecoder1> query1_;
+    snapshots::DomainGetLatestQuery<TKeyEncoder2, TValueDecoder2> query2_;
+};
+
+}  // namespace silkworm::datastore

--- a/silkworm/db/datastore/inverted_index_range_by_key_query.hpp
+++ b/silkworm/db/datastore/inverted_index_range_by_key_query.hpp
@@ -26,21 +26,21 @@ namespace silkworm::datastore {
 template <kvdb::EncoderConcept TKeyEncoder1, snapshots::EncoderConcept TKeyEncoder2>
 struct InvertedIndexRangeByKeyQuery {
     InvertedIndexRangeByKeyQuery(
-        datastore::EntityName inverted_index_name,
-        kvdb::InvertedIndex kvdb_inverted_index,
+        datastore::EntityName entity_name,
+        kvdb::InvertedIndex kvdb_entity,
         kvdb::ROTxn& tx,
         const snapshots::SnapshotRepositoryROAccess& repository)
-        : query1_{tx, kvdb_inverted_index},
-          query2_{repository, inverted_index_name} {}
+        : query1_{tx, kvdb_entity},
+          query2_{repository, entity_name} {}
 
     InvertedIndexRangeByKeyQuery(
-        datastore::EntityName inverted_index_name,
+        datastore::EntityName entity_name,
         kvdb::DatabaseRef database,
         kvdb::ROTxn& tx,
         const snapshots::SnapshotRepositoryROAccess& repository)
         : InvertedIndexRangeByKeyQuery{
-              inverted_index_name,
-              database.inverted_index(inverted_index_name),
+              entity_name,
+              database.inverted_index(entity_name),
               tx,
               repository,
           } {}

--- a/silkworm/db/datastore/inverted_index_range_by_key_query.hpp
+++ b/silkworm/db/datastore/inverted_index_range_by_key_query.hpp
@@ -45,13 +45,13 @@ struct InvertedIndexRangeByKeyQuery {
               repository,
           } {}
 
-    using TKey1 = decltype(TKeyEncoder1::value);
-    using TKey2 = decltype(TKeyEncoder2::value);
-    static_assert(std::same_as<TKey1, TKey2>);
-    using TKey = TKey1;
+    using Key1 = decltype(TKeyEncoder1::value);
+    using Key2 = decltype(TKeyEncoder2::value);
+    static_assert(std::same_as<Key1, Key2>);
+    using Key = Key1;
 
     template <bool ascending = true>
-    auto exec(TKey key, TimestampRange ts_range) {
+    auto exec(Key key, TimestampRange ts_range) {
         if constexpr (ascending) {
             return silkworm::views::concat(
                 query2_.template exec<ascending>(key, ts_range),

--- a/silkworm/db/datastore/kvdb/domain_delete_query.hpp
+++ b/silkworm/db/datastore/kvdb/domain_delete_query.hpp
@@ -25,13 +25,13 @@ struct DomainDeleteQuery {
     RWTxn& tx;
     Domain entity;
 
-    using TKey = decltype(TKeyEncoder::value);
-    using TValue = decltype(TValueEncoder::value);
+    using Key = decltype(TKeyEncoder::value);
+    using Value = decltype(TValueEncoder::value);
 
     void exec(
-        const TKey& key,
+        const Key& key,
         Timestamp timestamp,
-        const std::optional<TValue>& prev_value,
+        const std::optional<Value>& prev_value,
         Step prev_step) {
         if (prev_value) {
             DomainPutQuery<TKeyEncoder, RawEncoder<ByteView>> query{tx, entity};

--- a/silkworm/db/datastore/kvdb/domain_get_latest_query.hpp
+++ b/silkworm/db/datastore/kvdb/domain_get_latest_query.hpp
@@ -28,7 +28,7 @@ namespace silkworm::datastore::kvdb {
 
 template <EncoderConcept TKeyEncoder, DecoderConcept TValueDecoder>
 struct DomainGetLatestQuery {
-    RWTxn& tx;
+    ROTxn& tx;
     Domain entity;
 
     using Key = decltype(TKeyEncoder::value);

--- a/silkworm/db/datastore/kvdb/domain_get_latest_query.hpp
+++ b/silkworm/db/datastore/kvdb/domain_get_latest_query.hpp
@@ -31,15 +31,15 @@ struct DomainGetLatestQuery {
     RWTxn& tx;
     Domain entity;
 
-    using TKey = decltype(TKeyEncoder::value);
-    using TValue = decltype(TValueDecoder::value);
+    using Key = decltype(TKeyEncoder::value);
+    using Value = decltype(TValueDecoder::value);
 
     struct Result {
-        TValue value;
+        Value value;
         Step step;
     };
 
-    std::optional<Result> exec(const TKey& key) {
+    std::optional<Result> exec(const Key& key) {
         DomainKeyEncoder<TKeyEncoder> key_encoder{/* has_large_values = */ false};
         key_encoder.value.key.value = key;
         key_encoder.value.timestamp.value = Step{std::numeric_limits<decltype(Step::value)>::max()};

--- a/silkworm/db/datastore/kvdb/domain_put_latest_query.hpp
+++ b/silkworm/db/datastore/kvdb/domain_put_latest_query.hpp
@@ -28,10 +28,10 @@ struct DomainPutLatestQuery {
     RWTxn& tx;
     Domain entity;
 
-    using TKey = decltype(TKeyEncoder::value);
-    using TValue = decltype(TValueEncoder::value);
+    using Key = decltype(TKeyEncoder::value);
+    using Value = decltype(TValueEncoder::value);
 
-    void exec(const TKey& key, const TValue& value, Step step) {
+    void exec(const Key& key, const Value& value, Step step) {
         DomainKeyEncoder<TKeyEncoder> key_encoder{entity.has_large_values};
         key_encoder.value.key.value = key;
         key_encoder.value.timestamp.value = step;

--- a/silkworm/db/datastore/kvdb/domain_put_query.hpp
+++ b/silkworm/db/datastore/kvdb/domain_put_query.hpp
@@ -27,14 +27,14 @@ struct DomainPutQuery {
     RWTxn& tx;
     Domain entity;
 
-    using TKey = decltype(TKeyEncoder::value);
-    using TValue = decltype(TValueEncoder::value);
+    using Key = decltype(TKeyEncoder::value);
+    using Value = decltype(TValueEncoder::value);
 
     void exec(
-        const TKey& key,
-        const TValue& value,
+        const Key& key,
+        const Value& value,
         Timestamp timestamp,
-        const std::optional<TValue>& prev_value,
+        const std::optional<Value>& prev_value,
         Step prev_step) {
         DomainPutLatestQuery<TKeyEncoder, TValueEncoder> value_query{tx, entity};
         value_query.exec(key, value, prev_step);

--- a/silkworm/db/datastore/kvdb/history_delete_query.hpp
+++ b/silkworm/db/datastore/kvdb/history_delete_query.hpp
@@ -25,9 +25,9 @@ struct HistoryDeleteQuery {
     RWTxn& tx;
     History entity;
 
-    using TKey = decltype(TKeyEncoder::value);
+    using Key = decltype(TKeyEncoder::value);
 
-    void exec(const TKey& key, Timestamp timestamp) {
+    void exec(const Key& key, Timestamp timestamp) {
         HistoryPutQuery<TKeyEncoder, RawEncoder<ByteView>> query{tx, entity};
         query.exec(key, ByteView{}, timestamp);
     }

--- a/silkworm/db/datastore/kvdb/history_put_query.hpp
+++ b/silkworm/db/datastore/kvdb/history_put_query.hpp
@@ -36,10 +36,10 @@ struct HistoryPutQuery {
     RWTxn& tx;
     History entity;
 
-    using TKey = decltype(TKeyEncoder::value);
-    using TValue = decltype(TValueEncoder::value);
+    using Key = decltype(TKeyEncoder::value);
+    using Value = decltype(TValueEncoder::value);
 
-    void exec(const TKey& key, const TValue& value, Timestamp timestamp) {
+    void exec(const Key& key, const Value& value, Timestamp timestamp) {
         HistoryKeyEncoder<TKeyEncoder> key_encoder{entity.has_large_values};
         key_encoder.value.key.value = key;
         key_encoder.value.timestamp.value = timestamp;

--- a/silkworm/db/datastore/kvdb/inverted_index_put_query.hpp
+++ b/silkworm/db/datastore/kvdb/inverted_index_put_query.hpp
@@ -28,14 +28,14 @@ struct InvertedIndexPutQuery {
     RWTxn& tx;
     InvertedIndex entity;
 
-    using TKey = decltype(TKeyEncoder::value);
+    using Key = decltype(TKeyEncoder::value);
 
-    void exec(const TKey& key, const Timestamp timestamp, bool with_index_update) {
+    void exec(const Key& key, const Timestamp timestamp, bool with_index_update) {
         return exec<TimestampEncoder>(key, timestamp, with_index_update);
     }
 
     template <EncoderConcept TTimestampEncoder, typename TTimestamp = decltype(TTimestampEncoder::value)>
-    void exec(const TKey& key, const TTimestamp& timestamp, bool with_index_update) {
+    void exec(const Key& key, const TTimestamp& timestamp, bool with_index_update) {
         TKeyEncoder key_encoder;
         key_encoder.value = key;
         Slice key_slice = key_encoder.encode();

--- a/silkworm/db/datastore/kvdb/inverted_index_range_by_key_query.hpp
+++ b/silkworm/db/datastore/kvdb/inverted_index_range_by_key_query.hpp
@@ -34,14 +34,14 @@ struct InvertedIndexRangeByKeyQuery {
     ROTxn& tx;
     InvertedIndex entity;
 
-    using TKey = decltype(TKeyEncoder::value);
+    using Key = decltype(TKeyEncoder::value);
 
     //! A range of timestamps
     using Timestamps = std::ranges::filter_view<
         std::ranges::subrange<CursorValuesIterator<TimestampDecoder>>,
         decltype(std::declval<TimestampRange>().contains_predicate())>;
 
-    CursorValuesIterator<TimestampDecoder> begin(TKey key, TimestampRange ts_range, bool ascending) {
+    CursorValuesIterator<TimestampDecoder> begin(Key key, TimestampRange ts_range, bool ascending) {
         auto cursor = tx.ro_cursor_dup_sort(entity.index_table);
 
         TKeyEncoder key_encoder;
@@ -76,13 +76,13 @@ struct InvertedIndexRangeByKeyQuery {
         return {};
     }
 
-    Timestamps exec_with_eager_begin(TKey key, TimestampRange ts_range, bool ascending) {
+    Timestamps exec_with_eager_begin(Key key, TimestampRange ts_range, bool ascending) {
         auto begin_it = begin(std::move(key), ts_range, ascending);
         return std::ranges::subrange{std::move(begin_it), CursorValuesIterator<TimestampDecoder>{}} |
                std::views::filter(ts_range.contains_predicate());
     }
 
-    auto exec(TKey key, TimestampRange ts_range, bool ascending) {
+    auto exec(Key key, TimestampRange ts_range, bool ascending) {
         auto exec_func = [query = *this, key = std::move(key), ts_range, ascending](std::monostate) mutable {
             return query.exec_with_eager_begin(std::move(key), ts_range, ascending);
         };

--- a/silkworm/db/datastore/snapshot_merger.cpp
+++ b/silkworm/db/datastore/snapshot_merger.cpp
@@ -126,7 +126,7 @@ void SnapshotMerger::commit(std::shared_ptr<DataMigrationResult> result) {
 
     move_files(bundle.files(), snapshots_.path());
 
-    SnapshotBundle final_bundle{snapshots_.schema(), snapshots_.path(), bundle.step_range()};
+    SnapshotBundle final_bundle = snapshots_.open_bundle(bundle.step_range());
     snapshots_.replace_snapshot_bundles(std::move(final_bundle));
 
     for (auto& merged_bundle : merged_bundles) {

--- a/silkworm/db/datastore/snapshots/bloom_filter/bloom_filter.cpp
+++ b/silkworm/db/datastore/snapshots/bloom_filter/bloom_filter.cpp
@@ -49,7 +49,9 @@ uint64_t BloomFilter::optimal_bits_count(uint64_t max_key_count, double p) {
     return static_cast<uint64_t>(std::ceil(-static_cast<double>(max_key_count) * std::log(p) / (ln2 * ln2)));
 }
 
-BloomFilter::BloomFilter(std::filesystem::path path)
+BloomFilter::BloomFilter(
+    std::filesystem::path path,
+    std::optional<BloomFilterKeyHasher> data_key_hasher)
     : BloomFilter{kMinimumBitsCount, new_random_keys()} {
     if (!std::filesystem::exists(path)) {
         throw std::runtime_error("index file " + path.filename().string() + " doesn't exist");
@@ -62,6 +64,7 @@ BloomFilter::BloomFilter(std::filesystem::path path)
     file_stream >> *this;
 
     path_ = std::move(path);
+    data_key_hasher_ = std::move(data_key_hasher);
 }
 
 BloomFilter::BloomFilter()
@@ -86,7 +89,7 @@ void BloomFilter::add_hash(uint64_t hash) {
     ++inserted_count_;
 }
 
-bool BloomFilter::contains_hash(uint64_t hash) {
+bool BloomFilter::contains_hash(uint64_t hash) const {
     uint64_t r{1};
     for (size_t n = 0; n < kHardCodedK; ++n) {
         hash = ((hash << kRotation) | (hash >> kRotationOf64)) ^ keys_[n];
@@ -94,6 +97,10 @@ bool BloomFilter::contains_hash(uint64_t hash) {
         r &= (bits_[i >> 6] >> (i & 0x3F)) & uint64_t{1};
     }
     return r != 0;
+}
+
+bool BloomFilter::contains(ByteView data_key) const {
+    return contains_hash(data_key_hasher_->hash(data_key));
 }
 
 void BloomFilter::ensure_min_bits_count(uint64_t bits_count) {

--- a/silkworm/db/datastore/snapshots/bloom_filter/bloom_filter.hpp
+++ b/silkworm/db/datastore/snapshots/bloom_filter/bloom_filter.hpp
@@ -20,7 +20,10 @@
 #include <cstdint>
 #include <filesystem>
 #include <istream>
+#include <optional>
 #include <vector>
+
+#include "bloom_filter_key_hasher.hpp"
 
 namespace silkworm::snapshots::bloom_filter {
 
@@ -28,7 +31,9 @@ namespace silkworm::snapshots::bloom_filter {
 //! \remark Serialized binary format compatible with: https://github.com/holiman/bloomfilter
 class BloomFilter {
   public:
-    explicit BloomFilter(std::filesystem::path path);
+    explicit BloomFilter(
+        std::filesystem::path path,
+        std::optional<BloomFilterKeyHasher> data_key_hasher = std::nullopt);
     BloomFilter();
     BloomFilter(uint64_t max_key_count, double p);
 
@@ -43,7 +48,8 @@ class BloomFilter {
     //! Checks if filter contains the give \p hash value
     //! \param hash the value to check for presence
     //! \return false means "definitely does not contain value", true means "maybe contains value"
-    bool contains_hash(uint64_t hash);
+    bool contains_hash(uint64_t hash) const;
+    bool contains(ByteView data_key) const;
 
     friend std::istream& operator>>(std::istream& is, BloomFilter& filter);
 
@@ -62,6 +68,9 @@ class BloomFilter {
 
     //! The index file path
     std::filesystem::path path_;
+
+    //! Data key hasher
+    std::optional<BloomFilterKeyHasher> data_key_hasher_;
 
     //! The number of bits that the bitmap should be able to track
     uint64_t bits_count_;

--- a/silkworm/db/datastore/snapshots/bloom_filter/bloom_filter_key_hasher.cpp
+++ b/silkworm/db/datastore/snapshots/bloom_filter/bloom_filter_key_hasher.cpp
@@ -14,15 +14,18 @@
    limitations under the License.
 */
 
-#pragma once
+#include "bloom_filter_key_hasher.hpp"
 
-#include <silkworm/db/datastore/snapshots/common/raw_codec.hpp>
-#include <silkworm/db/datastore/snapshots/segment/kv_segment_reader.hpp>
+#include <array>
 
-#include "hash_decoder.hpp"
+#include "../common/encoding/murmur_hash3.hpp"
 
-namespace silkworm::db::state {
+namespace silkworm::snapshots::bloom_filter {
 
-using LogTopicsInvertedIndexKVSegmentReader = snapshots::segment::KVSegmentReader<HashSnapshotsDecoder, snapshots::RawDecoder<Bytes>>;
+uint64_t BloomFilterKeyHasher::hash(ByteView key) const {
+    std::array<uint64_t, 2> hash = {0, 0};
+    encoding::Murmur3{salt_}.hash_x64_128(key.data(), key.size(), hash.data());
+    return hash[0];
+}
 
-}  // namespace silkworm::db::state
+}  // namespace silkworm::snapshots::bloom_filter

--- a/silkworm/db/datastore/snapshots/bloom_filter/bloom_filter_key_hasher.hpp
+++ b/silkworm/db/datastore/snapshots/bloom_filter/bloom_filter_key_hasher.hpp
@@ -16,13 +16,17 @@
 
 #pragma once
 
-#include <silkworm/db/datastore/snapshots/common/raw_codec.hpp>
-#include <silkworm/db/datastore/snapshots/segment/kv_segment_reader.hpp>
+#include <silkworm/core/common/bytes.hpp>
 
-#include "hash_decoder.hpp"
+namespace silkworm::snapshots::bloom_filter {
 
-namespace silkworm::db::state {
+class BloomFilterKeyHasher {
+  public:
+    explicit BloomFilterKeyHasher(uint32_t salt) : salt_{salt} {}
+    uint64_t hash(ByteView key) const;
 
-using LogTopicsInvertedIndexKVSegmentReader = snapshots::segment::KVSegmentReader<HashSnapshotsDecoder, snapshots::RawDecoder<Bytes>>;
+  private:
+    uint32_t salt_;
+};
 
-}  // namespace silkworm::db::state
+}  // namespace silkworm::snapshots::bloom_filter

--- a/silkworm/db/datastore/snapshots/bloom_filter/bloom_filter_key_hasher_test.cpp
+++ b/silkworm/db/datastore/snapshots/bloom_filter/bloom_filter_key_hasher_test.cpp
@@ -14,15 +14,17 @@
    limitations under the License.
 */
 
-#pragma once
+#include "bloom_filter_key_hasher.hpp"
 
-#include <silkworm/db/datastore/snapshots/common/raw_codec.hpp>
-#include <silkworm/db/datastore/snapshots/segment/kv_segment_reader.hpp>
+#include <catch2/catch_test_macros.hpp>
 
-#include "hash_decoder.hpp"
+#include <silkworm/core/common/util.hpp>
 
-namespace silkworm::db::state {
+namespace silkworm::snapshots::bloom_filter {
 
-using LogTopicsInvertedIndexKVSegmentReader = snapshots::segment::KVSegmentReader<HashSnapshotsDecoder, snapshots::RawDecoder<Bytes>>;
+TEST_CASE("BloomFilterKeyHasher") {
+    CHECK(BloomFilterKeyHasher{0}.hash(*from_hex("CAFEBABE")) == 2809309899937206063u);
+    CHECK(BloomFilterKeyHasher{12345}.hash(*from_hex("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")) == 17810263873480351644u);
+}
 
-}  // namespace silkworm::db::state
+}  // namespace silkworm::snapshots::bloom_filter

--- a/silkworm/db/datastore/snapshots/btree/btree_index.cpp
+++ b/silkworm/db/datastore/snapshots/btree/btree_index.cpp
@@ -70,7 +70,7 @@ void BTreeIndex::warmup_if_empty_or_check(const KVSegmentReader& kv_segment) {
     }
 }
 
-std::optional<BTreeIndex::Cursor> BTreeIndex::seek(ByteView seek_key, const KVSegmentReader& kv_segment) {
+std::optional<BTreeIndex::Cursor> BTreeIndex::seek(ByteView seek_key, const KVSegmentReader& kv_segment) const {
     KeyValueIndex index{kv_segment, data_offsets_, file_path_};
     auto [found, key, value, data_index] = btree_->seek(seek_key, index);
     if (key.compare(seek_key) >= 0) {
@@ -85,7 +85,7 @@ std::optional<BTreeIndex::Cursor> BTreeIndex::seek(ByteView seek_key, const KVSe
     return std::nullopt;
 }
 
-std::optional<Bytes> BTreeIndex::get(ByteView key, const KVSegmentReader& kv_segment) {
+std::optional<Bytes> BTreeIndex::get(ByteView key, const KVSegmentReader& kv_segment) const {
     KeyValueIndex index{kv_segment, data_offsets_, file_path_};
     auto result = btree_->get(key, index);
     if (!result) {

--- a/silkworm/db/datastore/snapshots/btree/btree_index.hpp
+++ b/silkworm/db/datastore/snapshots/btree/btree_index.hpp
@@ -50,7 +50,7 @@ class BTreeIndex {
         friend class BTreeIndex;
 
         Cursor(
-            BTreeIndex* index,
+            const BTreeIndex* index,
             Bytes key,
             Bytes value,
             DataIndex data_index,
@@ -61,7 +61,7 @@ class BTreeIndex {
               data_index_{data_index},
               kv_segment_{kv_segment} {}
 
-        BTreeIndex* index_;
+        const BTreeIndex* index_;
         Bytes key_;
         Bytes value_;
         DataIndex data_index_;
@@ -89,13 +89,13 @@ class BTreeIndex {
     //! \return a cursor positioned at key >= \p seek_key or nullptr
     //! \details if \p seek_key is empty, first key is returned
     //! \details if \p seek_key is greater than any other key, std::nullopt is returned
-    std::optional<Cursor> seek(ByteView seek_key, const KVSegmentReader& kv_segment);
+    std::optional<Cursor> seek(ByteView seek_key, const KVSegmentReader& kv_segment) const;
 
     //! Get the value associated to the given key with exact match
     //! \param key the data key to match exactly
     //! \param kv_segment reader of the key-value data sequence
     //! \return the value associated at \p key or std::nullopt if not found
-    std::optional<Bytes> get(ByteView key, const KVSegmentReader& kv_segment);
+    std::optional<Bytes> get(ByteView key, const KVSegmentReader& kv_segment) const;
 
   private:
     class KeyValueIndex : public BTree::KeyValueIndex {

--- a/silkworm/db/datastore/snapshots/common/encoding/murmur_hash3.cpp
+++ b/silkworm/db/datastore/snapshots/common/encoding/murmur_hash3.cpp
@@ -21,7 +21,7 @@
 
 #include <cstddef>
 
-namespace silkworm::snapshots::rec_split {
+namespace silkworm::snapshots::encoding {
 
 // Platform-specific functions and macros
 
@@ -193,4 +193,4 @@ void murmur_hash3_x64_128(const void* key, const uint64_t len,
     reinterpret_cast<uint64_t*>(out)[1] = h2;
 }
 
-}  // namespace silkworm::snapshots::rec_split
+}  // namespace silkworm::snapshots::encoding

--- a/silkworm/db/datastore/snapshots/common/encoding/murmur_hash3.hpp
+++ b/silkworm/db/datastore/snapshots/common/encoding/murmur_hash3.hpp
@@ -31,7 +31,7 @@ typedef unsigned __int64 uint64_t;
 #include <cstdint>
 #endif  // !defined(_MSC_VER)
 
-namespace silkworm::snapshots::rec_split {
+namespace silkworm::snapshots::encoding {
 
 void murmur_hash3_x64_128(const void* key, uint64_t len, uint32_t seed, void* out);
 
@@ -51,4 +51,4 @@ class Murmur3 {
     uint32_t seed_;
 };
 
-}  // namespace silkworm::snapshots::rec_split
+}  // namespace silkworm::snapshots::encoding

--- a/silkworm/db/datastore/snapshots/common/encoding/murmur_hash3_test.cpp
+++ b/silkworm/db/datastore/snapshots/common/encoding/murmur_hash3_test.cpp
@@ -21,7 +21,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 
-namespace silkworm::snapshots::rec_split {
+namespace silkworm::snapshots::encoding {
 
 TEST_CASE("murmur_hash3_x64_128", "[silkworm][recsplit][support]") {
     constexpr size_t kHashBits{128};
@@ -67,4 +67,4 @@ TEST_CASE("Murmur3", "[silkworm][recsplit][support]") {
     delete[] hashed;
 }
 
-}  // namespace silkworm::snapshots::rec_split
+}  // namespace silkworm::snapshots::encoding

--- a/silkworm/db/datastore/snapshots/domain.hpp
+++ b/silkworm/db/datastore/snapshots/domain.hpp
@@ -28,7 +28,7 @@ namespace silkworm::snapshots {
 
 struct Domain {
     const segment::KVSegmentFileReader& kv_segment;
-    const rec_split::AccessorIndex& accessor_index;
+    const rec_split::AccessorIndex* accessor_index{nullptr};
     const bloom_filter::BloomFilter& existence_index;
     const btree::BTreeIndex& btree_index;
     std::optional<History> history;

--- a/silkworm/db/datastore/snapshots/domain_get_latest_query.hpp
+++ b/silkworm/db/datastore/snapshots/domain_get_latest_query.hpp
@@ -1,0 +1,90 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include "../common/step.hpp"
+#include "common/codec.hpp"
+#include "common/raw_codec.hpp"
+#include "domain.hpp"
+#include "segment/kv_segment_reader.hpp"
+#include "snapshot_bundle.hpp"
+#include "snapshot_repository_ro_access.hpp"
+
+namespace silkworm::snapshots {
+
+template <EncoderConcept TKeyEncoder, DecoderConcept TValueDecoder>
+struct DomainGetLatestSegmentQuery {
+    explicit DomainGetLatestSegmentQuery(Domain entity)
+        : entity_{std::move(entity)} {}
+    explicit DomainGetLatestSegmentQuery(
+        const SnapshotBundle& bundle,
+        datastore::EntityName entity_name)
+        : entity_{bundle.domain(entity_name)} {}
+
+    using Key = decltype(TKeyEncoder::value);
+    using Value = decltype(TValueDecoder::value);
+
+    std::optional<Value> exec(const Key& key) {
+        TKeyEncoder key_encoder;
+        key_encoder.value = key;
+        ByteView key_data = key_encoder.encode_word();
+
+        if (!entity_.existence_index.contains(key_data)) {
+            return std::nullopt;
+        }
+
+        std::optional<Bytes> value_data = entity_.btree_index.get(key_data, entity_.kv_segment);
+        if (!value_data) {
+            return std::nullopt;
+        }
+
+        TValueDecoder value_decoder;
+        value_decoder.decode_word(*value_data);
+        return std::move(value_decoder.value);
+    }
+
+  private:
+    Domain entity_;
+};
+
+template <EncoderConcept TKeyEncoder, DecoderConcept TValueDecoder>
+struct DomainGetLatestQuery {
+    const SnapshotRepositoryROAccess& repository;
+    datastore::EntityName entity_name;
+
+    using Key = decltype(TKeyEncoder::value);
+    using Value = decltype(TValueDecoder::value);
+
+    struct Result {
+        Value value;
+        datastore::Step step;
+    };
+
+    std::optional<Result> exec(const Key& key) {
+        for (auto& bundle_ptr : repository.view_bundles_reverse()) {
+            const SnapshotBundle& bundle = *bundle_ptr;
+            DomainGetLatestSegmentQuery<TKeyEncoder, TValueDecoder> query{bundle, entity_name};
+            auto value = query.exec(key);
+            if (value) {
+                return Result{std::move(*value), bundle.step_range().end};
+            }
+        }
+        return std::nullopt;
+    }
+};
+
+}  // namespace silkworm::snapshots

--- a/silkworm/db/datastore/snapshots/index_salt_file.cpp
+++ b/silkworm/db/datastore/snapshots/index_salt_file.cpp
@@ -1,0 +1,44 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "index_salt_file.hpp"
+
+#include <fstream>
+
+#include <silkworm/core/common/bytes_to_string.hpp>
+#include <silkworm/core/common/endian.hpp>
+
+namespace silkworm::snapshots {
+
+using namespace std;
+
+uint32_t IndexSaltFile::load() const {
+    Bytes data(sizeof(uint32_t), 0);
+    ifstream file{path_, std::ios::binary};
+    file.exceptions(ios::failbit | ios::badbit);
+    file.read(byte_ptr_cast(data.data()), static_cast<streamsize>(data.size()));
+    return endian::load_big_u32(data.data());
+}
+
+void IndexSaltFile::save(uint32_t value) const {
+    Bytes data(sizeof(uint32_t), 0);
+    endian::store_big_u32(data.data(), value);
+    ofstream file{path_, std::ios::binary | std::ios::trunc};
+    file.exceptions(ios::failbit | ios::badbit);
+    file.write(byte_ptr_cast(data.data()), static_cast<streamsize>(data.size()));
+}
+
+}  // namespace silkworm::snapshots

--- a/silkworm/db/datastore/snapshots/index_salt_file.hpp
+++ b/silkworm/db/datastore/snapshots/index_salt_file.hpp
@@ -1,0 +1,35 @@
+/*
+   Copyright 2024 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <filesystem>
+
+namespace silkworm::snapshots {
+
+class IndexSaltFile {
+  public:
+    explicit IndexSaltFile(std::filesystem::path path) : path_{std::move(path)} {}
+
+    uint32_t load() const;
+    void save(uint32_t value) const;
+    bool exists() const { return std::filesystem::exists(path_); }
+
+  private:
+    std::filesystem::path path_;
+};
+
+}  // namespace silkworm::snapshots

--- a/silkworm/db/datastore/snapshots/inverted_index_range_by_key_query.hpp
+++ b/silkworm/db/datastore/snapshots/inverted_index_range_by_key_query.hpp
@@ -39,12 +39,12 @@ auto timestamp_range_filter(elias_fano::EliasFanoList32 list, datastore::Timesta
 template <EncoderConcept TKeyEncoder>
 struct InvertedIndexFindByKeySegmentQuery {
     explicit InvertedIndexFindByKeySegmentQuery(
-        InvertedIndex inverted_index)
-        : inverted_index_{inverted_index} {}
+        InvertedIndex entity)
+        : entity_{entity} {}
     explicit InvertedIndexFindByKeySegmentQuery(
         const SnapshotBundle& bundle,
-        datastore::EntityName inverted_index_name)
-        : inverted_index_{bundle.inverted_index(inverted_index_name)} {}
+        datastore::EntityName entity_name)
+        : entity_{bundle.inverted_index(entity_name)} {}
 
     using Key = decltype(TKeyEncoder::value);
 
@@ -53,12 +53,12 @@ struct InvertedIndexFindByKeySegmentQuery {
         key_encoder.value = std::move(key);
         ByteView key_data = key_encoder.encode_word();
 
-        auto offset = inverted_index_.accessor_index.lookup_by_key(key_data);
+        auto offset = entity_.accessor_index.lookup_by_key(key_data);
         if (!offset) {
             return std::nullopt;
         }
 
-        auto reader = inverted_index_.kv_segment_reader<RawDecoder<Bytes>>();
+        auto reader = entity_.kv_segment_reader<RawDecoder<Bytes>>();
         std::optional<std::pair<Key, elias_fano::EliasFanoList32>> result = reader.seek_one(*offset);
 
         // ensure that the found key matches to avoid lookup_by_key false positives
@@ -75,23 +75,23 @@ struct InvertedIndexFindByKeySegmentQuery {
     }
 
   private:
-    InvertedIndex inverted_index_;
+    InvertedIndex entity_;
 };
 
 template <EncoderConcept TKeyEncoder>
 struct InvertedIndexRangeByKeyQuery {
     explicit InvertedIndexRangeByKeyQuery(
         const SnapshotRepositoryROAccess& repository,
-        datastore::EntityName inverted_index_name)
+        datastore::EntityName entity_name)
         : repository_{repository},
-          inverted_index_name_{inverted_index_name} {}
+          entity_name_{entity_name} {}
 
     using Key = decltype(TKeyEncoder::value);
 
     template <bool ascending = true>
     auto exec(Key key, datastore::TimestampRange ts_range) {
-        auto timestamps_in_bundle = [inverted_index_name = inverted_index_name_, key = std::move(key), ts_range](std::shared_ptr<SnapshotBundle> bundle) {
-            InvertedIndexFindByKeySegmentQuery<TKeyEncoder> query{*bundle, inverted_index_name};
+        auto timestamps_in_bundle = [entity_name = entity_name_, key = std::move(key), ts_range](std::shared_ptr<SnapshotBundle> bundle) {
+            InvertedIndexFindByKeySegmentQuery<TKeyEncoder> query{*bundle, entity_name};
             return query.template exec_filter<ascending>(key, ts_range);
         };
 
@@ -102,7 +102,7 @@ struct InvertedIndexRangeByKeyQuery {
 
   private:
     const SnapshotRepositoryROAccess& repository_;
-    datastore::EntityName inverted_index_name_;
+    datastore::EntityName entity_name_;
 };
 
 }  // namespace silkworm::snapshots

--- a/silkworm/db/datastore/snapshots/rec_split/rec_split.hpp
+++ b/silkworm/db/datastore/snapshots/rec_split/rec_split.hpp
@@ -76,11 +76,11 @@
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/common/memory_mapped_file.hpp>
 
+#include "../common/encoding/murmur_hash3.hpp"
 #include "../common/util/bitmask_operators.hpp"
 #include "../elias_fano/double_elias_fano_list.hpp"
 #include "../elias_fano/elias_fano_list.hpp"
 #include "golomb_rice.hpp"
-#include "murmur_hash3.hpp"
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
@@ -216,6 +216,7 @@ class RecSplit {
     using GolombRiceBuilder = GolombRiceVector::Builder;
     using EliasFano = elias_fano::EliasFanoList32;
     using DoubleEliasFano = elias_fano::DoubleEliasFanoList16;
+    using Murmur3 = encoding::Murmur3;
 
     //! The base class for RecSplit building strategies
     struct BuildingStrategy {

--- a/silkworm/db/datastore/snapshots/schema.cpp
+++ b/silkworm/db/datastore/snapshots/schema.cpp
@@ -83,10 +83,6 @@ Schema::DomainDef Schema::RepositoryDef::make_domain_schema(datastore::EntityNam
         .sub_dir_name(kDomainKVSegmentSubDirName)
         .tag(name2tag(name))
         .file_ext(kDomainKVSegmentFileExt);
-    schema.accessor_index(kDomainAccessorIndexName)
-        .sub_dir_name(kDomainAccessorIndexSubDirName)
-        .tag(name2tag(name))
-        .file_ext(kDomainAccessorIndexFileExt);
     schema.existence_index(kDomainExistenceIndexName)
         .sub_dir_name(kDomainExistenceIndexSubDirName)
         .tag(name2tag(name))
@@ -97,6 +93,14 @@ Schema::DomainDef Schema::RepositoryDef::make_domain_schema(datastore::EntityNam
         .file_ext(kDomainBTreeIndexFileExt);
     define_history_schema(name, schema);
     return schema;
+}
+
+Schema::DomainDef& Schema::DomainDef::with_accessor_index() {
+    accessor_index(kDomainAccessorIndexName)
+        .sub_dir_name(kDomainAccessorIndexSubDirName)
+        .tag(kv_segment(kDomainKVSegmentName).tag())
+        .file_ext(kDomainAccessorIndexFileExt);
+    return *this;
 }
 
 Schema::EntityDef Schema::RepositoryDef::make_history_schema(datastore::EntityName name) {

--- a/silkworm/db/datastore/snapshots/schema.hpp
+++ b/silkworm/db/datastore/snapshots/schema.hpp
@@ -185,9 +185,15 @@ class Schema {
             return *entity_defs_.at(name);
         }
 
+        RepositoryDef& index_salt_file_name(std::string_view value) {
+            index_salt_file_name_ = value;
+            return *this;
+        }
+
         const std::map<datastore::EntityName, std::shared_ptr<EntityDef>>& entities() const { return entity_defs_; }
         std::vector<std::string> file_extensions() const;
         std::optional<std::pair<datastore::EntityName, datastore::EntityName>> entity_name_by_path(const SnapshotPath& path) const;
+        const std::string& index_salt_file_name() const { return index_salt_file_name_.value(); }
 
       private:
         friend DomainDef;
@@ -200,6 +206,7 @@ class Schema {
         static void undefine_inverted_index_schema(EntityDef& schema);
 
         std::map<datastore::EntityName, std::shared_ptr<EntityDef>> entity_defs_;
+        std::optional<std::string> index_salt_file_name_;
     };
 
     RepositoryDef& repository(datastore::EntityName name) {

--- a/silkworm/db/datastore/snapshots/schema.hpp
+++ b/silkworm/db/datastore/snapshots/schema.hpp
@@ -164,6 +164,8 @@ class Schema {
             RepositoryDef::undefine_history_schema(*this);
             return *this;
         }
+
+        DomainDef& with_accessor_index();
     };
 
     class RepositoryDef {

--- a/silkworm/db/datastore/snapshots/snapshot_bundle.cpp
+++ b/silkworm/db/datastore/snapshots/snapshot_bundle.cpp
@@ -151,11 +151,14 @@ Domain SnapshotBundle::domain(datastore::EntityName name) const {
     auto& data = data_.entities.at(name);
     Domain domain{
         data.kv_segments.at(Schema::kDomainKVSegmentName),
-        data.accessor_indexes.at(Schema::kDomainAccessorIndexName),
+        nullptr,
         data.existence_indexes.at(Schema::kDomainExistenceIndexName),
         data.btree_indexes.at(Schema::kDomainBTreeIndexName),
         std::nullopt,
     };
+    if (data.accessor_indexes.contains(Schema::kDomainAccessorIndexName)) {
+        domain.accessor_index = &data.accessor_indexes.at(Schema::kDomainAccessorIndexName);
+    }
     if (data.segments.contains(Schema::kHistorySegmentName)) {
         domain.history.emplace(History{
             data.segments.at(Schema::kHistorySegmentName),

--- a/silkworm/db/datastore/snapshots/snapshot_bundle.hpp
+++ b/silkworm/db/datastore/snapshots/snapshot_bundle.hpp
@@ -49,7 +49,8 @@ struct SnapshotBundleData {
 SnapshotBundleData open_bundle_data(
     const Schema::RepositoryDef& schema,
     const std::filesystem::path& dir_path,
-    datastore::StepRange step_range);
+    datastore::StepRange step_range,
+    std::optional<uint32_t> index_salt);
 
 struct SnapshotBundlePaths {
     using StepRange = datastore::StepRange;
@@ -84,10 +85,11 @@ struct SnapshotBundle : public SegmentAndAccessorIndexProvider {
     SnapshotBundle(
         const Schema::RepositoryDef& schema,
         const std::filesystem::path& dir_path,
-        StepRange range)
+        StepRange range,
+        std::optional<uint32_t> index_salt)
         : SnapshotBundle{
               range,
-              open_bundle_data(schema, dir_path, range),
+              open_bundle_data(schema, dir_path, range, std::move(index_salt)),
           } {}
     ~SnapshotBundle() override;
 

--- a/silkworm/db/datastore/snapshots/snapshot_repository.cpp
+++ b/silkworm/db/datastore/snapshots/snapshot_repository.cpp
@@ -145,7 +145,7 @@ void SnapshotRepository::reopen_folder() {
             SnapshotBundlePaths bundle_paths{schema_, dir_path_, range};
             // if all bundle paths exist
             if (std::ranges::all_of(bundle_paths.files(), [](const fs::path& p) { return fs::exists(p); })) {
-                SnapshotBundle bundle{schema_, dir_path_, range};
+                SnapshotBundle bundle = open_bundle(range);
                 bundles->insert_or_assign(num, std::make_shared<SnapshotBundle>(std::move(bundle)));
             }
         }
@@ -159,6 +159,10 @@ void SnapshotRepository::reopen_folder() {
 
     SILK_INFO << "Total reopened bundles: " << bundles_count()
               << " max block available: " << max_block_available();
+}
+
+SnapshotBundle SnapshotRepository::open_bundle(StepRange range) const {
+    return SnapshotBundle{schema_, dir_path_, range, index_salt_};
 }
 
 std::shared_ptr<SnapshotBundle> SnapshotRepository::find_bundle(Timestamp t) const {

--- a/silkworm/db/datastore/snapshots/snapshot_repository.hpp
+++ b/silkworm/db/datastore/snapshots/snapshot_repository.hpp
@@ -54,6 +54,7 @@ class SnapshotRepository : public SnapshotRepositoryROAccess {
         bool open,
         Schema::RepositoryDef schema,
         std::unique_ptr<datastore::StepToTimestampConverter> step_converter,
+        std::optional<uint32_t> index_salt,
         std::unique_ptr<IndexBuildersFactory> index_builders_factory);
 
     SnapshotRepository(SnapshotRepository&&) = default;
@@ -107,6 +108,7 @@ class SnapshotRepository : public SnapshotRepositoryROAccess {
 
     bool is_stale_index_path(const SnapshotPath& index_path) const;
     SnapshotPathList stale_index_paths() const;
+    std::optional<uint32_t> load_index_salt() const;
 
     //! Path to the snapshots directory
     std::filesystem::path dir_path_;
@@ -116,6 +118,9 @@ class SnapshotRepository : public SnapshotRepositoryROAccess {
 
     //! Converts timestamp units to steps
     std::unique_ptr<datastore::StepToTimestampConverter> step_converter_;
+
+    //! Index salt
+    std::optional<uint32_t> index_salt_;
 
     //! Creates index builders
     std::unique_ptr<IndexBuildersFactory> index_builders_factory_;

--- a/silkworm/db/datastore/snapshots/snapshot_repository.hpp
+++ b/silkworm/db/datastore/snapshots/snapshot_repository.hpp
@@ -67,6 +67,9 @@ class SnapshotRepository : public SnapshotRepositoryROAccess {
 
     void reopen_folder();
 
+    //! Opens a detached bundle of snapshot files. Use add_snapshot_bundle or replace_snapshot_bundles to add it.
+    SnapshotBundle open_bundle(StepRange range) const;
+
     void add_snapshot_bundle(SnapshotBundle bundle);
 
     //! Replace bundles whose ranges are contained within the given bundle
@@ -79,6 +82,7 @@ class SnapshotRepository : public SnapshotRepositoryROAccess {
 
     std::vector<std::shared_ptr<IndexBuilder>> missing_indexes() const;
     void remove_stale_indexes() const;
+    const std::optional<uint32_t>& index_salt() const { return index_salt_; }
     void build_indexes(const SnapshotBundlePaths& bundle) const;
 
     BundlesView<MapValuesView<Bundles::key_type, Bundles::mapped_type>> view_bundles() const override {

--- a/silkworm/db/freezer.cpp
+++ b/silkworm/db/freezer.cpp
@@ -134,7 +134,7 @@ void Freezer::commit(std::shared_ptr<DataMigrationResult> result) {
     auto& bundle = freezer_result.bundle_paths;
     move_files(bundle.files(), snapshots_.path());
 
-    SnapshotBundle final_bundle{snapshots_.schema(), snapshots_.path(), bundle.step_range()};
+    SnapshotBundle final_bundle = snapshots_.open_bundle(bundle.step_range());
     snapshots_.add_snapshot_bundle(std::move(final_bundle));
 }
 

--- a/silkworm/db/snapshot_sync_test.cpp
+++ b/silkworm/db/snapshot_sync_test.cpp
@@ -133,11 +133,8 @@ TEST_CASE("SnapshotSync::update_block_headers", "[db][snapshot][sync]") {
 
     // Add a sample Snapshot bundle to the repository
     auto step_range = datastore::StepRange::from_block_num_range(snapshots::test_util::kSampleSnapshotBlockRange);
-    SnapshotBundle bundle{
-        step_range,
-        open_bundle_data(blocks::make_blocks_repository_schema(), tmp_dir_path, step_range),
-    };
     auto& repository = snapshot_sync.blocks_repository();
+    SnapshotBundle bundle = repository.open_bundle(step_range);
     repository.add_snapshot_bundle(std::move(bundle));
 
     // Update the block headers in the database according to the repository content

--- a/silkworm/db/state/account_codecs.hpp
+++ b/silkworm/db/state/account_codecs.hpp
@@ -45,19 +45,26 @@ struct AccountKVDBCodec : public datastore::kvdb::Codec {
 static_assert(datastore::kvdb::EncoderConcept<AccountKVDBCodec>);
 static_assert(datastore::kvdb::DecoderConcept<AccountKVDBCodec>);
 
-struct AccountDecoder : public snapshots::Decoder {
+struct AccountSnapshotsCodec : public snapshots::Codec {
     Account value;
+    Bytes word;
 
-    ~AccountDecoder() override = default;
+    ~AccountSnapshotsCodec() override = default;
 
-    void decode_word(ByteView word) override {
-        auto account = AccountCodec::from_encoded_storage_v3(word);
+    ByteView encode_word() override {
+        word = AccountCodec::encode_for_storage_v3(value);
+        return word;
+    }
+
+    void decode_word(ByteView input_word) override {
+        auto account = AccountCodec::from_encoded_storage_v3(input_word);
         if (!account)
-            throw DecodingException{account.error(), "AccountDecoder failed to decode Account"};
+            throw DecodingException{account.error(), "AccountSnapshotsCodec failed to decode Account"};
         value = std::move(*account);
     }
 };
 
-static_assert(snapshots::DecoderConcept<AccountDecoder>);
+static_assert(snapshots::EncoderConcept<AccountSnapshotsCodec>);
+static_assert(snapshots::DecoderConcept<AccountSnapshotsCodec>);
 
 }  // namespace silkworm::db::state

--- a/silkworm/db/state/accounts_domain.hpp
+++ b/silkworm/db/state/accounts_domain.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <silkworm/db/datastore/domain_get_latest_query.hpp>
 #include <silkworm/db/datastore/kvdb/domain_queries.hpp>
 #include <silkworm/db/datastore/snapshots/segment/kv_segment_reader.hpp>
 
@@ -24,10 +25,12 @@
 
 namespace silkworm::db::state {
 
-using AccountsDomainGetLatestQuery = datastore::kvdb::DomainGetLatestQuery<AddressKVDBEncoder, AccountKVDBCodec>;
+using AccountsDomainGetLatestQuery = datastore::DomainGetLatestQuery<
+    AddressKVDBEncoder, AddressSnapshotsEncoder,
+    AccountKVDBCodec, AccountSnapshotsCodec>;
 using AccountsDomainPutQuery = datastore::kvdb::DomainPutQuery<AddressKVDBEncoder, AccountKVDBCodec>;
 using AccountsDomainDeleteQuery = datastore::kvdb::DomainDeleteQuery<AddressKVDBEncoder, AccountKVDBCodec>;
 
-using AccountsDomainKVSegmentReader = snapshots::segment::KVSegmentReader<AddressDecoder, AccountDecoder>;
+using AccountsDomainKVSegmentReader = snapshots::segment::KVSegmentReader<AddressSnapshotsDecoder, AccountSnapshotsCodec>;
 
 }  // namespace silkworm::db::state

--- a/silkworm/db/state/address_codecs.hpp
+++ b/silkworm/db/state/address_codecs.hpp
@@ -37,18 +37,25 @@ struct AddressKVDBEncoder : public datastore::kvdb::Encoder {
 
 static_assert(datastore::kvdb::EncoderConcept<AddressKVDBEncoder>);
 
-struct AddressDecoder : public snapshots::Decoder {
+struct AddressSnapshotsCodec : public snapshots::Codec {
     evmc::address value;
+    ~AddressSnapshotsCodec() override = default;
 
-    ~AddressDecoder() override = default;
+    ByteView encode_word() override {
+        return ByteView{reinterpret_cast<uint8_t*>(&value.bytes), kAddressLength};
+    }
 
     void decode_word(ByteView word) override {
         if (word.size() < kAddressLength)
-            throw std::runtime_error{"AddressDecoder failed to decode"};
+            throw std::runtime_error{"AddressSnapshotsDecoder failed to decode"};
         std::memcpy(value.bytes, word.data(), kAddressLength);
     }
 };
 
-static_assert(snapshots::DecoderConcept<AddressDecoder>);
+static_assert(snapshots::EncoderConcept<AddressSnapshotsCodec>);
+static_assert(snapshots::DecoderConcept<AddressSnapshotsCodec>);
+
+using AddressSnapshotsEncoder = AddressSnapshotsCodec;
+using AddressSnapshotsDecoder = AddressSnapshotsCodec;
 
 }  // namespace silkworm::db::state

--- a/silkworm/db/state/address_codecs_test.cpp
+++ b/silkworm/db/state/address_codecs_test.cpp
@@ -22,13 +22,20 @@
 
 namespace silkworm::db::state {
 
-TEST_CASE("AddressDecoder") {
+TEST_CASE("AddressSnapshotsDecoder") {
     using evmc::literals::operator""_address;
-    AddressDecoder decoder;
+    AddressSnapshotsDecoder decoder;
     decoder.decode_word(*from_hex("0x000000000000000000636f6e736f6c652e6c6f67"));
     CHECK(decoder.value == 0x000000000000000000636f6e736f6c652e6c6f67_address);
 
     CHECK_THROWS_AS(decoder.decode_word({}), std::runtime_error);
+}
+
+TEST_CASE("AddressSnapshotsEncoder") {
+    using evmc::literals::operator""_address;
+    AddressSnapshotsEncoder encoder;
+    encoder.value = 0x000000000000000000636f6e736f6c652e6c6f67_address;
+    CHECK(encoder.encode_word() == *from_hex("0x000000000000000000636f6e736f6c652e6c6f67"));
 }
 
 }  // namespace silkworm::db::state

--- a/silkworm/db/state/code_domain.hpp
+++ b/silkworm/db/state/code_domain.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <silkworm/db/datastore/domain_get_latest_query.hpp>
 #include <silkworm/db/datastore/kvdb/domain_queries.hpp>
 #include <silkworm/db/datastore/snapshots/common/raw_codec.hpp>
 #include <silkworm/db/datastore/snapshots/segment/kv_segment_reader.hpp>
@@ -24,10 +25,12 @@
 
 namespace silkworm::db::state {
 
-using CodeDomainGetLatestQuery = datastore::kvdb::DomainGetLatestQuery<AddressKVDBEncoder, datastore::kvdb::RawDecoder<ByteView>>;
+using CodeDomainGetLatestQuery = datastore::DomainGetLatestQuery<
+    AddressKVDBEncoder, AddressSnapshotsEncoder,
+    datastore::kvdb::RawDecoder<Bytes>, snapshots::RawDecoder<Bytes>>;
 using CodeDomainPutQuery = datastore::kvdb::DomainPutQuery<AddressKVDBEncoder, datastore::kvdb::RawEncoder<ByteView>>;
 using CodeDomainDeleteQuery = datastore::kvdb::DomainDeleteQuery<AddressKVDBEncoder, datastore::kvdb::RawEncoder<ByteView>>;
 
-using CodeDomainKVSegmentReader = snapshots::segment::KVSegmentReader<AddressDecoder, snapshots::RawDecoder<Bytes>>;
+using CodeDomainKVSegmentReader = snapshots::segment::KVSegmentReader<AddressSnapshotsDecoder, snapshots::RawDecoder<Bytes>>;
 
 }  // namespace silkworm::db::state

--- a/silkworm/db/state/commitment_domain.hpp
+++ b/silkworm/db/state/commitment_domain.hpp
@@ -16,13 +16,16 @@
 
 #pragma once
 
+#include <silkworm/db/datastore/domain_get_latest_query.hpp>
 #include <silkworm/db/datastore/kvdb/domain_queries.hpp>
 #include <silkworm/db/datastore/snapshots/common/raw_codec.hpp>
 #include <silkworm/db/datastore/snapshots/segment/kv_segment_reader.hpp>
 
 namespace silkworm::db::state {
 
-using CommitmentDomainGetLatestQuery = datastore::kvdb::DomainGetLatestQuery<datastore::kvdb::RawEncoder<ByteView>, datastore::kvdb::RawDecoder<ByteView>>;
+using CommitmentDomainGetLatestQuery = datastore::DomainGetLatestQuery<
+    datastore::kvdb::RawEncoder<ByteView>, snapshots::RawEncoder<ByteView>,
+    datastore::kvdb::RawDecoder<Bytes>, snapshots::RawDecoder<Bytes>>;
 using CommitmentDomainPutQuery = datastore::kvdb::DomainPutQuery<datastore::kvdb::RawEncoder<ByteView>, datastore::kvdb::RawEncoder<ByteView>>;
 using CommitmentDomainDeleteQuery = datastore::kvdb::DomainDeleteQuery<datastore::kvdb::RawEncoder<ByteView>, datastore::kvdb::RawEncoder<ByteView>>;
 

--- a/silkworm/db/state/hash_decoder.hpp
+++ b/silkworm/db/state/hash_decoder.hpp
@@ -23,18 +23,18 @@
 
 namespace silkworm::db::state {
 
-struct HashDecoder : public snapshots::Decoder {
+struct HashSnapshotsDecoder : public snapshots::Decoder {
     Hash value;
 
-    ~HashDecoder() override = default;
+    ~HashSnapshotsDecoder() override = default;
 
     void decode_word(ByteView word) override {
         if (word.size() < kHashLength)
-            throw std::runtime_error{"HashDecoder failed to decode"};
+            throw std::runtime_error{"HashSnapshotsDecoder failed to decode"};
         value = Hash{word};
     }
 };
 
-static_assert(snapshots::DecoderConcept<HashDecoder>);
+static_assert(snapshots::DecoderConcept<HashSnapshotsDecoder>);
 
 }  // namespace silkworm::db::state

--- a/silkworm/db/state/hash_decoder_test.cpp
+++ b/silkworm/db/state/hash_decoder_test.cpp
@@ -22,9 +22,9 @@
 
 namespace silkworm::db::state {
 
-TEST_CASE("HashDecoder") {
+TEST_CASE("HashSnapshotsDecoder") {
     using evmc::literals::operator""_bytes32;
-    HashDecoder decoder;
+    HashSnapshotsDecoder decoder;
     decoder.decode_word(*from_hex("0xb397a22bb95bf14753ec174f02f99df3f0bdf70d1851cdff813ebf745f5aeb55"));
     CHECK(decoder.value == 0xb397a22bb95bf14753ec174f02f99df3f0bdf70d1851cdff813ebf745f5aeb55_bytes32);
 

--- a/silkworm/db/state/log_address_inverted_index.hpp
+++ b/silkworm/db/state/log_address_inverted_index.hpp
@@ -23,6 +23,6 @@
 
 namespace silkworm::db::state {
 
-using LogAddressInvertedIndexKVSegmentReader = snapshots::segment::KVSegmentReader<AddressDecoder, snapshots::RawDecoder<Bytes>>;
+using LogAddressInvertedIndexKVSegmentReader = snapshots::segment::KVSegmentReader<AddressSnapshotsDecoder, snapshots::RawDecoder<Bytes>>;
 
 }  // namespace silkworm::db::state

--- a/silkworm/db/state/receipts_domain.hpp
+++ b/silkworm/db/state/receipts_domain.hpp
@@ -18,13 +18,16 @@
 
 #include <stdexcept>
 
+#include <silkworm/db/datastore/domain_get_latest_query.hpp>
 #include <silkworm/db/datastore/kvdb/domain_queries.hpp>
 #include <silkworm/db/datastore/snapshots/segment/kv_segment_reader.hpp>
 #include <silkworm/db/datastore/snapshots/segment/seg/common/varint.hpp>
 
 namespace silkworm::db::state {
 
-using ReceiptsDomainGetLatestQuery = datastore::kvdb::DomainGetLatestQuery<datastore::kvdb::RawEncoder<ByteView>, datastore::kvdb::RawDecoder<ByteView>>;
+using ReceiptsDomainGetLatestQuery = datastore::DomainGetLatestQuery<
+    datastore::kvdb::RawEncoder<ByteView>, snapshots::RawEncoder<ByteView>,
+    datastore::kvdb::RawDecoder<Bytes>, snapshots::RawDecoder<Bytes>>;
 using ReceiptsDomainPutQuery = datastore::kvdb::DomainPutQuery<datastore::kvdb::RawEncoder<ByteView>, datastore::kvdb::RawEncoder<ByteView>>;
 using ReceiptsDomainDeleteQuery = datastore::kvdb::DomainDeleteQuery<datastore::kvdb::RawEncoder<ByteView>, datastore::kvdb::RawEncoder<ByteView>>;
 
@@ -34,31 +37,31 @@ enum class ReceiptsDomainKey : uint8_t {
     kFirstLogIndexKey = 2,
 };
 
-struct ReceiptsDomainKeyDecoder : public snapshots::Decoder {
+struct ReceiptsDomainKeySnapshotsDecoder : public snapshots::Decoder {
     ReceiptsDomainKey value{};
-    ~ReceiptsDomainKeyDecoder() override = default;
+    ~ReceiptsDomainKeySnapshotsDecoder() override = default;
     void decode_word(ByteView word) override {
         if (word.empty())
-            throw std::runtime_error{"ReceiptsDomainKeyDecoder failed to decode an empty word"};
+            throw std::runtime_error{"ReceiptsDomainKeySnapshotsDecoder failed to decode an empty word"};
         value = static_cast<ReceiptsDomainKey>(word[0]);
     }
 };
 
-static_assert(snapshots::DecoderConcept<ReceiptsDomainKeyDecoder>);
+static_assert(snapshots::DecoderConcept<ReceiptsDomainKeySnapshotsDecoder>);
 
-struct VarintDecoder : public snapshots::Decoder {
+struct VarintSnapshotsDecoder : public snapshots::Decoder {
     uint64_t value{};
-    ~VarintDecoder() override = default;
+    ~VarintSnapshotsDecoder() override = default;
     void decode_word(ByteView word) override {
         auto value_opt = snapshots::seg::varint::decode(word);
         if (!value_opt)
-            throw std::runtime_error{"VarintDecoder failed to decode"};
+            throw std::runtime_error{"VarintSnapshotsDecoder failed to decode"};
         value = *value_opt;
     }
 };
 
-static_assert(snapshots::DecoderConcept<VarintDecoder>);
+static_assert(snapshots::DecoderConcept<VarintSnapshotsDecoder>);
 
-using ReceiptsDomainKVSegmentReader = snapshots::segment::KVSegmentReader<ReceiptsDomainKeyDecoder, VarintDecoder>;
+using ReceiptsDomainKVSegmentReader = snapshots::segment::KVSegmentReader<ReceiptsDomainKeySnapshotsDecoder, VarintSnapshotsDecoder>;
 
 }  // namespace silkworm::db::state

--- a/silkworm/db/state/receipts_domain_test.cpp
+++ b/silkworm/db/state/receipts_domain_test.cpp
@@ -20,8 +20,8 @@
 
 namespace silkworm::db::state {
 
-TEST_CASE("ReceiptsDomainKeyDecoder") {
-    ReceiptsDomainKeyDecoder decoder;
+TEST_CASE("ReceiptsDomainKeySnapshotsDecoder") {
+    ReceiptsDomainKeySnapshotsDecoder decoder;
     decoder.decode_word(Bytes{1});
     CHECK(decoder.value == ReceiptsDomainKey::kCumulativeBlobGasUsedInBlockKey);
 

--- a/silkworm/db/state/schema_config.cpp
+++ b/silkworm/db/state/schema_config.cpp
@@ -22,6 +22,7 @@ namespace silkworm::db::state {
 
 snapshots::Schema::RepositoryDef make_state_repository_schema() {
     snapshots::Schema::RepositoryDef schema;
+    schema.index_salt_file_name("salt-state.txt");
 
     schema.domain(kDomainNameAccounts)
         .tag_override(kDomainAccountsTag);
@@ -68,12 +69,16 @@ std::unique_ptr<snapshots::IndexBuildersFactory> make_state_index_builders_facto
     return std::make_unique<StateIndexBuildersFactory>(make_state_repository_schema());
 }
 
-snapshots::SnapshotRepository make_state_repository(std::filesystem::path dir_path, bool open) {
+snapshots::SnapshotRepository make_state_repository(
+    std::filesystem::path dir_path,
+    bool open,
+    std::optional<uint32_t> index_salt) {
     return snapshots::SnapshotRepository{
         std::move(dir_path),
         open,
         make_state_repository_schema(),
         std::make_unique<datastore::StepToTxnIdConverter>(),
+        std::move(index_salt),
         make_state_index_builders_factory(),
     };
 }

--- a/silkworm/db/state/schema_config.hpp
+++ b/silkworm/db/state/schema_config.hpp
@@ -38,7 +38,8 @@ std::unique_ptr<snapshots::IndexBuildersFactory> make_state_index_builders_facto
 
 snapshots::SnapshotRepository make_state_repository(
     std::filesystem::path dir_path,
-    bool open = true);
+    bool open = true,
+    std::optional<uint32_t> index_salt = std::nullopt);
 
 inline constexpr datastore::EntityName kDomainNameAccounts{"Account"};
 inline constexpr datastore::EntityName kDomainNameStorage{"Storage"};

--- a/silkworm/db/state/storage_codecs.cpp
+++ b/silkworm/db/state/storage_codecs.cpp
@@ -30,4 +30,22 @@ datastore::kvdb::Slice StorageAddressAndLocationKVDBEncoder::encode() {
     return datastore::kvdb::to_slice(data);
 }
 
+ByteView StorageAddressAndLocationSnapshotsCodec::encode_word() {
+    // TODO: this extra copy could be avoided if encoders are able to contain a reference
+    codec.address.value = value.address;
+    codec.location_hash.value = value.location_hash;
+
+    word.clear();
+    word.reserve(kAddressLength + kHashLength);
+    word.append(codec.address.encode_word());
+    word.append(codec.location_hash.encode_word());
+    return word;
+}
+
+void StorageAddressAndLocationSnapshotsCodec::decode_word(ByteView input_word) {
+    codec.address.decode_word(input_word);
+    codec.location_hash.decode_word(input_word.substr(kAddressLength));
+    value = {codec.address.value, codec.location_hash.value};
+}
+
 }  // namespace silkworm::db::state

--- a/silkworm/db/state/storage_domain.hpp
+++ b/silkworm/db/state/storage_domain.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <silkworm/db/datastore/domain_get_latest_query.hpp>
 #include <silkworm/db/datastore/kvdb/domain_queries.hpp>
 #include <silkworm/db/datastore/snapshots/segment/kv_segment_reader.hpp>
 
@@ -23,10 +24,12 @@
 
 namespace silkworm::db::state {
 
-using StorageDomainGetLatestQuery = datastore::kvdb::DomainGetLatestQuery<StorageAddressAndLocationKVDBEncoder, Bytes32KVDBCodec>;
+using StorageDomainGetLatestQuery = datastore::DomainGetLatestQuery<
+    StorageAddressAndLocationKVDBEncoder, StorageAddressAndLocationSnapshotsCodec,
+    Bytes32KVDBCodec, Bytes32SnapshotsCodec>;
 using StorageDomainPutQuery = datastore::kvdb::DomainPutQuery<StorageAddressAndLocationKVDBEncoder, Bytes32KVDBCodec>;
 using StorageDomainDeleteQuery = datastore::kvdb::DomainDeleteQuery<StorageAddressAndLocationKVDBEncoder, Bytes32KVDBCodec>;
 
-using StorageDomainKVSegmentReader = snapshots::segment::KVSegmentReader<StorageAddressAndLocationDecoder, Bytes32Decoder>;
+using StorageDomainKVSegmentReader = snapshots::segment::KVSegmentReader<StorageAddressAndLocationSnapshotsCodec, Bytes32SnapshotsCodec>;
 
 }  // namespace silkworm::db::state

--- a/silkworm/db/state/storage_domain_test.cpp
+++ b/silkworm/db/state/storage_domain_test.cpp
@@ -22,19 +22,33 @@
 
 namespace silkworm::db::state {
 
-TEST_CASE("StorageAddressAndLocationDecoder") {
+TEST_CASE("StorageAddressAndLocationSnapshotsCodec.decode_word") {
     using evmc::literals::operator""_address;
     using evmc::literals::operator""_bytes32;
-    StorageAddressAndLocationDecoder decoder;
+    StorageAddressAndLocationSnapshotsCodec decoder;
 
     decoder.decode_word(
         *from_hex(
             "000000000000000000636f6e736f6c652e6c6f67"
             "000000000000000000000000000000000000000000005666856076ebaf477f07"));
-    CHECK(decoder.value.address.value == 0x000000000000000000636f6e736f6c652e6c6f67_address);
-    CHECK(decoder.value.location_hash.value == 0x000000000000000000000000000000000000000000005666856076ebaf477f07_bytes32);
+    CHECK(decoder.value.address == 0x000000000000000000636f6e736f6c652e6c6f67_address);
+    CHECK(decoder.value.location_hash == 0x000000000000000000000000000000000000000000005666856076ebaf477f07_bytes32);
 
     CHECK_THROWS_AS(decoder.decode_word({}), std::runtime_error);
+}
+
+TEST_CASE("StorageAddressAndLocationSnapshotsCodec.encode_word") {
+    using evmc::literals::operator""_address;
+    using evmc::literals::operator""_bytes32;
+    StorageAddressAndLocationSnapshotsCodec encoder;
+
+    encoder.value.address = 0x000000000000000000636f6e736f6c652e6c6f67_address;
+    encoder.value.location_hash = 0x000000000000000000000000000000000000000000005666856076ebaf477f07_bytes32;
+    CHECK(
+        encoder.encode_word() ==
+        *from_hex(
+            "000000000000000000636f6e736f6c652e6c6f67"
+            "000000000000000000000000000000000000000000005666856076ebaf477f07"));
 }
 
 }  // namespace silkworm::db::state

--- a/silkworm/db/state/traces_from_inverted_index.hpp
+++ b/silkworm/db/state/traces_from_inverted_index.hpp
@@ -23,6 +23,6 @@
 
 namespace silkworm::db::state {
 
-using TracesFromInvertedIndexKVSegmentReader = snapshots::segment::KVSegmentReader<AddressDecoder, snapshots::RawDecoder<Bytes>>;
+using TracesFromInvertedIndexKVSegmentReader = snapshots::segment::KVSegmentReader<AddressSnapshotsDecoder, snapshots::RawDecoder<Bytes>>;
 
 }  // namespace silkworm::db::state

--- a/silkworm/db/state/traces_to_inverted_index.hpp
+++ b/silkworm/db/state/traces_to_inverted_index.hpp
@@ -23,6 +23,6 @@
 
 namespace silkworm::db::state {
 
-using TracesToInvertedIndexKVSegmentReader = snapshots::segment::KVSegmentReader<AddressDecoder, snapshots::RawDecoder<Bytes>>;
+using TracesToInvertedIndexKVSegmentReader = snapshots::segment::KVSegmentReader<AddressSnapshotsDecoder, snapshots::RawDecoder<Bytes>>;
 
 }  // namespace silkworm::db::state

--- a/silkworm/execution/local_state.cpp
+++ b/silkworm/execution/local_state.cpp
@@ -19,6 +19,7 @@
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/db/state/accounts_domain.hpp>
 #include <silkworm/db/state/code_domain.hpp>
+#include <silkworm/db/state/schema_config.hpp>
 #include <silkworm/db/state/storage_domain.hpp>
 
 namespace silkworm::execution {
@@ -27,7 +28,12 @@ using namespace db::state;
 using namespace datastore;
 
 std::optional<Account> LocalState::read_account(const evmc::address& address) const noexcept {
-    AccountsDomainGetLatestQuery query{tx_, data_store_.state_db().accounts_domain()};
+    AccountsDomainGetLatestQuery query{
+        db::state::kDomainNameAccounts,
+        data_store_.chaindata,
+        tx_,
+        data_store_.state_repository,
+    };
     auto result = query.exec(address);
     if (result) {
         return std::move(result->value);
@@ -36,7 +42,12 @@ std::optional<Account> LocalState::read_account(const evmc::address& address) co
 }
 
 ByteView LocalState::read_code(const evmc::address& address, const evmc::bytes32& /*code_hash*/) const noexcept {
-    CodeDomainGetLatestQuery query{tx_, data_store_.state_db().code_domain()};
+    CodeDomainGetLatestQuery query{
+        db::state::kDomainNameCode,
+        data_store_.chaindata,
+        tx_,
+        data_store_.state_repository,
+    };
     auto result = query.exec(address);
     if (result) {
         return std::move(result->value);
@@ -48,7 +59,12 @@ evmc::bytes32 LocalState::read_storage(
     const evmc::address& address,
     uint64_t /*incarnation*/,
     const evmc::bytes32& location) const noexcept {
-    StorageDomainGetLatestQuery query{tx_, data_store_.state_db().storage_domain()};
+    StorageDomainGetLatestQuery query{
+        db::state::kDomainNameStorage,
+        data_store_.chaindata,
+        tx_,
+        data_store_.state_repository,
+    };
     auto result = query.exec({address, location});
     if (result) {
         return std::move(result->value);


### PR DESCRIPTION
DomainGetLatestQuery was implemented only for kvdb before.

This implements DomainGetLatestQuery for snapshots
and combines both queries on the datastore.

The example usages are updated in LocalState.

DomainGetLatestQuery uses BloomFilter existence index. Previously BloomFilter only accepted uint64_t as a lookup key. Now it is able to lookup using any ByteView key much like RecSplit/AccessorIndex. Hashing this key requires having a salt from "salt-state.txt". This file is read by SnapshotRepository::reopen_folder() and passed along to the BloomFilter constructor. If a SnapshotRepository is externally managed (via CAPI), the index_salt is expected to be passed on construction via CAPI.

Additional changes:
* disable domain accessor index by default - it is unused in Erigon 3 ATM
* move murmur_hash3 to snapshots/common - to reuse in BloomFilterKeyHasher
* "Snapshots" is added into snapshots codec names to distinguish from KVDB codecs, necessary codecs added
