### PR TITLE
node: handle stage Triggers progress

### DIFF
--- a/silkworm/node/cli/staged_pipeline.cpp
+++ b/silkworm/node/cli/staged_pipeline.cpp
@@ -427,7 +427,7 @@ void unwind(kvdb::EnvConfig& config, std::unique_ptr<DataDirectory>&& data_direc
 
         // Remove the block bodies up to the unwind point
         const auto body_cursor{txn.rw_cursor(db::table::kBlockBodies)};
-        const auto start_key{db::block_key(unwind_point)};
+        const auto start_key{db::block_key(unwind_point + 1)};
         std::size_t erased_bodies{0};
         auto body_data{body_cursor->lower_bound(kvdb::to_slice(start_key), /*throw_notfound=*/false)};
         while (body_data) {

--- a/silkworm/node/stagedsync/execution_pipeline.cpp
+++ b/silkworm/node/stagedsync/execution_pipeline.cpp
@@ -164,7 +164,7 @@ Stage::Result ExecutionPipeline::forward(db::RWTxn& cycle_txn, BlockNum target_b
             } /* clang-format on */
 
             const auto stage_head_number = read_stage_progress(cycle_txn, current_stage_name.data());
-            if (!stop_at_block && stage_head_number != target_block_num && current_stage_name != kTriggersStageKey) {
+            if (!stop_at_block && stage_head_number != target_block_num) {
                 SILK_ERROR_M(get_log_prefix(current_stage_name),
                              {"op", "Forward", "target", to_string(target_block_num), "reached", to_string(stage_head_number)});
                 throw std::logic_error("stage returned success with an block_num different from target=" +

--- a/silkworm/node/stagedsync/stages/stage_triggers.cpp
+++ b/silkworm/node/stagedsync/stages/stage_triggers.cpp
@@ -23,6 +23,11 @@ Stage::Result TriggersStage::forward(db::RWTxn& tx) {
     ioc_.restart();
     ioc_.run();
 
+    // Update its own progress to the previous stage progress to satisfy the execution pipeline constraints
+    const BlockNum previous_stage_progress = db::stages::read_stage_progress(tx, db::stages::kTxLookupKey);
+    update_progress(tx, previous_stage_progress);
+    tx.commit_and_renew();
+
     return Stage::Result::kSuccess;
 }
 

--- a/silkworm/node/stagedsync/stages/stage_triggers.hpp
+++ b/silkworm/node/stagedsync/stages/stage_triggers.hpp
@@ -16,8 +16,8 @@ class TriggersStage : public Stage, public datastore::StageScheduler {
     ~TriggersStage() override = default;
 
     Stage::Result forward(db::RWTxn& tx) override;
+    Stage::Result unwind(db::RWTxn& txn) override;
 
-    Stage::Result unwind(db::RWTxn&) override { return Stage::Result::kSuccess; }
     Stage::Result prune(db::RWTxn&) override { return Stage::Result::kSuccess; }
 
     Task<void> schedule(std::function<void(db::RWTxn&)> callback) override;


### PR DESCRIPTION
Handle progress for stage Triggers according to the progress rules checked by execution pipeline. This guarantees that it works when doing multiple forward/unwind using `staged_pipeline` dev tool and also plays nicely with `STOP_AT_BLOCK` debug option.

*Extra*
- fix block removal in `unwind` command of `staged_pipeline` dev tool