### PR TITLE
datastore: speedup lookup by EntityName

### DIFF
--- a/silkworm/db/data_store.cpp
+++ b/silkworm/db/data_store.cpp
@@ -51,18 +51,18 @@ datastore::kvdb::DatabaseUnmanaged DataStore::make_chaindata_database(datastore:
     };
 }
 
-std::map<datastore::EntityName, std::unique_ptr<datastore::kvdb::Database>> DataStore::make_databases_map(
+datastore::EntityMap<std::unique_ptr<datastore::kvdb::Database>> DataStore::make_databases_map(
     datastore::kvdb::Database chaindata_database) {
-    std::map<datastore::EntityName, std::unique_ptr<datastore::kvdb::Database>> databases;
+    datastore::EntityMap<std::unique_ptr<datastore::kvdb::Database>> databases;
     databases.emplace(datastore::kvdb::Schema::kDefaultEntityName, std::make_unique<datastore::kvdb::Database>(std::move(chaindata_database)));
     return databases;
 }
 
-std::map<datastore::EntityName, std::unique_ptr<snapshots::SnapshotRepository>> DataStore::make_repositories_map(
+datastore::EntityMap<std::unique_ptr<snapshots::SnapshotRepository>> DataStore::make_repositories_map(
     snapshots::SnapshotRepository blocks_repository,
     snapshots::SnapshotRepository state_repository_latest,
     snapshots::SnapshotRepository state_repository_historical) {
-    std::map<datastore::EntityName, std::unique_ptr<snapshots::SnapshotRepository>> repositories;
+    datastore::EntityMap<std::unique_ptr<snapshots::SnapshotRepository>> repositories;
     repositories.emplace(blocks::kBlocksRepositoryName, std::make_unique<snapshots::SnapshotRepository>(std::move(blocks_repository)));
     repositories.emplace(state::kStateRepositoryNameLatest, std::make_unique<snapshots::SnapshotRepository>(std::move(state_repository_latest)));
     repositories.emplace(state::kStateRepositoryNameHistorical, std::make_unique<snapshots::SnapshotRepository>(std::move(state_repository_historical)));

--- a/silkworm/db/data_store.hpp
+++ b/silkworm/db/data_store.hpp
@@ -96,9 +96,9 @@ class DataStore {
   private:
     static datastore::Schema make_schema();
 
-    static std::map<datastore::EntityName, std::unique_ptr<datastore::kvdb::Database>> make_databases_map(
+    static datastore::EntityMap<std::unique_ptr<datastore::kvdb::Database>> make_databases_map(
         datastore::kvdb::Database chaindata_database);
-    static std::map<datastore::EntityName, std::unique_ptr<snapshots::SnapshotRepository>> make_repositories_map(
+    static datastore::EntityMap<std::unique_ptr<snapshots::SnapshotRepository>> make_repositories_map(
         snapshots::SnapshotRepository blocks_repository,
         snapshots::SnapshotRepository state_repository_latest,
         snapshots::SnapshotRepository state_repository_historical);

--- a/silkworm/db/datastore/common/CMakeLists.txt
+++ b/silkworm/db/datastore/common/CMakeLists.txt
@@ -16,8 +16,10 @@
 
 include("${SILKWORM_MAIN_DIR}/cmake/common/targets.cmake")
 
+find_package(absl REQUIRED COMPONENTS flat_hash_map)
+
 silkworm_library(
   silkworm_datastore_common
-  PUBLIC silkworm_core
+  PUBLIC silkworm_core absl::flat_hash_map
   PRIVATE ""
 )

--- a/silkworm/db/datastore/data_store.hpp
+++ b/silkworm/db/datastore/data_store.hpp
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <map>
 #include <memory>
 
 #include "common/entity_name.hpp"
@@ -30,8 +29,8 @@ class DataStore {
   public:
     DataStore(
         Schema schema,
-        std::map<EntityName, std::unique_ptr<kvdb::Database>> databases,
-        std::map<EntityName, std::unique_ptr<snapshots::SnapshotRepository>> repositories)
+        EntityMap<std::unique_ptr<kvdb::Database>> databases,
+        EntityMap<std::unique_ptr<snapshots::SnapshotRepository>> repositories)
         : schema_{std::move(schema)},
           databases_{std::move(databases)},
           repositories_{std::move(repositories)} {}
@@ -44,8 +43,8 @@ class DataStore {
 
   private:
     Schema schema_;
-    std::map<EntityName, std::unique_ptr<kvdb::Database>> databases_;
-    std::map<EntityName, std::unique_ptr<snapshots::SnapshotRepository>> repositories_;
+    EntityMap<std::unique_ptr<kvdb::Database>> databases_;
+    EntityMap<std::unique_ptr<snapshots::SnapshotRepository>> repositories_;
 };
 
 }  // namespace silkworm::datastore

--- a/silkworm/db/datastore/kvdb/database.cpp
+++ b/silkworm/db/datastore/kvdb/database.cpp
@@ -26,9 +26,9 @@ static MapConfig make_table_config(const Schema::TableDef& table) {
     };
 }
 
-static std::map<EntityName, MapConfig> make_table_configs(
+static EntityMap<MapConfig> make_table_configs(
     const Schema::EntityDef& entity) {
-    std::map<datastore::EntityName, MapConfig> results;
+    EntityMap<MapConfig> results;
     for (auto& [name, def] : entity.tables()) {
         results.emplace(name, make_table_config(def));
     }

--- a/silkworm/db/datastore/kvdb/database.hpp
+++ b/silkworm/db/datastore/kvdb/database.hpp
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <map>
 #include <utility>
 
 #include "domain.hpp"
@@ -31,7 +30,7 @@ class DatabaseUnmanaged;
 
 class DatabaseRef {
   public:
-    using EntitiesMap = std::map<datastore::EntityName, std::map<datastore::EntityName, MapConfig>>;
+    using EntitiesMap = EntityMap<EntityMap<MapConfig>>;
 
     ROAccess access_ro() const { return ROAccess{env_}; }
     RWAccess access_rw() const { return RWAccess{env_}; }
@@ -81,7 +80,7 @@ class Database {
   private:
     mdbx::env_managed env_;
     Schema::DatabaseDef schema_;
-    std::map<datastore::EntityName, std::map<datastore::EntityName, MapConfig>> entities_;
+    EntityMap<EntityMap<MapConfig>> entities_;
 };
 
 class DatabaseUnmanaged {
@@ -104,7 +103,7 @@ class DatabaseUnmanaged {
   private:
     EnvUnmanaged env_;
     Schema::DatabaseDef schema_;
-    std::map<datastore::EntityName, std::map<datastore::EntityName, MapConfig>> entities_;
+    EntityMap<EntityMap<MapConfig>> entities_;
 };
 
 }  // namespace silkworm::datastore::kvdb

--- a/silkworm/db/datastore/kvdb/inverted_index_range_by_key_query_test.cpp
+++ b/silkworm/db/datastore/kvdb/inverted_index_range_by_key_query_test.cpp
@@ -16,6 +16,8 @@
 
 #include "inverted_index_range_by_key_query.hpp"
 
+#include <map>
+
 #include <catch2/catch_test_macros.hpp>
 
 #include "big_endian_codec.hpp"

--- a/silkworm/db/datastore/kvdb/schema.hpp
+++ b/silkworm/db/datastore/kvdb/schema.hpp
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <map>
 #include <memory>
 #include <optional>
 #include <string>
@@ -65,10 +64,10 @@ class Schema {
             return *this;
         }
 
-        const std::map<datastore::EntityName, TableDef>& tables() const { return table_defs_; }
+        const EntityMap<TableDef>& tables() const { return table_defs_; }
 
       private:
-        std::map<datastore::EntityName, TableDef> table_defs_;
+        EntityMap<TableDef> table_defs_;
     };
 
     class DomainDef : public EntityDef {
@@ -114,7 +113,7 @@ class Schema {
             return *entity_defs_.at(name);
         }
 
-        const std::map<datastore::EntityName, std::shared_ptr<EntityDef>>& entities() const { return entity_defs_; }
+        const EntityMap<std::shared_ptr<EntityDef>>& entities() const { return entity_defs_; }
 
       private:
         friend DomainDef;
@@ -126,7 +125,7 @@ class Schema {
         static void define_inverted_index_schema(datastore::EntityName name, EntityDef& schema);
         static void undefine_inverted_index_schema(EntityDef& schema);
 
-        std::map<datastore::EntityName, std::shared_ptr<EntityDef>> entity_defs_;
+        EntityMap<std::shared_ptr<EntityDef>> entity_defs_;
     };
 
     DatabaseDef& database(datastore::EntityName name) {
@@ -145,7 +144,7 @@ class Schema {
     static constexpr datastore::EntityName kInvIdxIndexName{"InvIdxIndex"};
 
   private:
-    std::map<datastore::EntityName, DatabaseDef> database_defs_;
+    EntityMap<DatabaseDef> database_defs_;
 };
 
 }  // namespace silkworm::datastore::kvdb

--- a/silkworm/db/datastore/snapshots/schema.hpp
+++ b/silkworm/db/datastore/snapshots/schema.hpp
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <map>
 #include <optional>
 #include <vector>
 
@@ -142,12 +141,12 @@ class Schema {
 
         EntityDef& tag_override(std::string_view tag);
 
-        const std::map<datastore::EntityName, std::shared_ptr<SnapshotFileDef>>& files() const { return file_defs_; }
+        const datastore::EntityMap<std::shared_ptr<SnapshotFileDef>>& files() const { return file_defs_; }
         std::vector<std::string> file_extensions() const;
         std::optional<datastore::EntityName> entity_name_by_path(const SnapshotPath& path) const;
 
       private:
-        std::map<datastore::EntityName, std::shared_ptr<SnapshotFileDef>> file_defs_;
+        datastore::EntityMap<std::shared_ptr<SnapshotFileDef>> file_defs_;
     };
 
     class DomainDef : public EntityDef {
@@ -201,7 +200,7 @@ class Schema {
             return *this;
         }
 
-        const std::map<datastore::EntityName, std::shared_ptr<EntityDef>>& entities() const { return entity_defs_; }
+        const datastore::EntityMap<std::shared_ptr<EntityDef>>& entities() const { return entity_defs_; }
         std::vector<std::string> file_extensions() const;
         std::optional<std::pair<datastore::EntityName, datastore::EntityName>> entity_name_by_path(const SnapshotPath& path) const;
         const std::string& index_salt_file_name() const { return index_salt_file_name_.value(); }
@@ -216,7 +215,7 @@ class Schema {
         static void define_inverted_index_schema(datastore::EntityName name, EntityDef& schema);
         static void undefine_inverted_index_schema(EntityDef& schema);
 
-        std::map<datastore::EntityName, std::shared_ptr<EntityDef>> entity_defs_;
+        datastore::EntityMap<std::shared_ptr<EntityDef>> entity_defs_;
         std::optional<std::string> index_salt_file_name_;
     };
 
@@ -254,7 +253,7 @@ class Schema {
     static constexpr std::string_view kInvIdxAccessorIndexFileExt{".efi"};
 
   private:
-    std::map<datastore::EntityName, RepositoryDef> repository_defs_;
+    datastore::EntityMap<RepositoryDef> repository_defs_;
 };
 
 }  // namespace silkworm::snapshots

--- a/silkworm/db/datastore/snapshots/snapshot_bundle.cpp
+++ b/silkworm/db/datastore/snapshots/snapshot_bundle.cpp
@@ -24,12 +24,12 @@ using namespace rec_split;
 using namespace segment;
 using namespace datastore;
 
-static std::map<datastore::EntityName, SnapshotPath> make_snapshot_paths(
+static datastore::EntityMap<SnapshotPath> make_snapshot_paths(
     Schema::SnapshotFileDef::Format format,
     const Schema::EntityDef& entity,
     const std::filesystem::path& dir_path,
     StepRange range) {
-    std::map<datastore::EntityName, SnapshotPath> results;
+    datastore::EntityMap<SnapshotPath> results;
     for (auto& [name, def] : entity.files()) {
         if (def->format() == format) {
             auto path = def->make_path(dir_path, range);
@@ -39,11 +39,11 @@ static std::map<datastore::EntityName, SnapshotPath> make_snapshot_paths(
     return results;
 }
 
-static std::map<datastore::EntityName, SegmentFileReader> open_segments(
+static datastore::EntityMap<SegmentFileReader> open_segments(
     const Schema::EntityDef& entity,
     const std::filesystem::path& dir_path,
     StepRange range) {
-    std::map<datastore::EntityName, SegmentFileReader> results;
+    datastore::EntityMap<SegmentFileReader> results;
     for (auto& [name, anyDef] : entity.files()) {
         if (anyDef->format() != Schema::SnapshotFileDef::Format::kSegment) continue;
         auto& def = dynamic_cast<const Schema::SegmentDef&>(*anyDef);
@@ -53,11 +53,11 @@ static std::map<datastore::EntityName, SegmentFileReader> open_segments(
     return results;
 }
 
-static std::map<datastore::EntityName, KVSegmentFileReader> open_kv_segments(
+static datastore::EntityMap<KVSegmentFileReader> open_kv_segments(
     const Schema::EntityDef& entity,
     const std::filesystem::path& dir_path,
     StepRange range) {
-    std::map<datastore::EntityName, KVSegmentFileReader> results;
+    datastore::EntityMap<KVSegmentFileReader> results;
     for (auto& [name, anyDef] : entity.files()) {
         if (anyDef->format() != Schema::SnapshotFileDef::Format::kKVSegment) continue;
         auto& def = dynamic_cast<const Schema::KVSegmentDef&>(*anyDef);
@@ -67,23 +67,23 @@ static std::map<datastore::EntityName, KVSegmentFileReader> open_kv_segments(
     return results;
 }
 
-static std::map<datastore::EntityName, AccessorIndex> open_accessor_indexes(
+static datastore::EntityMap<AccessorIndex> open_accessor_indexes(
     const Schema::EntityDef& entity,
     const std::filesystem::path& dir_path,
     StepRange range) {
-    std::map<datastore::EntityName, AccessorIndex> results;
+    datastore::EntityMap<AccessorIndex> results;
     for (auto& [name, path] : make_snapshot_paths(Schema::SnapshotFileDef::Format::kAccessorIndex, entity, dir_path, range)) {
         results.emplace(name, AccessorIndex{path});
     }
     return results;
 }
 
-static std::map<datastore::EntityName, bloom_filter::BloomFilter> open_existence_indexes(
+static datastore::EntityMap<bloom_filter::BloomFilter> open_existence_indexes(
     const Schema::EntityDef& entity,
     const std::filesystem::path& dir_path,
     StepRange range,
     std::optional<uint32_t> salt) {
-    std::map<datastore::EntityName, bloom_filter::BloomFilter> results;
+    datastore::EntityMap<bloom_filter::BloomFilter> results;
     for (auto& [name, path] : make_snapshot_paths(Schema::SnapshotFileDef::Format::kExistenceIndex, entity, dir_path, range)) {
         SILK_TRACE << "make_existence_indexes opens " << name.to_string() << " at " << path.filename();
         SILKWORM_ASSERT(salt);
@@ -92,11 +92,11 @@ static std::map<datastore::EntityName, bloom_filter::BloomFilter> open_existence
     return results;
 }
 
-static std::map<datastore::EntityName, btree::BTreeIndex> open_btree_indexes(
+static datastore::EntityMap<btree::BTreeIndex> open_btree_indexes(
     const Schema::EntityDef& entity,
     const std::filesystem::path& dir_path,
     StepRange range) {
-    std::map<datastore::EntityName, btree::BTreeIndex> results;
+    datastore::EntityMap<btree::BTreeIndex> results;
     for (auto& [name, path] : make_snapshot_paths(Schema::SnapshotFileDef::Format::kBTreeIndex, entity, dir_path, range)) {
         SILK_TRACE << "make_btree_indexes opens " << name.to_string() << " at " << path.filename();
         results.emplace(name, btree::BTreeIndex{path.path()});
@@ -207,12 +207,12 @@ std::vector<SnapshotPath> SnapshotBundle::segment_paths() const {
     return paths;
 }
 
-std::map<datastore::EntityName, SnapshotPath> SnapshotBundlePaths::segment_paths() const {
+datastore::EntityMap<SnapshotPath> SnapshotBundlePaths::segment_paths() const {
     auto& entity = *schema_.entities().at(Schema::kDefaultEntityName);
     return make_snapshot_paths(Schema::SnapshotFileDef::Format::kSegment, entity, dir_path_, step_range_);
 }
 
-std::map<datastore::EntityName, SnapshotPath> SnapshotBundlePaths::accessor_index_paths() const {
+datastore::EntityMap<SnapshotPath> SnapshotBundlePaths::accessor_index_paths() const {
     auto& entity = *schema_.entities().at(Schema::kDefaultEntityName);
     return make_snapshot_paths(Schema::SnapshotFileDef::Format::kAccessorIndex, entity, dir_path_, step_range_);
 }

--- a/silkworm/db/datastore/snapshots/snapshot_bundle.hpp
+++ b/silkworm/db/datastore/snapshots/snapshot_bundle.hpp
@@ -36,15 +36,15 @@
 namespace silkworm::snapshots {
 
 struct SnapshotBundleEntityData {
-    std::map<datastore::EntityName, segment::SegmentFileReader> segments;
-    std::map<datastore::EntityName, segment::KVSegmentFileReader> kv_segments;
-    std::map<datastore::EntityName, rec_split::AccessorIndex> accessor_indexes;
-    std::map<datastore::EntityName, bloom_filter::BloomFilter> existence_indexes;
-    std::map<datastore::EntityName, btree::BTreeIndex> btree_indexes;
+    datastore::EntityMap<segment::SegmentFileReader> segments;
+    datastore::EntityMap<segment::KVSegmentFileReader> kv_segments;
+    datastore::EntityMap<rec_split::AccessorIndex> accessor_indexes;
+    datastore::EntityMap<bloom_filter::BloomFilter> existence_indexes;
+    datastore::EntityMap<btree::BTreeIndex> btree_indexes;
 };
 
 struct SnapshotBundleData {
-    std::map<datastore::EntityName, SnapshotBundleEntityData> entities;
+    datastore::EntityMap<SnapshotBundleEntityData> entities;
 };
 
 SnapshotBundleData open_bundle_data(
@@ -67,8 +67,8 @@ struct SnapshotBundlePaths {
     StepRange step_range() const { return step_range_; }
 
     std::vector<std::filesystem::path> files() const;
-    std::map<datastore::EntityName, SnapshotPath> segment_paths() const;
-    std::map<datastore::EntityName, SnapshotPath> accessor_index_paths() const;
+    datastore::EntityMap<SnapshotPath> segment_paths() const;
+    datastore::EntityMap<SnapshotPath> accessor_index_paths() const;
 
   private:
     Schema::RepositoryDef schema_;

--- a/silkworm/db/datastore/snapshots/snapshot_repository.hpp
+++ b/silkworm/db/datastore/snapshots/snapshot_repository.hpp
@@ -87,11 +87,11 @@ class SnapshotRepository : public SnapshotRepositoryROAccess {
     const std::optional<uint32_t>& index_salt() const { return index_salt_; }
     void build_indexes(const SnapshotBundlePaths& bundle) const;
 
-    BundlesView<MapValuesView<Bundles::key_type, Bundles::mapped_type>> view_bundles() const override {
+    BundlesView<MapValuesView<Bundles::key_type, Bundles::mapped_type, Bundles>> view_bundles() const override {
         std::scoped_lock lock(*bundles_mutex_);
         return BundlesView{make_map_values_view(*bundles_), bundles_};
     }
-    BundlesView<MapValuesViewReverse<Bundles::key_type, Bundles::mapped_type>> view_bundles_reverse() const override {
+    BundlesView<MapValuesViewReverse<Bundles::key_type, Bundles::mapped_type, Bundles>> view_bundles_reverse() const override {
         std::scoped_lock lock(*bundles_mutex_);
         return BundlesView{std::ranges::reverse_view(make_map_values_view(*bundles_)), bundles_};
     }

--- a/silkworm/db/datastore/snapshots/snapshot_repository_ro_access.hpp
+++ b/silkworm/db/datastore/snapshots/snapshot_repository_ro_access.hpp
@@ -66,8 +66,8 @@ struct SnapshotRepositoryROAccess {
     //! All types of .seg and .idx files are available up to this timestamp
     virtual Timestamp max_timestamp_available() const = 0;
 
-    virtual BundlesView<MapValuesView<Bundles::key_type, Bundles::mapped_type>> view_bundles() const = 0;
-    virtual BundlesView<MapValuesViewReverse<Bundles::key_type, Bundles::mapped_type>> view_bundles_reverse() const = 0;
+    virtual BundlesView<MapValuesView<Bundles::key_type, Bundles::mapped_type, Bundles>> view_bundles() const = 0;
+    virtual BundlesView<MapValuesViewReverse<Bundles::key_type, Bundles::mapped_type, Bundles>> view_bundles_reverse() const = 0;
 
     virtual std::pair<std::optional<SegmentAndAccessorIndex>, std::shared_ptr<SnapshotBundle>> find_segment(
         const SegmentAndAccessorIndexNames& names,


### PR DESCRIPTION
Optimize entity lookup by EntityName taking 1-2% of time using a raw pointer comparison and hash strategy for EntityName, and using a absl::flat_hash_map instead of std::map.

![Screenshot_2025-03-06_at_12 08 21](https://github.com/user-attachments/assets/75edefc4-fb78-4a01-bd0b-fab2e849d3e9)
