### PR TITLE
datastore: fix debug_getModifiedAccountsBy regression

### DIFF
--- a/silkworm/db/datastore/common/ranges/caching_view.hpp
+++ b/silkworm/db/datastore/common/ranges/caching_view.hpp
@@ -56,7 +56,7 @@ class CachingView : public std::ranges::view_interface<CachingView<TRange>> {
 
         reference operator*() const {
             if (!cached_value_) {
-                cached_value_ = *it_;
+                cached_value_.emplace(std::move(*it_));
             }
             return *cached_value_;
         }

--- a/silkworm/db/datastore/common/ranges/merge_many_view.hpp
+++ b/silkworm/db/datastore/common/ranges/merge_many_view.hpp
@@ -29,6 +29,7 @@
 #include <silkworm/core/common/assert.hpp>
 
 #include "merge_compare_func.hpp"
+#include "vector_from_range.hpp"
 
 namespace silkworm::views {
 
@@ -57,9 +58,10 @@ class MergeManyView : public std::ranges::view_interface<MergeManyView<Range, Ra
         Iterator(
             Ranges& ranges,
             const Comp* comp, Proj proj)
-            : comp_{comp},
+            : ranges_{vector_from_range(ranges)},
+              comp_{comp},
               proj_{std::move(proj)} {
-            for (auto&& range : ranges) {
+            for (Range& range : ranges_) {
                 iterators_.emplace_back(std::ranges::begin(range));
                 sentinels_.emplace_back(std::ranges::end(range));
             }
@@ -154,6 +156,7 @@ class MergeManyView : public std::ranges::view_interface<MergeManyView<Range, Ra
             };
         }
 
+        std::vector<Range> ranges_;
         std::vector<RangeIterator> iterators_;
         std::vector<RangeSentinel> sentinels_;
         const Comp* comp_{nullptr};

--- a/silkworm/db/datastore/common/ranges/vector_from_range.hpp
+++ b/silkworm/db/datastore/common/ranges/vector_from_range.hpp
@@ -24,7 +24,7 @@
 namespace silkworm {
 
 template <std::ranges::input_range Range, typename Value = std::iter_value_t<std::ranges::iterator_t<Range>>>
-std::vector<Value> vector_from_range(Range range) {
+std::vector<Value> vector_from_range(Range&& range) {
     std::vector<Value> results;
     for (auto&& value : range) {
         results.emplace_back(std::move(value));
@@ -33,7 +33,7 @@ std::vector<Value> vector_from_range(Range range) {
 }
 
 template <std::ranges::input_range Range, typename Value = std::iter_value_t<std::ranges::iterator_t<Range>>>
-std::vector<Value> vector_from_range_copy(Range range) {
+std::vector<Value> vector_from_range_copy(Range&& range) {
     std::vector<Value> results;
     std::ranges::copy(range, std::back_inserter(results));
     return results;

--- a/silkworm/db/datastore/snapshots/history_range_in_period_query.hpp
+++ b/silkworm/db/datastore/snapshots/history_range_in_period_query.hpp
@@ -77,7 +77,7 @@ struct HistoryRangeInPeriodSegmentQuery {
 
         auto ii_reader = entity_.inverted_index.kv_segment_reader<RawDecoder<Bytes>>();
 
-        return ii_reader |
+        return silkworm::ranges::owning_view(std::move(ii_reader)) |
                std::views::transform(std::move(lookup_kv_pair_func)) |
                silkworm::views::caching |
                std::views::filter([](const std::optional<ResultItem>& result_opt) { return result_opt.has_value(); }) |

--- a/silkworm/db/datastore/snapshots/segment/kv_segment_reader.hpp
+++ b/silkworm/db/datastore/snapshots/segment/kv_segment_reader.hpp
@@ -174,18 +174,18 @@ class KVSegmentReader {
     using KeyDecoderType = TKeyDecoder;
     using ValueDecoderType = TValueDecoder;
 
-    explicit KVSegmentReader(const KVSegmentFileReader& reader) : reader_(reader) {}
+    explicit KVSegmentReader(const KVSegmentFileReader& reader) : reader_{&reader} {}
 
     Iterator begin() const {
-        return Iterator{reader_.begin(std::make_shared<TKeyDecoder>(), std::make_shared<TValueDecoder>())};
+        return Iterator{reader_->begin(std::make_shared<TKeyDecoder>(), std::make_shared<TValueDecoder>())};
     }
 
     Iterator end() const {
-        return Iterator{reader_.end()};
+        return Iterator{reader_->end()};
     }
 
     Iterator seek(uint64_t offset) const {
-        return Iterator{reader_.seek(offset, std::nullopt, std::make_shared<TKeyDecoder>(), std::make_shared<TValueDecoder>())};
+        return Iterator{reader_->seek(offset, std::nullopt, std::make_shared<TKeyDecoder>(), std::make_shared<TValueDecoder>())};
     }
 
     std::optional<typename Iterator::value_type_owned> seek_one(uint64_t offset) const {
@@ -193,10 +193,10 @@ class KVSegmentReader {
         return (it != end()) ? std::optional{it.move_value()} : std::nullopt;
     }
 
-    const SnapshotPath& path() const { return reader_.path(); }
+    const SnapshotPath& path() const { return reader_->path(); }
 
   private:
-    const KVSegmentFileReader& reader_;
+    const KVSegmentFileReader* reader_;
 };
 
 template <DecoderConcept TKeyDecoder>
@@ -248,18 +248,18 @@ class KVSegmentKeysReader {
 
     using KeyDecoderType = TKeyDecoder;
 
-    explicit KVSegmentKeysReader(const KVSegmentFileReader& reader) : reader_(reader) {}
+    explicit KVSegmentKeysReader(const KVSegmentFileReader& reader) : reader_{&reader} {}
 
     Iterator begin() const {
-        return Iterator{reader_.begin(std::make_shared<TKeyDecoder>(), {})};
+        return Iterator{reader_->begin(std::make_shared<TKeyDecoder>(), {})};
     }
 
     Iterator end() const {
-        return Iterator{reader_.end()};
+        return Iterator{reader_->end()};
     }
 
     Iterator seek(uint64_t offset) const {
-        return Iterator{reader_.seek(offset, std::nullopt, std::make_shared<TKeyDecoder>(), {})};
+        return Iterator{reader_->seek(offset, std::nullopt, std::make_shared<TKeyDecoder>(), {})};
     }
 
     std::optional<typename Iterator::value_type> seek_one(uint64_t offset) const {
@@ -267,10 +267,10 @@ class KVSegmentKeysReader {
         return (it != end()) ? std::optional{std::move(*it)} : std::nullopt;
     }
 
-    const SnapshotPath& path() const { return reader_.path(); }
+    const SnapshotPath& path() const { return reader_->path(); }
 
   private:
-    const KVSegmentFileReader& reader_;
+    const KVSegmentFileReader* reader_;
 };
 
 template <DecoderConcept TValueDecoder>
@@ -322,18 +322,18 @@ class KVSegmentValuesReader {
 
     using ValueDecoderType = TValueDecoder;
 
-    explicit KVSegmentValuesReader(const KVSegmentFileReader& reader) : reader_(reader) {}
+    explicit KVSegmentValuesReader(const KVSegmentFileReader& reader) : reader_{&reader} {}
 
     Iterator begin() const {
-        return Iterator{reader_.begin({}, std::make_shared<TValueDecoder>())};
+        return Iterator{reader_->begin({}, std::make_shared<TValueDecoder>())};
     }
 
     Iterator end() const {
-        return Iterator{reader_.end()};
+        return Iterator{reader_->end()};
     }
 
     Iterator seek(uint64_t offset) const {
-        return Iterator{reader_.seek(offset, std::nullopt, {}, std::make_shared<TValueDecoder>())};
+        return Iterator{reader_->seek(offset, std::nullopt, {}, std::make_shared<TValueDecoder>())};
     }
 
     std::optional<typename Iterator::value_type> seek_one(uint64_t offset) const {
@@ -341,10 +341,10 @@ class KVSegmentValuesReader {
         return (it != end()) ? std::optional{std::move(*it)} : std::nullopt;
     }
 
-    const SnapshotPath& path() const { return reader_.path(); }
+    const SnapshotPath& path() const { return reader_->path(); }
 
   private:
-    const KVSegmentFileReader& reader_;
+    const KVSegmentFileReader* reader_;
 };
 
 template <class TKVSegmentReader>

--- a/silkworm/db/datastore/snapshots/segment/kv_segment_test.cpp
+++ b/silkworm/db/datastore/snapshots/segment/kv_segment_test.cpp
@@ -14,6 +14,9 @@
    limitations under the License.
 */
 
+#include <concepts>
+#include <ranges>
+
 #include <catch2/catch_test_macros.hpp>
 
 #include <silkworm/core/common/bytes_to_string.hpp>
@@ -44,6 +47,15 @@ struct CharCodec : public Codec {
         value = *byte_ptr_cast(input_word_view.data());
     }
 };
+
+static_assert(std::ranges::input_range<KVSegmentReader<StringCodec, CharCodec>>);
+static_assert(std::movable<KVSegmentReader<StringCodec, CharCodec>>);
+
+static_assert(std::ranges::input_range<KVSegmentKeysReader<StringCodec>>);
+static_assert(std::movable<KVSegmentKeysReader<StringCodec>>);
+
+static_assert(std::ranges::input_range<KVSegmentValuesReader<CharCodec>>);
+static_assert(std::movable<KVSegmentValuesReader<CharCodec>>);
 
 TEST_CASE("KVSegmentFile") {
     using namespace datastore;

--- a/silkworm/db/datastore/snapshots/segment/segment_reader.hpp
+++ b/silkworm/db/datastore/snapshots/segment/segment_reader.hpp
@@ -167,18 +167,18 @@ class SegmentReader {
 
     using DecoderType = TDecoder;
 
-    explicit SegmentReader(const SegmentFileReader& reader) : reader_(reader) {}
+    explicit SegmentReader(const SegmentFileReader& reader) : reader_{&reader} {}
 
     Iterator begin() const {
-        return Iterator{reader_.begin(std::make_shared<TDecoder>())};
+        return Iterator{reader_->begin(std::make_shared<TDecoder>())};
     }
 
     Iterator end() const {
-        return Iterator{reader_.end()};
+        return Iterator{reader_->end()};
     }
 
     Iterator seek(uint64_t offset, std::optional<ByteView> check_prefix = std::nullopt) const {
-        return Iterator{reader_.seek(offset, check_prefix, std::make_shared<TDecoder>())};
+        return Iterator{reader_->seek(offset, check_prefix, std::make_shared<TDecoder>())};
     }
 
     std::optional<typename Iterator::value_type> seek_one(uint64_t offset, std::optional<ByteView> check_prefix = std::nullopt) const {
@@ -194,10 +194,10 @@ class SegmentReader {
         return iterator_read_into_vector(std::move(it), count);
     }
 
-    const SnapshotPath& path() const { return reader_.path(); }
+    const SnapshotPath& path() const { return reader_->path(); }
 
   private:
-    const SegmentFileReader& reader_;
+    const SegmentFileReader* reader_;
 };
 
 template <class TSegmentReader>

--- a/silkworm/db/datastore/snapshots/segment/segment_test.cpp
+++ b/silkworm/db/datastore/snapshots/segment/segment_test.cpp
@@ -14,6 +14,9 @@
    limitations under the License.
 */
 
+#include <concepts>
+#include <ranges>
+
 #include <catch2/catch_test_macros.hpp>
 
 #include <silkworm/infra/common/directories.hpp>
@@ -23,6 +26,9 @@
 #include "segment_writer.hpp"
 
 namespace silkworm::snapshots::segment {
+
+static_assert(std::ranges::input_range<SegmentReader<StringCodec>>);
+static_assert(std::movable<SegmentReader<StringCodec>>);
 
 TEST_CASE("SegmentFile") {
     using namespace datastore;


### PR DESCRIPTION
* owning_view: support SegmentReader (make it movable)
* caching_view: move instead of assigning to support more cases
* merge_many: hold produced ranges, not only their iterators