### PR TITLE
rpc: get EVM opcode names from evmone

### DIFF
--- a/silkworm/rpc/common/util.cpp
+++ b/silkworm/rpc/common/util.cpp
@@ -16,6 +16,8 @@
 
 #include "util.hpp"
 
+#include <evmone/instructions_traits.hpp>
+
 #include <silkworm/core/types/evmc_bytes32.hpp>
 
 namespace silkworm {
@@ -156,15 +158,12 @@ std::string get_opcode_hex(uint8_t opcode) {
     return {'0', 'x', kHexDigits[opcode >> 4], kHexDigits[opcode & 0xf]};
 }
 
-std::optional<std::string> get_opcode_name(const char* const* names, std::uint8_t opcode) {
-    SILKWORM_ASSERT(names != nullptr);
-
-    std::optional<std::string> op_name;
-    const auto name = names[opcode];
-    if (name != nullptr) {
-        op_name = name;
-    }
-    return op_name;
+std::optional<std::string_view> get_opcode_name(std::uint8_t opcode) noexcept {
+    // TODO(evmone): evmone can provide a function like this directly with optimized lookup table.
+    const auto name = evmone::instr::traits[opcode].name;
+    if (name == nullptr)
+        return std::nullopt;  // TODO: return "UNDEFINED"?
+    return name;
 }
 
 }  // namespace silkworm

--- a/silkworm/rpc/common/util.hpp
+++ b/silkworm/rpc/common/util.hpp
@@ -55,7 +55,9 @@ inline evmc::bytes32 bytes32_from_hex(const std::string& s) {
 std::ostream& operator<<(std::ostream& out, const Account& account);
 
 std::string get_opcode_hex(uint8_t opcode);
-std::optional<std::string> get_opcode_name(const char* const* names, std::uint8_t opcode);
+
+/// Returns the opcode name or std::nullopt if the opcode is undefined.
+std::optional<std::string_view> get_opcode_name(std::uint8_t opcode) noexcept;
 }  // namespace silkworm
 
 inline auto hash_of(const silkworm::ByteView& bytes) {

--- a/silkworm/rpc/common/util_test.cpp
+++ b/silkworm/rpc/common/util_test.cpp
@@ -224,37 +224,12 @@ TEST_CASE("lookup_chain_config", "[rpc][common][util]") {
 }
 
 TEST_CASE("get_opcode_name") {
-    const char* names[256] = {
-        /* 0x00 */ "STOP",
-        /* 0x01 */ "ADD",
-        /* 0x02 */ "MUL",
-        /* 0x03 */ "SUB",
-        /* 0x04 */ "DIV",
-        /* 0x05 */ "SDIV",
-        /* 0x06 */ "MOD",
-        /* 0x07 */ "SMOD",
-        /* 0x08 */ "ADDMOD",
-        /* 0x09 */ "MULMOD",
-        /* 0x0a */ "EXP",
-        /* 0x0b */ "SIGNEXTEND",
-        /* 0x0c */ nullptr,
-        /* 0x0d */ nullptr,
-        /* 0x0e */ nullptr,
-        /* 0x0f */ nullptr,
-        /* 0x10 */ "LT",
-        /* 0x11 */ "GT",
-        /* 0x12 */ "SLT",
-        /* 0x13 */ "SGT",
-        /* 0x14 */ "EQ",
-        /* 0x15 */ "ISZERO",
-        /* 0x16 */ "AND"};
-
     SECTION("valid op_code") {
-        auto op_code_name = get_opcode_name(names, 0x00);
+        auto op_code_name = get_opcode_name(0x00);
         CHECK(op_code_name == "STOP");
     }
     SECTION("not existent op_code") {
-        auto op_code_name = get_opcode_name(names, 0x0d);
+        auto op_code_name = get_opcode_name(0x0d);
         CHECK(!op_code_name.has_value());
     }
 }

--- a/silkworm/rpc/core/evm_debug.hpp
+++ b/silkworm/rpc/core/evm_debug.hpp
@@ -98,8 +98,6 @@ class DebugTracer : public EvmTracer {
     const DebugConfig& config_;
     std::vector<DebugLog> logs_;
     std::map<evmc::address, Storage> storage_;
-    const char* const* opcode_names_ = nullptr;
-    const char* const* latest_opcode_names_ = nullptr;
     const evmc_instruction_metrics* metrics_ = nullptr;
     std::optional<uint8_t> last_opcode_;
 };

--- a/silkworm/rpc/core/evm_trace.hpp
+++ b/silkworm/rpc/core/evm_trace.hpp
@@ -156,7 +156,6 @@ class VmTraceTracer : public silkworm::EvmTracer {
     std::int32_t transaction_index_;
     std::stack<std::string> index_prefix_;
     std::stack<std::reference_wrapper<VmTrace>> traces_stack_;
-    const char* const* opcode_names_ = nullptr;
     const evmc_instruction_metrics* metrics_ = nullptr;
     std::stack<int64_t> start_gas_;
     std::stack<TraceMemory> trace_memory_stack_;
@@ -249,7 +248,6 @@ class TraceTracer : public silkworm::EvmTracer {
     std::vector<Trace>& traces_;
     silkworm::IntraBlockState& initial_ibs_;
     std::optional<uint8_t> last_opcode_;
-    const char* const* opcode_names_ = nullptr;
     int64_t initial_gas_{0};
     int32_t current_depth_{-1};
     std::set<evmc::address> created_address_;
@@ -323,7 +321,6 @@ class StateDiffTracer : public silkworm::EvmTracer {
     StateAddresses& state_addresses_;
     std::map<evmc::address, std::set<std::string>> diff_storage_;
     std::map<evmc::address, silkworm::ByteView> code_;
-    const char* const* opcode_names_ = nullptr;
 };
 
 struct TraceCallTraces {


### PR DESCRIPTION
Use evmone's instruction traits instead of EVMC to get the opcode names.