### PR TITLE
execution: use read-only tx in LocalState

### DIFF
--- a/silkworm/execution/local_state.hpp
+++ b/silkworm/execution/local_state.hpp
@@ -38,7 +38,7 @@ class LocalState : public State {
         db::DataStoreRef data_store)
         : txn_id_{txn_id},
           data_store_{std::move(data_store)},
-          tx_{data_store_.chaindata.access_rw().start_rw_tx()} {}
+          tx_{data_store_.chaindata.access_ro().start_ro_tx()} {}
 
     std::optional<Account> read_account(const evmc::address& address) const noexcept override;
 
@@ -73,22 +73,22 @@ class LocalState : public State {
     void begin_block(BlockNum /*block_num*/, size_t /*updated_accounts_count*/) override {}
 
     void update_account(
-        const evmc::address& address,
-        std::optional<Account> initial,
-        std::optional<Account> current) override;
+        const evmc::address& /*address*/,
+        std::optional<Account> /*initial*/,
+        std::optional<Account> /*current*/) override {}
 
     void update_account_code(
-        const evmc::address& address,
-        uint64_t incarnation,
-        const evmc::bytes32& code_hash,
-        ByteView code) override;
+        const evmc::address& /*address*/,
+        uint64_t /*incarnation*/,
+        const evmc::bytes32& /*code_hash*/,
+        ByteView /*code*/) override {}
 
     void update_storage(
-        const evmc::address& address,
-        uint64_t incarnation,
-        const evmc::bytes32& location,
-        const evmc::bytes32& initial,
-        const evmc::bytes32& current) override;
+        const evmc::address& /*address*/,
+        uint64_t /*incarnation*/,
+        const evmc::bytes32& /*location*/,
+        const evmc::bytes32& /*initial*/,
+        const evmc::bytes32& /*current*/) override {}
 
     void unwind_state_changes(BlockNum /*block_num*/) override {}
 
@@ -99,7 +99,7 @@ class LocalState : public State {
 
     std::optional<TxnId> txn_id_;
     db::DataStoreRef data_store_;
-    mutable datastore::kvdb::RWTxnManaged tx_;
+    mutable datastore::kvdb::ROTxnManaged tx_;
 };
 
 }  // namespace silkworm::execution


### PR DESCRIPTION
Both `LocalState` and `RemoteState` are implementations of the `State` interface aimed at providing support for call execution, i.e. transaction re-execution or simulation required by many RPC end-points.

As such, `LocalState` must use a read-only database transaction because:
1. it doesn't need any read-write support (no persistent change is produced)
2. can be instantiated multiple times concurrently to offer parallel call execution
