### PR TITLE
fix: Fix inconsistent initialization style in ExecutionProcessor

### DIFF
--- a/docs/code_style.md
+++ b/docs/code_style.md
@@ -58,7 +58,7 @@ Bad:
 
 	BlockNum expected_blocknum{previous_progress + 1};
 	ChainConfig& config{kMainnetConfig};
-	ExecutionProcessor processor(block, *rule_set, buffer, *chain_config);
+	ExecutionProcessor processor{block, *rule_set, buffer, *chain_config};
 
 Copy initialization can use either style:
 


### PR DESCRIPTION
I noticed an inconsistency in the initialization of `ExecutionProcessor` that didn't align with the project's style guidelines. The code used parentheses (`()`) instead of braces (`{}`) for initialization.  

Updated the following:  
```cpp
ExecutionProcessor processor(block, *rule_set, buffer, *chain_config);
```
to:  
```cpp
ExecutionProcessor processor{block, *rule_set, buffer, *chain_config};
```  

This change ensures the code follows the recommended style outlined in the documentation. 