### PR TITLE
integration tests: update exception list after PR 2771

### DIFF
--- a/.github/workflows/rpc-integration-tests.yml
+++ b/.github/workflows/rpc-integration-tests.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout RPC Tests Repository & Install Requirements
         run: |
           rm -rf ${{runner.workspace}}/rpc-tests
-          git -c advice.detachedHead=false clone --depth 1 --branch v1.50.0 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
+          git -c advice.detachedHead=false clone --depth 1 --branch v1.51.0 https://github.com/erigontech/rpc-tests ${{runner.workspace}}/rpc-tests
           cd ${{runner.workspace}}/rpc-tests
           pip3 install -r requirements.txt --break-system-packages
 

--- a/.github/workflows/run_integration_tests.sh
+++ b/.github/workflows/run_integration_tests.sh
@@ -16,7 +16,6 @@ rm -rf ./mainnet/results/
 # debug_traceBlockByNumber[24-28]: response different wrt erigon
 python3 ./run_tests.py --continue --blockchain mainnet --jwt "$2" --display-only-fail --json-diff --port 51515 --transport_type http -x \
 debug_accountRange,\
-debug_getModifiedAccountsBy,\
 debug_storageRangeAt,\
 debug_traceBlockByNumber/test_24,\
 debug_traceBlockByNumber/test_25,\
@@ -31,7 +30,6 @@ debug_traceTransaction/test_74,\
 debug_traceTransaction/test_75,\
 debug_traceTransaction/test_77,\
 engine_,\
-erigon_getBalanceChangesInBlock,\
 eth_getLogs/test_16,\
 eth_getLogs/test_17,\
 eth_getLogs/test_18,\


### PR DESCRIPTION
Re-enable skipped APIs after fix in #2771 

This PR is connected to https://github.com/erigontech/rpc-tests/pull/349