### PR TITLE
db: add D/II LRU caches in snapshots

### DIFF
--- a/silkworm/capi/silkworm_test.cpp
+++ b/silkworm/capi/silkworm_test.cpp
@@ -985,7 +985,7 @@ TEST_CASE_METHOD(CApiTest, "CAPI silkworm_add_state_snapshot", "[capi]") {
     const auto kv_segment_path_string{kv_segment_file.path().path().string()};
 
     const snapshot_test::SampleAccountsDomainExistenceIndexFile existence_index_file{tmp_dir.path()};
-    bloom_filter::BloomFilter existence_index{existence_index_file.path().path(), bloom_filter::BloomFilterKeyHasher{kZeroSalt}};
+    bloom_filter::BloomFilter existence_index{existence_index_file.path().path(), KeyHasher{kZeroSalt}};
     const auto existence_index_path_string{existence_index_file.path().path().string()};
 
     const snapshot_test::SampleAccountsDomainBTreeIndexFile btree_index_file{tmp_dir.path()};

--- a/silkworm/capi/snapshots.cpp
+++ b/silkworm/capi/snapshots.cpp
@@ -94,7 +94,7 @@ static snapshots::SnapshotBundleEntityData build_domain_bundle_data(
         Schema::kDomainExistenceIndexName,
         bloom_filter::BloomFilter{
             parse_snapshot_path(snapshot.existence_index.file_path).path(),
-            bloom_filter::BloomFilterKeyHasher{index_salt},
+            KeyHasher{index_salt},
         });
     data.btree_indexes.emplace(
         Schema::kDomainBTreeIndexName,

--- a/silkworm/db/blocks/schema_config.cpp
+++ b/silkworm/db/blocks/schema_config.cpp
@@ -69,6 +69,7 @@ snapshots::SnapshotRepository make_blocks_repository(
         kStepToBlockNumConverter,
         index_salt,
         make_blocks_index_builders_factory(),
+        std::nullopt,
     };
 }
 

--- a/silkworm/db/blocks/schema_config.cpp
+++ b/silkworm/db/blocks/schema_config.cpp
@@ -69,7 +69,8 @@ snapshots::SnapshotRepository make_blocks_repository(
         kStepToBlockNumConverter,
         index_salt,
         make_blocks_index_builders_factory(),
-        std::nullopt,
+        std::nullopt,  // no domain caches
+        std::nullopt,  // no inverted index caches
     };
 }
 

