### PR TITLE
datastore: reduce transform copies

### DIFF
--- a/silkworm/db/datastore/common/ranges/merge_unique_many_view.hpp
+++ b/silkworm/db/datastore/common/ranges/merge_unique_many_view.hpp
@@ -33,11 +33,11 @@
 namespace silkworm::views {
 
 template <
-    std::ranges::input_range Range,
-    class Container = std::vector<Range>,
+    std::ranges::input_range Ranges,
+    std::ranges::input_range Range = std::iter_value_t<std::ranges::iterator_t<Ranges>>,
     class Comp = MergeUniqueCompareFunc,
     class Proj = std::identity>
-class MergeUniqueManyView : public std::ranges::view_interface<MergeUniqueManyView<Range, Container, Comp, Proj>> {
+class MergeUniqueManyView : public std::ranges::view_interface<MergeUniqueManyView<Range, Ranges, Comp, Proj>> {
   public:
     class Iterator {
       public:
@@ -54,11 +54,11 @@ class MergeUniqueManyView : public std::ranges::view_interface<MergeUniqueManyVi
 
         Iterator() = default;
         Iterator(
-            Container& ranges,
+            Ranges& ranges,
             const Comp* comp, Proj proj)
             : comp_{comp},
               proj_{std::move(proj)} {
-            for (auto& range : ranges) {
+            for (auto&& range : ranges) {
                 iterators_.emplace_back(std::ranges::begin(range));
                 sentinels_.emplace_back(std::ranges::end(range));
             }
@@ -153,7 +153,7 @@ class MergeUniqueManyView : public std::ranges::view_interface<MergeUniqueManyVi
     static_assert(std::input_iterator<Iterator>);
 
     MergeUniqueManyView(
-        Container ranges,
+        Ranges ranges,
         Comp comp, Proj proj)
         : ranges_{std::move(ranges)},
           comp_{std::move(comp)},
@@ -167,21 +167,21 @@ class MergeUniqueManyView : public std::ranges::view_interface<MergeUniqueManyVi
     std::default_sentinel_t end() const { return std::default_sentinel; }
 
   private:
-    Container ranges_;
+    Ranges ranges_;
     Comp comp_;
     Proj proj_;
 };
 
 template <
-    class Range,
-    class Container = std::vector<Range>,
+    class Ranges,
+    class Range = std::iter_value_t<std::ranges::iterator_t<Ranges>>,
     class Comp = MergeUniqueCompareFunc,
     class Proj = std::identity>
-MergeUniqueManyView<Range, Container, Comp, Proj> merge_unique_many(
-    Container&& ranges,
+MergeUniqueManyView<Ranges, Range, Comp, Proj> merge_unique_many(
+    Ranges&& ranges,
     Comp comp = {}, Proj proj = {}) {
-    return MergeUniqueManyView<Range, Container, Comp, Proj>{
-        std::forward<Container>(ranges),
+    return MergeUniqueManyView<Ranges, Range, Comp, Proj>{
+        std::forward<Ranges>(ranges),
         std::move(comp),
         std::move(proj),
     };

--- a/silkworm/db/datastore/common/ranges/merge_unique_many_view_test.cpp
+++ b/silkworm/db/datastore/common/ranges/merge_unique_many_view_test.cpp
@@ -23,8 +23,8 @@
 
 namespace silkworm::views {
 
-static_assert(std::ranges::input_range<MergeUniqueManyView<std::vector<int>>>);
-static_assert(std::ranges::view<MergeUniqueManyView<std::vector<int>>>);
+static_assert(std::ranges::input_range<MergeUniqueManyView<std::vector<std::vector<int>>>>);
+static_assert(std::ranges::view<MergeUniqueManyView<std::vector<std::vector<int>>>>);
 
 template <std::ranges::input_range TRange>
 std::vector<TRange> ranges(TRange r1, TRange r2) {
@@ -35,24 +35,22 @@ std::vector<TRange> ranges(TRange r1, TRange r2) {
 }
 
 TEST_CASE("MergeUniqueManyView") {
-    using VectorRange = silkworm::ranges::OwningView<std::vector<int>>;
-
-    CHECK(vector_from_range(merge_unique_many<VectorRange>(ranges(
+    CHECK(vector_from_range(merge_unique_many(ranges(
               silkworm::ranges::owning_view(std::vector<int>{1, 2, 3}),
               silkworm::ranges::owning_view(std::vector<int>{2, 3, 4})))) ==
           std::vector<int>{1, 2, 3, 4});
 
-    CHECK(vector_from_range(merge_unique_many<VectorRange>(ranges(
+    CHECK(vector_from_range(merge_unique_many(ranges(
               silkworm::ranges::owning_view(std::vector<int>{1, 2, 3, 4, 5}),
               silkworm::ranges::owning_view(std::vector<int>{3, 4, 5, 6, 7})))) ==
           std::vector<int>{1, 2, 3, 4, 5, 6, 7});
 
-    CHECK(vector_from_range(merge_unique_many<VectorRange>(ranges(
+    CHECK(vector_from_range(merge_unique_many(ranges(
               silkworm::ranges::owning_view(std::vector<int>{1, 2, 3, 4, 5, 5, 5}),
               silkworm::ranges::owning_view(std::vector<int>{3, 4, 5, 6, 7})))) ==
           std::vector<int>{1, 2, 3, 4, 5, 6, 7});
 
-    CHECK(vector_from_range(merge_unique_many<VectorRange>(ranges(
+    CHECK(vector_from_range(merge_unique_many(ranges(
               silkworm::ranges::owning_view(std::vector<int>{0, 2, 2, 2, 4, 5, 6, 6, 7, 7}),
               silkworm::ranges::owning_view(std::vector<int>{0, 0, 1, 2, 3, 5, 5, 6, 8, 9})))) ==
           std::vector<int>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
@@ -60,23 +58,21 @@ TEST_CASE("MergeUniqueManyView") {
     using IntPredicate = std::function<bool(int)>;
     IntPredicate even = [](int x) { return x % 2 == 0; };
     IntPredicate odd = [](int x) { return x % 2 == 1; };
-    using VectorRangeFiltered = std::ranges::filter_view<VectorRange, IntPredicate>;
-    CHECK(vector_from_range(merge_unique_many<VectorRangeFiltered>(ranges(
+    CHECK(vector_from_range(merge_unique_many(ranges(
               silkworm::ranges::owning_view(std::vector<int>{1, 2, 3}) | std::views::filter(even),
               silkworm::ranges::owning_view(std::vector<int>{2, 3, 4}) | std::views::filter(odd)))) ==
           std::vector<int>{2, 3});
-    CHECK(vector_from_range(merge_unique_many<VectorRangeFiltered>(ranges(
+    CHECK(vector_from_range(merge_unique_many(ranges(
               silkworm::ranges::owning_view(std::vector<int>{1, 2, 3}) | std::views::filter(odd),
               silkworm::ranges::owning_view(std::vector<int>{2, 3, 4}) | std::views::filter(even)))) ==
           std::vector<int>{1, 2, 3, 4});
 
-    CHECK(vector_from_range(merge_unique_many<VectorRange>(ranges(std::vector<int>{}, std::vector<int>{}))).empty());
-    CHECK(vector_from_range(merge_unique_many<VectorRange>(ranges(silkworm::ranges::owning_view(std::vector<int>{1, 2, 3}), silkworm::ranges::owning_view(std::vector<int>{})))) == std::vector<int>{1, 2, 3});
-    CHECK(vector_from_range(merge_unique_many<VectorRange>(ranges(silkworm::ranges::owning_view(std::vector<int>{}), silkworm::ranges::owning_view(std::vector<int>{2, 3, 4})))) == std::vector<int>{2, 3, 4});
+    CHECK(vector_from_range(merge_unique_many(ranges(std::vector<int>{}, std::vector<int>{}))).empty());
+    CHECK(vector_from_range(merge_unique_many(ranges(silkworm::ranges::owning_view(std::vector<int>{1, 2, 3}), silkworm::ranges::owning_view(std::vector<int>{})))) == std::vector<int>{1, 2, 3});
+    CHECK(vector_from_range(merge_unique_many(ranges(silkworm::ranges::owning_view(std::vector<int>{}), silkworm::ranges::owning_view(std::vector<int>{2, 3, 4})))) == std::vector<int>{2, 3, 4});
 
     using IntToVectorFunc = std::function<std::vector<int>(int)>;
-    using VectorTransformJoinRange = std::ranges::join_view<std::ranges::transform_view<VectorRange, IntToVectorFunc>>;
-    CHECK(vector_from_range(merge_unique_many<VectorTransformJoinRange>(ranges(
+    CHECK(vector_from_range(merge_unique_many(ranges(
               silkworm::ranges::owning_view(std::vector<int>{1, 2, 3}) | std::views::transform(IntToVectorFunc{[](int v) { return std::vector<int>{v, v, v}; }}) | std::views::join,
               silkworm::ranges::owning_view(std::vector<int>{4, 4, 4}) | std::views::transform(IntToVectorFunc{[](int v) { return std::vector<int>{v}; }}) | std::views::join))) ==
           std::vector<int>{1, 2, 3, 4});

--- a/silkworm/db/datastore/domain_range_latest_query.hpp
+++ b/silkworm/db/datastore/domain_range_latest_query.hpp
@@ -19,6 +19,7 @@
 #include <silkworm/core/common/assert.hpp>
 
 #include "common/pair_get.hpp"
+#include "common/ranges/caching_view.hpp"
 #include "common/ranges/merge_unique_view.hpp"
 #include "kvdb/database.hpp"
 #include "kvdb/domain_range_latest_query.hpp"
@@ -86,7 +87,7 @@ struct DomainRangeLatestQuery {
         return ResultItem{std::move(key), std::move(value)};
     }
 
-    static constexpr auto kDecodeKVPairFunc = [](std::pair<Bytes, Bytes>&& kv_pair) -> ResultItem {
+    static constexpr auto kDecodeKVPairFunc = [](std::pair<Bytes, Bytes>& kv_pair) -> ResultItem {
         return decode_kv_pair(std::move(kv_pair));
     };
 
@@ -99,7 +100,8 @@ struct DomainRangeLatestQuery {
                    silkworm::views::MergeUniqueCompareFunc{},
                    PairGetFirst<Bytes, Bytes>{},
                    PairGetFirst<Bytes, Bytes>{}) |
-               std::views::transform(kDecodeKVPairFunc);
+               std::views::transform(kDecodeKVPairFunc) |
+               silkworm::views::caching;
     }
 
   private:

--- a/silkworm/db/datastore/kvdb/domain_range_latest_query.hpp
+++ b/silkworm/db/datastore/kvdb/domain_range_latest_query.hpp
@@ -23,6 +23,7 @@
 #include <silkworm/core/common/assert.hpp>
 
 #include "../common/pair_get.hpp"
+#include "../common/ranges/caching_view.hpp"
 #include "../common/ranges/unique_view.hpp"
 #include "cursor_iterator.hpp"
 #include "domain.hpp"
@@ -90,7 +91,8 @@ struct DomainRangeLatestQuery {
                std::views::transform([](auto&& kvts_pair) { return std::pair<ByteView, ByteView>{kvts_pair.first.key.value, kvts_pair.second.value.value}; }) |
                silkworm::views::unique<silkworm::views::MergeUniqueCompareFunc, PairGetFirst<ByteView, ByteView>> |  // filter out duplicate keys when has_large_values
                std::views::take_while(std::move(before_key_end_predicate)) |
-               std::views::transform(kDecodeKVPairFunc);
+               std::views::transform(kDecodeKVPairFunc) |
+               silkworm::views::caching;
     }
 
     auto exec(const Key& key_start, const Key& key_end, bool ascending) {

--- a/silkworm/db/datastore/kvdb/history_range_query.hpp
+++ b/silkworm/db/datastore/kvdb/history_range_query.hpp
@@ -145,7 +145,8 @@ struct HistoryRangeQuery {
                std::views::transform(std::move(seek_func)) |
                silkworm::views::caching |
                std::views::filter(as_bool_predicate<std::shared_ptr<ROCursor>>) |
-               std::views::transform(kv_pair_from_cursor_func(entity.has_large_values));
+               std::views::transform(kv_pair_from_cursor_func(entity.has_large_values)) |
+               silkworm::views::caching;
     }
 
     auto exec(TimestampRange ts_range, bool ascending) {

--- a/silkworm/db/datastore/snapshots/history_range_query.hpp
+++ b/silkworm/db/datastore/snapshots/history_range_query.hpp
@@ -74,11 +74,12 @@ struct HistoryRangeSegmentQuery {
 
         auto ii_reader = entity_.inverted_index.kv_segment_reader<RawDecoder<Bytes>>();
 
-        return std::ranges::subrange{ii_reader.begin(), ii_reader.end()} |
+        return ii_reader |
                std::views::transform(std::move(lookup_kv_pair_func)) |
                silkworm::views::caching |
                std::views::filter([](const std::optional<ResultItem>& result_opt) { return result_opt.has_value(); }) |
-               std::views::transform([](std::optional<ResultItem> result_opt) -> ResultItem { return std::move(*result_opt); });
+               std::views::transform([](std::optional<ResultItem>& result_opt) -> ResultItem { return std::move(*result_opt); }) |
+               silkworm::views::caching;
     }
 
   private:

--- a/silkworm/db/kv/api/local_transaction.cpp
+++ b/silkworm/db/kv/api/local_transaction.cpp
@@ -314,7 +314,7 @@ Task<PaginatedKeysValues> LocalTransaction::range_as_of(DomainRangeQuery query) 
 
     // TODO: this is just a test example, instead of direct iteration, apply page_size using std::views::chunk,
     // TODO: save the range for future requests using page_token and return the first chunk
-    for ([[maybe_unused]] decltype(store_query)::ResultItem&& kv_pair : store_query.exec(query.from_key, query.to_key, query.timestamp, query.ascending_order) | std::views::take(limit)) {
+    for ([[maybe_unused]] decltype(store_query)::ResultItem& kv_pair : store_query.exec(query.from_key, query.to_key, query.timestamp, query.ascending_order) | std::views::take(limit)) {
     }
 
     // TODO(canepat) implement using E3-like aggregator abstraction [tx_id_ must be changed]


### PR DESCRIPTION
* make sure transform predicate moves Bytes instead of copying
* apply caching after transform to avoid accidental double move
* fix DomainRangeLatestQuery to hold std::shared_ptr<SnapshotBundle> of affected bundles for the lifetime of the results range
* deduce merge_unique_many template args