### PR TITLE
capi: single individual txn receipts into database 

### DIFF
--- a/silkworm/capi/silkworm.cpp
+++ b/silkworm/capi/silkworm.cpp
@@ -620,7 +620,7 @@ SILKWORM_EXPORT int silkworm_execute_txn(SilkwormHandle handle, MDBX_txn* mdbx_t
         return SILKWORM_INVALID_HANDLE;
     }
 
-    std::cerr << "silkworm_execute_txn block_num: " << std::to_string(block_num) << " txn_index: " << std::to_string(txn_index) << " txn_num: " << std::to_string(txn_num) << '\n';
+    SILK_DEBUG << "silkworm_execute_txn block_num: " << std::to_string(block_num) << " txn_index: " << std::to_string(txn_index) << " txn_num: " << std::to_string(txn_num);
 
     silkworm::Hash block_header_hash{};
     memcpy(block_header_hash.bytes, block_hash.bytes, sizeof(block_hash.bytes));

--- a/silkworm/capi/silkworm.cpp
+++ b/silkworm/capi/silkworm.cpp
@@ -620,7 +620,7 @@ SILKWORM_EXPORT int silkworm_execute_txn(SilkwormHandle handle, MDBX_txn* mdbx_t
         return SILKWORM_INVALID_HANDLE;
     }
 
-    SILK_DEBUG << "silkworm_execute_txn block_num: " << std::to_string(block_num) << " txn_index: " << std::to_string(txn_index) << " txn_num: " << std::to_string(txn_num);
+    std::cerr << "silkworm_execute_txn block_num: " << std::to_string(block_num) << " txn_index: " << std::to_string(txn_index) << " txn_num: " << std::to_string(txn_num) << '\n';
 
     silkworm::Hash block_header_hash{};
     memcpy(block_header_hash.bytes, block_hash.bytes, sizeof(block_hash.bytes));
