### PR TITLE
ci: fix Windows build after PR 2632

### DIFF
--- a/silkworm/core/rlp/decode_test.cpp
+++ b/silkworm/core/rlp/decode_test.cpp
@@ -28,7 +28,7 @@ template <class T>
 static T decode_success(std::string_view hex) {
     Bytes bytes{*from_hex(hex)};
     ByteView view{bytes};
-    T res;
+    T res{};
     REQUIRE(decode(view, res));
     return res;
 }

--- a/silkworm/db/datastore/concat_view.hpp
+++ b/silkworm/db/datastore/concat_view.hpp
@@ -103,7 +103,7 @@ class ConcatView : public std::ranges::view_interface<ConcatView<Range1, Range2>
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
                 if (*it2_ == *sentinel2_) {
-#if !defined(_WIN32) && __GNUC__ < 12 && !defined(__clang__)
+#if defined(__GNUC__) && __GNUC__ < 12 && !defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
                     it2_ = std::nullopt;

--- a/silkworm/db/datastore/concat_view.hpp
+++ b/silkworm/db/datastore/concat_view.hpp
@@ -98,7 +98,7 @@ class ConcatView : public std::ranges::view_interface<ConcatView<Range1, Range2>
                 }
             } else if (it2_) {
                 ++(*it2_);
-#if !defined(_WIN32) && __GNUC__ < 12 && !defined(__clang__)
+#if defined(__GNUC__) && __GNUC__ < 12 && !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif

--- a/silkworm/db/datastore/concat_view.hpp
+++ b/silkworm/db/datastore/concat_view.hpp
@@ -98,12 +98,12 @@ class ConcatView : public std::ranges::view_interface<ConcatView<Range1, Range2>
                 }
             } else if (it2_) {
                 ++(*it2_);
-#if __GNUC__ < 12 && !defined(__clang__)
+#if !defined(_WIN32) && __GNUC__ < 12 && !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
                 if (*it2_ == *sentinel2_) {
-#if __GNUC__ < 12 && !defined(__clang__)
+#if !defined(_WIN32) && __GNUC__ < 12 && !defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
                     it2_ = std::nullopt;
@@ -118,6 +118,12 @@ class ConcatView : public std::ranges::view_interface<ConcatView<Range1, Range2>
         }
         friend bool operator!=(const Iterator& it, const std::default_sentinel_t&) {
             return it.it1_ || it.it2_;
+        }
+        friend bool operator==(const std::default_sentinel_t& s, const Iterator& it) {
+            return it == s;
+        }
+        friend bool operator!=(const std::default_sentinel_t& s, const Iterator& it) {
+            return it != s;
         }
 
       private:

--- a/silkworm/db/datastore/kvdb/inverted_index_range_by_key_query_test.cpp
+++ b/silkworm/db/datastore/kvdb/inverted_index_range_by_key_query_test.cpp
@@ -44,7 +44,7 @@ void init_inverted_index(RWTxn& tx, InvertedIndex ii, std::multimap<uint64_t, Ti
 
 TEST_CASE("InvertedIndexRangeByKeyQuery") {
     const TemporaryDirectory tmp_dir;
-    ::mdbx::env_managed env = open_env(EnvConfig{.path = tmp_dir.path(), .create = true, .in_memory = true});
+    ::mdbx::env_managed env = open_env(EnvConfig{.path = tmp_dir.path().string(), .create = true, .in_memory = true});
 
     EntityName name{"Test"};
     Schema::DatabaseDef schema;

--- a/silkworm/db/datastore/snapshots/bittorrent/torrent_file.cpp
+++ b/silkworm/db/datastore/snapshots/bittorrent/torrent_file.cpp
@@ -33,7 +33,7 @@
 
 namespace silkworm::snapshots::bittorrent {
 
-static constexpr int kDefaultPieceSize = 2_Mebi;
+static constexpr int kDefaultPieceSize = static_cast<int>(2_Mebi);
 
 TorrentFile::TorrentFile(ByteView data)
     : params_(lt::load_torrent_buffer(byte_view_to_str_span(data))) {

--- a/silkworm/db/datastore/snapshots/elias_fano/list_iterator.hpp
+++ b/silkworm/db/datastore/snapshots/elias_fano/list_iterator.hpp
@@ -32,14 +32,14 @@ concept IndexedListConcept = requires(const TList list) {
 
 static_assert(IndexedListConcept<std::vector<int>>);
 
-template </* IndexedListConcept */ class TList, typename TValueReference = typename TList::value_type&>
+template </* IndexedListConcept */ class TList, typename TValue = typename TList::value_type>
 class ListIterator {
   public:
-    using value_type = typename TList::value_type;
+    using value_type = TValue;
     using iterator_category [[maybe_unused]] = std::random_access_iterator_tag;
     using difference_type = std::ptrdiff_t;
     using pointer = value_type*;
-    using reference = TValueReference;
+    using reference = value_type;
 
     ListIterator() = default;
     ListIterator(const TList& list, size_t i) : list_{&list}, i_{i} {}

--- a/silkworm/infra/concurrency/task_group_test.cpp
+++ b/silkworm/infra/concurrency/task_group_test.cpp
@@ -57,7 +57,7 @@ static Task<void> wait_until_cancelled(bool* is_cancelled) {
         steady_timer timer(executor);
         timer.expires_after(1h);
         co_await timer.async_wait(use_awaitable);
-    } catch (const boost::system::system_error& ex) {
+    } catch (const boost::system::system_error&) {
         *is_cancelled = true;
     }
 }

--- a/silkworm/infra/concurrency/timeout_test.cpp
+++ b/silkworm/infra/concurrency/timeout_test.cpp
@@ -83,7 +83,7 @@ Task<void> wait_until_cancelled_bad() {
         steady_timer timer(executor);
         timer.expires_after(1h);
         co_await timer.async_wait(use_awaitable);
-    } catch (const boost::system::system_error& ex) {
+    } catch (const boost::system::system_error&) {
         throw BadCancelException();
     }
 }

--- a/silkworm/infra/grpc/server/server_context_pool.cpp
+++ b/silkworm/infra/grpc/server/server_context_pool.cpp
@@ -32,7 +32,7 @@ static std::string build_thread_name(const char name_tag[11], size_t id) {
 ServerContext::ServerContext(size_t context_id, ServerCompletionQueuePtr queue)
     : Context{context_id},
       server_grpc_context_{std::make_unique<agrpc::GrpcContext>(std::move(queue))},
-      client_grpc_context_{std::make_unique<agrpc::GrpcContext>(std::make_unique<grpc::CompletionQueue>())},
+      client_grpc_context_{std::make_unique<agrpc::GrpcContext>()},
       server_grpc_context_work_{boost::asio::make_work_guard(server_grpc_context_->get_executor())},
       client_grpc_context_work_{boost::asio::make_work_guard(client_grpc_context_->get_executor())} {}
 

--- a/silkworm/interfaces/CMakeLists.txt
+++ b/silkworm/interfaces/CMakeLists.txt
@@ -45,14 +45,17 @@ add_dependencies(
 )
 # cmake-format: on
 
-if(NOT MSVC)
+# Disable warning in gRPC generated code on different compilers
+if(MSVC)
+  target_compile_options(silkworm_interfaces PRIVATE /wd4100) # C4100: unreferenced formal parameter
+else()
   target_compile_options(silkworm_interfaces PRIVATE -Wno-sign-conversion)
 
   check_cxx_compiler_flag("-Wno-deprecated-pragma" HAS_NO_DEPRECATED_PRAGMA)
   if(HAS_NO_DEPRECATED_PRAGMA)
     target_compile_options(silkworm_interfaces PRIVATE -Wno-deprecated-pragma)
   endif()
-endif(NOT MSVC)
+endif()
 
 target_include_directories(silkworm_interfaces PUBLIC "${SILKWORM_MAIN_DIR};${CMAKE_CURRENT_SOURCE_DIR}")
 

--- a/silkworm/rpc/commands/debug_api.cpp
+++ b/silkworm/rpc/commands/debug_api.cpp
@@ -274,7 +274,7 @@ Task<void> DebugRpcApi::handle_debug_storage_range_at(const nlohmann::json& requ
         }
 
         reply = make_json_content(request, result);
-    } catch (const std::invalid_argument& e) {
+    } catch (const std::invalid_argument&) {
         nlohmann::json result = {{"storage", nullptr}, {"nextKey", nullptr}};
         reply = make_json_content(request, result);
     } catch (const std::exception& e) {

--- a/silkworm/rpc/commands/erigon_api.cpp
+++ b/silkworm/rpc/commands/erigon_api.cpp
@@ -248,7 +248,7 @@ Task<void> ErigonRpcApi::handle_erigon_get_header_by_hash(const nlohmann::json& 
         } else {
             reply = make_json_content(request, *header);
         }
-    } catch (const std::invalid_argument& iv) {
+    } catch (const std::invalid_argument&) {
         reply = make_json_error(request, kServerError, "block header not found: 0x" + silkworm::to_hex(block_hash));
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
@@ -423,7 +423,7 @@ Task<void> ErigonRpcApi::handle_erigon_get_logs_by_hash(const nlohmann::json& re
         SILK_DEBUG << "logs.size(): " << logs.size();
 
         reply = make_json_content(request, logs);
-    } catch (const std::invalid_argument& iv) {
+    } catch (const std::invalid_argument&) {
         reply = make_json_content(request, nullptr);
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();

--- a/silkworm/rpc/commands/eth_api.cpp
+++ b/silkworm/rpc/commands/eth_api.cpp
@@ -205,7 +205,7 @@ Task<void> EthereumRpcApi::handle_eth_get_block_by_hash(const nlohmann::json& re
         } else {
             make_glaze_json_null_content(request, reply);
         }
-    } catch (const std::invalid_argument& iv) {
+    } catch (const std::invalid_argument&) {
         make_glaze_json_null_content(request, reply);
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
@@ -247,7 +247,7 @@ Task<void> EthereumRpcApi::handle_eth_get_block_by_number(const nlohmann::json& 
         } else {
             make_glaze_json_null_content(request, reply);
         }
-    } catch (const std::invalid_argument& iv) {
+    } catch (const std::invalid_argument&) {
         make_glaze_json_null_content(request, reply);
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
@@ -283,7 +283,7 @@ Task<void> EthereumRpcApi::handle_eth_get_block_transaction_count_by_hash(const 
         } else {
             reply = make_json_content(request, nullptr);
         }
-    } catch (const std::invalid_argument& iv) {
+    } catch (const std::invalid_argument&) {
         reply = make_json_content(request, nullptr);
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
@@ -322,7 +322,7 @@ Task<void> EthereumRpcApi::handle_eth_get_block_transaction_count_by_number(cons
         } else {
             reply = make_json_content(request, nullptr);
         }
-    } catch (const std::invalid_argument& iv) {
+    } catch (const std::invalid_argument&) {
         reply = make_json_content(request, nullptr);
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
@@ -374,7 +374,7 @@ Task<void> EthereumRpcApi::handle_eth_get_uncle_by_block_hash_and_index(const nl
         } else {
             make_glaze_json_null_content(request, reply);
         }
-    } catch (const std::invalid_argument& iv) {
+    } catch (const std::invalid_argument&) {
         make_glaze_json_null_content(request, reply);
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
@@ -428,7 +428,7 @@ Task<void> EthereumRpcApi::handle_eth_get_uncle_by_block_num_and_index(const nlo
         } else {
             make_glaze_json_null_content(request, reply);
         }
-    } catch (const std::invalid_argument& iv) {
+    } catch (const std::invalid_argument&) {
         make_glaze_json_null_content(request, reply);
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
@@ -465,7 +465,7 @@ Task<void> EthereumRpcApi::handle_eth_get_uncle_count_by_block_hash(const nlohma
             const auto ommers = block_with_hash->block.ommers.size();
             reply = make_json_content(request, to_quantity(ommers));
         }
-    } catch (const std::invalid_argument& iv) {
+    } catch (const std::invalid_argument&) {
         reply = make_json_content(request, nullptr);
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
@@ -554,7 +554,7 @@ Task<void> EthereumRpcApi::handle_eth_get_transaction_by_hash(const nlohmann::js
         } else {
             make_glaze_json_content(request, tx_with_block->transaction, reply);
         }
-    } catch (const std::invalid_argument& iv) {
+    } catch (const std::invalid_argument&) {
         make_glaze_json_null_content(request, reply);
     } catch (const boost::system::system_error& se) {
         make_glaze_json_null_content(request, reply);
@@ -601,7 +601,7 @@ Task<void> EthereumRpcApi::handle_eth_get_raw_transaction_by_hash(const nlohmann
             silkworm::rlp::encode(rlp.buffer, tx_with_block->transaction, false);
             reply = make_json_content(request, rlp);
         }
-    } catch (const std::invalid_argument& iv) {
+    } catch (const std::invalid_argument&) {
         Rlp rlp{};
         reply = make_json_content(request, rlp);
     } catch (const std::exception& e) {
@@ -649,7 +649,7 @@ Task<void> EthereumRpcApi::handle_eth_get_transaction_by_block_hash_and_index(co
         } else {
             reply = make_json_content(request, nullptr);
         }
-    } catch (const std::invalid_argument& iv) {
+    } catch (const std::invalid_argument&) {
         reply = make_json_content(request, nullptr);
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
@@ -697,7 +697,7 @@ Task<void> EthereumRpcApi::handle_eth_get_raw_transaction_by_block_hash_and_inde
             Rlp rlp{};
             reply = make_json_content(request, rlp);
         }
-    } catch (const std::invalid_argument& iv) {
+    } catch (const std::invalid_argument&) {
         Rlp rlp{};
         reply = make_json_content(request, rlp);
     } catch (const std::exception& e) {
@@ -748,7 +748,7 @@ Task<void> EthereumRpcApi::handle_eth_get_transaction_by_block_num_and_index(con
             Rlp rlp{};
             reply = make_json_content(request, rlp);
         }
-    } catch (const std::invalid_argument& iv) {
+    } catch (const std::invalid_argument&) {
         Rlp rlp{};
         reply = make_json_content(request, rlp);
     } catch (const std::exception& e) {
@@ -799,7 +799,7 @@ Task<void> EthereumRpcApi::handle_eth_get_raw_transaction_by_block_num_and_index
             Rlp rlp{};
             reply = make_json_content(request, rlp);
         }
-    } catch (const std::invalid_argument& iv) {
+    } catch (const std::invalid_argument&) {
         Rlp rlp{};
         reply = make_json_content(request, rlp);
     } catch (const std::exception& e) {
@@ -859,7 +859,7 @@ Task<void> EthereumRpcApi::handle_eth_get_transaction_receipt(const nlohmann::js
             throw std::invalid_argument{"Unexpected transaction index in handle_eth_get_transaction_receipt"};
         }
         reply = make_json_content(request, receipts[*tx_index]);
-    } catch (const std::invalid_argument& iv) {
+    } catch (const std::invalid_argument&) {
         reply = make_json_content(request, {});
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
@@ -929,7 +929,7 @@ Task<void> EthereumRpcApi::handle_eth_estimate_gas(const nlohmann::json& request
         const auto estimated_gas = co_await estimate_gas_oracle.estimate_gas(call, latest_block, txn_id, block_num_for_gas_limit);
 
         reply = make_json_content(request, to_quantity(estimated_gas));
-    } catch (const std::invalid_argument& iv) {
+    } catch (const std::invalid_argument&) {
         reply = make_json_content(request, to_quantity(0));
     } catch (const rpc::EstimateGasException& e) {
         SILK_ERROR << "EstimateGasException: code: " << e.error_code() << " message: " << e.message() << " processing request: " << request.dump();
@@ -979,7 +979,7 @@ Task<void> EthereumRpcApi::handle_eth_get_balance(const nlohmann::json& request,
         std::optional<silkworm::Account> account{co_await state_reader.read_account(address)};
 
         reply = make_json_content(request, "0x" + (account ? intx::hex(account->balance) : "0"));
-    } catch (const std::invalid_argument& iv) {
+    } catch (const std::invalid_argument&) {
         reply = make_json_content(request, "0x0");
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
@@ -1390,7 +1390,7 @@ Task<void> EthereumRpcApi::handle_eth_create_access_list(const nlohmann::json& r
             txn = call.to_transaction(current_access_list, nonce);
             saved_access_list = current_access_list;
         }
-    } catch (const std::invalid_argument& iv) {
+    } catch (const std::invalid_argument&) {
         reply = make_json_content(request, {});
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
@@ -1494,7 +1494,7 @@ Task<void> EthereumRpcApi::handle_eth_call_bundle(const nlohmann::json& request,
             bundle_info.bundle_hash = hash_of(hash_data);
             reply = make_json_content(request, bundle_info);
         }
-    } catch (const std::invalid_argument& iv) {
+    } catch (const std::invalid_argument&) {
         reply = make_json_content(request, {});
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
@@ -1543,7 +1543,7 @@ Task<void> EthereumRpcApi::handle_eth_new_filter(const nlohmann::json& request, 
         } else {
             reply = make_json_error(request, kServerError, "TODO");
         }
-    } catch (const std::invalid_argument& iv) {
+    } catch (const std::invalid_argument&) {
         reply = make_json_content(request, {});
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
@@ -1628,7 +1628,7 @@ Task<void> EthereumRpcApi::handle_eth_get_filter_logs(const nlohmann::json& requ
         filter.end = end;
 
         reply = make_json_content(request, filter.logs);
-    } catch (const std::invalid_argument& iv) {
+    } catch (const std::invalid_argument&) {
         reply = make_json_content(request, {});
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
@@ -1750,7 +1750,7 @@ Task<void> EthereumRpcApi::handle_eth_get_logs(const nlohmann::json& request, st
         co_await logs_walker.get_logs(start, end, filter.addresses, filter.topics, logs);
 
         make_glaze_json_content(request, logs, reply);
-    } catch (const std::invalid_argument& iv) {
+    } catch (const std::invalid_argument&) {
         std::vector<silkworm::rpc::Log> log{};
         make_glaze_json_content(request, log, reply);
     } catch (const std::exception& e) {

--- a/silkworm/rpc/commands/ots_api.cpp
+++ b/silkworm/rpc/commands/ots_api.cpp
@@ -48,6 +48,7 @@ namespace bitmap {
     using namespace silkworm::datastore::kvdb::bitmap;
 }
 
+//! The current supported version of the Otterscan API
 static constexpr int kCurrentApiLevel{8};
 
 //! The window size used when probing history periodically
@@ -1032,7 +1033,7 @@ Task<ChunkProviderResponse> ChunkProvider::get() {
                 key_value = co_await cursor_->previous();
             }
         }
-    } catch (const std::exception& e) {
+    } catch (const std::exception&) {
         error_ = true;
     }
 
@@ -1068,7 +1069,7 @@ Task<ChunkLocatorResponse> ChunkLocator::get(BlockNum min_block) {
 
         co_return ChunkLocatorResponse{ChunkProvider{cursor_, address_, navigate_forward_, key_value}, true, false};
 
-    } catch (const std::exception& e) {
+    } catch (const std::exception&) {
         co_return ChunkLocatorResponse{ChunkProvider{cursor_, address_, navigate_forward_, key_value}, false, true};
     }
 }
@@ -1128,7 +1129,7 @@ Task<BlockProviderResponse> ForwardBlockProvider::get() {
                 co_return BlockProviderResponse{0, false, false};
             }
 
-        } catch (std::exception& e) {
+        } catch (std::exception&) {
             finished_ = true;
             co_return BlockProviderResponse{0, false, true};
         }
@@ -1155,7 +1156,7 @@ Task<BlockProviderResponse> ForwardBlockProvider::get() {
             auto bitmap = bitmap::parse(chunk_provider_res.chunk);
             iterator(bitmap);
 
-        } catch (std::exception& e) {
+        } catch (std::exception&) {
             finished_ = true;
             co_return BlockProviderResponse{0, false, true};
         }
@@ -1254,7 +1255,7 @@ Task<BlockProviderResponse> BackwardBlockProvider::get() {
                 reverse_iterator(bitmap);
             }
 
-        } catch (std::exception& e) {
+        } catch (std::exception&) {
             finished_ = true;
             co_return BlockProviderResponse{0, false, true};
         }
@@ -1281,7 +1282,7 @@ Task<BlockProviderResponse> BackwardBlockProvider::get() {
             auto bitmap = bitmap::parse(chunk_provider_res.chunk);
             reverse_iterator(bitmap);
 
-        } catch (std::exception& e) {
+        } catch (std::exception&) {
             finished_ = true;
             co_return BlockProviderResponse{0, false, true};
         }

--- a/silkworm/rpc/commands/trace_api.cpp
+++ b/silkworm/rpc/commands/trace_api.cpp
@@ -438,7 +438,7 @@ Task<void> TraceRpcApi::handle_trace_get(const nlohmann::json& request, nlohmann
                 reply = make_json_content(request);
             }
         }
-    } catch (const std::exception& e) {
+    } catch (const std::exception&) {
         reply = make_json_content(request);
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();
@@ -474,7 +474,7 @@ Task<void> TraceRpcApi::handle_trace_transaction(const nlohmann::json& request, 
             auto result = co_await executor.trace_transaction(*(tx_with_block->block_with_hash), tx_with_block->transaction, /* gas_bailout */ false);
             reply = make_json_content(request, result);
         }
-    } catch (const std::exception& e) {
+    } catch (const std::exception&) {
         reply = make_json_content(request);
     } catch (...) {
         SILK_ERROR << "unexpected exception processing request: " << request.dump();

--- a/silkworm/sentry/discovery/node_db/node_db_sqlite_test.cpp
+++ b/silkworm/sentry/discovery/node_db/node_db_sqlite_test.cpp
@@ -24,8 +24,9 @@
 
 namespace silkworm::sentry::discovery::node_db {
 
-using namespace boost::asio;
+namespace ip = boost::asio::ip;
 using namespace std::chrono_literals;
+using boost::asio::any_io_executor;
 
 bool operator==(const NodeAddress& lhs, const NodeAddress& rhs) {
     return (lhs.ip == rhs.ip) &&

--- a/silkworm/sentry/message_receiver.cpp
+++ b/silkworm/sentry/message_receiver.cpp
@@ -104,7 +104,7 @@ Task<void> MessageReceiver::receive_messages(std::shared_ptr<rlpx::Peer> peer) {
         Message message;
         try {
             message = co_await peer->receive_message();
-        } catch (const rlpx::Peer::DisconnectedError& ex) {
+        } catch (const rlpx::Peer::DisconnectedError&) {
             break;
         }
 

--- a/silkworm/sentry/rlpx/crypto/hmac.cpp
+++ b/silkworm/sentry/rlpx/crypto/hmac.cpp
@@ -23,8 +23,12 @@
 
 namespace silkworm::sentry::rlpx::crypto {
 
+#ifdef _WIN32
+#pragma warning(disable : 4996)
+#else
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 
 Bytes hmac(ByteView key, ByteView data1, ByteView data2, ByteView data3) {
     SILKWORM_ASSERT(key.size() == 32);


### PR DESCRIPTION
Fix the errors in Windows build after #2632:

- `kvdb/inverted_index_range_by_key_query_test.cpp`: explicit conversion from `std::filesystem::path` to `std::string`
- `snapshots/elias_fano/list_iterator.hpp`: `ListIterator::operator*` now returns `value_type` to fix MSVC conversion error. We could rename `ListIterator` as `ValueListIterator` to highlight it indeed iterates over primitive type values (i.e. integers)

plus other errors come to light after these:

- `local_transaction.cpp`, `concat_view_test.cpp`: add dual overloaded `operator==` and `operator!=` for `std::default_sentinel_t` in `ConcatView`

*Extras*
fix some MSVC warnings 