### PR TITLE
rpcdaemon: refactoring for ExecutionResult::error_code

### DIFF
--- a/silkworm/rpc/core/call_many.cpp
+++ b/silkworm/rpc/core/call_many.cpp
@@ -100,7 +100,7 @@ CallManyResult CallExecutor::executes_all_bundles(const silkworm::ChainConfig& c
             }
 
             nlohmann::json reply;
-            if (call_execution_result.error_code == evmc_status_code::EVMC_SUCCESS) {
+            if (call_execution_result.status_code == evmc_status_code::EVMC_SUCCESS) {
                 if (rpc::compatibility::is_erigon_json_api_compatibility_required()) {
                     reply["value"] = silkworm::to_hex(call_execution_result.data);
                 } else {

--- a/silkworm/rpc/core/estimate_gas_oracle.cpp
+++ b/silkworm/rpc/core/estimate_gas_oracle.cpp
@@ -98,7 +98,7 @@ Task<intx::uint256> EstimateGasOracle::estimate_gas(const Call& call, const silk
                 hi = mid;
             } else {
                 if (result.pre_check_error_code && result.pre_check_error_code != PreCheckErrorCode::kIntrinsicGasTooLow) {
-                    result.error_code = evmc_status_code::EVMC_SUCCESS;
+                    result.status_code = evmc_status_code::EVMC_SUCCESS;
                     return result;
                 }
                 lo = mid;
@@ -110,10 +110,10 @@ Task<intx::uint256> EstimateGasOracle::estimate_gas(const Call& call, const silk
             EVMExecutor executor{block, config_, workers_, state_overrides};
             transaction.gas_limit = hi;
             result = try_execution(executor, transaction);
-            SILK_DEBUG << "HI == cap tested again with " << (result.error_code == evmc_status_code::EVMC_SUCCESS ? "succeed" : "failed");
+            SILK_DEBUG << "HI == cap tested again with " << (result.status_code == evmc_status_code::EVMC_SUCCESS ? "succeed" : "failed");
         } else if (!result.pre_check_error_code || result.pre_check_error_code == PreCheckErrorCode::kIntrinsicGasTooLow) {
             result.pre_check_error = std::nullopt;
-            result.error_code = evmc_status_code::EVMC_SUCCESS;
+            result.status_code = evmc_status_code::EVMC_SUCCESS;
         }
 
         SILK_DEBUG << "EstimateGasOracle::estimate_gas returns " << hi;
@@ -122,7 +122,7 @@ Task<intx::uint256> EstimateGasOracle::estimate_gas(const Call& call, const silk
     });
 
     if (!exec_result.success()) {
-        if (exec_result.error_code == evmc_status_code::EVMC_OUT_OF_GAS) {
+        if (exec_result.status_code == evmc_status_code::EVMC_OUT_OF_GAS) {
             std::string error_msg = "gas required exceeds allowance (" + std::to_string(hi) + ")";
             throw EstimateGasException{-32000, error_msg};
         }
@@ -141,7 +141,7 @@ void EstimateGasOracle::throw_exception(ExecutionResult& result) {
         throw EstimateGasException{-32000, *result.pre_check_error};
     }
     auto error_message = result.error_message();
-    SILK_DEBUG << "result message: " << error_message << ", code " << *result.error_code;
+    SILK_DEBUG << "result message: " << error_message << ", code " << *result.status_code;
     if (result.data.empty()) {
         throw EstimateGasException{-32000, error_message};
     }

--- a/silkworm/rpc/core/estimate_gas_oracle_test.cpp
+++ b/silkworm/rpc/core/estimate_gas_oracle_test.cpp
@@ -103,8 +103,8 @@ TEST_CASE("estimate gas") {
     MockEstimateGasOracle estimate_gas_oracle{block_header_provider, account_reader, config, workers, *tx, storage, accounts_overrides};
 
     SECTION("Call empty, always fails but success in last step") {
-        ExecutionResult expect_result_ok{.error_code = evmc_status_code::EVMC_SUCCESS};
-        ExecutionResult expect_result_fail{.error_code = evmc_status_code::EVMC_OUT_OF_GAS};
+        ExecutionResult expect_result_ok{.status_code = evmc_status_code::EVMC_SUCCESS};
+        ExecutionResult expect_result_fail{.status_code = evmc_status_code::EVMC_OUT_OF_GAS};
         EXPECT_CALL(estimate_gas_oracle, try_execution(_, _))
             .Times(16)
             .WillOnce(Return(expect_result_fail))
@@ -130,7 +130,7 @@ TEST_CASE("estimate gas") {
     }
 
     SECTION("Call empty, always succeeds") {
-        ExecutionResult expect_result_ok{.error_code = evmc_status_code::EVMC_SUCCESS};
+        ExecutionResult expect_result_ok{.status_code = evmc_status_code::EVMC_SUCCESS};
         EXPECT_CALL(estimate_gas_oracle, try_execution(_, _)).Times(14).WillRepeatedly(Return(expect_result_ok));
         auto result = boost::asio::co_spawn(pool, estimate_gas_oracle.estimate_gas(call, block, 244087591818874), boost::asio::use_future);
         const intx::uint256& estimate_gas = result.get();
@@ -138,8 +138,8 @@ TEST_CASE("estimate gas") {
     }
 
     SECTION("Call empty, alternatively fails and succeeds") {
-        ExecutionResult expect_result_ok{.error_code = evmc_status_code::EVMC_SUCCESS};
-        ExecutionResult expect_result_fail{.error_code = evmc_status_code::EVMC_OUT_OF_GAS};
+        ExecutionResult expect_result_ok{.status_code = evmc_status_code::EVMC_SUCCESS};
+        ExecutionResult expect_result_fail{.status_code = evmc_status_code::EVMC_OUT_OF_GAS};
         EXPECT_CALL(estimate_gas_oracle, try_execution(_, _))
             .Times(14)
             .WillOnce(Return(expect_result_fail))
@@ -163,8 +163,8 @@ TEST_CASE("estimate gas") {
     }
 
     SECTION("Call empty, alternatively succeeds and fails") {
-        ExecutionResult expect_result_ok{.error_code = evmc_status_code::EVMC_SUCCESS};
-        ExecutionResult expect_result_fail{.error_code = evmc_status_code::EVMC_OUT_OF_GAS};
+        ExecutionResult expect_result_ok{.status_code = evmc_status_code::EVMC_SUCCESS};
+        ExecutionResult expect_result_fail{.status_code = evmc_status_code::EVMC_OUT_OF_GAS};
         EXPECT_CALL(estimate_gas_oracle, try_execution(_, _))
             .Times(14)
             .WillOnce(Return(expect_result_ok))
@@ -188,11 +188,11 @@ TEST_CASE("estimate gas") {
     }
 
     SECTION("Call empty, alternatively succeeds and fails with intrinsic") {
-        ExecutionResult expect_result_ok{.error_code = evmc_status_code::EVMC_SUCCESS};
+        ExecutionResult expect_result_ok{.status_code = evmc_status_code::EVMC_SUCCESS};
         ExecutionResult expect_result_fail_pre_check{
             .pre_check_error = "intrinsic ",
             .pre_check_error_code = PreCheckErrorCode::kIntrinsicGasTooLow};
-        ExecutionResult expect_result_fail{.error_code = evmc_status_code::EVMC_OUT_OF_GAS};
+        ExecutionResult expect_result_fail{.status_code = evmc_status_code::EVMC_OUT_OF_GAS};
         EXPECT_CALL(estimate_gas_oracle, try_execution(_, _))
             .Times(14)
             .WillOnce(Return(expect_result_ok))
@@ -217,8 +217,8 @@ TEST_CASE("estimate gas") {
 
     SECTION("Call with gas, always fails but succes last step") {
         call.gas = kTxGas * 4;
-        ExecutionResult expect_result_ok{.error_code = evmc_status_code::EVMC_SUCCESS};
-        ExecutionResult expect_result_fail{.error_code = evmc_status_code::EVMC_OUT_OF_GAS};
+        ExecutionResult expect_result_ok{.status_code = evmc_status_code::EVMC_SUCCESS};
+        ExecutionResult expect_result_fail{.status_code = evmc_status_code::EVMC_OUT_OF_GAS};
         EXPECT_CALL(estimate_gas_oracle, try_execution(_, _))
             .Times(17)
             .WillOnce(Return(expect_result_fail))
@@ -246,7 +246,7 @@ TEST_CASE("estimate gas") {
 
     SECTION("Call with gas, always succeeds") {
         call.gas = kTxGas * 4;
-        ExecutionResult expect_result_ok{.error_code = evmc_status_code::EVMC_SUCCESS};
+        ExecutionResult expect_result_ok{.status_code = evmc_status_code::EVMC_SUCCESS};
         EXPECT_CALL(estimate_gas_oracle, try_execution(_, _))
             .Times(15)
             .WillRepeatedly(Return(expect_result_ok));
@@ -257,8 +257,8 @@ TEST_CASE("estimate gas") {
     }
 
     SECTION("Call with gas_price, gas not capped") {
-        ExecutionResult expect_result_ok{.error_code = evmc_status_code::EVMC_SUCCESS};
-        ExecutionResult expect_result_fail{.error_code = evmc_status_code::EVMC_OUT_OF_GAS};
+        ExecutionResult expect_result_ok{.status_code = evmc_status_code::EVMC_SUCCESS};
+        ExecutionResult expect_result_fail{.status_code = evmc_status_code::EVMC_OUT_OF_GAS};
         call.gas = kTxGas * 2;
         call.gas_price = intx::uint256{10'000};
 
@@ -287,8 +287,8 @@ TEST_CASE("estimate gas") {
     }
 
     SECTION("Call with gas_price, gas capped") {
-        ExecutionResult expect_result_ok{.error_code = evmc_status_code::EVMC_SUCCESS};
-        ExecutionResult expect_result_fail{.error_code = evmc_status_code::EVMC_OUT_OF_GAS};
+        ExecutionResult expect_result_ok{.status_code = evmc_status_code::EVMC_SUCCESS};
+        ExecutionResult expect_result_fail{.status_code = evmc_status_code::EVMC_OUT_OF_GAS};
         call.gas = kTxGas * 2;
         call.gas_price = intx::uint256{40'000};
 
@@ -314,8 +314,8 @@ TEST_CASE("estimate gas") {
     }
 
     SECTION("Call with gas_price and value, gas not capped") {
-        ExecutionResult expect_result_ok{.error_code = evmc_status_code::EVMC_SUCCESS};
-        ExecutionResult expect_result_fail{.error_code = evmc_status_code::EVMC_OUT_OF_GAS};
+        ExecutionResult expect_result_ok{.status_code = evmc_status_code::EVMC_SUCCESS};
+        ExecutionResult expect_result_fail{.status_code = evmc_status_code::EVMC_OUT_OF_GAS};
         call.gas = kTxGas * 2;
         call.gas_price = intx::uint256{10'000};
         call.value = intx::uint256{500'000'000};
@@ -345,8 +345,8 @@ TEST_CASE("estimate gas") {
     }
 
     SECTION("Call with gas_price and value, gas capped") {
-        ExecutionResult expect_result_ok{.error_code = evmc_status_code::EVMC_SUCCESS};
-        ExecutionResult expect_result_fail{.error_code = evmc_status_code::EVMC_OUT_OF_GAS};
+        ExecutionResult expect_result_ok{.status_code = evmc_status_code::EVMC_SUCCESS};
+        ExecutionResult expect_result_fail{.status_code = evmc_status_code::EVMC_OUT_OF_GAS};
         call.gas = kTxGas * 2;
         call.gas_price = intx::uint256{20'000};
         call.value = intx::uint256{500'000'000};
@@ -373,7 +373,7 @@ TEST_CASE("estimate gas") {
     }
 
     SECTION("Call gas above allowance, always succeeds, gas capped") {
-        ExecutionResult expect_result_ok{.error_code = evmc_status_code::EVMC_SUCCESS};
+        ExecutionResult expect_result_ok{.status_code = evmc_status_code::EVMC_SUCCESS};
         call.gas = kGasCap * 2;
         EXPECT_CALL(estimate_gas_oracle, try_execution(_, _)).Times(25).WillRepeatedly(Return(expect_result_ok));
         auto result = boost::asio::co_spawn(pool, estimate_gas_oracle.estimate_gas(call, block, 244087591818874), boost::asio::use_future);
@@ -383,7 +383,7 @@ TEST_CASE("estimate gas") {
     }
 
     SECTION("Call gas below minimum, always succeeds") {
-        ExecutionResult expect_result_ok{.error_code = evmc_status_code::EVMC_SUCCESS};
+        ExecutionResult expect_result_ok{.status_code = evmc_status_code::EVMC_SUCCESS};
         call.gas = kTxGas / 2;
 
         EXPECT_CALL(estimate_gas_oracle, try_execution(_, _)).Times(14).WillRepeatedly(Return(expect_result_ok));
@@ -394,7 +394,7 @@ TEST_CASE("estimate gas") {
     }
 
     SECTION("Call with too high value, exception") {
-        ExecutionResult expect_result_fail{.error_code = evmc_status_code::EVMC_OUT_OF_GAS};
+        ExecutionResult expect_result_fail{.status_code = evmc_status_code::EVMC_OUT_OF_GAS};
         call.value = intx::uint256{2'000'000'000};
 
         try {
@@ -415,7 +415,7 @@ TEST_CASE("estimate gas") {
         ExecutionResult expect_result_fail_pre_check{
             .pre_check_error = "insufficient funds",
             .pre_check_error_code = PreCheckErrorCode::kInsufficientFunds};
-        ExecutionResult expect_result_fail{.error_code = evmc_status_code::EVMC_OUT_OF_GAS};
+        ExecutionResult expect_result_fail{.status_code = evmc_status_code::EVMC_OUT_OF_GAS};
         call.gas = kTxGas * 2;
         call.gas_price = intx::uint256{20'000};
         call.value = intx::uint256{500'000'000};
@@ -442,7 +442,7 @@ TEST_CASE("estimate gas") {
         ExecutionResult expect_result_fail_pre_check{
             .pre_check_error = "insufficient funds",
             .pre_check_error_code = PreCheckErrorCode::kInsufficientFunds};
-        ExecutionResult expect_result_fail{.error_code = evmc_status_code::EVMC_OUT_OF_GAS, .data = data};
+        ExecutionResult expect_result_fail{.status_code = evmc_status_code::EVMC_OUT_OF_GAS, .data = data};
         call.gas = kTxGas * 2;
         call.gas_price = intx::uint256{20'000};
         call.value = intx::uint256{500'000'000};
@@ -468,7 +468,7 @@ TEST_CASE("estimate gas") {
         ExecutionResult expect_result_fail_pre_check{
             .pre_check_error = "insufficient funds",
             .pre_check_error_code = PreCheckErrorCode::kInsufficientFunds};
-        ExecutionResult expect_result_fail{.error_code = evmc_status_code::EVMC_INVALID_INSTRUCTION};
+        ExecutionResult expect_result_fail{.status_code = evmc_status_code::EVMC_INVALID_INSTRUCTION};
         call.gas = kTxGas * 2;
         call.gas_price = intx::uint256{20'000};
         call.value = intx::uint256{500'000'000};

--- a/silkworm/rpc/core/evm_debug.cpp
+++ b/silkworm/rpc/core/evm_debug.cpp
@@ -559,13 +559,13 @@ Task<void> DebugExecutor::execute(
         debug_tracer->flush_logs();
         stream.close_array();
 
-        SILK_DEBUG << "result error_code: " << execution_result.error_code.value_or(0) << ", message: " << execution_result.error_message();
+        SILK_DEBUG << "result error_code: " << execution_result.status_code.value_or(evmc_status_code::EVMC_SUCCESS) << ", message: " << execution_result.error_message();
 
         if (!execution_result.pre_check_error) {
             stream.write_json_field("failed", !execution_result.success());
             stream.write_field("gas", transaction.gas_limit - execution_result.gas_left);
-            const auto error_code = execution_result.error_code.value_or(evmc_status_code::EVMC_SUCCESS);
-            if (error_code == evmc_status_code::EVMC_SUCCESS || error_code == evmc_status_code::EVMC_REVERT) {
+            const auto status_code = execution_result.status_code.value_or(evmc_status_code::EVMC_SUCCESS);
+            if (status_code == evmc_status_code::EVMC_SUCCESS || status_code == evmc_status_code::EVMC_REVERT) {
                 stream.write_field("returnValue", silkworm::to_hex(execution_result.data));
             } else {
                 stream.write_field("returnValue", "");

--- a/silkworm/rpc/core/evm_executor.cpp
+++ b/silkworm/rpc/core/evm_executor.cpp
@@ -41,8 +41,8 @@ std::string ExecutionResult::error_message(bool full_error) const {
     if (pre_check_error) {
         return *pre_check_error;
     }
-    if (error_code) {
-        return silkworm::rpc::EVMExecutor::get_error_message(*error_code, data, full_error);
+    if (status_code) {
+        return silkworm::rpc::EVMExecutor::get_error_message(*status_code, data, full_error);
     }
     return "";
 }

--- a/silkworm/rpc/core/evm_executor.hpp
+++ b/silkworm/rpc/core/evm_executor.hpp
@@ -50,14 +50,14 @@ enum class PreCheckErrorCode {
 };
 
 struct ExecutionResult {
-    std::optional<int64_t> error_code;
+    std::optional<evmc_status_code> status_code;
     uint64_t gas_left{0};
     Bytes data;
     std::optional<std::string> pre_check_error{std::nullopt};
     std::optional<PreCheckErrorCode> pre_check_error_code{std::nullopt};
 
     bool success() const {
-        return ((error_code == std::nullopt || *error_code == evmc_status_code::EVMC_SUCCESS) && pre_check_error == std::nullopt);
+        return ((status_code == std::nullopt || *status_code == evmc_status_code::EVMC_SUCCESS) && pre_check_error == std::nullopt);
     }
 
     std::string error_message(bool full_error = true) const;

--- a/silkworm/rpc/core/evm_executor_test.cpp
+++ b/silkworm/rpc/core/evm_executor_test.cpp
@@ -74,7 +74,7 @@ TEST_CASE_METHOD(EVMExecutorTest, "EVMExecutor") {
 
         EVMExecutor executor{block, *chain_config_ptr, workers, state};
         const auto result = executor.call(txn, {});
-        CHECK(result.error_code == std::nullopt);
+        CHECK(result.status_code == std::nullopt);
         CHECK(result.pre_check_error.value() == "intrinsic gas too low: have 0, want 53000");
     }
 
@@ -89,7 +89,7 @@ TEST_CASE_METHOD(EVMExecutorTest, "EVMExecutor") {
 
         EVMExecutor executor{block, *chain_config_ptr, workers, state};
         const auto result = executor.call(txn, {});
-        CHECK(result.error_code == std::nullopt);
+        CHECK(result.status_code == std::nullopt);
         CHECK(result.pre_check_error.value() == "fee cap less than block base fee: address 0xa872626373628737383927236382161739290870, gasFeeCap: 2 baseFee: 7");
     }
 
@@ -105,7 +105,7 @@ TEST_CASE_METHOD(EVMExecutorTest, "EVMExecutor") {
 
         EVMExecutor executor{block, *chain_config_ptr, workers, state};
         const auto result = executor.call(txn, {});
-        CHECK(result.error_code == std::nullopt);
+        CHECK(result.status_code == std::nullopt);
         CHECK(result.pre_check_error.value() == "tip higher than fee cap: address 0xa872626373628737383927236382161739290870, tip: 24 gasFeeCap: 2");
     }
 
@@ -128,7 +128,7 @@ TEST_CASE_METHOD(EVMExecutorTest, "EVMExecutor") {
 
         EVMExecutor executor{block, *chain_config_ptr, workers, state};
         const auto result = executor.call(txn, {});
-        CHECK(result.error_code == std::nullopt);
+        CHECK(result.status_code == std::nullopt);
         CHECK(result.pre_check_error.value() == "insufficient funds for gas * price + value: address 0xa872626373628737383927236382161739290870 have 0 want 60000");
     }
 
@@ -152,7 +152,7 @@ TEST_CASE_METHOD(EVMExecutorTest, "EVMExecutor") {
         EVMExecutor executor{block, *chain_config_ptr, workers, state};
         const auto result = executor.call(txn, {}, false, /* gasBailout */ true);
         executor.reset();
-        CHECK(result.error_code == 0);
+        CHECK(result.status_code == evmc_status_code::EVMC_SUCCESS);
     }
 
     AccessList access_list{
@@ -182,7 +182,7 @@ TEST_CASE_METHOD(EVMExecutorTest, "EVMExecutor") {
 
         EVMExecutor executor{block, *chain_config_ptr, workers, state};
         const auto result = executor.call(txn, {}, true, /* gasBailout */ true);
-        CHECK(result.error_code == 0);
+        CHECK(result.status_code == 0);
     }
 
     static silkworm::Bytes error_data{

--- a/silkworm/rpc/core/evm_trace.cpp
+++ b/silkworm/rpc/core/evm_trace.cpp
@@ -1678,7 +1678,7 @@ Task<std::string> TraceCallExecutor::trace_transaction_error(const TransactionWi
         auto execution_result = executor.call(txn, {}, /*refund=*/true, /*gas_bailout=*/false);
 
         std::string result = "0x";
-        if (execution_result.error_code != evmc_status_code::EVMC_SUCCESS) {
+        if (execution_result.status_code != evmc_status_code::EVMC_SUCCESS) {
             result = "0x" + silkworm::to_hex(execution_result.data);
         }
         return result;


### PR DESCRIPTION
In ExecutionResult changed 
`std::optional<int64_t> error_code;`
in
`std::optional<evmc_status_code> status_code;`