@@ -697,7 +697,7 @@ SILKWORM_EXPORT int silkworm_execute_txn(SilkwormHandle handle, MDBX_txn* mdbx_t
 
     try {
         processor.flush_state();
-        state.insert_receipts(block_number, std::vector<silkworm::Receipt>{receipt});
+        state.insert_receipt(receipt, transaction.total_blob_gas());
     } catch (const std::exception& ex) {
         SILK_ERROR << "transaction post-processing failed: " << ex.what();
         return SILKWORM_INTERNAL_ERROR;

--- a/silkworm/core/state/state.hpp
+++ b/silkworm/core/state/state.hpp
@@ -64,6 +64,8 @@ class State : public BlockState {
 
     virtual void insert_receipts(BlockNum block_num, const std::vector<Receipt>& receipts) = 0;
 
+    virtual void insert_receipt([[maybe_unused]] const Receipt& receipt, [[maybe_unused]] uint64_t blob_gas_used){};
+
     virtual void insert_call_traces(BlockNum block_num, const CallTraces& traces) = 0;
 
     /** @name State changes

--- a/silkworm/db/state/receipts_domain.hpp
+++ b/silkworm/db/state/receipts_domain.hpp
@@ -62,6 +62,18 @@ struct VarintSnapshotsDecoder : public snapshots::Decoder {
 
 static_assert(snapshots::DecoderConcept<VarintSnapshotsDecoder>);
 
+struct VarintSnapshotEncoder : public snapshots::Encoder {
+    Bytes& output_buffer;
+    uint64_t value{};
+    VarintSnapshotEncoder(Bytes& output, uint64_t val) : output_buffer(output), value{val} {}
+    ~VarintSnapshotEncoder() override = default;
+    ByteView encode_word() override {
+        return snapshots::seg::varint::encode(output_buffer, value);
+    }
+};
+
+static_assert(snapshots::EncoderConcept<VarintSnapshotEncoder>);
+
 using ReceiptsDomainKVSegmentReader = snapshots::segment::KVSegmentReader<ReceiptsDomainKeySnapshotsDecoder, VarintSnapshotsDecoder>;
 
 struct ReceiptsDomainGetLatestQuery : public datastore::DomainGetLatestQuery<

--- a/silkworm/execution/domain_state.cpp
+++ b/silkworm/execution/domain_state.cpp
@@ -120,7 +120,6 @@ void DomainState::insert_receipt(const Receipt& receipt, uint64_t cumulative_blo
 
     // Encode cumulative gas used in block - receipt should already contain txn gas used + block gas used so far
     {
-        std::cerr << "Saving Cumulative gas used in receipts: " << '\n';
         const Bytes gas_used_key{static_cast<uint8_t>(ReceiptsDomainKey::kCumulativeGasUsedInBlockKey)};
         Bytes encoded_value;
         VarintSnapshotEncoder encoder{encoded_value, receipt.cumulative_gas_used};
@@ -130,7 +129,6 @@ void DomainState::insert_receipt(const Receipt& receipt, uint64_t cumulative_blo
 
     // Encode cumulative blob gas used - requires interface extension to include list of executed transactions
     {
-        std::cerr << "Saving blog gas used in receipts: " << '\n';
         const Bytes gas_used_key{static_cast<uint8_t>(ReceiptsDomainKey::kCumulativeBlobGasUsedInBlockKey)};
         Bytes encoded_value;
         VarintSnapshotEncoder encoder{encoded_value, cumulative_blob_gas_used};
@@ -140,7 +138,6 @@ void DomainState::insert_receipt(const Receipt& receipt, uint64_t cumulative_blo
 
     // Log index - this should correspond to actual log index in a block (0 for now)
     {
-        std::cerr << "Saving log index in receipts: " << '\n';
         const Bytes gas_used_key{static_cast<uint8_t>(ReceiptsDomainKey::kFirstLogIndexKey)};
         Bytes encoded_value;
         VarintSnapshotEncoder encoder{encoded_value, 0};

--- a/silkworm/execution/domain_state.cpp
+++ b/silkworm/execution/domain_state.cpp
@@ -23,6 +23,8 @@
 #include <silkworm/db/state/step_txn_id_converter.hpp>
 #include <silkworm/db/state/storage_domain.hpp>
 
+#include "silkworm/db/state/receipts_domain.hpp"
+
 namespace silkworm::execution {
 
 using namespace db::state;
@@ -103,9 +105,48 @@ std::optional<evmc::bytes32> DomainState::canonical_hash(BlockNum block_num) con
     return data_model_.read_canonical_header_hash(block_num);
 }
 
-void DomainState::insert_receipts(BlockNum block_num, const std::vector<Receipt>& receipts) {
-    // TODO: write to domain receipts table db::state::kDomainNameReceipts
-    db::write_receipts(tx_, receipts, block_num);
+void DomainState::insert_receipts([[maybe_unused]] BlockNum block_num, const std::vector<Receipt>& receipts) {
+    // This has to be changed when block execution is fully supported
+    for ([[maybe_unused]] const auto& receipt : receipts) {
+        // Insert individual receipt, taking into account:
+        // 1. blob_gas_used() provided by a transaction (requires passing vector<Transactions>)
+        // 2. log index within block (bump log indexes with every receipt)
+        // 3. Cumulative gas used - accumulate while iterating over receipts
+    }
+}
+
+void DomainState::insert_receipt(const Receipt& receipt, uint64_t cumulative_blob_gas_used) {
+    ReceiptsDomainPutQuery query{database_, tx_};
+
+    // Encode cumulative gas used in block - receipt should already contain txn gas used + block gas used so far
+    {
+        std::cerr << "Saving Cumulative gas used in receipts: " << '\n';
+        const Bytes gas_used_key{static_cast<uint8_t>(ReceiptsDomainKey::kCumulativeGasUsedInBlockKey)};
+        Bytes encoded_value;
+        VarintSnapshotEncoder encoder{encoded_value, receipt.cumulative_gas_used};
+        const auto encoded_view = encoder.encode_word();
+        query.exec(gas_used_key, encoded_view, txn_id_, std::nullopt, current_step());
+    }
+
+    // Encode cumulative blob gas used - requires interface extension to include list of executed transactions
+    {
+        std::cerr << "Saving blog gas used in receipts: " << '\n';
+        const Bytes gas_used_key{static_cast<uint8_t>(ReceiptsDomainKey::kCumulativeBlobGasUsedInBlockKey)};
+        Bytes encoded_value;
+        VarintSnapshotEncoder encoder{encoded_value, cumulative_blob_gas_used};
+        const auto encoded_view = encoder.encode_word();
+        query.exec(gas_used_key, encoded_view, txn_id_, std::nullopt, current_step());
+    }
+
+    // Log index - this should correspond to actual log index in a block (0 for now)
+    {
+        std::cerr << "Saving log index in receipts: " << '\n';
+        const Bytes gas_used_key{static_cast<uint8_t>(ReceiptsDomainKey::kFirstLogIndexKey)};
+        Bytes encoded_value;
+        VarintSnapshotEncoder encoder{encoded_value, 0};
+        const auto encoded_view = encoder.encode_word();
+        query.exec(gas_used_key, encoded_view, txn_id_, std::nullopt, current_step());
+    }
 }
 
 datastore::Step DomainState::current_step() const {

--- a/silkworm/execution/domain_state.hpp
+++ b/silkworm/execution/domain_state.hpp
@@ -88,6 +88,8 @@ class DomainState : public State {
 
     void insert_receipts(BlockNum block_num, const std::vector<Receipt>& receipts) override;
 
+    void insert_receipt(const Receipt& receipt, uint64_t cumulative_blob_gas_used) override;
+
     void insert_call_traces(BlockNum /*block_num*/, const CallTraces& /*traces*/) override {}
 
     void begin_block(BlockNum /*block_num*/, size_t /*updated_accounts_count*/) override {}


### PR DESCRIPTION
We store relevant pieces of receipt into db every time a txn is executed by silkworm. 