### PR TITLE
evm: enable evmone APIv2 in block executor

### DIFF
--- a/silkworm/core/execution/processor.hpp
+++ b/silkworm/core/execution/processor.hpp
@@ -88,7 +88,6 @@ class ExecutionProcessor {
     evmone::state::BlockInfo evm1_block_;
 
     //! Execute transactions using evmone APIv2 only and apply the result state diff to the state.
-    //! TODO: This flag currently has no effect.
     bool evm1_v2_ = false;
 };
 

--- a/silkworm/node/execution/block/block_executor.cpp
+++ b/silkworm/node/execution/block/block_executor.cpp
@@ -32,7 +32,7 @@ BlockExecutor::BlockExecutor(const ChainConfig* chain_config, bool write_receipt
       write_change_sets_{write_change_sets} {}
 
 ValidationResult BlockExecutor::execute_single(const Block& block, db::Buffer& state_buffer, AnalysisCache& analysis_cache) {
-    ExecutionProcessor processor{block, *protocol_rule_set_, state_buffer, *chain_config_, false};
+    ExecutionProcessor processor{block, *protocol_rule_set_, state_buffer, *chain_config_, true};
     processor.evm().analysis_cache = &analysis_cache;
 
     CallTraces traces;


### PR DESCRIPTION
This include a evmone change where we make sure the tracer is invoked even for empty code.