--- a/silkworm/db/cli/snapshots.cpp
+++ b/silkworm/db/cli/snapshots.cpp
@@ -518,7 +518,7 @@ void open_existence_index(const SnapshotSubcommandSettings& settings) {
 
     std::chrono::time_point start{std::chrono::steady_clock::now()};
     seg::Decompressor kv_decompressor{settings.input_file_path};
-    bloom_filter::BloomFilter existence_index{existence_index_file_path, bloom_filter::BloomFilterKeyHasher{salt}};
+    bloom_filter::BloomFilter existence_index{existence_index_file_path, KeyHasher{salt}};
 
     SILK_INFO << "Starting KV scan and existence index check";
     size_t key_count{0}, found_count{0}, nonexistent_count{0}, nonexistent_found_count{0};

--- a/silkworm/db/datastore/common/entity_name.hpp
+++ b/silkworm/db/datastore/common/entity_name.hpp
@@ -35,6 +35,9 @@ struct EntityName {
     friend bool operator!=(const EntityName& lhs, const EntityName& rhs) {
         return lhs.name.data() != rhs.name.data();
     }
+    friend bool operator<(const EntityName& lhs, const EntityName& rhs) {
+        return lhs.name < rhs.name;
+    }
 
     std::string to_string() const { return std::string{name}; }
 

--- a/silkworm/db/datastore/snapshots/bloom_filter/bloom_filter.cpp
+++ b/silkworm/db/datastore/snapshots/bloom_filter/bloom_filter.cpp
@@ -51,7 +51,7 @@ uint64_t BloomFilter::optimal_bits_count(uint64_t max_key_count, double p) {
 
 BloomFilter::BloomFilter(
     std::filesystem::path path,
-    std::optional<BloomFilterKeyHasher> data_key_hasher)
+    std::optional<KeyHasher> data_key_hasher)
     : BloomFilter{kMinimumBitsCount, new_random_keys()} {
     if (!std::filesystem::exists(path)) {
         throw std::runtime_error("index file " + path.filename().string() + " doesn't exist");

--- a/silkworm/db/datastore/snapshots/bloom_filter/bloom_filter.hpp
+++ b/silkworm/db/datastore/snapshots/bloom_filter/bloom_filter.hpp
@@ -23,7 +23,7 @@
 #include <optional>
 #include <vector>
 
-#include "bloom_filter_key_hasher.hpp"
+#include "../common/key_hasher.hpp"
 
 namespace silkworm::snapshots::bloom_filter {
 
@@ -33,7 +33,7 @@ class BloomFilter {
   public:
     explicit BloomFilter(
         std::filesystem::path path,
-        std::optional<BloomFilterKeyHasher> data_key_hasher = std::nullopt);
+        std::optional<KeyHasher> data_key_hasher = std::nullopt);
     BloomFilter();
     BloomFilter(uint64_t max_key_count, double p);
 
@@ -70,7 +70,7 @@ class BloomFilter {
     std::filesystem::path path_;
 
     //! Data key hasher
-    std::optional<BloomFilterKeyHasher> data_key_hasher_;
+    std::optional<KeyHasher> data_key_hasher_;
 
     //! The number of bits that the bitmap should be able to track
     uint64_t bits_count_;

--- a/silkworm/db/datastore/snapshots/common/cache.hpp
+++ b/silkworm/db/datastore/snapshots/common/cache.hpp
@@ -1,0 +1,55 @@
+/*
+   Copyright 2025 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <optional>
+#include <utility>
+
+#include <silkworm/core/common/lru_cache.hpp>
+
+#include "key_hasher.hpp"
+
+namespace silkworm::snapshots {
+
+template <typename Value>
+class Cache {
+  public:
+    Cache(size_t size, uint32_t salt) : cache_{size, /*thread_safe=*/true}, key_hasher_{salt} {}
+
+    void put(uint64_t key_hash_high, const Value& value) {
+        cache_.put(key_hash_high, value);
+    }
+
+    std::optional<Value> get(uint64_t key_hash_high) {
+        return cache_.get_as_copy(key_hash_high);
+    }
+
+    std::pair<std::optional<Value>, uint64_t> get(ByteView key) {
+        const uint64_t hash_high = key_hasher_.hash(key);
+        return {get(hash_high), hash_high};
+    }
+
+    void clear() noexcept {
+        cache_.clear();
+    }
+
+  private:
+    LruCache<uint64_t, Value> cache_;
+    KeyHasher key_hasher_;
+};
+
+}  // namespace silkworm::snapshots

--- a/silkworm/db/datastore/snapshots/common/cache.hpp
+++ b/silkworm/db/datastore/snapshots/common/cache.hpp
@@ -34,10 +34,6 @@ class Cache {
         cache_.put(key_hash_high, value);
     }
 
-    void put(ByteView key, const Value& value) {
-        cache_.put(key_hasher_.hash(key), value);
-    }
-
     std::optional<Value> get(uint64_t key_hash_high) {
         return cache_.get_as_copy(key_hash_high);
     }

--- a/silkworm/db/datastore/snapshots/common/cache.hpp
+++ b/silkworm/db/datastore/snapshots/common/cache.hpp
@@ -34,6 +34,10 @@ class Cache {
         cache_.put(key_hash_high, value);
     }
 
+    void put(ByteView key, const Value& value) {
+        cache_.put(key_hasher_.hash(key), value);
+    }
+
     std::optional<Value> get(uint64_t key_hash_high) {
         return cache_.get_as_copy(key_hash_high);
     }

--- a/silkworm/db/datastore/snapshots/common/key_hasher.cpp
+++ b/silkworm/db/datastore/snapshots/common/key_hasher.cpp
@@ -14,18 +14,18 @@
    limitations under the License.
 */
 
-#include "bloom_filter_key_hasher.hpp"
+#include "key_hasher.hpp"
 
 #include <array>
 
 #include "../common/encoding/murmur_hash3.hpp"
 
-namespace silkworm::snapshots::bloom_filter {
+namespace silkworm::snapshots {
 
-uint64_t BloomFilterKeyHasher::hash(ByteView key) const {
+uint64_t KeyHasher::hash(ByteView key) const {
     std::array<uint64_t, 2> hash = {0, 0};
     encoding::Murmur3{salt_}.hash_x64_128(key.data(), key.size(), hash.data());
     return hash[0];
 }
 
-}  // namespace silkworm::snapshots::bloom_filter
+}  // namespace silkworm::snapshots

--- a/silkworm/db/datastore/snapshots/common/key_hasher.hpp
+++ b/silkworm/db/datastore/snapshots/common/key_hasher.hpp
@@ -18,15 +18,15 @@
 
 #include <silkworm/core/common/bytes.hpp>
 
-namespace silkworm::snapshots::bloom_filter {
+namespace silkworm::snapshots {
 
-class BloomFilterKeyHasher {
+class KeyHasher {
   public:
-    explicit BloomFilterKeyHasher(uint32_t salt) : salt_{salt} {}
+    explicit KeyHasher(uint32_t salt) : salt_{salt} {}
     uint64_t hash(ByteView key) const;
 
   private:
     uint32_t salt_;
 };
 
-}  // namespace silkworm::snapshots::bloom_filter
+}  // namespace silkworm::snapshots

--- a/silkworm/db/datastore/snapshots/common/key_hasher_test.cpp
+++ b/silkworm/db/datastore/snapshots/common/key_hasher_test.cpp
@@ -14,17 +14,17 @@
    limitations under the License.
 */
 
-#include "bloom_filter_key_hasher.hpp"
+#include "key_hasher.hpp"
 
 #include <catch2/catch_test_macros.hpp>
 
 #include <silkworm/core/common/util.hpp>
 
-namespace silkworm::snapshots::bloom_filter {
+namespace silkworm::snapshots {
 
-TEST_CASE("BloomFilterKeyHasher") {
-    CHECK(BloomFilterKeyHasher{0}.hash(*from_hex("CAFEBABE")) == 2809309899937206063u);
-    CHECK(BloomFilterKeyHasher{12345}.hash(*from_hex("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")) == 17810263873480351644u);
+TEST_CASE("KeyHasher") {
+    CHECK(KeyHasher{0}.hash(*from_hex("CAFEBABE")) == 2809309899937206063u);
+    CHECK(KeyHasher{12345}.hash(*from_hex("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")) == 17810263873480351644u);
 }
 
-}  // namespace silkworm::snapshots::bloom_filter
+}  // namespace silkworm::snapshots

--- a/silkworm/db/datastore/snapshots/domain_cache.hpp
+++ b/silkworm/db/datastore/snapshots/domain_cache.hpp
@@ -28,11 +28,11 @@
 
 namespace silkworm::snapshots {
 
-struct DomainCacheData {
+struct DomainGetLatestCacheData {
     BytesOrByteView value;
     std::optional<datastore::Step> range_end{0};
 };
-using DomainCache = Cache<DomainCacheData>;
-using DomainCaches = std::map<datastore::EntityName, std::unique_ptr<DomainCache>>;
+using DomainGetLatestCache = Cache<DomainGetLatestCacheData>;
+using DomainGetLatestCaches = std::map<datastore::EntityName, std::unique_ptr<DomainGetLatestCache>>;
 
 }  // namespace silkworm::snapshots

--- a/silkworm/db/datastore/snapshots/domain_cache.hpp
+++ b/silkworm/db/datastore/snapshots/domain_cache.hpp
@@ -18,15 +18,21 @@
 
 #include <map>
 #include <memory>
+#include <optional>
 
 #include <silkworm/core/common/bytes.hpp>
 
 #include "../common/entity_name.hpp"
+#include "../common/step.hpp"
 #include "common/cache.hpp"
 
 namespace silkworm::snapshots {
 
-using DomainCache = Cache<BytesOrByteView>;
+struct DomainCacheData {
+    BytesOrByteView value;
+    std::optional<datastore::Step> range_end{0};
+};
+using DomainCache = Cache<DomainCacheData>;
 using DomainCaches = std::map<datastore::EntityName, std::unique_ptr<DomainCache>>;
 
 }  // namespace silkworm::snapshots

--- a/silkworm/db/datastore/snapshots/domain_cache.hpp
+++ b/silkworm/db/datastore/snapshots/domain_cache.hpp
@@ -1,0 +1,61 @@
+/*
+   Copyright 2025 The Silkworm Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#pragma once
+
+#include <map>
+#include <memory>
+#include <optional>
+#include <utility>
+
+#include <silkworm/core/common/bytes.hpp>
+#include <silkworm/core/common/lru_cache.hpp>
+
+#include "../common/entity_name.hpp"
+#include "common/key_hasher.hpp"
+
+namespace silkworm::snapshots {
+
+class DomainCache {
+  public:
+    DomainCache(size_t size, uint32_t salt)
+        : cache_{size, /*thread_safe=*/true}, key_hasher_{salt} {}
+
+    void put(uint64_t key_hash_high, const BytesOrByteView& value) {
+        cache_.put(key_hash_high, value);
+    }
+
+    std::optional<BytesOrByteView> get(uint64_t key_hash_high) {
+        return cache_.get_as_copy(key_hash_high);
+    }
+
+    std::pair<std::optional<BytesOrByteView>, uint64_t> get(ByteView key) {
+        const uint64_t hash_high = key_hasher_.hash(key);
+        return {get(hash_high), hash_high};
+    }
+
+    void clear() noexcept {
+        cache_.clear();
+    }
+
+  private:
+    LruCache<uint64_t, BytesOrByteView> cache_;
+    KeyHasher key_hasher_;
+};
+
+using DomainCaches = std::map<datastore::EntityName, std::unique_ptr<DomainCache>>;
+
+}  // namespace silkworm::snapshots

--- a/silkworm/db/datastore/snapshots/domain_get_latest_query.hpp
+++ b/silkworm/db/datastore/snapshots/domain_get_latest_query.hpp
@@ -81,7 +81,7 @@ struct DomainGetLatestQuery {
     };
 
     std::optional<Result> exec(const Key& key) {
-        DomainCache* cache = repository.domain_cache(entity_name);
+        DomainGetLatestCache* cache = repository.domain_get_latest_cache(entity_name);
 
         TKeyEncoder key_encoder;
         key_encoder.value = key;
@@ -89,7 +89,7 @@ struct DomainGetLatestQuery {
 
         uint64_t key_hash_hi{0};
         if (cache) {
-            std::optional<DomainCacheData> cached_data;
+            std::optional<DomainGetLatestCacheData> cached_data;
             if (std::tie(cached_data, key_hash_hi) = cache->get(key_data); cached_data) {
                 if (!cached_data->range_end) {  // hit in cache but value not found
                     return std::nullopt;

--- a/silkworm/db/datastore/snapshots/history_get_query.hpp
+++ b/silkworm/db/datastore/snapshots/history_get_query.hpp
@@ -34,6 +34,7 @@ struct HistoryGetQuery {
         : timestamp_query_{
               repository,
               [](const SnapshotBundle& bundle) { return bundle.history(segment_names.front()).inverted_index; },
+              [&]() { return repository.inverted_index_cache(segment_names.front()); },
           },
           value_query_{repository} {}
 

--- a/silkworm/db/datastore/snapshots/history_get_query.hpp
+++ b/silkworm/db/datastore/snapshots/history_get_query.hpp
@@ -34,7 +34,7 @@ struct HistoryGetQuery {
         : timestamp_query_{
               repository,
               [](const SnapshotBundle& bundle) { return bundle.history(segment_names.front()).inverted_index; },
-              [&]() { return repository.inverted_index_cache(segment_names.front()); },
+              [&]() { return repository.inverted_index_seek_cache(segment_names.front()); },
           },
           value_query_{repository} {}
 

--- a/silkworm/db/datastore/snapshots/inverted_index_cache.hpp
+++ b/silkworm/db/datastore/snapshots/inverted_index_cache.hpp
@@ -27,11 +27,11 @@
 
 namespace silkworm::snapshots {
 
-struct InvertedIndexTimestamps {
+struct InvertedIndexCacheData {
     datastore::Timestamp requested;
     datastore::Timestamp found;
 };
-using InvertedIndexCache = Cache<InvertedIndexTimestamps>;
+using InvertedIndexCache = Cache<InvertedIndexCacheData>;
 using InvertedIndexCaches = std::map<datastore::EntityName, std::unique_ptr<InvertedIndexCache>>;
 
 }  // namespace silkworm::snapshots

--- a/silkworm/db/datastore/snapshots/inverted_index_cache.hpp
+++ b/silkworm/db/datastore/snapshots/inverted_index_cache.hpp
@@ -18,15 +18,20 @@
 
 #include <map>
 #include <memory>
+#include <utility>
 
-#include <silkworm/core/common/bytes.hpp>
+#include <silkworm/db/datastore/common/timestamp.hpp>
 
 #include "../common/entity_name.hpp"
 #include "common/cache.hpp"
 
 namespace silkworm::snapshots {
 
-using DomainCache = Cache<BytesOrByteView>;
-using DomainCaches = std::map<datastore::EntityName, std::unique_ptr<DomainCache>>;
+struct InvertedIndexTimestamps {
+    datastore::Timestamp requested;
+    datastore::Timestamp found;
+};
+using InvertedIndexCache = Cache<InvertedIndexTimestamps>;
+using InvertedIndexCaches = std::map<datastore::EntityName, std::unique_ptr<InvertedIndexCache>>;
 
 }  // namespace silkworm::snapshots

--- a/silkworm/db/datastore/snapshots/inverted_index_cache.hpp
+++ b/silkworm/db/datastore/snapshots/inverted_index_cache.hpp
@@ -27,11 +27,11 @@
 
 namespace silkworm::snapshots {
 
-struct InvertedIndexCacheData {
+struct InvertedIndexSeekCacheData {
     datastore::Timestamp requested;
     datastore::Timestamp found;
 };
-using InvertedIndexCache = Cache<InvertedIndexCacheData>;
-using InvertedIndexCaches = std::map<datastore::EntityName, std::unique_ptr<InvertedIndexCache>>;
+using InvertedIndexSeekCache = Cache<InvertedIndexSeekCacheData>;
+using InvertedIndexSeekCaches = std::map<datastore::EntityName, std::unique_ptr<InvertedIndexSeekCache>>;
 
 }  // namespace silkworm::snapshots

--- a/silkworm/db/datastore/snapshots/inverted_index_find_by_key_segment_query.hpp
+++ b/silkworm/db/datastore/snapshots/inverted_index_find_by_key_segment_query.hpp
@@ -73,7 +73,10 @@ struct InvertedIndexFindByKeySegmentQuery {
         TKeyEncoder key_encoder;
         key_encoder.value = std::move(key);
         ByteView key_data = key_encoder.encode_word();
+        return exec_raw(key_data);
+    }
 
+    std::optional<elias_fano::EliasFanoList32> exec_raw(ByteView key_data) {
         auto offset = entity_.accessor_index.lookup_by_key(key_data);
         if (!offset) {
             return std::nullopt;

--- a/silkworm/db/datastore/snapshots/inverted_index_seek_query.hpp
+++ b/silkworm/db/datastore/snapshots/inverted_index_seek_query.hpp
@@ -66,7 +66,7 @@ struct InvertedIndexSeekQuery {
     explicit InvertedIndexSeekQuery(
         const SnapshotRepositoryROAccess& repository,
         std::function<InvertedIndex(const SnapshotBundle&)> entity_provider,
-        std::function<InvertedIndexCache*()> cache_provider)
+        std::function<InvertedIndexSeekCache*()> cache_provider)
         : repository_{repository},
           entity_provider_{std::move(entity_provider)},
           cache_provider_{std::move(cache_provider)} {}
@@ -74,7 +74,7 @@ struct InvertedIndexSeekQuery {
     using Key = decltype(TKeyEncoder::value);
 
     std::optional<datastore::Timestamp> exec(Key key, datastore::Timestamp timestamp) {
-        InvertedIndexCache* cache = cache_provider_();
+        InvertedIndexSeekCache* cache = cache_provider_();
 
         TKeyEncoder key_encoder;
         key_encoder.value = std::move(key);
@@ -82,7 +82,7 @@ struct InvertedIndexSeekQuery {
 
         uint64_t key_hash_hi{0};
         if (cache) {
-            std::optional<InvertedIndexCacheData> cached_data;
+            std::optional<InvertedIndexSeekCacheData> cached_data;
             if (std::tie(cached_data, key_hash_hi) = cache->get(key_data); cached_data) {
                 if (cached_data->requested <= timestamp) {
                     if (timestamp <= cached_data->found) {
@@ -116,7 +116,7 @@ struct InvertedIndexSeekQuery {
   private:
     const SnapshotRepositoryROAccess& repository_;
     std::function<InvertedIndex(const SnapshotBundle&)> entity_provider_;
-    std::function<InvertedIndexCache*()> cache_provider_;
+    std::function<InvertedIndexSeekCache*()> cache_provider_;
 };
 
 }  // namespace silkworm::snapshots

--- a/silkworm/db/datastore/snapshots/snapshot_bundle.cpp
+++ b/silkworm/db/datastore/snapshots/snapshot_bundle.cpp
@@ -87,7 +87,7 @@ static datastore::EntityMap<bloom_filter::BloomFilter> open_existence_indexes(
     for (auto& [name, path] : make_snapshot_paths(Schema::SnapshotFileDef::Format::kExistenceIndex, entity, dir_path, range)) {
         SILK_TRACE << "make_existence_indexes opens " << name.to_string() << " at " << path.filename();
         SILKWORM_ASSERT(salt);
-        results.emplace(name, bloom_filter::BloomFilter{path.path(), bloom_filter::BloomFilterKeyHasher{*salt}});
+        results.emplace(name, bloom_filter::BloomFilter{path.path(), KeyHasher{*salt}});
     }
     return results;
 }

--- a/silkworm/db/datastore/snapshots/snapshot_repository.cpp
+++ b/silkworm/db/datastore/snapshots/snapshot_repository.cpp
@@ -41,8 +41,8 @@ SnapshotRepository::SnapshotRepository(
     StepToTimestampConverter step_converter,
     std::optional<uint32_t> index_salt,
     std::unique_ptr<IndexBuildersFactory> index_builders_factory,
-    std::optional<DomainCaches> domain_caches,
-    std::optional<InvertedIndexCaches> inverted_index_caches)
+    std::optional<DomainGetLatestCaches> domain_caches,
+    std::optional<InvertedIndexSeekCaches> inverted_index_caches)
     : name_(std::move(name)),
       dir_path_(std::move(dir_path)),
       schema_(std::move(schema)),
@@ -76,13 +76,13 @@ void SnapshotRepository::replace_snapshot_bundles(SnapshotBundle bundle) {
     bundles_ = bundles;
 }
 
-DomainCache* SnapshotRepository::domain_cache(const datastore::EntityName& name) const {
+DomainGetLatestCache* SnapshotRepository::domain_get_latest_cache(const datastore::EntityName& name) const {
     if (!domain_caches_) return nullptr;
     if (!domain_caches_->contains(name)) return nullptr;
     return domain_caches_->at(name).get();
 }
 
-InvertedIndexCache* SnapshotRepository::inverted_index_cache(const datastore::EntityName& name) const {
+InvertedIndexSeekCache* SnapshotRepository::inverted_index_seek_cache(const datastore::EntityName& name) const {
     if (!inverted_index_caches_) return nullptr;
     if (!inverted_index_caches_->contains(name)) return nullptr;
     return inverted_index_caches_->at(name).get();

--- a/silkworm/db/datastore/snapshots/snapshot_repository.cpp
+++ b/silkworm/db/datastore/snapshots/snapshot_repository.cpp
@@ -41,7 +41,8 @@ SnapshotRepository::SnapshotRepository(
     StepToTimestampConverter step_converter,
     std::optional<uint32_t> index_salt,
     std::unique_ptr<IndexBuildersFactory> index_builders_factory,
-    std::optional<DomainCaches> domain_caches)
+    std::optional<DomainCaches> domain_caches,
+    std::optional<InvertedIndexCaches> inverted_index_caches)
     : name_(std::move(name)),
       dir_path_(std::move(dir_path)),
       schema_(std::move(schema)),
@@ -50,7 +51,8 @@ SnapshotRepository::SnapshotRepository(
       index_builders_factory_(std::move(index_builders_factory)),
       bundles_(std::make_shared<Bundles>()),
       bundles_mutex_(std::make_unique<std::mutex>()),
-      domain_caches_{std::move(domain_caches)} {
+      domain_caches_{std::move(domain_caches)},
+      inverted_index_caches_{std::move(inverted_index_caches)} {
     if (open) reopen_folder();
 }
 
@@ -78,6 +80,12 @@ DomainCache* SnapshotRepository::domain_cache(const datastore::EntityName& name)
     if (!domain_caches_) return nullptr;
     if (!domain_caches_->contains(name)) return nullptr;
     return domain_caches_->at(name).get();
+}
+
+InvertedIndexCache* SnapshotRepository::inverted_index_cache(const datastore::EntityName& name) const {
+    if (!inverted_index_caches_) return nullptr;
+    if (!inverted_index_caches_->contains(name)) return nullptr;
+    return inverted_index_caches_->at(name).get();
 }
 
 size_t SnapshotRepository::bundles_count() const {

--- a/silkworm/db/datastore/snapshots/snapshot_repository.hpp
+++ b/silkworm/db/datastore/snapshots/snapshot_repository.hpp
@@ -59,8 +59,8 @@ class SnapshotRepository : public SnapshotRepositoryROAccess {
         datastore::StepToTimestampConverter step_converter,
         std::optional<uint32_t> index_salt,
         std::unique_ptr<IndexBuildersFactory> index_builders_factory,
-        std::optional<DomainCaches> domain_caches,
-        std::optional<InvertedIndexCaches> inverted_index_caches);
+        std::optional<DomainGetLatestCaches> domain_caches,
+        std::optional<InvertedIndexSeekCaches> inverted_index_caches);
 
     SnapshotRepository(SnapshotRepository&&) = default;
     SnapshotRepository& operator=(SnapshotRepository&&) noexcept = delete;
@@ -81,8 +81,8 @@ class SnapshotRepository : public SnapshotRepositoryROAccess {
     //! Replace bundles whose ranges are contained within the given bundle
     void replace_snapshot_bundles(SnapshotBundle bundle);
 
-    DomainCache* domain_cache(const datastore::EntityName& name) const override;
-    InvertedIndexCache* inverted_index_cache(const datastore::EntityName& name) const override;
+    DomainGetLatestCache* domain_get_latest_cache(const datastore::EntityName& name) const override;
+    InvertedIndexSeekCache* inverted_index_seek_cache(const datastore::EntityName& name) const override;
 
     size_t bundles_count() const override;
 
@@ -150,8 +150,8 @@ class SnapshotRepository : public SnapshotRepositoryROAccess {
     std::unique_ptr<std::mutex> bundles_mutex_;
 
     //! Cache for D/II values across all bundles
-    std::optional<DomainCaches> domain_caches_;
-    std::optional<InvertedIndexCaches> inverted_index_caches_;
+    std::optional<DomainGetLatestCaches> domain_caches_;
+    std::optional<InvertedIndexSeekCaches> inverted_index_caches_;
 };
 
 }  // namespace silkworm::snapshots

--- a/silkworm/db/datastore/snapshots/snapshot_repository.hpp
+++ b/silkworm/db/datastore/snapshots/snapshot_repository.hpp
@@ -58,7 +58,8 @@ class SnapshotRepository : public SnapshotRepositoryROAccess {
         Schema::RepositoryDef schema,
         datastore::StepToTimestampConverter step_converter,
         std::optional<uint32_t> index_salt,
-        std::unique_ptr<IndexBuildersFactory> index_builders_factory);
+        std::unique_ptr<IndexBuildersFactory> index_builders_factory,
+        std::optional<DomainCaches> domain_caches);
 
     SnapshotRepository(SnapshotRepository&&) = default;
     SnapshotRepository& operator=(SnapshotRepository&&) noexcept = delete;
@@ -78,6 +79,8 @@ class SnapshotRepository : public SnapshotRepositoryROAccess {
 
     //! Replace bundles whose ranges are contained within the given bundle
     void replace_snapshot_bundles(SnapshotBundle bundle);
+
+    DomainCache* domain_cache(const datastore::EntityName& name) const override;
 
     size_t bundles_count() const override;
 
@@ -143,6 +146,9 @@ class SnapshotRepository : public SnapshotRepositoryROAccess {
     //! Full snapshot bundles ordered by block_from
     std::shared_ptr<Bundles> bundles_;
     std::unique_ptr<std::mutex> bundles_mutex_;
+
+    //! Cache for domain values across all bundles
+    std::optional<DomainCaches> domain_caches_;
 };
 
 }  // namespace silkworm::snapshots

--- a/silkworm/db/datastore/snapshots/snapshot_repository.hpp
+++ b/silkworm/db/datastore/snapshots/snapshot_repository.hpp
@@ -59,7 +59,8 @@ class SnapshotRepository : public SnapshotRepositoryROAccess {
         datastore::StepToTimestampConverter step_converter,
         std::optional<uint32_t> index_salt,
         std::unique_ptr<IndexBuildersFactory> index_builders_factory,
-        std::optional<DomainCaches> domain_caches);
+        std::optional<DomainCaches> domain_caches,
+        std::optional<InvertedIndexCaches> inverted_index_caches);
 
     SnapshotRepository(SnapshotRepository&&) = default;
     SnapshotRepository& operator=(SnapshotRepository&&) noexcept = delete;
@@ -81,6 +82,7 @@ class SnapshotRepository : public SnapshotRepositoryROAccess {
     void replace_snapshot_bundles(SnapshotBundle bundle);
 
     DomainCache* domain_cache(const datastore::EntityName& name) const override;
+    InvertedIndexCache* inverted_index_cache(const datastore::EntityName& name) const override;
 
     size_t bundles_count() const override;
 
@@ -147,8 +149,9 @@ class SnapshotRepository : public SnapshotRepositoryROAccess {
     std::shared_ptr<Bundles> bundles_;
     std::unique_ptr<std::mutex> bundles_mutex_;
 
-    //! Cache for domain values across all bundles
+    //! Cache for D/II values across all bundles
     std::optional<DomainCaches> domain_caches_;
+    std::optional<InvertedIndexCaches> inverted_index_caches_;
 };
 
 }  // namespace silkworm::snapshots

--- a/silkworm/db/datastore/snapshots/snapshot_repository_ro_access.hpp
+++ b/silkworm/db/datastore/snapshots/snapshot_repository_ro_access.hpp
@@ -28,6 +28,7 @@
 #include "../common/step.hpp"
 #include "../common/timestamp.hpp"
 #include "common/util/iterator/map_values_view.hpp"
+#include "domain_cache.hpp"
 #include "segment_and_accessor_index.hpp"
 
 namespace silkworm::snapshots {
@@ -59,6 +60,8 @@ struct SnapshotRepositoryROAccess {
     };
 
     virtual ~SnapshotRepositoryROAccess() = default;
+
+    virtual DomainCache* domain_cache(const datastore::EntityName& name) const = 0;
 
     virtual size_t bundles_count() const = 0;
 

--- a/silkworm/db/datastore/snapshots/snapshot_repository_ro_access.hpp
+++ b/silkworm/db/datastore/snapshots/snapshot_repository_ro_access.hpp
@@ -62,8 +62,8 @@ struct SnapshotRepositoryROAccess {
 
     virtual ~SnapshotRepositoryROAccess() = default;
 
-    virtual DomainCache* domain_cache(const datastore::EntityName& name) const = 0;
-    virtual InvertedIndexCache* inverted_index_cache(const datastore::EntityName& name) const = 0;
+    virtual DomainGetLatestCache* domain_get_latest_cache(const datastore::EntityName& name) const = 0;
+    virtual InvertedIndexSeekCache* inverted_index_seek_cache(const datastore::EntityName& name) const = 0;
 
     virtual size_t bundles_count() const = 0;
 

--- a/silkworm/db/datastore/snapshots/snapshot_repository_ro_access.hpp
+++ b/silkworm/db/datastore/snapshots/snapshot_repository_ro_access.hpp
@@ -29,6 +29,7 @@
 #include "../common/timestamp.hpp"
 #include "common/util/iterator/map_values_view.hpp"
 #include "domain_cache.hpp"
+#include "inverted_index_cache.hpp"
 #include "segment_and_accessor_index.hpp"
 
 namespace silkworm::snapshots {
@@ -62,6 +63,7 @@ struct SnapshotRepositoryROAccess {
     virtual ~SnapshotRepositoryROAccess() = default;
 
     virtual DomainCache* domain_cache(const datastore::EntityName& name) const = 0;
+    virtual InvertedIndexCache* inverted_index_cache(const datastore::EntityName& name) const = 0;
 
     virtual size_t bundles_count() const = 0;
 

--- a/silkworm/db/state/schema_config.cpp
+++ b/silkworm/db/state/schema_config.cpp
@@ -109,12 +109,12 @@ static auto make_caches(std::optional<uint32_t> salt) {
     return caches;
 }
 
-static snapshots::DomainCaches make_domain_caches(std::optional<uint32_t> salt) {
-    return make_caches<snapshots::DomainCache, kDomainCacheEnvVar, kDefaultDomainCacheSize>(salt);
+static snapshots::DomainGetLatestCaches make_domain_caches(std::optional<uint32_t> salt) {
+    return make_caches<snapshots::DomainGetLatestCache, kDomainCacheEnvVar, kDefaultDomainCacheSize>(salt);
 }
 
-static snapshots::InvertedIndexCaches make_inverted_index_caches(std::optional<uint32_t> salt) {
-    return make_caches<snapshots::InvertedIndexCache, kInvertedIndexCacheEnvVar, kDefaultInvertedIndexCacheSize>(salt);
+static snapshots::InvertedIndexSeekCaches make_inverted_index_caches(std::optional<uint32_t> salt) {
+    return make_caches<snapshots::InvertedIndexSeekCache, kInvertedIndexCacheEnvVar, kDefaultInvertedIndexCacheSize>(salt);
 }
 
 static snapshots::SnapshotRepository make_state_repository(


### PR DESCRIPTION
### Functionality

- Introduce Domain LRU cache (one for each entity) used in `DomainGetLatestQuery `
- Introduce InvertedIndex LRU cache (one for each entity) used in `InvertedIndexSeekQuery`
- Introduce `exec_raw` in segment queries to avoid multiple key encoding
- Move `BloomFilterKeyHasher` and rename as `KeyHasher` for reuse in snapshot LRU caches

### Performance

MacBookPro M1-Max 64GB RAM

- master: f22d3473dafbab954d8387914960c5d1074bfc47
```
% ./run_perf_tests.py -m 2 -p pattern/mainnet/stress_test_eth_getLogs_15M.tar -r 5 -t 1000:20 -y eth_getLogs
Performance Test started
[1. 1] daemon: executes test qps: 1000 time: 20 -> [R=100.00% max=1.68s]
[1. 2] daemon: executes test qps: 1000 time: 20 -> [R=100.00% max=1.058s]
[1. 3] daemon: executes test qps: 1000 time: 20 -> [R=100.00% max=1.032s]
[1. 4] daemon: executes test qps: 1000 time: 20 -> [R=100.00% max=980.002ms]
[1. 5] daemon: executes test qps: 1000 time: 20 -> [R=100.00% max=1.053s]
Performance Test completed successfully.
```

- this branch: 540eb5382011efe189e73d536ddd86791b0b75b8
```
./run_perf_tests.py -m 2 -p pattern/mainnet/stress_test_eth_getLogs_15M.tar -r 5 -t 1000:20 -y eth_getLogs
Performance Test started
Test repetitions: 5 on sequence: 1000:20 for pattern: pattern/mainnet/stress_test_eth_getLogs_15M.tar
[1. 1] daemon: executes test qps: 1000 time: 20 -> [R=100.00% max=744.158ms]
[1. 2] daemon: executes test qps: 1000 time: 20 -> [R=100.00% max=588.391ms]
[1. 3] daemon: executes test qps: 1000 time: 20 -> [R=100.00% max=615.164ms]
[1. 4] daemon: executes test qps: 1000 time: 20 -> [R=100.00% max=597.833ms]
[1. 5] daemon: executes test qps: 1000 time: 20 -> [R=100.00% max=594.024ms]
Performance Test completed successfully.
```
