### PR TITLE
db: split latest and historical snapshots repos

### DIFF
--- a/cmd/capi/execute.cpp
+++ b/cmd/capi/execute.cpp
@@ -144,7 +144,7 @@ const char* make_path(const snapshots::SnapshotPath& p) {
     return path;
 }
 
-std::vector<SilkwormChainSnapshot> collect_all_snapshots(const SnapshotRepository& repository) {
+std::vector<SilkwormBlocksSnapshotBundle> collect_all_snapshot_bundles(const SnapshotRepository& repository) {
     std::vector<SilkwormHeadersSnapshot> headers_snapshot_sequence;
     std::vector<SilkwormBodiesSnapshot> bodies_snapshot_sequence;
     std::vector<SilkwormTransactionsSnapshot> transactions_snapshot_sequence;
@@ -209,15 +209,15 @@ std::vector<SilkwormChainSnapshot> collect_all_snapshots(const SnapshotRepositor
     ensure(bodies_snapshot_sequence.size() == repository.bundles_count(), "invalid body snapshot count");
     ensure(transactions_snapshot_sequence.size() == repository.bundles_count(), "invalid tx snapshot count");
 
-    std::vector<SilkwormChainSnapshot> snapshot_sequence;
+    std::vector<SilkwormBlocksSnapshotBundle> snapshot_sequence;
     snapshot_sequence.reserve(headers_snapshot_sequence.size());
     for (size_t i{0}; i < headers_snapshot_sequence.size(); ++i) {
-        SilkwormChainSnapshot chain_snapshot{
+        SilkwormBlocksSnapshotBundle bundle{
             headers_snapshot_sequence[i],
             bodies_snapshot_sequence[i],
             transactions_snapshot_sequence[i],
         };
-        snapshot_sequence.push_back(chain_snapshot);
+        snapshot_sequence.push_back(bundle);
     }
     return snapshot_sequence;
 }
@@ -293,22 +293,22 @@ int execute_blocks(SilkwormHandle handle, ExecuteBlocksSettings settings, const 
     };
 
     // Collect all snapshots
-    auto all_chain_snapshots{collect_all_snapshots(data_store.ref().blocks_repository)};
+    auto snapshot_bundles = collect_all_snapshot_bundles(data_store.ref().blocks_repository);
     [[maybe_unused]] auto _ = gsl::finally([&]() {
-        for (auto& chain_snapshot : all_chain_snapshots) {
-            delete[] chain_snapshot.headers.segment.file_path;
-            delete[] chain_snapshot.headers.header_hash_index.file_path;
-            delete[] chain_snapshot.bodies.segment.file_path;
-            delete[] chain_snapshot.bodies.block_num_index.file_path;
-            delete[] chain_snapshot.transactions.segment.file_path;
-            delete[] chain_snapshot.transactions.tx_hash_index.file_path;
-            delete[] chain_snapshot.transactions.tx_hash_2_block_index.file_path;
+        for (auto& bundle : snapshot_bundles) {
+            delete[] bundle.headers.segment.file_path;
+            delete[] bundle.headers.header_hash_index.file_path;
+            delete[] bundle.bodies.segment.file_path;
+            delete[] bundle.bodies.block_num_index.file_path;
+            delete[] bundle.transactions.segment.file_path;
+            delete[] bundle.transactions.tx_hash_index.file_path;
+            delete[] bundle.transactions.tx_hash_2_block_index.file_path;
         }
     });
-    for (auto& chain_snapshot : all_chain_snapshots) {
-        const int add_snapshot_status_code{silkworm_add_blocks_snapshot(handle, &chain_snapshot)};
+    for (auto& bundle : snapshot_bundles) {
+        const int add_snapshot_status_code{silkworm_add_blocks_snapshot_bundle(handle, &bundle)};
         if (add_snapshot_status_code != SILKWORM_OK) {
-            SILK_ERROR << "silkworm_add_blocks_snapshot failed [code=" << std::to_string(add_snapshot_status_code) << "]";
+            SILK_ERROR << "silkworm_add_blocks_snapshot_bundle failed [code=" << std::to_string(add_snapshot_status_code) << "]";
             return add_snapshot_status_code;
         }
     }

--- a/silkworm/capi/fork_validator.cpp
+++ b/silkworm/capi/fork_validator.cpp
@@ -132,7 +132,8 @@ SILKWORM_EXPORT int silkworm_start_fork_validator(SilkwormHandle handle, MDBX_en
     silkworm::db::DataStoreRef data_store{
         chaindata.ref(),
         *handle->blocks_repository,
-        *handle->state_repository,
+        *handle->state_repository_latest,
+        *handle->state_repository_historical,
     };
     silkworm::db::DataModelFactory data_model_factory{std::move(data_store)};
 

--- a/silkworm/capi/instance.hpp
+++ b/silkworm/capi/instance.hpp
@@ -49,7 +49,8 @@ struct SilkwormInstance {
     silkworm::NodeSettings node_settings;
     std::unique_ptr<silkworm::datastore::kvdb::DatabaseUnmanaged> chaindata;
     std::unique_ptr<silkworm::snapshots::SnapshotRepository> blocks_repository;
-    std::unique_ptr<silkworm::snapshots::SnapshotRepository> state_repository;
+    std::unique_ptr<silkworm::snapshots::SnapshotRepository> state_repository_latest;
+    std::unique_ptr<silkworm::snapshots::SnapshotRepository> state_repository_historical;
     std::unique_ptr<silkworm::rpc::Daemon> rpcdaemon;
     std::unique_ptr<silkworm::stagedsync::ExecutionEngine> execution_engine;
 

--- a/silkworm/capi/rpcdaemon.cpp
+++ b/silkworm/capi/rpcdaemon.cpp
@@ -109,7 +109,8 @@ SILKWORM_EXPORT int silkworm_start_rpcdaemon(SilkwormHandle handle, MDBX_env* en
     db::DataStoreRef data_store{
         handle->chaindata->ref(),
         *handle->blocks_repository,
-        *handle->state_repository,
+        *handle->state_repository_latest,
+        *handle->state_repository_historical,
     };
 
     // Create the one-and-only Silkrpc daemon

--- a/silkworm/capi/silkworm.h
+++ b/silkworm/capi/silkworm.h
@@ -89,7 +89,7 @@ struct SilkwormTransactionsSnapshot {
     struct SilkwormMemoryMappedFile tx_hash_2_block_index;
 };
 
-struct SilkwormChainSnapshot {
+struct SilkwormBlocksSnapshotBundle {
     struct SilkwormHeadersSnapshot headers;
     struct SilkwormBodiesSnapshot bodies;
     struct SilkwormTransactionsSnapshot transactions;
@@ -112,16 +112,22 @@ struct SilkwormDomainSnapshot {
     struct SilkwormMemoryMappedFile btree_index;      // .bt
     bool has_accessor_index;
     struct SilkwormMemoryMappedFile accessor_index;  // .kvi
-    bool has_history;
-    struct SilkwormHistorySnapshot history;
 };
 
-struct SilkwormStateSnapshot {
+struct SilkwormStateSnapshotBundleLatest {
     struct SilkwormDomainSnapshot accounts;
     struct SilkwormDomainSnapshot storage;
     struct SilkwormDomainSnapshot code;
     struct SilkwormDomainSnapshot commitment;
     struct SilkwormDomainSnapshot receipts;
+};
+
+struct SilkwormStateSnapshotBundleHistorical {
+    struct SilkwormHistorySnapshot accounts;
+    struct SilkwormHistorySnapshot storage;
+    struct SilkwormHistorySnapshot code;
+    struct SilkwormHistorySnapshot receipts;
+
     struct SilkwormInvertedIndexSnapshot log_addresses;
     struct SilkwormInvertedIndexSnapshot log_topics;
     struct SilkwormInvertedIndexSnapshot traces_from;
@@ -177,20 +183,28 @@ SILKWORM_EXPORT int silkworm_init(SilkwormHandle* handle, const struct SilkwormS
 SILKWORM_EXPORT int silkworm_build_recsplit_indexes(SilkwormHandle handle, struct SilkwormMemoryMappedFile* segments[], size_t len) SILKWORM_NOEXCEPT;
 
 /**
- * \brief Notify Silkworm about a new *block* snapshot to use.
+ * \brief Notify Silkworm about a new *block* snapshot bundle to use.
  * \param[in] handle A valid Silkworm instance handle, got with silkworm_init.
- * \param[in] snapshot A snapshot to use.
+ * \param[in] bundle A *block* snapshot bundle to use.
  * \return SILKWORM_OK (=0) on success, a non-zero error value on failure.
  */
-SILKWORM_EXPORT int silkworm_add_blocks_snapshot(SilkwormHandle handle, struct SilkwormChainSnapshot* snapshot) SILKWORM_NOEXCEPT;
+SILKWORM_EXPORT int silkworm_add_blocks_snapshot_bundle(SilkwormHandle handle, const struct SilkwormBlocksSnapshotBundle* bundle) SILKWORM_NOEXCEPT;
 
 /**
- * \brief Notify Silkworm about a new *state* snapshot to use.
+ * \brief Notify Silkworm about a new *latest state* snapshot bundle to use.
  * \param[in] handle A valid Silkworm instance handle, got with silkworm_init.
- * \param[in] snapshot A *state* snapshot to use.
+ * \param[in] bundle A *latest state* snapshot bundle to use.
  * \return SILKWORM_OK (=0) on success, a non-zero error value on failure.
  */
-SILKWORM_EXPORT int silkworm_add_state_snapshot(SilkwormHandle handle, const struct SilkwormStateSnapshot* snapshot) SILKWORM_NOEXCEPT;
+SILKWORM_EXPORT int silkworm_add_state_snapshot_bundle_latest(SilkwormHandle handle, const struct SilkwormStateSnapshotBundleLatest* bundle) SILKWORM_NOEXCEPT;
+
+/**
+ * \brief Notify Silkworm about a new *historical state* snapshot bundle to use.
+ * \param[in] handle A valid Silkworm instance handle, got with silkworm_init.
+ * \param[in] bundle A *historical state* snapshot bundle to use.
+ * \return SILKWORM_OK (=0) on success, a non-zero error value on failure.
+ */
+SILKWORM_EXPORT int silkworm_add_state_snapshot_bundle_historical(SilkwormHandle handle, const struct SilkwormStateSnapshotBundleHistorical* bundle) SILKWORM_NOEXCEPT;
 
 /**
  * \brief Get libmdbx version for compatibility checks.

--- a/silkworm/db/data_store.cpp
+++ b/silkworm/db/data_store.cpp
@@ -24,7 +24,8 @@ datastore::Schema DataStore::make_schema() {
 
     snapshots::Schema snapshots;
     snapshots.repository(blocks::kBlocksRepositoryName) = blocks::make_blocks_repository_schema();
-    snapshots.repository(state::kStateRepositoryName) = state::make_state_repository_schema();
+    snapshots.repository(state::kStateRepositoryNameLatest) = state::make_state_repository_schema_latest();
+    snapshots.repository(state::kStateRepositoryNameHistorical) = state::make_state_repository_schema_historical();
 
     return {
         std::move(kvdb),
@@ -59,10 +60,12 @@ std::map<datastore::EntityName, std::unique_ptr<datastore::kvdb::Database>> Data
 
 std::map<datastore::EntityName, std::unique_ptr<snapshots::SnapshotRepository>> DataStore::make_repositories_map(
     snapshots::SnapshotRepository blocks_repository,
-    snapshots::SnapshotRepository state_repository) {
+    snapshots::SnapshotRepository state_repository_latest,
+    snapshots::SnapshotRepository state_repository_historical) {
     std::map<datastore::EntityName, std::unique_ptr<snapshots::SnapshotRepository>> repositories;
     repositories.emplace(blocks::kBlocksRepositoryName, std::make_unique<snapshots::SnapshotRepository>(std::move(blocks_repository)));
-    repositories.emplace(state::kStateRepositoryName, std::make_unique<snapshots::SnapshotRepository>(std::move(state_repository)));
+    repositories.emplace(state::kStateRepositoryNameLatest, std::make_unique<snapshots::SnapshotRepository>(std::move(state_repository_latest)));
+    repositories.emplace(state::kStateRepositoryNameHistorical, std::make_unique<snapshots::SnapshotRepository>(std::move(state_repository_historical)));
     return repositories;
 }
 

--- a/silkworm/db/datastore/snapshots/domain.hpp
+++ b/silkworm/db/datastore/snapshots/domain.hpp
@@ -20,7 +20,6 @@
 
 #include "bloom_filter/bloom_filter.hpp"
 #include "btree/btree_index.hpp"
-#include "history.hpp"
 #include "rec_split/accessor_index.hpp"
 #include "segment/kv_segment_reader.hpp"
 
@@ -31,7 +30,6 @@ struct Domain {
     const rec_split::AccessorIndex* accessor_index{nullptr};
     const bloom_filter::BloomFilter& existence_index;
     const btree::BTreeIndex& btree_index;
-    std::optional<History> history;
 };
 
 }  // namespace silkworm::snapshots

--- a/silkworm/db/datastore/snapshots/history_get_query.hpp
+++ b/silkworm/db/datastore/snapshots/history_get_query.hpp
@@ -33,7 +33,7 @@ struct HistoryGetQuery {
     explicit HistoryGetQuery(const SnapshotRepositoryROAccess& repository)
         : timestamp_query_{
               repository,
-              [](const SnapshotBundle& bundle) { return bundle.domain(segment_names.front()).history->inverted_index; },
+              [](const SnapshotBundle& bundle) { return bundle.history(segment_names.front()).inverted_index; },
           },
           value_query_{repository} {}
 

--- a/silkworm/db/datastore/snapshots/schema.hpp
+++ b/silkworm/db/datastore/snapshots/schema.hpp
@@ -159,29 +159,11 @@ class Schema {
             return *this;
         }
 
-        DomainDef& history_compression_enabled(bool value) {
-            segment(kHistorySegmentName).compression_enabled(value);
-            return *this;
-        }
-
-        DomainDef& without_history() {
-            RepositoryDef::undefine_history_schema(*this);
-            return *this;
-        }
-
         DomainDef& with_accessor_index();
     };
 
     class RepositoryDef {
       public:
-        const DomainDef& domain(datastore::EntityName name) const {
-            return dynamic_cast<DomainDef&>(*entity_defs_.at(name));
-        }
-
-        const EntityDef& inverted_index(datastore::EntityName name) const {
-            return *entity_defs_.at(name);
-        }
-
         EntityDef& default_entity() {
             entity_defs_.try_emplace(kDefaultEntityName, std::make_shared<EntityDef>());
             return *entity_defs_.at(kDefaultEntityName);
@@ -192,8 +174,25 @@ class Schema {
             return dynamic_cast<DomainDef&>(*entity_defs_.at(name));
         }
 
+        const DomainDef& domain(datastore::EntityName name) const {
+            return dynamic_cast<DomainDef&>(*entity_defs_.at(name));
+        }
+
+        EntityDef& history(datastore::EntityName name) {
+            entity_defs_.try_emplace(name, std::make_shared<EntityDef>(make_history_schema(name)));
+            return *entity_defs_.at(name);
+        }
+
+        const EntityDef& history(datastore::EntityName name) const {
+            return *entity_defs_.at(name);
+        }
+
         EntityDef& inverted_index(datastore::EntityName name) {
             entity_defs_.try_emplace(name, std::make_shared<EntityDef>(make_inverted_index_schema(name)));
+            return *entity_defs_.at(name);
+        }
+
+        const EntityDef& inverted_index(datastore::EntityName name) const {
             return *entity_defs_.at(name);
         }
 

--- a/silkworm/db/datastore/snapshots/snapshot_bundle.cpp
+++ b/silkworm/db/datastore/snapshots/snapshot_bundle.cpp
@@ -157,19 +157,20 @@ Domain SnapshotBundle::domain(datastore::EntityName name) const {
         nullptr,
         data.existence_indexes.at(Schema::kDomainExistenceIndexName),
         data.btree_indexes.at(Schema::kDomainBTreeIndexName),
-        std::nullopt,
     };
     if (data.accessor_indexes.contains(Schema::kDomainAccessorIndexName)) {
         domain.accessor_index = &data.accessor_indexes.at(Schema::kDomainAccessorIndexName);
     }
-    if (data.segments.contains(Schema::kHistorySegmentName)) {
-        domain.history.emplace(History{
-            data.segments.at(Schema::kHistorySegmentName),
-            data.accessor_indexes.at(Schema::kHistoryAccessorIndexName),
-            inverted_index(name),
-        });
-    }
     return domain;
+}
+
+History SnapshotBundle::history(datastore::EntityName name) const {
+    auto& data = data_.entities.at(name);
+    return History{
+        data.segments.at(Schema::kHistorySegmentName),
+        data.accessor_indexes.at(Schema::kHistoryAccessorIndexName),
+        inverted_index(name),
+    };
 }
 
 InvertedIndex SnapshotBundle::inverted_index(datastore::EntityName name) const {

--- a/silkworm/db/datastore/snapshots/snapshot_bundle.hpp
+++ b/silkworm/db/datastore/snapshots/snapshot_bundle.hpp
@@ -25,6 +25,7 @@
 #include "common/snapshot_path.hpp"
 #include "common/util/iterator/map_values_view.hpp"
 #include "domain.hpp"
+#include "history.hpp"
 #include "inverted_index.hpp"
 #include "rec_split/accessor_index.hpp"
 #include "schema.hpp"
@@ -114,6 +115,7 @@ struct SnapshotBundle : public SegmentAndAccessorIndexProvider {
     }
 
     Domain domain(datastore::EntityName name) const;
+    History history(datastore::EntityName name) const;
     InvertedIndex inverted_index(datastore::EntityName name) const;
 
     StepRange step_range() const { return step_range_; }

--- a/silkworm/db/kv/api/local_transaction.cpp
+++ b/silkworm/db/kv/api/local_transaction.cpp
@@ -95,7 +95,7 @@ Task<PaginatedTimestamps> LocalTransaction::index_range(IndexRangeQuery query) {
         inverted_index_name,
         data_store_.chaindata,
         txn_,
-        data_store_.state_repository,
+        data_store_.state_repository_historical,
     };
 
     // TODO: convert query from/to to ts_range

--- a/silkworm/db/state/schema_config.hpp
+++ b/silkworm/db/state/schema_config.hpp
@@ -29,14 +29,19 @@
 
 namespace silkworm::db::state {
 
-inline constexpr datastore::EntityName kStateRepositoryName{"State"};
+inline constexpr datastore::EntityName kStateRepositoryNameLatest{"StateLatest"};
+inline constexpr datastore::EntityName kStateRepositoryNameHistorical{"StateHistorical"};
 
-snapshots::Schema::RepositoryDef make_state_repository_schema();
+snapshots::Schema::RepositoryDef make_state_repository_schema_latest();
+snapshots::Schema::RepositoryDef make_state_repository_schema_historical();
 datastore::kvdb::Schema::DatabaseDef make_state_database_schema();
 
-std::unique_ptr<snapshots::IndexBuildersFactory> make_state_index_builders_factory();
+snapshots::SnapshotRepository make_state_repository_latest(
+    std::filesystem::path dir_path,
+    bool open = true,
+    std::optional<uint32_t> index_salt = std::nullopt);
 
-snapshots::SnapshotRepository make_state_repository(
+snapshots::SnapshotRepository make_state_repository_historical(
     std::filesystem::path dir_path,
     bool open = true,
     std::optional<uint32_t> index_salt = std::nullopt);

--- a/silkworm/db/test_util/temp_snapshots.hpp
+++ b/silkworm/db/test_util/temp_snapshots.hpp
@@ -438,16 +438,16 @@ class SampleAccountsDomainSegmentFile : public TemporarySnapshotFile {
               "6ac2c4fe4a725053da119b9d4f515140a2d7239c40b45ac3950d941fc4fe") {}
 };
 
-//! Sample Accounts KVEI file generated using Erigon aggregator_test.go:generateKV
-class SampleAccountsDomainKVEIFile : public TemporarySnapshotFile {
+//! Sample Accounts existence index file generated using Erigon aggregator_test.go:generateKV
+class SampleAccountsDomainExistenceIndexFile : public TemporarySnapshotFile {
   public:
     //! This ctor lets you pass any snapshot content and is used to produce broken snapshots
-    SampleAccountsDomainKVEIFile(const std::filesystem::path& tmp_dir, std::string_view hex)
+    SampleAccountsDomainExistenceIndexFile(const std::filesystem::path& tmp_dir, std::string_view hex)
         : TemporarySnapshotFile{tmp_dir, "v1-accounts.0-1024.kvei", *from_hex(hex)} {}
 
     //! This ctor captures the correct sample snapshot content once for all
-    explicit SampleAccountsDomainKVEIFile(const std::filesystem::path& tmp_dir)
-        : SampleAccountsDomainKVEIFile(
+    explicit SampleAccountsDomainExistenceIndexFile(const std::filesystem::path& tmp_dir)
+        : SampleAccountsDomainExistenceIndexFile(
               tmp_dir,
               "00000000000000007630320a03000000000000000a0000000000000060000000"
               "00000000cc6bab7ea3f92b90703c27812255d1e5c7ffdf994578ee3c428838c0"
@@ -455,62 +455,22 @@ class SampleAccountsDomainKVEIFile : public TemporarySnapshotFile {
               "32c645a280eb7ce40acab41e296fc6b9bafcfa2edd3b2dc83b0994ab") {}
 };
 
-//! Sample Accounts BT file generated using Erigon aggregator_test.go:generateKV
-class SampleAccountsDomainBTFile : public TemporarySnapshotFile {
+//! Sample Accounts B-tree index file generated using Erigon aggregator_test.go:generateKV
+class SampleAccountsDomainBTreeIndexFile : public TemporarySnapshotFile {
   public:
     //! This ctor lets you pass any snapshot content and is used to produce broken snapshots
-    SampleAccountsDomainBTFile(const std::filesystem::path& tmp_dir, std::string_view hex)
+    SampleAccountsDomainBTreeIndexFile(const std::filesystem::path& tmp_dir, std::string_view hex)
         : TemporarySnapshotFile{tmp_dir, "v1-accounts.0-1024.bt", *from_hex(hex)} {}
 
     //! This ctor captures the correct sample snapshot content once for all
-    explicit SampleAccountsDomainBTFile(const std::filesystem::path& tmp_dir)
-        : SampleAccountsDomainBTFile(
+    explicit SampleAccountsDomainBTreeIndexFile(const std::filesystem::path& tmp_dir)
+        : SampleAccountsDomainBTreeIndexFile(
               tmp_dir,
               "000000000000000900000000000004e300cc0b241b9d9f080000000000000000"
               "2922891400000000000000000000000000000000000000000000000000000000"
               "0000000000000001000000000000000000340194fdc2fa2ffcc041d3ff12045b"
               "73c86e4ff95ff662a5eee82abdf44a2d0b75fb180daf48a79ee0b10d39460000"
               "000000000000") {}
-};
-
-//! Sample empty Accounts EF file
-class SampleAccountsDomainEFFile : public TemporarySnapshotFile {
-  public:
-    //! This ctor lets you pass any snapshot content and is used to produce broken snapshots
-    SampleAccountsDomainEFFile(const std::filesystem::path& tmp_dir, std::string_view hex)
-        : TemporarySnapshotFile{tmp_dir, "v1-accounts.0-1024.ef", *from_hex(hex)} {}
-
-    //! This ctor captures the correct sample snapshot content once for all
-    explicit SampleAccountsDomainEFFile(const std::filesystem::path& tmp_dir)
-        : SampleAccountsDomainEFFile(
-              tmp_dir,
-              "0000000000000000000000000000000000000000000000000000000000000000") {}
-};
-
-//! Sample empty Accounts EFI file
-class SampleAccountsDomainEFIFile : public TemporarySnapshotFile {
-  public:
-    //! This ctor lets you pass any snapshot content and is used to produce broken snapshots
-    SampleAccountsDomainEFIFile(const std::filesystem::path& tmp_dir, std::string_view hex)
-        : TemporarySnapshotFile{tmp_dir, "v1-accounts.0-1024.efi", *from_hex(hex)} {}
-
-    //! This ctor captures the correct sample snapshot content once for all
-    explicit SampleAccountsDomainEFIFile(const std::filesystem::path& tmp_dir)
-        : SampleAccountsDomainEFIFile(
-              tmp_dir,
-              "0000000000000000000000000000000000000000000000000000000008000000"
-              "0014"
-              "106393C187CAE21A6453CEC3F7376937643E521DDBD2BE983740C6412F6572CB"
-              "717D47562F1CE4704CD6EB4C63BEFB7C9BFD8C5E18C8DA73082F20E10092A9A3"
-              "2ADA2CE68D21DEFCE33CB4F3E7C6466B3980BE458C509C59C466FD9584828E8C"
-              "45F0AABE1A61EDE6F6E7B8B33AD9B98D4EF95E25F4B4983D81175195173B92D3"
-              "4E50927D8DD159781EA2099D1FAFAE7F425C8A06FBAAA815CD4216006C74052A"
-              "00"
-              "00000000"
-              "0000000000000000000000000000000000000000000000000000000000000000"
-              "0000000000000000000000000000000000000000000000000000000000000000"
-              "0000000000000000000000000000000000000000000000000000000000000000"
-              "0000000000000000") {}
 };
 
 }  // namespace silkworm::snapshots::test_util

--- a/silkworm/execution/domain_state.hpp
+++ b/silkworm/execution/domain_state.hpp
@@ -39,7 +39,7 @@ class DomainState : public State {
         datastore::kvdb::RWTxn& tx,
         datastore::kvdb::DatabaseRef& database,
         snapshots::SnapshotRepository& blocks_repository,
-        snapshots::SnapshotRepository& state_repository)
+        snapshots::SnapshotRepositoryROAccess& state_repository)
         : txn_id_{txn_id},
           tx_{tx},
           database_{database},
@@ -50,7 +50,7 @@ class DomainState : public State {
         TxnId txn_id,
         datastore::kvdb::RWTxn& tx,
         datastore::kvdb::DatabaseRef& database,
-        snapshots::SnapshotRepository& state_repository,
+        snapshots::SnapshotRepositoryROAccess& state_repository,
         db::DataModel& data_model)
 
         : txn_id_{txn_id},
@@ -115,7 +115,7 @@ class DomainState : public State {
     TxnId txn_id_;
     datastore::kvdb::RWTxn& tx_;
     datastore::kvdb::DatabaseRef& database_;
-    snapshots::SnapshotRepository& state_repository_;
+    snapshots::SnapshotRepositoryROAccess& state_repository_;
     db::DataModel data_model_;
 };
 

--- a/silkworm/execution/domain_state_test.cpp
+++ b/silkworm/execution/domain_state_test.cpp
@@ -50,7 +50,7 @@ TEST_CASE("DomainState data access", "[execution][domain][state]") {
     auto rw_tx = ds_context.chaindata_rw().start_rw_tx();
 
     auto db_ref = ds_context->chaindata().ref();
-    auto sut = DomainState{1, rw_tx, db_ref, ds_context->blocks_repository(), ds_context->state_repository()};
+    auto sut = DomainState{1, rw_tx, db_ref, ds_context->blocks_repository(), ds_context->state_repository_latest()};
     auto header0_hash = sut.canonical_hash(0);
     auto header0 = sut.read_header(0, header0_hash.value());
 
@@ -169,7 +169,7 @@ TEST_CASE("DomainState data access", "[execution][domain][state]") {
         CHECK(account_66_read->balance == account_66_v2.balance);
 
         auto next_step_txn_id = silkworm::datastore::kStepSizeForTemporalSnapshots + 1;
-        auto sut2 = DomainState{next_step_txn_id, rw_tx, db_ref, ds_context->blocks_repository(), ds_context->state_repository()};
+        auto sut2 = DomainState{next_step_txn_id, rw_tx, db_ref, ds_context->blocks_repository(), ds_context->state_repository_latest()};
         Account account_66_v3{
             .nonce = 10,
             .balance = 262,
@@ -228,7 +228,7 @@ TEST_CASE("DomainState data access", "[execution][domain][state]") {
         CHECK(code_66_read == code_66);
 
         auto next_step_txn_id = silkworm::datastore::kStepSizeForTemporalSnapshots + 1;
-        auto sut2 = DomainState{next_step_txn_id, rw_tx, db_ref, ds_context->blocks_repository(), ds_context->state_repository()};
+        auto sut2 = DomainState{next_step_txn_id, rw_tx, db_ref, ds_context->blocks_repository(), ds_context->state_repository_latest()};
         code_66 = *from_hex("0x6044");
         code_hash_66 = std::bit_cast<evmc_bytes32>(keccak256(code_66));
         sut2.update_account_code(
@@ -285,7 +285,7 @@ TEST_CASE("DomainState data access", "[execution][domain][state]") {
         CHECK(storage_66_01 == 0x0124_bytes32);
 
         auto next_step_txn_id = silkworm::datastore::kStepSizeForTemporalSnapshots + 1;
-        auto sut2 = DomainState{next_step_txn_id, rw_tx, db_ref, ds_context->blocks_repository(), ds_context->state_repository()};
+        auto sut2 = DomainState{next_step_txn_id, rw_tx, db_ref, ds_context->blocks_repository(), ds_context->state_repository_latest()};
         sut2.update_storage(
             0x668bdf435d810c91414ec09147daa6db62406379_address,
             kDefaultIncarnation,
@@ -307,7 +307,7 @@ TEST_CASE("DomainState empty overriden methods do nothing", "[execution][domain]
     auto rw_tx = ds_context.chaindata_rw().start_rw_tx();
 
     auto db_ref = ds_context->chaindata().ref();
-    auto sut = DomainState{1, rw_tx, db_ref, ds_context->blocks_repository(), ds_context->state_repository()};
+    auto sut = DomainState{1, rw_tx, db_ref, ds_context->blocks_repository(), ds_context->state_repository_latest()};
 
     CHECK_NOTHROW(sut.insert_block(Block{}, evmc::bytes32{}));
     CHECK_NOTHROW(sut.canonize_block(0, evmc::bytes32{}));

--- a/silkworm/execution/local_state.hpp
+++ b/silkworm/execution/local_state.hpp
@@ -98,8 +98,8 @@ class LocalState : public State {
     }
 
     template <typename DomainQuery>
-    auto make_query() const {
-        return DomainQuery{data_store_.chaindata, tx_, data_store_.state_repository};
+    auto query_as_of() const {
+        return DomainQuery{data_store_.chaindata, tx_, data_store_.state_repository_latest, data_store_.state_repository_historical};
     }
 
     std::optional<TxnId> txn_id_;


### PR DESCRIPTION
Split state repository into 2: latest and historical.
* "latest" contains Domains data
* "historical" contains II and History data

This fixes a problem of having unlimited frozen steps in domain snapshots. II and History snapshots are capped at 64 steps, but Domain can grow to 1024. When it happens, the snapshot bundles become not full (e.g. a domain file with 256 steps doesn't align to a history file with 64 steps).

DomainGetAsOfQuery now accepts both repositories and uses them accordingly. `optional<snapshots::History>` is removed from snapshots::Domain, because it is a separate entity. DomainState only uses the latest state repository.

refactorings:
* call composite structs "bundle" in the C API to reflect our terminology
* refactor snapshot addition methods to the same structure
* change DomainGetAsOfQuery to accept `optional<Timestamp>` to simplify LocalState impl
* unit test refactored to improve naming