### PR TITLE
datastore: ASAN-compatible EntityName

### DIFF
--- a/silkworm/db/blocks/schema_config.hpp
+++ b/silkworm/db/blocks/schema_config.hpp
@@ -26,7 +26,7 @@
 
 namespace silkworm::db::blocks {
 
-inline constexpr datastore::EntityName kBlocksRepositoryName{"Blocks"};
+inline const datastore::EntityName kBlocksRepositoryName{"Blocks"};
 
 inline constexpr std::string_view kSegmentExtension{".seg"};
 inline constexpr std::string_view kIdxExtension{".idx"};
@@ -40,40 +40,40 @@ snapshots::SnapshotRepository make_blocks_repository(
     bool open = true,
     std::optional<uint32_t> index_salt = std::nullopt);
 
-inline constexpr datastore::EntityName kHeaderSegmentName{"headers"};
-inline constexpr std::string_view kHeaderSegmentTag = kHeaderSegmentName.name;
+inline const datastore::EntityName kHeaderSegmentName{"headers"};
+inline constexpr std::string_view kHeaderSegmentTag{"headers"};
 //! Index header_hash -> block_num -> headers_segment_offset
-inline constexpr datastore::EntityName kIdxHeaderHashName{"headers.idx"};
+inline const datastore::EntityName kIdxHeaderHashName{"headers.idx"};
 inline constexpr std::string_view kIdxHeaderHashTag = kHeaderSegmentTag;
-inline constexpr snapshots::SegmentAndAccessorIndexNames kHeaderSegmentAndIdxNames{
+inline const snapshots::SegmentAndAccessorIndexNames kHeaderSegmentAndIdxNames{
     snapshots::Schema::kDefaultEntityName,
     kHeaderSegmentName,
     kIdxHeaderHashName,
 };
 
-inline constexpr datastore::EntityName kBodySegmentName{"bodies"};
-inline constexpr std::string_view kBodySegmentTag = kBodySegmentName.name;
+inline const datastore::EntityName kBodySegmentName{"bodies"};
+inline constexpr std::string_view kBodySegmentTag{"bodies"};
 //! Index block_num -> bodies_segment_offset
-inline constexpr datastore::EntityName kIdxBodyNumberName{"bodies.idx"};
+inline const datastore::EntityName kIdxBodyNumberName{"bodies.idx"};
 inline constexpr std::string_view kIdxBodyNumberTag = kBodySegmentTag;
-inline constexpr snapshots::SegmentAndAccessorIndexNames kBodySegmentAndIdxNames{
+inline const snapshots::SegmentAndAccessorIndexNames kBodySegmentAndIdxNames{
     snapshots::Schema::kDefaultEntityName,
     kBodySegmentName,
     kIdxBodyNumberName,
 };
 
-inline constexpr datastore::EntityName kTxnSegmentName{"transactions"};
-inline constexpr std::string_view kTxnSegmentTag = kTxnSegmentName.name;
+inline const datastore::EntityName kTxnSegmentName{"transactions"};
+inline constexpr std::string_view kTxnSegmentTag{"transactions"};
 //! Index transaction_hash -> txn_id -> transactions_segment_offset
-inline constexpr datastore::EntityName kIdxTxnHashName{"transactions.idx"};
+inline const datastore::EntityName kIdxTxnHashName{"transactions.idx"};
 inline constexpr std::string_view kIdxTxnHashTag = kTxnSegmentTag;
-inline constexpr snapshots::SegmentAndAccessorIndexNames kTxnSegmentAndIdxNames{
+inline const snapshots::SegmentAndAccessorIndexNames kTxnSegmentAndIdxNames{
     snapshots::Schema::kDefaultEntityName,
     kTxnSegmentName,
     kIdxTxnHashName,
 };
 //! Index transaction_hash -> block_num
-inline constexpr datastore::EntityName kIdxTxnHash2BlockName{"transactions-to-block.idx"};
+inline const datastore::EntityName kIdxTxnHash2BlockName{"transactions-to-block.idx"};
 inline constexpr std::string_view kIdxTxnHash2BlockTag{"transactions-to-block"};
 
 struct BundleDataRef {

--- a/silkworm/db/datastore/common/entity_name.cpp
+++ b/silkworm/db/datastore/common/entity_name.cpp
@@ -1,0 +1,41 @@
+/*
+   Copyright 2025 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "entity_name.hpp"
+
+#include <algorithm>
+
+#include <silkworm/core/common/assert.hpp>
+
+namespace silkworm::datastore {
+
+std::vector<std::string> EntityName::pool_;
+
+std::string_view EntityName::intern(std::string_view name) {
+    auto it = std::ranges::find(pool_, name);
+    if (it != pool_.end()) {
+        return *it;
+    }
+
+    static constexpr size_t kMaxEntityNames = 64;
+    pool_.reserve(kMaxEntityNames);
+    SILKWORM_ASSERT(pool_.size() < pool_.capacity());
+
+    pool_.push_back(std::string{name});
+    return pool_.back();
+}
+
+}  // namespace silkworm::datastore

--- a/silkworm/db/datastore/common/entity_name.hpp
+++ b/silkworm/db/datastore/common/entity_name.hpp
@@ -18,6 +18,7 @@
 
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include <absl/container/flat_hash_map.h>
 
@@ -25,6 +26,8 @@ namespace silkworm::datastore {
 
 struct EntityName {
     const std::string_view name;
+
+    explicit EntityName(std::string_view name1) : name{intern(name1)} {}
 
     friend bool operator==(const EntityName& lhs, const EntityName& rhs) {
         return lhs.name.data() == rhs.name.data();
@@ -34,6 +37,10 @@ struct EntityName {
     }
 
     std::string to_string() const { return std::string{name}; }
+
+  private:
+    static std::string_view intern(std::string_view name);
+    static std::vector<std::string> pool_;
 };
 
 template <typename TValue>

--- a/silkworm/db/datastore/kvdb/schema.hpp
+++ b/silkworm/db/datastore/kvdb/schema.hpp
@@ -136,12 +136,12 @@ class Schema {
         return database(kDefaultEntityName);
     }
 
-    static constexpr datastore::EntityName kDefaultEntityName{"_"};
+    static inline const datastore::EntityName kDefaultEntityName{"_"};
 
-    static constexpr datastore::EntityName kDomainValuesName{"DomainValues"};
-    static constexpr datastore::EntityName kHistoryValuesName{"HistoryValues"};
-    static constexpr datastore::EntityName kInvIdxKeysName{"InvIdxKeys"};
-    static constexpr datastore::EntityName kInvIdxIndexName{"InvIdxIndex"};
+    static inline const datastore::EntityName kDomainValuesName{"DomainValues"};
+    static inline const datastore::EntityName kHistoryValuesName{"HistoryValues"};
+    static inline const datastore::EntityName kInvIdxKeysName{"InvIdxKeys"};
+    static inline const datastore::EntityName kInvIdxIndexName{"InvIdxIndex"};
 
   private:
     EntityMap<DatabaseDef> database_defs_;

--- a/silkworm/db/datastore/snapshots/history_range_by_keys_query.hpp
+++ b/silkworm/db/datastore/snapshots/history_range_by_keys_query.hpp
@@ -62,7 +62,7 @@ struct HistoryRangeByKeysSegmentQuery {
         datastore::Timestamp ts = ts_opt->second;
 
         // query history value using the timestamp and key_data
-        static constexpr SegmentAndAccessorIndexNames kDummySegmentNames;
+        static const SegmentAndAccessorIndexNames kDummySegmentNames{datastore::EntityName{{}}, datastore::EntityName{{}}, datastore::EntityName{{}}};
         FindByKeySegmentQuery<AccessorIndexKeyEncoder, RawDecoder<Bytes>, kDummySegmentNames> value_query{entity_.segment_and_index()};
         auto value_opt = value_query.exec(AccessorIndexKeyEncoder::Value{ts, key_data});
         if (!value_opt) return std::nullopt;

--- a/silkworm/db/datastore/snapshots/history_range_in_period_query.hpp
+++ b/silkworm/db/datastore/snapshots/history_range_in_period_query.hpp
@@ -56,7 +56,7 @@ struct HistoryRangeInPeriodSegmentQuery {
         if (ts >= ts_range.end) return std::nullopt;
 
         // query history value using the timestamp and key_data
-        static constexpr SegmentAndAccessorIndexNames kDummySegmentNames;
+        static const SegmentAndAccessorIndexNames kDummySegmentNames{datastore::EntityName{{}}, datastore::EntityName{{}}, datastore::EntityName{{}}};
         FindByKeySegmentQuery<AccessorIndexKeyEncoder, TValueDecoder, kDummySegmentNames> value_query{entity_.segment_and_index()};
         auto value_opt = value_query.exec(AccessorIndexKeyEncoder::Value{ts, key_data});
         if (!value_opt) return std::nullopt;

--- a/silkworm/db/datastore/snapshots/schema.hpp
+++ b/silkworm/db/datastore/snapshots/schema.hpp
@@ -223,32 +223,32 @@ class Schema {
         return repository_defs_[name];
     }
 
-    static constexpr datastore::EntityName kDefaultEntityName{"_"};
+    static inline const datastore::EntityName kDefaultEntityName{"_"};
 
-    static constexpr datastore::EntityName kDomainKVSegmentName{"DomainKVSegment"};
+    static inline const datastore::EntityName kDomainKVSegmentName{"DomainKVSegment"};
     static constexpr std::string_view kDomainKVSegmentSubDirName{"domain"};
     static constexpr std::string_view kDomainKVSegmentFileExt{".kv"};
-    static constexpr datastore::EntityName kDomainAccessorIndexName{"DomainAccessorIndex"};
+    static inline const datastore::EntityName kDomainAccessorIndexName{"DomainAccessorIndex"};
     static constexpr std::string_view kDomainAccessorIndexSubDirName{"domain"};
     static constexpr std::string_view kDomainAccessorIndexFileExt{".kvi"};
-    static constexpr datastore::EntityName kDomainExistenceIndexName{"DomainExistenceIndex"};
+    static inline const datastore::EntityName kDomainExistenceIndexName{"DomainExistenceIndex"};
     static constexpr std::string_view kDomainExistenceIndexSubDirName{"domain"};
     static constexpr std::string_view kDomainExistenceIndexFileExt{".kvei"};
-    static constexpr datastore::EntityName kDomainBTreeIndexName{"DomainBTreeIndex"};
+    static inline const datastore::EntityName kDomainBTreeIndexName{"DomainBTreeIndex"};
     static constexpr std::string_view kDomainBTreeIndexSubDirName{"domain"};
     static constexpr std::string_view kDomainBTreeIndexFileExt{".bt"};
 
-    static constexpr datastore::EntityName kHistorySegmentName{"HistorySegment"};
+    static inline const datastore::EntityName kHistorySegmentName{"HistorySegment"};
     static constexpr std::string_view kHistorySegmentSubDirName{"history"};
     static constexpr std::string_view kHistorySegmentFileExt{".v"};
-    static constexpr datastore::EntityName kHistoryAccessorIndexName{"HistoryAccessorIndex"};
+    static inline const datastore::EntityName kHistoryAccessorIndexName{"HistoryAccessorIndex"};
     static constexpr std::string_view kHistoryAccessorIndexSubDirName{"accessor"};
     static constexpr std::string_view kHistoryAccessorIndexFileExt{".vi"};
 
-    static constexpr datastore::EntityName kInvIdxKVSegmentName{"InvIdxKVSegment"};
+    static inline const datastore::EntityName kInvIdxKVSegmentName{"InvIdxKVSegment"};
     static constexpr std::string_view kInvIdxKVSegmentSubDirName{"idx"};
     static constexpr std::string_view kInvIdxKVSegmentFileExt{".ef"};
-    static constexpr datastore::EntityName kInvIdxAccessorIndexName{"InvIdxAccessorIndex"};
+    static inline const datastore::EntityName kInvIdxAccessorIndexName{"InvIdxAccessorIndex"};
     static constexpr std::string_view kInvIdxAccessorIndexSubDirName{"accessor"};
     static constexpr std::string_view kInvIdxAccessorIndexFileExt{".efi"};
 

--- a/silkworm/db/snapshot_repository_test.cpp
+++ b/silkworm/db/snapshot_repository_test.cpp
@@ -45,9 +45,9 @@ static SnapshotRepository make_repository(std::filesystem::path dir_path) {
 
 // NOLINTBEGIN(readability-identifier-naming)
 struct SnapshotType {
-    static constexpr auto headers{db::blocks::kHeaderSegmentAndIdxNames};
-    static constexpr auto bodies{db::blocks::kBodySegmentAndIdxNames};
-    static constexpr auto transactions{db::blocks::kTxnSegmentAndIdxNames};
+    static inline const SegmentAndAccessorIndexNames headers{db::blocks::kHeaderSegmentAndIdxNames};
+    static inline const SegmentAndAccessorIndexNames bodies{db::blocks::kBodySegmentAndIdxNames};
+    static inline const SegmentAndAccessorIndexNames transactions{db::blocks::kTxnSegmentAndIdxNames};
 };
 // NOLINTEND(readability-identifier-naming)
 

--- a/silkworm/db/state/schema_config.hpp
+++ b/silkworm/db/state/schema_config.hpp
@@ -29,8 +29,8 @@
 
 namespace silkworm::db::state {
 
-inline constexpr datastore::EntityName kStateRepositoryNameLatest{"StateLatest"};
-inline constexpr datastore::EntityName kStateRepositoryNameHistorical{"StateHistorical"};
+inline const datastore::EntityName kStateRepositoryNameLatest{"StateLatest"};
+inline const datastore::EntityName kStateRepositoryNameHistorical{"StateHistorical"};
 
 snapshots::Schema::RepositoryDef make_state_repository_schema_latest();
 snapshots::Schema::RepositoryDef make_state_repository_schema_historical();
@@ -46,16 +46,16 @@ snapshots::SnapshotRepository make_state_repository_historical(
     bool open = true,
     std::optional<uint32_t> index_salt = std::nullopt);
 
-inline constexpr datastore::EntityName kDomainNameAccounts{"Account"};
-inline constexpr datastore::EntityName kDomainNameStorage{"Storage"};
-inline constexpr datastore::EntityName kDomainNameCode{"Code"};
-inline constexpr datastore::EntityName kDomainNameCommitment{"Commitment"};
-inline constexpr datastore::EntityName kDomainNameReceipts{"Receipt"};
+inline const datastore::EntityName kDomainNameAccounts{"Account"};
+inline const datastore::EntityName kDomainNameStorage{"Storage"};
+inline const datastore::EntityName kDomainNameCode{"Code"};
+inline const datastore::EntityName kDomainNameCommitment{"Commitment"};
+inline const datastore::EntityName kDomainNameReceipts{"Receipt"};
 
-inline constexpr datastore::EntityName kInvIdxNameLogAddress{"LogAddress"};
-inline constexpr datastore::EntityName kInvIdxNameLogTopics{"LogTopics"};
-inline constexpr datastore::EntityName kInvIdxNameTracesFrom{"TracesFrom"};
-inline constexpr datastore::EntityName kInvIdxNameTracesTo{"TracesTo"};
+inline const datastore::EntityName kInvIdxNameLogAddress{"LogAddress"};
+inline const datastore::EntityName kInvIdxNameLogTopics{"LogTopics"};
+inline const datastore::EntityName kInvIdxNameTracesFrom{"TracesFrom"};
+inline const datastore::EntityName kInvIdxNameTracesTo{"TracesTo"};
 
 inline constexpr std::string_view kDomainAccountsTag{"accounts"};
 inline constexpr std::string_view kInvIdxLogAddressTag{"logaddrs"};
@@ -90,27 +90,27 @@ struct StateDatabaseRef {
     datastore::kvdb::InvertedIndex traces_to_inverted_index() const { return {database.inverted_index(kInvIdxNameTracesTo)}; }
 };
 
-inline constexpr snapshots::SegmentAndAccessorIndexNames kHistorySegmentAndIdxNamesAccounts{
+inline const snapshots::SegmentAndAccessorIndexNames kHistorySegmentAndIdxNamesAccounts{
     kDomainNameAccounts,
     snapshots::Schema::kHistorySegmentName,
     snapshots::Schema::kHistoryAccessorIndexName,
 };
-inline constexpr snapshots::SegmentAndAccessorIndexNames kHistorySegmentAndIdxNamesStorage{
+inline const snapshots::SegmentAndAccessorIndexNames kHistorySegmentAndIdxNamesStorage{
     kDomainNameStorage,
     snapshots::Schema::kHistorySegmentName,
     snapshots::Schema::kHistoryAccessorIndexName,
 };
-inline constexpr snapshots::SegmentAndAccessorIndexNames kHistorySegmentAndIdxNamesCode{
+inline const snapshots::SegmentAndAccessorIndexNames kHistorySegmentAndIdxNamesCode{
     kDomainNameCode,
     snapshots::Schema::kHistorySegmentName,
     snapshots::Schema::kHistoryAccessorIndexName,
 };
-inline constexpr snapshots::SegmentAndAccessorIndexNames kHistorySegmentAndIdxNamesCommitment{
+inline const snapshots::SegmentAndAccessorIndexNames kHistorySegmentAndIdxNamesCommitment{
     kDomainNameCommitment,
     snapshots::Schema::kHistorySegmentName,
     snapshots::Schema::kHistoryAccessorIndexName,
 };
-inline constexpr snapshots::SegmentAndAccessorIndexNames kHistorySegmentAndIdxNamesReceipts{
+inline const snapshots::SegmentAndAccessorIndexNames kHistorySegmentAndIdxNamesReceipts{
     kDomainNameReceipts,
     snapshots::Schema::kHistorySegmentName,
     snapshots::Schema::kHistoryAccessorIndexName,


### PR DESCRIPTION
Problem:
ASAN makes constexpr string_view address unstable between translation units.

Solution:
Use Java String intern() approach to produce stable addresses.
Although it disallows constexpr usage it is more flexible
and supports EntityName reuse across multiple DLLs and runtimes.