### PR TITLE
rpcdaemon: debug_traceCall with txIndex

### DIFF
--- a/.github/workflows/rpc-integration-tests.yml
+++ b/.github/workflows/rpc-integration-tests.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout RPC Tests Repository & Install Requirements
         run: |
           rm -rf ${{runner.workspace}}/rpc-tests
-          git -c advice.detachedHead=false clone --depth 1 --branch v1.35.0 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
+          git -c advice.detachedHead=false clone --depth 1 --branch v1.36.0 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
           cd ${{runner.workspace}}/rpc-tests
           pip3 install -r requirements.txt --break-system-packages
 

--- a/.github/workflows/rpc-integration-tests.yml
+++ b/.github/workflows/rpc-integration-tests.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout RPC Tests Repository & Install Requirements
         run: |
           rm -rf ${{runner.workspace}}/rpc-tests
-          git -c advice.detachedHead=false clone --depth 1 --branch v1.36.0 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
+          git -c advice.detachedHead=false clone --depth 1 --branch v1.36.1 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
           cd ${{runner.workspace}}/rpc-tests
           pip3 install -r requirements.txt --break-system-packages
 

--- a/.github/workflows/run_integration_tests.sh
+++ b/.github/workflows/run_integration_tests.sh
@@ -27,6 +27,7 @@ debug_traceBlockByNumber/test_11,\
 debug_traceBlockByNumber/test_12,\
 debug_traceBlockByNumber/test_29,\
 debug_traceCall/test_16,\
+debug_traceCall/test_17,\
 debug_traceCall/test_20,\
 debug_traceCall/test_21,\
 debug_traceTransaction/test_25.json,\

--- a/.github/workflows/run_integration_tests.sh
+++ b/.github/workflows/run_integration_tests.sh
@@ -26,6 +26,9 @@ debug_traceBlockByNumber/test_10,\
 debug_traceBlockByNumber/test_11,\
 debug_traceBlockByNumber/test_12,\
 debug_traceBlockByNumber/test_29,\
+debug_traceCall/test_16,\
+debug_traceCall/test_20,\
+debug_traceCall/test_21,\
 debug_traceTransaction/test_25.json,\
 debug_traceTransaction/test_36.json,\
 debug_traceTransaction/test_43.json,\

--- a/silkworm/rpc/core/evm_debug.cpp
+++ b/silkworm/rpc/core/evm_debug.cpp
@@ -390,6 +390,17 @@ Task<void> DebugExecutor::trace_call(json::Stream& stream, const BlockNumOrHash&
     }
     rpc::Transaction transaction{call.to_transaction()};
 
+    if (config_.tx_index) {
+        const auto tx_index = static_cast<size_t>(config_.tx_index.value());
+        if (tx_index > block_with_hash->block.transactions.size()) {
+            std::ostringstream oss;
+            oss << "TxIndex " << tx_index << " greater than #tnx in block " << block_num_or_hash;
+            const Error error{-32000, oss.str()};
+            stream.write_json_field("error", error);
+
+            co_return;
+        }
+    }
     stream.write_field("result");
     stream.open_object();
 

--- a/silkworm/rpc/core/evm_debug.hpp
+++ b/silkworm/rpc/core/evm_debug.hpp
@@ -49,6 +49,7 @@ struct DebugConfig {
     bool disable_memory{false};
     bool disable_stack{false};
     bool no_refunds{false};
+    std::optional<int32_t> tx_index;
 };
 
 std::string uint256_to_hex(const evmone::uint256& x);


### PR DESCRIPTION
Fixes #1652 supporting optional `txIndex` parameter in `debug_traceCall`