### PR TITLE
cmake: fix conan grpc binary download

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -24,7 +24,9 @@ class SilkwormRecipe(ConanFile):
         self.requires('boost/1.83.0', override=True)
         self.requires('cli11/2.2.0')
         self.requires('gmp/6.2.1')
-        self.requires('grpc/1.67.1', override=True)
+        # fix to an older recipe revision due to missing binary packages for the latest revision
+        # see https://github.com/conan-io/conan-center-index/issues/26959
+        self.requires('grpc/1.67.1#c214ddb4e04e8d9a44d3a100defc9706', override=True)
         self.requires('gtest/1.12.1')
         self.requires('jwt-cpp/0.6.0')
         self.requires('libtorrent/2.0.10')


### PR DESCRIPTION
### Problem

The grpc conan recipe was updated on 2025-03-25 to revision 2b1ac43c5934cc4bcc326335166e8838, see the output of:

    conan list 'grpc/1.67.1#*' -r=conancenter -f=compact
    
That update is broken on conancenter - it doesn't have any associated binary packages as [reported in this issue](https://github.com/conan-io/conan-center-index/issues/26959), see the output of:

    conan list 'grpc/1.67.1#2b1ac43c5934cc4bcc326335166e8838:*' -r=conancenter -f=compact

### Solution

Hardcode the previous recipe revision from 2025-02-24 that contains associated binary packages on conancenter:

    conan list 'grpc/1.67.1#c214ddb4e04e8d9a44d3a100defc9706:*' -r=conancenter -f=compact