### PR TITLE
Adding block_start/block_end entrypoints, fixing saving receipts

### DIFF
--- a/silkworm/capi/instance.hpp
+++ b/silkworm/capi/instance.hpp
@@ -22,6 +22,8 @@
 
 #include <boost/asio/cancellation_signal.hpp>
 
+#include <silkworm/core/types/receipt.hpp>
+#include <silkworm/core/types/transaction.hpp>
 #include <silkworm/infra/common/log.hpp>
 #include <silkworm/infra/concurrency/context_pool_settings.hpp>
 #include <silkworm/node/common/node_settings.hpp>
@@ -59,4 +61,10 @@ struct SilkwormInstance {
     // sentry
     std::unique_ptr<std::thread> sentry_thread;
     boost::asio::cancellation_signal sentry_stop_signal;
+
+    // TODO: This has to be changed and encapsulated by a proper block caching state
+    // Keeps all the receipts created in the current block
+    std::vector<silkworm::Receipt> receipts_in_current_block;
+    // Keeps all transactions executed in current block
+    std::vector<std::pair<silkworm::TxnId, silkworm::Transaction>> transactions_in_current_block;
 };

--- a/silkworm/capi/silkworm.h
+++ b/silkworm/capi/silkworm.h
@@ -431,6 +431,25 @@ SILKWORM_EXPORT int silkworm_execute_blocks_perpetual(SilkwormHandle handle, MDB
  */
 SILKWORM_EXPORT int silkworm_execute_txn(SilkwormHandle handle, MDBX_txn* mdbx_tx, uint64_t block_num, struct SilkwormBytes32 block_hash, uint64_t txn_index, uint64_t txn_num, uint64_t* gas_used, uint64_t* blob_gas_used) SILKWORM_NOEXCEPT;
 
+ /**
+ * \brief Signals starting block execution
+ * \param[in] handle A valid Silkworm instance handle, got with silkworm_init.
+ * \param[in] mdbx_tx A valid external read-write MDBX transaction.
+ * \param[in] block_num The number of the block containing the transaction.
+ * \param[in] block_hash The hash of the block.
+ * \return SILKWORM_OK (=0) on success, a non-zero error value on failure.
+ */
+ SILKWORM_EXPORT int silkworm_block_exec_start(SilkwormHandle handle, MDBX_txn* mdbx_tx, uint64_t block_num, struct SilkwormBytes32 block_hash) SILKWORM_NOEXCEPT;
+
+/**
+ * \brief Signals completing block execution
+ * \param[in] handle A valid Silkworm instance handle, got with silkworm_init.
+ * \param[in] mdbx_tx A valid external read-write MDBX transaction.
+ * \param[in] mdbx_in_mem_temp_tx A valid in memory MDBX transaction for silkworm->erigon communication
+ * \return SILKWORM_OK (=0) on success, a non-zero error value on failure.
+ */
+ SILKWORM_EXPORT int silkworm_block_exec_end(SilkwormHandle handle, MDBX_txn* mdbx_tx, MDBX_txn* mdbx_in_mem_temp_tx) SILKWORM_NOEXCEPT;
+
 /**
  * \brief Finalize the Silkworm C API library.
  * \param[in] handle A valid Silkworm instance handle got with silkworm_init.

--- a/silkworm/core/state/state.hpp
+++ b/silkworm/core/state/state.hpp
@@ -62,9 +62,12 @@ class State : public BlockState {
 
     virtual void decanonize_block(BlockNum block_num) = 0;
 
-    virtual void insert_receipts(BlockNum block_num, const std::vector<Receipt>& receipts) = 0;
+    virtual void insert_receipts([[maybe_unused]] BlockNum block_num, [[maybe_unused]] const std::vector<Receipt>& receipts){};
 
-    virtual void insert_receipt([[maybe_unused]] const Receipt& receipt, [[maybe_unused]] uint64_t blob_gas_used){};
+    // Added in Erigon3
+    virtual void insert_txn_receipts([[maybe_unused]] std::vector<Receipt>& receipts, [[maybe_unused]] const std::vector<std::pair<TxnId, Transaction>>& transactions){};
+
+    virtual void insert_receipt([[maybe_unused]] const Receipt& receipt, [[maybe_unused]] uint64_t current_log_index, [[maybe_unused]] uint64_t blob_gas_used){};
 
     virtual void insert_call_traces(BlockNum block_num, const CallTraces& traces) = 0;
 

--- a/silkworm/execution/domain_state.hpp
+++ b/silkworm/execution/domain_state.hpp
@@ -86,9 +86,9 @@ class DomainState : public State {
 
     void decanonize_block(BlockNum /*block_num*/) override {}
 
-    void insert_receipts(BlockNum block_num, const std::vector<Receipt>& receipts) override;
+    void insert_txn_receipts(std::vector<Receipt>& receipts, const std::vector<std::pair<TxnId, Transaction>>& transactions) override;
 
-    void insert_receipt(const Receipt& receipt, uint64_t cumulative_blob_gas_used) override;
+    void insert_receipt(const Receipt& receipt, uint64_t current_log_index, uint64_t cumulative_blob_gas_used) override;
 
     void insert_call_traces(BlockNum /*block_num*/, const CallTraces& /*traces*/) override {}
 


### PR DESCRIPTION
This pull request resolves an issue with saving receipts by ensuring that the correct `gas`, `blob_gas`, and `logIndex` values are used. These values must be calculated individually for each receipt, taking into account the receipts generated previously in the same block. To facilitate this, I introduced `block_start` and `block_end` entry points in Silkworm that Erigon must utilize.
For now, to keep the implementation straightforward, receipts remain in the Silkworm instance, though this will need revisiting in the future. Furthermore, computing the `receipts_root_hash` requires that all receipts be accessible within Erigon, so the idea of using a temporary MDBX store will be explored later.