### PR TITLE
datastore: optimize StorageAddressAndLocation encoding

### DIFF
--- a/silkworm/db/state/address_codecs.hpp
+++ b/silkworm/db/state/address_codecs.hpp
@@ -25,17 +25,27 @@
 
 namespace silkworm::db::state {
 
-struct AddressKVDBEncoder : public datastore::kvdb::Encoder {
+struct AddressKVDBCodec : public datastore::kvdb::Codec {
     evmc::address value;
 
-    ~AddressKVDBEncoder() override = default;
+    ~AddressKVDBCodec() override = default;
 
     datastore::kvdb::Slice encode() override {
         return {&value.bytes, kAddressLength};
     }
+
+    void decode(datastore::kvdb::Slice slice) override {
+        if (slice.size() < kAddressLength)
+            throw std::runtime_error{"AddressKVDBDecoder failed to decode"};
+        std::memcpy(value.bytes, slice.data(), kAddressLength);
+    }
 };
 
-static_assert(datastore::kvdb::EncoderConcept<AddressKVDBEncoder>);
+static_assert(datastore::kvdb::EncoderConcept<AddressKVDBCodec>);
+static_assert(datastore::kvdb::EncoderConcept<AddressKVDBCodec>);
+
+using AddressKVDBEncoder = AddressKVDBCodec;
+using AddressKVDBDecoder = AddressKVDBCodec;
 
 struct AddressSnapshotsCodec : public snapshots::Codec {
     evmc::address value;

--- a/silkworm/db/state/storage_codecs.hpp
+++ b/silkworm/db/state/storage_codecs.hpp
@@ -85,26 +85,31 @@ struct PackedBytes32SnapshotsCodec : public snapshots::Codec {
 static_assert(snapshots::EncoderConcept<PackedBytes32SnapshotsCodec>);
 static_assert(snapshots::DecoderConcept<PackedBytes32SnapshotsCodec>);
 
+#pragma pack(push)
+#pragma pack(1)
 struct StorageAddressAndLocation {
     evmc::address address;
     evmc::bytes32 location_hash;
 };
+#pragma pack(pop)
 
-struct StorageAddressAndLocationKVDBEncoder : public datastore::kvdb::Encoder {
+struct StorageAddressAndLocationKVDBCodec : public datastore::kvdb::Codec {
     StorageAddressAndLocation value;
 
     struct {
-        AddressKVDBEncoder address;
+        AddressKVDBCodec address;
         Bytes32KVDBCodec location_hash;
-    } encoder;
+    } codec;
 
-    Bytes data;
-
-    ~StorageAddressAndLocationKVDBEncoder() override = default;
+    ~StorageAddressAndLocationKVDBCodec() override = default;
 
     datastore::kvdb::Slice encode() override;
+    void decode(datastore::kvdb::Slice slice) override;
 };
-static_assert(datastore::kvdb::EncoderConcept<StorageAddressAndLocationKVDBEncoder>);
+static_assert(datastore::kvdb::EncoderConcept<StorageAddressAndLocationKVDBCodec>);
+static_assert(datastore::kvdb::DecoderConcept<StorageAddressAndLocationKVDBCodec>);
+using StorageAddressAndLocationKVDBEncoder = StorageAddressAndLocationKVDBCodec;
+using StorageAddressAndLocationKVDBDecoder = StorageAddressAndLocationKVDBCodec;
 
 struct StorageAddressAndLocationSnapshotsCodec : public snapshots::Codec {
     StorageAddressAndLocation value;
@@ -113,8 +118,6 @@ struct StorageAddressAndLocationSnapshotsCodec : public snapshots::Codec {
         AddressSnapshotsCodec address;
         Bytes32SnapshotsCodec location_hash;
     } codec;
-
-    Bytes word;
 
     ~StorageAddressAndLocationSnapshotsCodec() override = default;
 

--- a/silkworm/db/state/storage_codecs_benchmark.cpp
+++ b/silkworm/db/state/storage_codecs_benchmark.cpp
@@ -1,0 +1,48 @@
+/*
+   Copyright 2025 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include <array>
+#include <numeric>
+
+#include <benchmark/benchmark.h>
+
+#include <silkworm/core/common/random_number.hpp>
+
+#include "storage_codecs.hpp"
+
+namespace silkworm::db::state {
+
+template <size_t kSize>
+static void fill_random_byte_array(uint8_t (&arr)[kSize]) {
+    static RandomNumber random{0, UINT8_MAX};
+    for (uint8_t& v : arr) {
+        v = static_cast<uint8_t>(random.generate_one());
+    }
+}
+
+static void storage_address_and_location_encoder(benchmark::State& state) {
+    StorageAddressAndLocationSnapshotsCodec encoder;
+    fill_random_byte_array(encoder.value.address.bytes);
+    fill_random_byte_array(encoder.value.location_hash.bytes);
+
+    for ([[maybe_unused]] auto _ : state) {
+        ByteView word = encoder.encode_word();
+        [[maybe_unused]] unsigned char sum = std::accumulate(word.begin(), word.end(), static_cast<unsigned char>(0));
+    }
+}
+BENCHMARK(storage_address_and_location_encoder);
+
+}  // namespace silkworm::db::state


### PR DESCRIPTION
Optimize away 2,7% of time spent in encode_word() by avoiding copies using a binary-compatible StorageAddressAndLocation structure.

![Screenshot_2025-03-06_at_16 32 25](https://github.com/user-attachments/assets/0e084c48-0d28-444c-bb42-21198c3af533)
