### PR TITLE
rpcdaemon: StateReader's txn_id must be nullopt in case of latest block

### DIFF
--- a/.github/workflows/rpc-integration-tests.yml
+++ b/.github/workflows/rpc-integration-tests.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout RPC Tests Repository & Install Requirements
         run: |
           rm -rf ${{runner.workspace}}/rpc-tests
-          git -c advice.detachedHead=false clone --depth 1 --branch v1.36.1 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
+          git -c advice.detachedHead=false clone --depth 1 --branch v1.37.0 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
           cd ${{runner.workspace}}/rpc-tests
           pip3 install -r requirements.txt --break-system-packages
 

--- a/silkworm/db/kv/grpc/client/endpoint/temporal_point.cpp
+++ b/silkworm/db/kv/grpc/client/endpoint/temporal_point.cpp
@@ -50,7 +50,7 @@ proto::GetLatestReq get_latest_request_from_query(const api::GetLatestQuery& que
 
 api::GetLatestResult get_latest_result_from_response(const proto::GetLatestReply& response) {
     api::GetLatestResult result;
-    result.success = true;
+    result.success = !response.v().empty();
     result.value = string_to_bytes(response.v());
     return result;
 }

--- a/silkworm/db/kv/grpc/client/endpoint/temporal_point.cpp
+++ b/silkworm/db/kv/grpc/client/endpoint/temporal_point.cpp
@@ -50,7 +50,7 @@ proto::GetLatestReq get_latest_request_from_query(const api::GetLatestQuery& que
 
 api::GetLatestResult get_latest_result_from_response(const proto::GetLatestReply& response) {
     api::GetLatestResult result;
-    result.success = response.ok();
+    result.success = true;
     result.value = string_to_bytes(response.v());
     return result;
 }

--- a/silkworm/db/kv/state_reader.cpp
+++ b/silkworm/db/kv/state_reader.cpp
@@ -52,6 +52,7 @@ Task<std::optional<Account>> StateReader::read_account(const evmc::address& addr
         co_return std::nullopt;
     }
 
+    // Non-existent account has empty encoded value
     if (result.value.empty()) {
         co_return std::nullopt;
     }

--- a/silkworm/db/kv/state_reader.cpp
+++ b/silkworm/db/kv/state_reader.cpp
@@ -19,8 +19,8 @@
 #include <silkworm/core/common/empty_hashes.hpp>
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/core/types/account.hpp>
-#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/core/types/address.hpp>
+#include <silkworm/core/types/evmc_bytes32.hpp>
 #include <silkworm/db/state/account_codec.hpp>
 #include <silkworm/db/tables.hpp>
 #include <silkworm/db/util.hpp>

--- a/silkworm/db/kv/state_reader.cpp
+++ b/silkworm/db/kv/state_reader.cpp
@@ -52,7 +52,7 @@ Task<std::optional<Account>> StateReader::read_account(const evmc::address& addr
         co_return std::nullopt;
     }
 
-    if (result.value.size() == 0) {
+    if (result.value.empty()) {
         co_return std::nullopt;
     }
 

--- a/silkworm/db/kv/state_reader.cpp
+++ b/silkworm/db/kv/state_reader.cpp
@@ -20,6 +20,7 @@
 #include <silkworm/core/common/util.hpp>
 #include <silkworm/core/types/account.hpp>
 #include <silkworm/core/types/evmc_bytes32.hpp>
+#include <silkworm/core/types/address.hpp>
 #include <silkworm/db/state/account_codec.hpp>
 #include <silkworm/db/tables.hpp>
 #include <silkworm/db/util.hpp>
@@ -48,6 +49,10 @@ Task<std::optional<Account>> StateReader::read_account(const evmc::address& addr
     }
 
     if (!result.success) {
+        co_return std::nullopt;
+    }
+
+    if (result.value.size() == 0) {
         co_return std::nullopt;
     }
 

--- a/silkworm/execution/local_state.cpp
+++ b/silkworm/execution/local_state.cpp
@@ -104,7 +104,6 @@ void LocalState::update_account(
     const evmc::address& address,
     std::optional<Account> initial,
     std::optional<Account> current) {
-
     if (!txn_id_) {
         /* mgt on latest for Battle */
         return;

--- a/silkworm/execution/local_state.cpp
+++ b/silkworm/execution/local_state.cpp
@@ -28,7 +28,6 @@ using namespace db::state;
 using namespace datastore;
 
 std::optional<Account> LocalState::read_account(const evmc::address& address) const noexcept {
-
     if (!txn_id_) {
         AccountsDomainGetLatestQuery query{
             data_store_.chaindata,
@@ -67,7 +66,6 @@ evmc::bytes32 LocalState::read_storage(
     const evmc::address& address,
     uint64_t /*incarnation*/,
     const evmc::bytes32& location) const noexcept {
-
     if (!txn_id_) {
         StorageDomainGetLatestQuery query{
             data_store_.chaindata,
@@ -79,7 +77,7 @@ evmc::bytes32 LocalState::read_storage(
             return result->value;
         }
     } else {
-            // historical request on *txn_id timestamp
+        // historical request on *txn_id timestamp
     }
     return {};
 }
@@ -118,7 +116,6 @@ void LocalState::update_account(
     const evmc::address& address,
     std::optional<Account> initial,
     std::optional<Account> current) {
-
     /* should be managed request on Latest(txn_id == nullopt) and historical (txn_id != nullopt) */
 
     Step current_step = Step::from_txn_id(*txn_id_);
@@ -136,7 +133,6 @@ void LocalState::update_account_code(
     uint64_t /*incarnation*/,
     const evmc::bytes32& /*code_hash*/,
     ByteView code) {
-
     /* should be managed request on Latest(txn_id == nullopt) and historical (txn_id != nullopt) */
 
     Step current_step = Step::from_txn_id(*txn_id_);
@@ -153,7 +149,6 @@ void LocalState::update_storage(
     const evmc::bytes32& location,
     const evmc::bytes32& initial,
     const evmc::bytes32& current) {
-
     /* should be managed request on Latest(txn_id == nullopt) and historical (txn_id != nullopt) */
 
     Step current_step = Step::from_txn_id(*txn_id_);

--- a/silkworm/execution/local_state.cpp
+++ b/silkworm/execution/local_state.cpp
@@ -104,13 +104,19 @@ void LocalState::update_account(
     const evmc::address& address,
     std::optional<Account> initial,
     std::optional<Account> current) {
-    Step current_step = Step::from_txn_id(txn_id_);
+
+    if (!txn_id_) {
+        /* mgt on latest for Battle */
+        return;
+    }
+
+    Step current_step = Step::from_txn_id(*txn_id_);
     if (current) {
         AccountsDomainPutQuery query{tx_, data_store_.state_db().accounts_domain()};
-        query.exec(address, *current, txn_id_, initial, current_step);
+        query.exec(address, *current, *txn_id_, initial, current_step);
     } else {
         AccountsDomainDeleteQuery query{tx_, data_store_.state_db().accounts_domain()};
-        query.exec(address, txn_id_, initial, current_step);
+        query.exec(address, *txn_id_, initial, current_step);
     }
 }
 
@@ -119,12 +125,16 @@ void LocalState::update_account_code(
     uint64_t /*incarnation*/,
     const evmc::bytes32& /*code_hash*/,
     ByteView code) {
-    Step current_step = Step::from_txn_id(txn_id_);
+    if (!txn_id_) {
+        /* mgt on latest for Battle */
+        return;
+    }
+    Step current_step = Step::from_txn_id(*txn_id_);
     CodeDomainPutQuery query{tx_, data_store_.state_db().code_domain()};
     std::optional<ByteView> initial_code = read_code(address, evmc::bytes32{});
     if (initial_code && initial_code->empty())
         initial_code = std::nullopt;
-    query.exec(address, code, txn_id_, initial_code, current_step);
+    query.exec(address, code, *txn_id_, initial_code, current_step);
 }
 
 void LocalState::update_storage(
@@ -133,9 +143,13 @@ void LocalState::update_storage(
     const evmc::bytes32& location,
     const evmc::bytes32& initial,
     const evmc::bytes32& current) {
-    Step current_step = Step::from_txn_id(txn_id_);
+    if (!txn_id_) {
+        /* mgt on latest for Battle */
+        return;
+    }
+    Step current_step = Step::from_txn_id(*txn_id_);
     StorageDomainPutQuery query{tx_, data_store_.state_db().storage_domain()};
-    query.exec({address, location}, current, txn_id_, initial, current_step);
+    query.exec({address, location}, current, *txn_id_, initial, current_step);
 }
 
 }  // namespace silkworm::execution

--- a/silkworm/execution/local_state.hpp
+++ b/silkworm/execution/local_state.hpp
@@ -34,7 +34,7 @@ namespace silkworm::execution {
 class LocalState : public State {
   public:
     explicit LocalState(
-        TxnId txn_id,
+        std::optional<TxnId> txn_id,
         db::DataStoreRef data_store)
         : txn_id_{txn_id},
           data_store_{std::move(data_store)},
@@ -97,7 +97,7 @@ class LocalState : public State {
         return db::DataModelFactory{data_store_}(tx_);
     }
 
-    TxnId txn_id_;
+    std::optional<TxnId> txn_id_;
     db::DataStoreRef data_store_;
     mutable datastore::kvdb::RWTxnManaged tx_;
 };

--- a/silkworm/execution/remote_state.hpp
+++ b/silkworm/execution/remote_state.hpp
@@ -39,7 +39,7 @@ class AsyncRemoteState {
     explicit AsyncRemoteState(
         db::kv::api::Transaction& tx,
         const db::chain::ChainStorage& storage,
-        TxnId txn_id)
+        std::optional<TxnId> txn_id)
         : storage_(storage), state_reader_(tx, txn_id) {}
 
     Task<std::optional<Account>> read_account(const evmc::address& address) const noexcept;
@@ -75,7 +75,7 @@ class RemoteState : public State {
         boost::asio::any_io_executor& executor,
         db::kv::api::Transaction& tx,
         const db::chain::ChainStorage& storage,
-        TxnId txn_id)
+        std::optional<TxnId> txn_id)
         : executor_(executor), async_state_{tx, storage, txn_id} {}
 
     std::optional<Account> read_account(const evmc::address& address) const noexcept override;

--- a/silkworm/execution/state_factory.cpp
+++ b/silkworm/execution/state_factory.cpp
@@ -27,7 +27,7 @@ namespace silkworm::execution {
 std::shared_ptr<State> StateFactory::create_state(
     boost::asio::any_io_executor& executor,
     const db::chain::ChainStorage& storage,
-    TxnId txn_id) {
+    std::optional<TxnId> txn_id) {
     if (tx.is_local()) {
         auto& local_tx = dynamic_cast<db::kv::api::LocalTransaction&>(tx);
         return std::make_shared<LocalState>(txn_id, local_tx.data_store());

--- a/silkworm/execution/state_factory.hpp
+++ b/silkworm/execution/state_factory.hpp
@@ -33,7 +33,7 @@ struct StateFactory {
     std::shared_ptr<State> create_state(
         boost::asio::any_io_executor& executor,
         const db::chain::ChainStorage& storage,
-        TxnId txn_id);
+        std::optional<TxnId> txn_id);
 };
 
 }  // namespace silkworm::execution

--- a/silkworm/rpc/commands/debug_api.cpp
+++ b/silkworm/rpc/commands/debug_api.cpp
@@ -452,7 +452,7 @@ Task<void> DebugRpcApi::handle_debug_trace_call(const nlohmann::json& request, j
         tx->set_state_cache_enabled(/*cache_enabled=*/is_latest_block);
 
         debug::DebugExecutor executor{*block_cache_, workers_, *tx, config};
-        co_await executor.trace_call(stream, block_num_or_hash, *chain_storage, call);
+        co_await executor.trace_call(stream, block_num_or_hash, *chain_storage, call, is_latest_block);
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
         std::ostringstream oss;

--- a/silkworm/rpc/commands/parity_api.cpp
+++ b/silkworm/rpc/commands/parity_api.cpp
@@ -68,7 +68,10 @@ Task<void> ParityRpcApi::handle_parity_list_storage_keys(const nlohmann::json& r
         const auto block_num = co_await block_reader.get_block_num(block_id);
         SILK_DEBUG << "read account with address: " << address << " block number: " << block_num;
 
-        const auto txn_number = co_await tx->user_txn_id_at(block_num);
+        std::optional<TxnId> txn_number;
+        if (co_await block_reader.is_latest_block_num(block_num)) {
+            txn_number = co_await tx->user_txn_id_at(block_num);
+        }
 
         StateReader state_reader{*tx, txn_number};
         std::optional<Account> account = co_await state_reader.read_account(address);

--- a/silkworm/rpc/commands/trace_api.cpp
+++ b/silkworm/rpc/commands/trace_api.cpp
@@ -66,7 +66,7 @@ Task<void> TraceRpcApi::handle_trace_call(const nlohmann::json& request, nlohman
         tx->set_state_cache_enabled(is_latest_block);
 
         trace::TraceCallExecutor executor{*block_cache_, *chain_storage, workers_, *tx};
-        const auto result = co_await executor.trace_call(block_with_hash->block, call, config);
+        const auto result = co_await executor.trace_call(block_with_hash->block, call, config, is_latest_block);
 
         if (result.pre_check_error) {
             reply = make_json_error(request, kServerError, result.pre_check_error.value());
@@ -115,7 +115,7 @@ Task<void> TraceRpcApi::handle_trace_call_many(const nlohmann::json& request, nl
         tx->set_state_cache_enabled(is_latest_block);
 
         trace::TraceCallExecutor executor{*block_cache_, *chain_storage, workers_, *tx};
-        const auto result = co_await executor.trace_calls(block_with_hash->block, trace_calls);
+        const auto result = co_await executor.trace_calls(block_with_hash->block, trace_calls, is_latest_block);
 
         if (result.pre_check_error) {
             reply = make_json_error(request, kServerError, result.pre_check_error.value());

--- a/silkworm/rpc/commands/trace_api.cpp
+++ b/silkworm/rpc/commands/trace_api.cpp
@@ -244,8 +244,12 @@ Task<void> TraceRpcApi::handle_trace_replay_block_transactions(const nlohmann::j
         const auto chain_storage = tx->create_storage();
         const auto block_with_hash = co_await core::read_block_by_block_num_or_hash(*block_cache_, *chain_storage, *tx, block_num_or_hash);
         if (block_with_hash) {
+            rpc::BlockReader block_reader{*chain_storage, *tx};
+            const bool is_latest_block = co_await block_reader.is_latest_block_num(block_with_hash->block.header.number);
+            tx->set_state_cache_enabled(is_latest_block);
+
             trace::TraceCallExecutor executor{*block_cache_, *chain_storage, workers_, *tx};
-            const auto result = co_await executor.trace_block_transactions(block_with_hash->block, config);
+            const auto result = co_await executor.trace_block_transactions(block_with_hash->block, config, is_latest_block);
             reply = make_json_content(request, result);
         } else {
             reply = make_json_error(request, kInvalidParams, "block not found");
@@ -330,10 +334,13 @@ Task<void> TraceRpcApi::handle_trace_block(const nlohmann::json& request, nlohma
             co_await tx->close();  // RAII not (yet) available with coroutines
             co_return;
         }
+        rpc::BlockReader block_reader{*chain_storage, *tx};
+        const bool is_latest_block = co_await block_reader.is_latest_block_num(block_with_hash->block.header.number);
+        tx->set_state_cache_enabled(is_latest_block);
 
         trace::TraceCallExecutor executor{*block_cache_, *chain_storage, workers_, *tx};
         trace::Filter filter;
-        const auto result = co_await executor.trace_block(*block_with_hash, filter);
+        const auto result = co_await executor.trace_block(*block_with_hash, filter, nullptr /* json::Stream */, is_latest_block);
         reply = make_json_content(request, result);
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();

--- a/silkworm/rpc/core/block_reader.cpp
+++ b/silkworm/rpc/core/block_reader.cpp
@@ -59,7 +59,7 @@ Task<void> BlockReader::read_balance_changes(BlockCache& cache, const BlockNumOr
     const auto end_txn_number = co_await transaction_.first_txn_num_in_block(block_num + 1);
 
     auto is_latest = co_await is_latest_block_num(block_num);
-    std::optional<TxnId> txn_id{std::nullopt};
+    std::optional<TxnId> txn_id;
     if (!is_latest) {
         txn_id = co_await transaction_.user_txn_id_at(block_num + 1);
     }

--- a/silkworm/rpc/core/block_reader.cpp
+++ b/silkworm/rpc/core/block_reader.cpp
@@ -55,10 +55,15 @@ Task<void> BlockReader::read_balance_changes(BlockCache& cache, const BlockNumOr
 
     SILK_TRACE << "read_balance_changes: block_num: " << block_num;
 
+
     const auto start_txn_number = co_await transaction_.first_txn_num_in_block(block_num);
     const auto end_txn_number = co_await transaction_.first_txn_num_in_block(block_num + 1);
 
-    const auto txn_id = co_await transaction_.user_txn_id_at(block_num + 1);
+    auto is_latest =  co_await is_latest_block_num(block_num);
+    std::optional<TxnId> txn_id{std::nullopt};
+    if (!is_latest) {
+       txn_id = co_await transaction_.user_txn_id_at(block_num + 1);
+    }
     StateReader state_reader{transaction_, txn_id};
 
     db::kv::api::HistoryRangeQuery query{
@@ -95,7 +100,7 @@ Task<void> BlockReader::read_balance_changes(BlockCache& cache, const BlockNumOr
     SILK_DEBUG << "Changed balances: " << balance_changes.size();
 }
 
-Task<BlockNum> BlockReader::get_forkchoice_block_num(const char* block_hash_tag) {
+Task<BlockNum> BlockReader::get_forkchoice_block_num(const char* block_hash_tag) const {
     const auto kv_pair = co_await transaction_.get(table::kLastForkchoiceName, string_to_bytes(block_hash_tag));
     const auto block_hash_data = kv_pair.value;
     if (block_hash_data.empty()) {
@@ -109,12 +114,12 @@ Task<BlockNum> BlockReader::get_forkchoice_block_num(const char* block_hash_tag)
     co_return *block_num;
 }
 
-Task<bool> BlockReader::is_latest_block_num(BlockNum block_num) {
+Task<bool> BlockReader::is_latest_block_num(BlockNum block_num) const {
     const auto last_executed_block_num = co_await get_latest_executed_block_num();
     co_return last_executed_block_num == block_num;
 }
 
-Task<BlockNum> BlockReader::get_block_num_by_tag(const std::string& block_id) {
+Task<BlockNum> BlockReader::get_block_num_by_tag(const std::string& block_id) const {
     BlockNum block_num{0};
     if (block_id == kEarliestBlockId) {
         block_num = kEarliestBlockNum;
@@ -131,7 +136,7 @@ Task<BlockNum> BlockReader::get_block_num_by_tag(const std::string& block_id) {
     co_return block_num;
 }
 
-Task<std::pair<BlockNum, bool>> BlockReader::get_block_num(const std::string& block_id, bool latest_required) {
+Task<std::pair<BlockNum, bool>> BlockReader::get_block_num(const std::string& block_id, bool latest_required)  const {
     BlockNum block_num{0};
     bool is_latest_block = false;
     bool check_if_latest = false;
@@ -166,12 +171,12 @@ Task<std::pair<BlockNum, bool>> BlockReader::get_block_num(const std::string& bl
     co_return std::make_pair(block_num, is_latest_block);
 }
 
-Task<BlockNum> BlockReader::get_block_num(const std::string& block_id) {
+Task<BlockNum> BlockReader::get_block_num(const std::string& block_id) const {
     const auto [block_num, _] = co_await get_block_num(block_id, /*latest_required=*/false);
     co_return block_num;
 }
 
-Task<std::pair<BlockNum, bool>> BlockReader::get_block_num(const BlockNumOrHash& block_num_or_hash) {
+Task<std::pair<BlockNum, bool>> BlockReader::get_block_num(const BlockNumOrHash& block_num_or_hash) const {
     if (block_num_or_hash.is_tag()) {
         co_return co_await get_block_num(block_num_or_hash.tag(), true);
     } else if (block_num_or_hash.is_number()) {
@@ -188,25 +193,25 @@ Task<std::pair<BlockNum, bool>> BlockReader::get_block_num(const BlockNumOrHash&
     }
 }
 
-Task<BlockNum> BlockReader::get_block_num(const Hash& hash) {
+Task<BlockNum> BlockReader::get_block_num(const Hash& hash) const {
     auto bn = co_await chain_storage_.read_block_num(hash);
     ensure(bn != 0, "get_block_num: block with hash not found");
     co_return *bn;
 }
 
-Task<BlockNum> BlockReader::get_current_block_num() {
+Task<BlockNum> BlockReader::get_current_block_num() const {
     co_return co_await stages::get_sync_stage_progress(transaction_, stages::kFinish);
 }
 
-Task<BlockNum> BlockReader::get_max_block_num() {
+Task<BlockNum> BlockReader::get_max_block_num() const {
     co_return co_await stages::get_sync_stage_progress(transaction_, stages::kHeaders);
 }
 
-Task<BlockNum> BlockReader::get_latest_executed_block_num() {
+Task<BlockNum> BlockReader::get_latest_executed_block_num() const {
     co_return co_await stages::get_sync_stage_progress(transaction_, stages::kExecution);
 }
 
-Task<BlockNum> BlockReader::get_latest_block_num() {
+Task<BlockNum> BlockReader::get_latest_block_num() const {
     const auto kv_pair = co_await transaction_.get(table::kLastForkchoiceName, string_to_bytes(kHeadBlockHash));
     const auto head_block_hash_data = kv_pair.value;
     if (!head_block_hash_data.empty()) {
@@ -220,15 +225,15 @@ Task<BlockNum> BlockReader::get_latest_block_num() {
     co_return co_await get_latest_executed_block_num();
 }
 
-Task<BlockNum> BlockReader::get_forkchoice_finalized_block_num() {
+Task<BlockNum> BlockReader::get_forkchoice_finalized_block_num() const {
     co_return co_await get_forkchoice_block_num(kFinalizedBlockHash);
 }
 
-Task<BlockNum> BlockReader::get_forkchoice_safe_block_num() {
+Task<BlockNum> BlockReader::get_forkchoice_safe_block_num() const {
     co_return co_await get_forkchoice_block_num(kSafeBlockHash);
 }
 
-Task<bool> BlockReader::is_latest_block_num(const BlockNumOrHash& block_num_or_hash) {
+Task<bool> BlockReader::is_latest_block_num(const BlockNumOrHash& block_num_or_hash) const {
     if (block_num_or_hash.is_tag()) {
         co_return block_num_or_hash.tag() == kLatestBlockId || block_num_or_hash.tag() == kPendingBlockId;
     } else {

--- a/silkworm/rpc/core/block_reader.cpp
+++ b/silkworm/rpc/core/block_reader.cpp
@@ -55,14 +55,13 @@ Task<void> BlockReader::read_balance_changes(BlockCache& cache, const BlockNumOr
 
     SILK_TRACE << "read_balance_changes: block_num: " << block_num;
 
-
     const auto start_txn_number = co_await transaction_.first_txn_num_in_block(block_num);
     const auto end_txn_number = co_await transaction_.first_txn_num_in_block(block_num + 1);
 
-    auto is_latest =  co_await is_latest_block_num(block_num);
+    auto is_latest = co_await is_latest_block_num(block_num);
     std::optional<TxnId> txn_id{std::nullopt};
     if (!is_latest) {
-       txn_id = co_await transaction_.user_txn_id_at(block_num + 1);
+        txn_id = co_await transaction_.user_txn_id_at(block_num + 1);
     }
     StateReader state_reader{transaction_, txn_id};
 
@@ -136,7 +135,7 @@ Task<BlockNum> BlockReader::get_block_num_by_tag(const std::string& block_id) co
     co_return block_num;
 }
 
-Task<std::pair<BlockNum, bool>> BlockReader::get_block_num(const std::string& block_id, bool latest_required)  const {
+Task<std::pair<BlockNum, bool>> BlockReader::get_block_num(const std::string& block_id, bool latest_required) const {
     BlockNum block_num{0};
     bool is_latest_block = false;
     bool check_if_latest = false;

--- a/silkworm/rpc/core/block_reader.hpp
+++ b/silkworm/rpc/core/block_reader.hpp
@@ -57,7 +57,7 @@ class BlockReader {
 
     Task<std::pair<BlockNum, bool>> get_block_num(const std::string& block_id, bool latest_required) const;
 
-    Task<BlockNum> get_block_num(const std::string& block_id) const ;
+    Task<BlockNum> get_block_num(const std::string& block_id) const;
 
     Task<std::pair<BlockNum, bool>> get_block_num(const BlockNumOrHash& block_num_or_hash) const;
 

--- a/silkworm/rpc/core/block_reader.hpp
+++ b/silkworm/rpc/core/block_reader.hpp
@@ -51,36 +51,36 @@ class BlockReader {
 
     Task<void> read_balance_changes(BlockCache& cache, const BlockNumOrHash& block_num_or_hash, BalanceChanges& balance_changes) const;
 
-    Task<bool> is_latest_block_num(BlockNum block_num);
+    Task<bool> is_latest_block_num(BlockNum block_num) const;
 
-    Task<BlockNum> get_block_num_by_tag(const std::string& block_id);
+    Task<BlockNum> get_block_num_by_tag(const std::string& block_id) const;
 
-    Task<std::pair<BlockNum, bool>> get_block_num(const std::string& block_id, bool latest_required);
+    Task<std::pair<BlockNum, bool>> get_block_num(const std::string& block_id, bool latest_required) const;
 
-    Task<BlockNum> get_block_num(const std::string& block_id);
+    Task<BlockNum> get_block_num(const std::string& block_id) const ;
 
-    Task<std::pair<BlockNum, bool>> get_block_num(const BlockNumOrHash& block_num_or_hash);
+    Task<std::pair<BlockNum, bool>> get_block_num(const BlockNumOrHash& block_num_or_hash) const;
 
-    Task<BlockNum> get_block_num(const Hash& hash);
+    Task<BlockNum> get_block_num(const Hash& hash) const;
 
-    Task<BlockNum> get_current_block_num();
+    Task<BlockNum> get_current_block_num() const;
 
-    Task<BlockNum> get_max_block_num();
+    Task<BlockNum> get_max_block_num() const;
 
-    Task<BlockNum> get_latest_block_num();
+    Task<BlockNum> get_latest_block_num() const;
 
-    Task<BlockNum> get_latest_executed_block_num();
+    Task<BlockNum> get_latest_executed_block_num() const;
 
-    Task<BlockNum> get_forkchoice_finalized_block_num();
+    Task<BlockNum> get_forkchoice_finalized_block_num() const;
 
-    Task<BlockNum> get_forkchoice_safe_block_num();
+    Task<BlockNum> get_forkchoice_safe_block_num() const;
 
-    Task<bool> is_latest_block_num(const BlockNumOrHash& block_num_or_hash);
+    Task<bool> is_latest_block_num(const BlockNumOrHash& block_num_or_hash) const;
 
     Task<std::optional<BlockHeader>> read_header(BlockNum block_num) { co_return co_await chain_storage_.read_canonical_header(block_num); }
 
   private:
-    Task<BlockNum> get_forkchoice_block_num(const char* block_hash_tag);
+    Task<BlockNum> get_forkchoice_block_num(const char* block_hash_tag) const;
     const db::chain::ChainStorage& chain_storage_;
     db::kv::api::Transaction& transaction_;
 };

--- a/silkworm/rpc/core/call_many.cpp
+++ b/silkworm/rpc/core/call_many.cpp
@@ -158,7 +158,7 @@ Task<CallManyResult> CallExecutor::execute(
 
     if (co_await block_reader_.is_latest_block_num(block_with_hash->block.header.number) == false) {
         const uint32_t transaction_index =
-            context.transaction_index == -1 ? block_with_hash->block.transactions.size() : static_cast<uint32_t>(context.transaction_index);
+            context.transaction_index == -1 ? static_cast<uint32_t>(block_with_hash->block.transactions.size()) : static_cast<uint32_t>(context.transaction_index);
         txn_id = co_await transaction_.user_txn_id_at(block_with_hash->block.header.number, transaction_index);
     }
     result = co_await async_task(workers_.executor(), [&]() -> CallManyResult {

--- a/silkworm/rpc/core/call_many.cpp
+++ b/silkworm/rpc/core/call_many.cpp
@@ -157,8 +157,8 @@ Task<CallManyResult> CallExecutor::execute(
     std::optional<TxnId> txn_id;
 
     if (co_await block_reader_.is_latest_block_num(block_with_hash->block.header.number) == false) {
-        const uint64_t transaction_index =
-            context.transaction_index == -1 ? block_with_hash->block.transactions.size() : static_cast<uint64_t>(context.transaction_index);
+        const uint32_t transaction_index =
+            context.transaction_index == -1 ? block_with_hash->block.transactions.size() : static_cast<uint32_t>(context.transaction_index);
         txn_id = co_await transaction_.user_txn_id_at(block_with_hash->block.header.number, transaction_index);
     }
     result = co_await async_task(workers_.executor(), [&]() -> CallManyResult {

--- a/silkworm/rpc/core/call_many.cpp
+++ b/silkworm/rpc/core/call_many.cpp
@@ -40,7 +40,7 @@ CallManyResult CallExecutor::executes_all_bundles(const silkworm::ChainConfig& c
                                                   const Bundles& bundles,
                                                   std::optional<std::uint64_t> opt_timeout,
                                                   const AccountsOverrides& accounts_overrides,
-                                                  TxnId txn_id,
+                                                  std::optional<TxnId> txn_id,
                                                   boost::asio::any_io_executor& this_executor) {
     CallManyResult result;
     const auto& block = block_with_hash->block;
@@ -151,12 +151,16 @@ Task<CallManyResult> CallExecutor::execute(
     if (!block_with_hash) {
         throw std::invalid_argument("read_block_by_block_num_or_hash: block not found");
     }
-    const uint64_t transaction_index =
-        context.transaction_index == -1 ? block_with_hash->block.transactions.size() : static_cast<uint64_t>(context.transaction_index);
 
     auto this_executor = co_await boost::asio::this_coro::executor;
-    const auto min_tx_num = co_await transaction_.first_txn_num_in_block(block_with_hash->block.header.number);
-    const auto txn_id = min_tx_num + transaction_index + 1;  // for system txn in the beginning of block
+
+    std::optional<TxnId> txn_id;
+
+    if (co_await block_reader_.is_latest_block_num(block_with_hash->block.header.number) == false) {
+        const uint64_t transaction_index =
+            context.transaction_index == -1 ? block_with_hash->block.transactions.size() : static_cast<uint64_t>(context.transaction_index);
+        txn_id = co_await transaction_.user_txn_id_at(block_with_hash->block.header.number, transaction_index);
+    }
     result = co_await async_task(workers_.executor(), [&]() -> CallManyResult {
         return executes_all_bundles(chain_config,
                                     *chain_storage,

--- a/silkworm/rpc/core/call_many.hpp
+++ b/silkworm/rpc/core/call_many.hpp
@@ -30,6 +30,7 @@
 #include <silkworm/db/kv/api/state_cache.hpp>
 #include <silkworm/db/kv/api/transaction.hpp>
 #include <silkworm/rpc/common/worker_pool.hpp>
+#include <silkworm/rpc/core/block_reader.hpp>
 #include <silkworm/rpc/core/evm_executor.hpp>
 #include <silkworm/rpc/types/call.hpp>
 
@@ -45,8 +46,9 @@ class CallExecutor {
     explicit CallExecutor(
         db::kv::api::Transaction& transaction,
         BlockCache& block_cache,
-        WorkerPool& workers)
-        : transaction_(transaction), block_cache_(block_cache), workers_{workers} {}
+        WorkerPool& workers,
+        rpc::BlockReader& block_reader)
+        : transaction_(transaction), block_cache_(block_cache), workers_{workers}, block_reader_{block_reader} {}
     virtual ~CallExecutor() = default;
 
     CallExecutor(const CallExecutor&) = delete;
@@ -64,12 +66,13 @@ class CallExecutor {
                                         const Bundles& bundles,
                                         std::optional<std::uint64_t> opt_timeout,
                                         const AccountsOverrides& accounts_overrides,
-                                        TxnId txn_id,
+                                        std::optional<TxnId> txn_id,
                                         boost::asio::any_io_executor& executor);
 
   private:
     db::kv::api::Transaction& transaction_;
     BlockCache& block_cache_;
     WorkerPool& workers_;
+    rpc::BlockReader& block_reader_;
 };
 }  // namespace silkworm::rpc::call

--- a/silkworm/rpc/core/estimate_gas_oracle.cpp
+++ b/silkworm/rpc/core/estimate_gas_oracle.cpp
@@ -25,7 +25,7 @@
 
 namespace silkworm::rpc {
 
-Task<intx::uint256> EstimateGasOracle::estimate_gas(const Call& call, const silkworm::Block& block, TxnId txn_id, std::optional<BlockNum> block_num_for_gas_limit) {
+Task<intx::uint256> EstimateGasOracle::estimate_gas(const Call& call, const silkworm::Block& block, std::optional<TxnId> txn_id, std::optional<BlockNum> block_num_for_gas_limit) {
     SILK_DEBUG << "EstimateGasOracle::estimate_gas called";
 
     const auto block_num = block.header.number;

--- a/silkworm/rpc/core/estimate_gas_oracle.hpp
+++ b/silkworm/rpc/core/estimate_gas_oracle.hpp
@@ -37,7 +37,7 @@ inline constexpr std::uint64_t kTxGas = 21'000;
 inline constexpr std::uint64_t kGasCap = 50'000'000;
 
 using BlockHeaderProvider = std::function<Task<std::optional<silkworm::BlockHeader>>(uint64_t)>;
-using AccountReader = std::function<Task<std::optional<silkworm::Account>>(const evmc::address&, TxnId txn_id)>;
+using AccountReader = std::function<Task<std::optional<silkworm::Account>>(const evmc::address&, std::optional<TxnId> txn_id)>;
 
 struct EstimateGasException : public std::exception {
   public:
@@ -90,7 +90,7 @@ class EstimateGasOracle {
     EstimateGasOracle(const EstimateGasOracle&) = delete;
     EstimateGasOracle& operator=(const EstimateGasOracle&) = delete;
 
-    Task<intx::uint256> estimate_gas(const Call& call, const silkworm::Block& latest_block, TxnId txn_id, std::optional<BlockNum> block_num_for_gas_limit = {});
+    Task<intx::uint256> estimate_gas(const Call& call, const silkworm::Block& latest_block, std::optional<TxnId> txn_id, std::optional<BlockNum> block_num_for_gas_limit = {});
 
   protected:
     virtual ExecutionResult try_execution(EVMExecutor& executor, const silkworm::Block& block, const silkworm::Transaction& transaction);

--- a/silkworm/rpc/core/estimate_gas_oracle_test.cpp
+++ b/silkworm/rpc/core/estimate_gas_oracle_test.cpp
@@ -84,7 +84,7 @@ TEST_CASE("estimate gas") {
         co_return block_header;
     };
 
-    AccountReader account_reader = [&account](const evmc::address& /*address*/, std::optional<TxnId>/* txn_id */) -> Task<std::optional<silkworm::Account>> {
+    AccountReader account_reader = [&account](const evmc::address& /*address*/, std::optional<TxnId> /* txn_id */) -> Task<std::optional<silkworm::Account>> {
         co_return account;
     };
 

--- a/silkworm/rpc/core/estimate_gas_oracle_test.cpp
+++ b/silkworm/rpc/core/estimate_gas_oracle_test.cpp
@@ -84,7 +84,7 @@ TEST_CASE("estimate gas") {
         co_return block_header;
     };
 
-    AccountReader account_reader = [&account](const evmc::address& /*address*/, BlockNum /*block_num*/) -> Task<std::optional<silkworm::Account>> {
+    AccountReader account_reader = [&account](const evmc::address& /*address*/, std::optional<TxnId>/* txn_id */) -> Task<std::optional<silkworm::Account>> {
         co_return account;
     };
 

--- a/silkworm/rpc/core/evm_debug.cpp
+++ b/silkworm/rpc/core/evm_debug.cpp
@@ -383,7 +383,7 @@ Task<void> DebugExecutor::trace_block(json::Stream& stream, const ChainStorage& 
     co_return;
 }
 
-Task<void> DebugExecutor::trace_call(json::Stream& stream, const BlockNumOrHash& block_num_or_hash, const ChainStorage& storage, const Call& call) {
+Task<void> DebugExecutor::trace_call(json::Stream& stream, const BlockNumOrHash& block_num_or_hash, const ChainStorage& storage, const Call& call, bool is_latest_block) {
     const auto block_with_hash = co_await rpc::core::read_block_by_block_num_or_hash(block_cache_, storage, tx_, block_num_or_hash);
     if (!block_with_hash) {
         co_return;
@@ -408,7 +408,7 @@ Task<void> DebugExecutor::trace_call(json::Stream& stream, const BlockNumOrHash&
     const auto block_num = block.header.number + (config_.tx_index ? 0 : 1);
     const auto index = config_.tx_index ? config_.tx_index.value() : 0;
     // trace_call semantics: we must execute the call from the state at the end of the given block, so we pass block.header.number + 1
-    co_await execute(stream, storage, block_num, block, transaction, index);
+    co_await execute(stream, storage, block_num, block, transaction, index, is_latest_block);
     stream.close_object();
 
     co_return;
@@ -522,7 +522,8 @@ Task<void> DebugExecutor::execute(
     BlockNum block_num,
     const silkworm::Block& block,
     const Transaction& transaction,
-    int32_t index) {
+    int32_t index,
+    bool is_latest_block) {
     SILK_TRACE << "DebugExecutor::execute: "
                << " block_num: " << block_num
                << " transaction: {" << transaction << "}"
@@ -535,7 +536,11 @@ Task<void> DebugExecutor::execute(
     // We must do the execution at the state after the txn identified by the given index within the given block
     // at the state after the block identified by the given block_num
     execution::StateFactory state_factory{tx_};
-    const auto txn_id = co_await tx_.user_txn_id_at(block_num, static_cast<uint32_t>(index));
+
+    std::optional<TxnId> txn_id;
+    if (!is_latest_block) {
+        txn_id = co_await tx_.user_txn_id_at(block_num, static_cast<uint32_t>(index));
+    }
 
     co_await async_task(workers_.executor(), [&]() {
         const auto state = state_factory.create_state(current_executor, storage, txn_id);

--- a/silkworm/rpc/core/evm_debug.hpp
+++ b/silkworm/rpc/core/evm_debug.hpp
@@ -136,7 +136,7 @@ class DebugExecutor {
 
     Task<void> trace_block(json::Stream& stream, const ChainStorage& storage, BlockNum block_num);
     Task<void> trace_block(json::Stream& stream, const ChainStorage& storage, const evmc::bytes32& block_hash);
-    Task<void> trace_call(json::Stream& stream, const BlockNumOrHash& block_num_or_hash, const ChainStorage& storage, const Call& call);
+    Task<void> trace_call(json::Stream& stream, const BlockNumOrHash& block_num_or_hash, const ChainStorage& storage, const Call& call, bool is_latest_block);
     Task<void> trace_transaction(json::Stream& stream, const ChainStorage& storage, const evmc::bytes32& tx_hash);
     Task<void> trace_call_many(json::Stream& stream, const ChainStorage& storage, const Bundles& bundles, const SimulationContext& context);
 
@@ -152,7 +152,8 @@ class DebugExecutor {
         BlockNum block_num,
         const silkworm::Block& block,
         const Transaction& transaction,
-        int32_t = -1);
+        int32_t index = -1,
+        bool is_latest_block = false);
 
     Task<void> execute(
         json::Stream& stream,

--- a/silkworm/rpc/core/evm_debug.hpp
+++ b/silkworm/rpc/core/evm_debug.hpp
@@ -138,7 +138,7 @@ class DebugExecutor {
     Task<void> trace_block(json::Stream& stream, const ChainStorage& storage, const evmc::bytes32& block_hash);
     Task<void> trace_call(json::Stream& stream, const BlockNumOrHash& block_num_or_hash, const ChainStorage& storage, const Call& call, bool is_latest_block);
     Task<void> trace_transaction(json::Stream& stream, const ChainStorage& storage, const evmc::bytes32& tx_hash);
-    Task<void> trace_call_many(json::Stream& stream, const ChainStorage& storage, const Bundles& bundles, const SimulationContext& context);
+    Task<void> trace_call_many(json::Stream& stream, const ChainStorage& storage, const Bundles& bundles, const SimulationContext& context, bool is_latest_block);
 
   protected:
     Task<void> execute(json::Stream& stream, const ChainStorage& storage, const silkworm::Block& block, const Call& call);
@@ -160,7 +160,8 @@ class DebugExecutor {
         const ChainStorage& storage,
         std::shared_ptr<BlockWithHash> block_with_hash,
         const Bundles& bundles,
-        int32_t transaction_index);
+        int32_t transaction_index,
+        bool is_latest_block = false);
 
     BlockCache& block_cache_;
     WorkerPool& workers_;

--- a/silkworm/rpc/core/evm_executor.cpp
+++ b/silkworm/rpc/core/evm_executor.cpp
@@ -291,7 +291,7 @@ Task<ExecutionResult> EVMExecutor::call(
     WorkerPool& workers,
     const silkworm::Block& block,
     const silkworm::Transaction& txn,
-    const TxnId txn_id,
+    const std::optional<TxnId> txn_id,
     StateFactory state_factory,
     const Tracers& tracers,
     bool refund,

--- a/silkworm/rpc/core/evm_executor.hpp
+++ b/silkworm/rpc/core/evm_executor.hpp
@@ -84,7 +84,7 @@ using Tracers = std::vector<std::shared_ptr<EvmTracer>>;
 
 class EVMExecutor {
   public:
-    using StateFactory = std::function<std::shared_ptr<State>(boost::asio::any_io_executor&, BlockNum, const ChainStorage&)>;
+    using StateFactory = std::function<std::shared_ptr<State>(boost::asio::any_io_executor&, std::optional<TxnId>, const ChainStorage&)>;
 
     static Task<ExecutionResult> call(
         const silkworm::ChainConfig& config,
@@ -92,7 +92,7 @@ class EVMExecutor {
         WorkerPool& workers,
         const silkworm::Block& block,
         const silkworm::Transaction& txn,
-        TxnId txn_id,
+        std::optional<TxnId> txn_id,
         StateFactory state_factory,
         const Tracers& tracers = {},
         bool refund = true,

--- a/silkworm/rpc/core/evm_trace.cpp
+++ b/silkworm/rpc/core/evm_trace.cpp
@@ -1472,14 +1472,14 @@ Task<std::vector<TraceCallResult>> TraceCallExecutor::trace_block_transactions(c
     co_return call_result;
 }
 
-Task<TraceCallResult> TraceCallExecutor::trace_call(const silkworm::Block& block, const Call& call, const TraceConfig& config) {
+Task<TraceCallResult> TraceCallExecutor::trace_call(const silkworm::Block& block, const Call& call, const TraceConfig& config, bool is_latest_block) {
     // trace_call semantics: we must execute the call from the state at the end of the given block, so we pass block.header.number + 1
     rpc::Transaction transaction{call.to_transaction()};
-    auto result = co_await execute(block.header.number + 1, block, transaction, /*index=*/-1, config, /*gas_bailout=*/true);
+    auto result = co_await execute(block.header.number + 1, block, transaction, /*index=*/-1, config, /*gas_bailout=*/true, is_latest_block);
     co_return result;
 }
 
-Task<TraceManyCallResult> TraceCallExecutor::trace_calls(const silkworm::Block& block, const std::vector<TraceCall>& calls) {
+Task<TraceManyCallResult> TraceCallExecutor::trace_calls(const silkworm::Block& block, const std::vector<TraceCall>& calls, bool is_latest_block) {
     const auto block_num = block.header.number;
     SILK_DEBUG << "trace_call_many: "
                << " block_num: " << block_num
@@ -1490,7 +1490,10 @@ Task<TraceManyCallResult> TraceCallExecutor::trace_calls(const silkworm::Block& 
 
     execution::StateFactory state_factory{tx_};
     // trace_calls semantics: we must execute the call from the state at the end of the given block, so we pass block.header.number + 1
-    const auto txn_id = co_await tx_.user_txn_id_at(block_num + 1);
+    std::optional<TxnId> txn_id;
+    if (!is_latest_block) {
+        txn_id = co_await tx_.user_txn_id_at(block_num + 1);
+    }
 
     const auto trace_calls_result = co_await async_task(workers_.executor(), [&]() -> TraceManyCallResult {
         auto state = state_factory.create_state(current_executor, chain_storage_, txn_id);
@@ -1586,7 +1589,7 @@ Task<TraceDeployResult> TraceCallExecutor::trace_deploy_transaction(const silkwo
 
 Task<TraceCallResult> TraceCallExecutor::trace_transaction(const silkworm::Block& block, const rpc::Transaction& transaction, const TraceConfig& config) {
     // trace_transaction semantics: we must execute the txn from the state at the current block
-    return execute(block.header.number, block, transaction, gsl::narrow<int32_t>(transaction.transaction_index), config, /*gas_bailout=*/false);
+    return execute(block.header.number, block, transaction, gsl::narrow<int32_t>(transaction.transaction_index), config, /*gas_bailout=*/false, false /* is_latest_block */);
 }
 
 Task<std::vector<Trace>> TraceCallExecutor::trace_transaction(const BlockWithHash& block_with_hash, const rpc::Transaction& transaction, bool gas_bailout) {
@@ -1594,7 +1597,7 @@ Task<std::vector<Trace>> TraceCallExecutor::trace_transaction(const BlockWithHas
 
     // trace_transaction semantics: we must execute the txn from the state at the position transaction_index of the current block
     const auto result = co_await execute(block_with_hash.block.header.number, block_with_hash.block, transaction,
-                                         gsl::narrow<int32_t>(transaction.transaction_index), {false, true, false}, gas_bailout);
+                                         gsl::narrow<int32_t>(transaction.transaction_index), {false, true, false}, gas_bailout, false /* is_latest_block */);
     const auto& trace_result = result.traces.trace;
 
     const auto tnx_hash = transaction.hash();
@@ -1794,7 +1797,8 @@ Task<TraceCallResult> TraceCallExecutor::execute(
     const rpc::Transaction& transaction,
     std::int32_t index,
     const TraceConfig& config,
-    bool gas_bailout) {
+    bool gas_bailout,
+    bool is_latest_block) {
     SILK_DEBUG << "execute: "
                << " block_num: " << std::dec << block_num
                << " transaction: {" << transaction << "}"
@@ -1807,7 +1811,11 @@ Task<TraceCallResult> TraceCallExecutor::execute(
     // We must do the execution at the state after the txn identified by the given index within the given block
     // at the state after the block identified by the given block_num
     execution::StateFactory state_factory{tx_};
-    const auto txn_id = co_await tx_.user_txn_id_at(block_num, gsl::narrow<uint32_t>(transaction.transaction_index));
+    std::optional<TxnId> txn_id;
+    if (!is_latest_block) {
+        txn_id = co_await tx_.user_txn_id_at(block_num, gsl::narrow<uint32_t>(transaction.transaction_index));
+    }
+
     auto state = state_factory.create_state(current_executor, chain_storage_, txn_id);
     auto curr_state = state_factory.create_state(current_executor, chain_storage_, txn_id);
     const auto trace_call_result = co_await async_task(workers_.executor(), [&]() -> TraceCallResult {

--- a/silkworm/rpc/core/evm_trace.hpp
+++ b/silkworm/rpc/core/evm_trace.hpp
@@ -495,8 +495,8 @@ class TraceCallExecutor {
 
     Task<std::vector<Trace>> trace_block(const BlockWithHash& block_with_hash, Filter& filter, json::Stream* stream = nullptr);
     Task<std::vector<TraceCallResult>> trace_block_transactions(const silkworm::Block& block, const TraceConfig& config);
-    Task<TraceCallResult> trace_call(const silkworm::Block& block, const Call& call, const TraceConfig& config);
-    Task<TraceManyCallResult> trace_calls(const silkworm::Block& block, const std::vector<TraceCall>& calls);
+    Task<TraceCallResult> trace_call(const silkworm::Block& block, const Call& call, const TraceConfig& config, bool is_latest_block = false);
+    Task<TraceManyCallResult> trace_calls(const silkworm::Block& block, const std::vector<TraceCall>& calls, bool is_latest_block = false);
     Task<TraceDeployResult> trace_deploy_transaction(const silkworm::Block& block, const evmc::address& contract_address);
     Task<TraceCallResult> trace_transaction(const silkworm::Block& block, const rpc::Transaction& transaction, const TraceConfig& config);
     Task<std::vector<Trace>> trace_transaction(const silkworm::BlockWithHash& block, const rpc::Transaction& transaction, bool gas_bailout);
@@ -515,7 +515,8 @@ class TraceCallExecutor {
         const rpc::Transaction& transaction,
         std::int32_t index,
         const TraceConfig& config,
-        bool gas_bailout);
+        bool gas_bailout,
+        bool is_latest_block);
 
     silkworm::BlockCache& block_cache_;
     const ChainStorage& chain_storage_;

--- a/silkworm/rpc/core/evm_trace.hpp
+++ b/silkworm/rpc/core/evm_trace.hpp
@@ -493,8 +493,8 @@ class TraceCallExecutor {
     TraceCallExecutor(const TraceCallExecutor&) = delete;
     TraceCallExecutor& operator=(const TraceCallExecutor&) = delete;
 
-    Task<std::vector<Trace>> trace_block(const BlockWithHash& block_with_hash, Filter& filter, json::Stream* stream = nullptr);
-    Task<std::vector<TraceCallResult>> trace_block_transactions(const silkworm::Block& block, const TraceConfig& config);
+    Task<std::vector<Trace>> trace_block(const BlockWithHash& block_with_hash, Filter& filter, json::Stream* stream = nullptr, bool is_latest_block = false);
+    Task<std::vector<TraceCallResult>> trace_block_transactions(const silkworm::Block& block, const TraceConfig& config, bool is_latest_block = false);
     Task<TraceCallResult> trace_call(const silkworm::Block& block, const Call& call, const TraceConfig& config, bool is_latest_block = false);
     Task<TraceManyCallResult> trace_calls(const silkworm::Block& block, const std::vector<TraceCall>& calls, bool is_latest_block = false);
     Task<TraceDeployResult> trace_deploy_transaction(const silkworm::Block& block, const evmc::address& contract_address);


### PR DESCRIPTION
Updated API to manage query on latest Block:
- `eth_getBalance` + integration_test
- `eth_getTransactionCount` + integration_test
- `eth_getCode` + integration_test*
- `eth getStorageAt` + integration_test
- `eth_call` + integration_test*
- `eth_callBunlde` + integration_test
- `eth_createAccessList` + integration_test*
- `ots_hasCode` + integration_test*
- `parity_listStorageKeys` + integration_test
- `eth_callMany` + integration_test*
- `trace_call` + integration_test*
- `trace_callMany` 
- `debug_traceCall`  + integration_test*
- `debug_traceCallMany` + integration_test*
- `ots_getContractCreator` - always on latest
- `eth_estimateGas` - always on latest
- `trace_block`
- `trace_replayBlockTransaction`

This PR is associated to rpc-tests  https://github.com/erigontech/rpc-tests/pull/323
