### PR TITLE
db: cache chain config in local kv::api

### DIFF
--- a/silkworm/db/chain/local_chain_storage.cpp
+++ b/silkworm/db/chain/local_chain_storage.cpp
@@ -23,8 +23,18 @@
 
 namespace silkworm::db::chain {
 
+LocalChainStorage::LocalChainStorage(
+    db::DataModel data_model,
+    std::shared_ptr<Cache> cache)
+    : data_model_{data_model},
+      cache_{cache} {
+    std::call_once(cache_->chain_config_once_flag, [this] {
+        cache_->chain_config = data_model_.read_chain_config();
+    });
+}
+
 Task<ChainConfig> LocalChainStorage::read_chain_config() const {
-    const auto chain_config{data_model_.read_chain_config()};
+    const auto chain_config = cache_->chain_config;
     if (!chain_config) {
         throw std::runtime_error{"empty chain config data in storage"};
     }

--- a/silkworm/db/chain/local_chain_storage.cpp
+++ b/silkworm/db/chain/local_chain_storage.cpp
@@ -17,28 +17,16 @@
 #include "local_chain_storage.hpp"
 
 #include <bit>
-#include <stdexcept>
 
 #include <silkworm/db/access_layer.hpp>
 
 namespace silkworm::db::chain {
 
-LocalChainStorage::LocalChainStorage(
-    db::DataModel data_model,
-    std::shared_ptr<Cache> cache)
-    : data_model_{data_model},
-      cache_{cache} {
-    std::call_once(cache_->chain_config_once_flag, [this] {
-        cache_->chain_config = data_model_.read_chain_config();
-    });
-}
+LocalChainStorage::LocalChainStorage(db::DataModel data_model, const ChainConfig& chain_config)
+    : data_model_{data_model}, chain_config_{chain_config} {}
 
 Task<ChainConfig> LocalChainStorage::read_chain_config() const {
-    const auto chain_config = cache_->chain_config;
-    if (!chain_config) {
-        throw std::runtime_error{"empty chain config data in storage"};
-    }
-    co_return *chain_config;
+    co_return chain_config_;
 }
 
 Task<BlockNum> LocalChainStorage::max_block_num() const {

--- a/silkworm/db/chain/local_chain_storage.hpp
+++ b/silkworm/db/chain/local_chain_storage.hpp
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <mutex>
+
 #include <silkworm/db/access_layer.hpp>
 
 #include "chain_storage.hpp"
@@ -26,8 +28,14 @@ namespace silkworm::db::chain {
 //! in local database (accessed via MDBX API) or local snapshot files (accessed via custom snapshot API)
 class LocalChainStorage : public ChainStorage {
   public:
-    explicit LocalChainStorage(db::DataModel data_model)
-        : data_model_{data_model} {}
+    struct Cache {
+        std::optional<ChainConfig> chain_config;
+        std::once_flag chain_config_once_flag;
+    };
+
+    LocalChainStorage(
+        db::DataModel data_model,
+        std::shared_ptr<Cache> cache);
     ~LocalChainStorage() override = default;
 
     Task<ChainConfig> read_chain_config() const override;
@@ -74,6 +82,7 @@ class LocalChainStorage : public ChainStorage {
 
   private:
     db::DataModel data_model_;
+    std::shared_ptr<Cache> cache_;
 };
 
 }  // namespace silkworm::db::chain

--- a/silkworm/db/chain/local_chain_storage.hpp
+++ b/silkworm/db/chain/local_chain_storage.hpp
@@ -16,8 +16,6 @@
 
 #pragma once
 
-#include <mutex>
-
 #include <silkworm/db/access_layer.hpp>
 
 #include "chain_storage.hpp"
@@ -28,14 +26,7 @@ namespace silkworm::db::chain {
 //! in local database (accessed via MDBX API) or local snapshot files (accessed via custom snapshot API)
 class LocalChainStorage : public ChainStorage {
   public:
-    struct Cache {
-        std::optional<ChainConfig> chain_config;
-        std::once_flag chain_config_once_flag;
-    };
-
-    LocalChainStorage(
-        db::DataModel data_model,
-        std::shared_ptr<Cache> cache);
+    LocalChainStorage(db::DataModel data_model, const ChainConfig& chain_config);
     ~LocalChainStorage() override = default;
 
     Task<ChainConfig> read_chain_config() const override;
@@ -82,7 +73,7 @@ class LocalChainStorage : public ChainStorage {
 
   private:
     db::DataModel data_model_;
-    std::shared_ptr<Cache> cache_;
+    const ChainConfig& chain_config_;
 };
 
 }  // namespace silkworm::db::chain

--- a/silkworm/db/kv/api/direct_service.cpp
+++ b/silkworm/db/kv/api/direct_service.cpp
@@ -23,10 +23,11 @@
 
 namespace silkworm::db::kv::api {
 
-DirectService::DirectService(ServiceRouter router, DataStoreRef data_store, StateCache* state_cache)
+DirectService::DirectService(ServiceRouter router, DataStoreRef data_store, const ChainConfig& chain_config, StateCache* state_cache)
     : router_{router},
       data_store_{std::move(data_store)},
-      shared_transaction_cache_{std::make_shared<LocalTransaction::Cache>(state_cache)} {}
+      chain_config_{chain_config},
+      state_cache_{state_cache} {}
 
 // rpc Version(google.protobuf.Empty) returns (types.VersionReply);
 Task<Version> DirectService::version() {
@@ -35,7 +36,7 @@ Task<Version> DirectService::version() {
 
 // rpc Tx(stream Cursor) returns (stream Pair);
 Task<std::unique_ptr<Transaction>> DirectService::begin_transaction() {
-    co_return std::make_unique<LocalTransaction>(data_store_, shared_transaction_cache_);
+    co_return std::make_unique<LocalTransaction>(data_store_, chain_config_, state_cache_);
 }
 
 // rpc StateChanges(StateChangeRequest) returns (stream StateChangeBatch);

--- a/silkworm/db/kv/api/direct_service.cpp
+++ b/silkworm/db/kv/api/direct_service.cpp
@@ -26,7 +26,7 @@ namespace silkworm::db::kv::api {
 DirectService::DirectService(ServiceRouter router, DataStoreRef data_store, StateCache* state_cache)
     : router_{router},
       data_store_{std::move(data_store)},
-      state_cache_{state_cache} {}
+      shared_transaction_cache_{std::make_shared<LocalTransaction::Cache>(state_cache)} {}
 
 // rpc Version(google.protobuf.Empty) returns (types.VersionReply);
 Task<Version> DirectService::version() {
@@ -35,7 +35,7 @@ Task<Version> DirectService::version() {
 
 // rpc Tx(stream Cursor) returns (stream Pair);
 Task<std::unique_ptr<Transaction>> DirectService::begin_transaction() {
-    co_return std::make_unique<LocalTransaction>(data_store_, state_cache_);
+    co_return std::make_unique<LocalTransaction>(data_store_, shared_transaction_cache_);
 }
 
 // rpc StateChanges(StateChangeRequest) returns (stream StateChangeBatch);

--- a/silkworm/db/kv/api/direct_service.hpp
+++ b/silkworm/db/kv/api/direct_service.hpp
@@ -18,6 +18,7 @@
 
 #include <silkworm/db/data_store.hpp>
 
+#include "local_transaction.hpp"
 #include "service.hpp"
 #include "service_router.hpp"
 
@@ -52,8 +53,7 @@ class DirectService : public Service {
     //! The data store
     DataStoreRef data_store_;
 
-    //! The local state cache built upon incoming state changes
-    StateCache* state_cache_;
+    std::shared_ptr<LocalTransaction::Cache> shared_transaction_cache_;
 };
 
 }  // namespace silkworm::db::kv::api

--- a/silkworm/db/kv/api/direct_service.hpp
+++ b/silkworm/db/kv/api/direct_service.hpp
@@ -28,7 +28,7 @@ namespace silkworm::db::kv::api {
 //! This is used both client-side by 'direct' (i.e. no-gRPC) implementation and server-side by gRPC server.
 class DirectService : public Service {
   public:
-    DirectService(ServiceRouter router, DataStoreRef data_store, StateCache* state_cache);
+    DirectService(ServiceRouter router, DataStoreRef data_store, const ChainConfig& chain_config, StateCache* state_cache);
     ~DirectService() override = default;
 
     DirectService(const DirectService&) = delete;
@@ -53,7 +53,11 @@ class DirectService : public Service {
     //! The data store
     DataStoreRef data_store_;
 
-    std::shared_ptr<LocalTransaction::Cache> shared_transaction_cache_;
+    //! The chain configuration
+    const ChainConfig& chain_config_;
+
+    //! The local state cache built upon incoming state changes
+    StateCache* state_cache_;
 };
 
 }  // namespace silkworm::db::kv::api

--- a/silkworm/db/kv/api/direct_service_test.cpp
+++ b/silkworm/db/kv/api/direct_service_test.cpp
@@ -36,11 +36,12 @@ struct DirectServiceTest : public test_util::KVTestBase {
 
     TemporaryDirectory tmp_dir;
     TestDataStore data_store{tmp_dir};
+    ChainConfig chain_config{kMainnetConfig};
 
     StateChangeChannelPtr channel{std::make_shared<StateChangeChannel>(ioc_.get_executor())};
     concurrency::Channel<StateChangesCall> state_changes_calls_channel{ioc_.get_executor()};
     std::unique_ptr<StateCache> state_cache{std::make_unique<CoherentStateCache>()};
-    DirectService service{ServiceRouter{state_changes_calls_channel}, data_store->ref(), state_cache.get()};
+    DirectService service{ServiceRouter{state_changes_calls_channel}, data_store->ref(), chain_config, state_cache.get()};
     std::vector<StateChangeSet> change_set_vector;
 };
 

--- a/silkworm/db/kv/api/local_transaction.cpp
+++ b/silkworm/db/kv/api/local_transaction.cpp
@@ -139,8 +139,7 @@ Task<std::shared_ptr<CursorDupSort>> LocalTransaction::get_cursor(const std::str
 std::shared_ptr<chain::ChainStorage> LocalTransaction::create_storage() {
     // The calling thread *must* be the *same* which created this LocalTransaction instance
     return std::make_shared<chain::LocalChainStorage>(
-        DataModel{tx_, data_store_.blocks_repository},
-        cache_->chain_storage_cache());
+        DataModel{tx_, data_store_.blocks_repository}, chain_config_);
 }
 
 Task<TxnId> LocalTransaction::first_txn_num_in_block(BlockNum block_num) {

--- a/silkworm/db/kv/api/local_transaction.cpp
+++ b/silkworm/db/kv/api/local_transaction.cpp
@@ -138,7 +138,9 @@ Task<std::shared_ptr<CursorDupSort>> LocalTransaction::get_cursor(const std::str
 
 std::shared_ptr<chain::ChainStorage> LocalTransaction::create_storage() {
     // The calling thread *must* be the *same* which created this LocalTransaction instance
-    return std::make_shared<chain::LocalChainStorage>(DataModel{tx_, data_store_.blocks_repository});
+    return std::make_shared<chain::LocalChainStorage>(
+        DataModel{tx_, data_store_.blocks_repository},
+        cache_->chain_storage_cache());
 }
 
 Task<TxnId> LocalTransaction::first_txn_num_in_block(BlockNum block_num) {

--- a/silkworm/db/kv/api/local_transaction.hpp
+++ b/silkworm/db/kv/api/local_transaction.hpp
@@ -24,6 +24,7 @@
 
 #include <silkworm/infra/concurrency/task.hpp>
 
+#include <silkworm/db/chain/local_chain_storage.hpp>
 #include <silkworm/db/data_store.hpp>
 
 #include "base_transaction.hpp"
@@ -34,9 +35,27 @@ namespace silkworm::db::kv::api {
 
 class LocalTransaction : public BaseTransaction {
   public:
-    LocalTransaction(DataStoreRef data_store, StateCache* state_cache)
-        : BaseTransaction(state_cache),
+    class Cache {
+      public:
+        using ChainStorageCache = db::chain::LocalChainStorage::Cache;
+        explicit Cache(StateCache* state_cache)
+            : state_cache_{state_cache},
+              chain_storage_cache_{std::make_shared<ChainStorageCache>()} {}
+        StateCache* state_cache() const { return state_cache_; }
+        std::shared_ptr<ChainStorageCache> chain_storage_cache() const { return chain_storage_cache_; }
+
+      private:
+        //! The local state cache built upon incoming state changes
+        StateCache* state_cache_;
+        std::shared_ptr<ChainStorageCache> chain_storage_cache_;
+    };
+
+    LocalTransaction(
+        DataStoreRef data_store,
+        std::shared_ptr<Cache> cache)
+        : BaseTransaction{cache->state_cache()},
           data_store_{std::move(data_store)},
+          cache_{std::move(cache)},
           tx_{data_store_.chaindata.access_ro().start_ro_tx()} {}
 
     ~LocalTransaction() override = default;
@@ -105,6 +124,7 @@ class LocalTransaction : public BaseTransaction {
     std::map<std::string, std::shared_ptr<CursorDupSort>> dup_cursors_;
 
     DataStoreRef data_store_;
+    std::shared_ptr<Cache> cache_;
     uint32_t last_cursor_id_{0};
     datastore::kvdb::ROTxnManaged tx_;
     uint64_t tx_id_{++next_tx_id_};

--- a/silkworm/db/kv/state_changes_stream_test.cpp
+++ b/silkworm/db/kv/state_changes_stream_test.cpp
@@ -75,7 +75,9 @@ struct StateChangesStreamTest : public StateCacheTestBase {
 struct DirectStateChangesStreamTest : public StateChangesStreamTest {
     TemporaryDirectory tmp_dir;
     test_util::TestDataStore data_store{tmp_dir};
-    std::shared_ptr<api::DirectService> direct_service{std::make_shared<api::DirectService>(router, data_store->ref(), state_cache.get())};
+    ChainConfig chain_config;
+    std::shared_ptr<api::DirectService> direct_service{
+        std::make_shared<api::DirectService>(router, data_store->ref(), chain_config, state_cache.get())};
     api::DirectClient direct_client{direct_service};
     StateChangesStream stream{context_, direct_client};
 };

--- a/silkworm/rpc/daemon.hpp
+++ b/silkworm/rpc/daemon.hpp
@@ -21,6 +21,7 @@
 #include <string>
 #include <vector>
 
+#include <silkworm/core/chain/config.hpp>
 #include <silkworm/db/data_store.hpp>
 #include <silkworm/db/datastore/kvdb/mdbx.hpp>
 #include <silkworm/db/kv/api/client.hpp>
@@ -44,8 +45,9 @@ class Daemon {
   public:
     static int run(const DaemonSettings& settings);
 
-    explicit Daemon(
+    Daemon(
         DaemonSettings settings,
+        std::optional<ChainConfig> chain_config,
         std::optional<db::DataStoreRef> data_store);
 
     Daemon(const Daemon&) = delete;
@@ -73,6 +75,9 @@ class Daemon {
 
     //! The RPC daemon configuration settings.
     DaemonSettings settings_;
+
+    //! The chain configuration or std::nullopt if working remotely
+    std::optional<ChainConfig> chain_config_;
 
     //! The factory of gRPC client-side channels.
     ChannelFactory create_channel_;

--- a/silkworm/rpc/test_util/api_test_database.hpp
+++ b/silkworm/rpc/test_util/api_test_database.hpp
@@ -78,13 +78,21 @@ class TestDataStoreBase {
 
 class LocalContextTestBase : public ServiceContextTestBase {
   public:
-    explicit LocalContextTestBase(db::DataStoreRef data_store, db::kv::api::StateCache* state_cache) {
+    LocalContextTestBase(db::DataStoreRef data_store, db::kv::api::StateCache* state_cache) {
+        datastore::kvdb::ROTxnManaged ro_txn = data_store.chaindata.access_ro().start_ro_tx();
+        auto chain_config = db::read_chain_config(ro_txn);
+        SILKWORM_ASSERT(chain_config);
+        chain_config_ = std::move(*chain_config);
         db::kv::api::StateChangeRunner runner{ioc_.get_executor()};
         db::kv::api::ServiceRouter router{runner.state_changes_calls_channel()};
         add_private_service<db::kv::api::Client>(ioc_,
                                                  std::make_unique<db::kv::api::DirectClient>(
-                                                     std::make_shared<db::kv::api::DirectService>(router, std::move(data_store), state_cache)));
+                                                     std::make_shared<db::kv::api::DirectService>(
+                                                         router, std::move(data_store), chain_config_, state_cache)));
     }
+
+  private:
+    ChainConfig chain_config_;
 };
 
 template <typename TestRequestHandler>

--- a/silkworm/sync/sync.cpp
+++ b/silkworm/sync/sync.cpp
@@ -53,7 +53,7 @@ Sync::Sync(const boost::asio::any_io_executor& executor,
             .num_workers = 1,  // single-client so just one worker should be OK
             .jwt_secret_file = rpc_settings.jwt_secret_file,
         };
-        engine_rpc_server_ = std::make_unique<rpc::Daemon>(engine_rpc_settings, data_store);
+        engine_rpc_server_ = std::make_unique<rpc::Daemon>(engine_rpc_settings, std::make_optional(config), data_store);
 
         // Create the synchronization algorithm based on Casper + LMD-GHOST, i.e. PoS
         auto pos_sync = std::make_shared<PoSSync>(block_exchange_, execution);


### PR DESCRIPTION
It is possible to cache the ChainConfig structure after reading it from mdbx, because it is immutable after the node has started.

This optimization shaves off 0,6% of total time during stress_test_eth_call_20M.tar.

![Screenshot 2025-03-18 at 13 05 00](https://github.com/user-attachments/assets/cf467f68-e842-4cde-8b96-f0872fad57c5)
