### PR TITLE
capi: calculate receipts' properties after each txn

### DIFF
--- a/silkworm/capi/instance.hpp
+++ b/silkworm/capi/instance.hpp
@@ -50,8 +50,12 @@ struct SilkwormInstance {
     boost::asio::cancellation_signal sentry_stop_signal;
 
     // TODO: This has to be changed and encapsulated by a proper block caching state
-    // Keeps all the receipts created in the current block
-    std::vector<silkworm::Receipt> receipts_in_current_block;
-    // Keeps all transactions executed in current block
-    std::vector<std::pair<silkworm::TxnId, silkworm::Transaction>> transactions_in_current_block;
+    struct ExecutionResult {
+        silkworm::TxnId tx_id = 0;
+        uint64_t blob_gas_used = 0;
+        silkworm::Receipt receipt;
+        uint64_t log_index = 0;
+    };
+    // Keeps all the transactions and receipts created in the current block
+    std::vector<ExecutionResult> executions_in_block;
 };

--- a/silkworm/capi/silkworm.cpp
+++ b/silkworm/capi/silkworm.cpp
@@ -775,8 +775,6 @@ SILKWORM_EXPORT int silkworm_block_exec_end(SilkwormHandle handle, MDBX_txn* mdb
         const auto log_index = handle->executions_in_block[index].log_index;
         const auto blob_gas_used = handle->executions_in_block[index].blob_gas_used;
         state.insert_receipt(receipt, log_index, blob_gas_used);
-
-        index++;
     }
 
     return SILKWORM_OK;

--- a/silkworm/capi/silkworm.cpp
+++ b/silkworm/capi/silkworm.cpp
@@ -684,8 +684,19 @@ SILKWORM_EXPORT int silkworm_execute_txn(SilkwormHandle handle, MDBX_txn* mdbx_t
 
     try {
         processor.flush_state();
-        handle->transactions_in_current_block.push_back({txn_id_, transaction});
-        handle->receipts_in_current_block.push_back(receipt);
+        SilkwormInstance::ExecutionResult exec_result{
+            .tx_id = txn_id_,
+            .blob_gas_used = transaction.total_blob_gas(),
+            .receipt = receipt,
+            .log_index = 0};
+
+        if (!handle->executions_in_block.empty()) {
+            const auto& prev = handle->executions_in_block.back();
+            exec_result.blob_gas_used += prev.blob_gas_used;
+            exec_result.receipt.cumulative_gas_used += prev.receipt.cumulative_gas_used;
+            exec_result.log_index += std::size(prev.receipt.logs);
+        }
+        handle->executions_in_block.push_back(std::move(exec_result));
     } catch (const std::exception& ex) {
         SILK_ERROR << "transaction post-processing failed: " << ex.what();
         return SILKWORM_INTERNAL_ERROR;
@@ -714,11 +725,8 @@ SILKWORM_EXPORT int silkworm_block_exec_start(SilkwormHandle handle, MDBX_txn* m
 
     // TODO: cache block here for future reuse with transactions within same (block_exec_start, block_exec_end) range
 
-    // Clear any receipts created in previous blocks
-    handle->receipts_in_current_block.clear();
-
-    // Clear any transactions executed in previous blocks
-    handle->transactions_in_current_block.clear();
+    // Clear any transactoins and receipts created in previous blocks
+    handle->executions_in_block.clear();
 
     return SILKWORM_OK;
 }
@@ -732,22 +740,43 @@ SILKWORM_EXPORT int silkworm_block_exec_end(SilkwormHandle handle, MDBX_txn* mdb
         return SILKWORM_INVALID_MDBX_TXN;
     }
 
-    SILKWORM_ASSERT(std::size(handle->receipts_in_current_block) == std::size(handle->transactions_in_current_block));
+    // Temporary db used for silkworm->erigon communication
+    auto unmanaged_in_mem_tx = datastore::kvdb::RWTxnUnmanaged{mdbx_in_mem_temp_tx};
+    auto rw_in_mem_cursor = unmanaged_in_mem_tx.rw_cursor(db::table::kBlockReceipts);
 
-    auto unmanaged_tx = datastore::kvdb::RWTxnUnmanaged{mdbx_in_mem_temp_tx};
-    auto rw_cursor = unmanaged_tx.rw_cursor(db::table::kBlockReceipts);
-    uint64_t receipt_idx = 0;
-    for (const auto& receipt : handle->receipts_in_current_block) {
+    // Persistent db used for shared domains
+    auto unmanaged_tx = datastore::kvdb::RWTxnUnmanaged{mdbx_tx};
+    auto unmanaged_env = silkworm::datastore::kvdb::EnvUnmanaged{::mdbx_txn_env(mdbx_tx)};
+    auto chain_db = db::DataStore::make_chaindata_database(std::move(unmanaged_env));
+    auto db_ref = chain_db.ref();
+
+    for (uint64_t index = 0; index < std::size(handle->executions_in_block); ++index) {
+        const auto& receipt = handle->executions_in_block[index].receipt;
+
         Bytes rlp_encoded;
         rlp::encode(rlp_encoded, receipt);
 
         Bytes key(sizeof(int64_t), '\0');
 
-        endian::store_big_u64(key.data(), receipt_idx);
+        endian::store_big_u64(key.data(), index);
 
-        rw_cursor->insert(datastore::kvdb::Slice(key), datastore::kvdb::Slice(rlp_encoded));
+        rw_in_mem_cursor->insert(datastore::kvdb::Slice(key), datastore::kvdb::Slice(rlp_encoded));
 
-        receipt_idx++;
+        const auto& tx_id = handle->executions_in_block[index].tx_id;
+
+        execution::DomainState state{
+            tx_id,
+            unmanaged_tx,
+            db_ref,
+            *handle->blocks_repository,
+            *handle->state_repository_latest,
+        };
+
+        const auto log_index = handle->executions_in_block[index].log_index;
+        const auto blob_gas_used = handle->executions_in_block[index].blob_gas_used;
+        state.insert_receipt(receipt, log_index, blob_gas_used);
+
+        index++;
     }
 
     return SILKWORM_OK;

--- a/silkworm/core/state/state.hpp
+++ b/silkworm/core/state/state.hpp
@@ -51,9 +51,6 @@ class State : public BlockState {
 
     virtual void insert_receipts([[maybe_unused]] BlockNum block_num, [[maybe_unused]] const std::vector<Receipt>& receipts){};
 
-    // Added in Erigon3
-    virtual void insert_txn_receipts([[maybe_unused]] std::vector<Receipt>& receipts, [[maybe_unused]] const std::vector<std::pair<TxnId, Transaction>>& transactions){};
-
     virtual void insert_receipt([[maybe_unused]] const Receipt& receipt, [[maybe_unused]] uint64_t current_log_index, [[maybe_unused]] uint64_t blob_gas_used){};
 
     virtual void insert_call_traces(BlockNum block_num, const CallTraces& traces) = 0;

--- a/silkworm/execution/domain_state.cpp
+++ b/silkworm/execution/domain_state.cpp
@@ -92,29 +92,6 @@ std::optional<evmc::bytes32> DomainState::canonical_hash(BlockNum block_num) con
     return data_model_.read_canonical_header_hash(block_num);
 }
 
-void DomainState::insert_txn_receipts(std::vector<Receipt>& receipts, const std::vector<std::pair<TxnId, Transaction>>& transactions) {
-    uint64_t log_index = 0;
-    uint64_t blob_gas_used = 0;
-    uint64_t gas_used = 0;
-
-    for (size_t i = 0; i < std::size(receipts); i++) {
-        auto& receipt = receipts[i];
-        const auto& [txn_id, transaction] = transactions[i];
-        gas_used += receipt.cumulative_gas_used;
-
-        // Receipt contains gas used within a block + gas used by itself
-        receipt.cumulative_gas_used = gas_used;
-
-        // Update blob gas used by transaction
-        blob_gas_used += transaction.total_blob_gas();
-
-        insert_receipt(receipt, log_index, blob_gas_used);
-
-        // Update log index for the next receipt
-        log_index += std::size(receipt.logs);
-    }
-}
-
 void DomainState::insert_receipt(const Receipt& receipt, uint64_t current_log_index, uint64_t cumulative_blob_gas_used) {
     ReceiptsDomainPutQuery query{database_, tx_};
 

--- a/silkworm/execution/domain_state.hpp
+++ b/silkworm/execution/domain_state.hpp
@@ -73,8 +73,6 @@ class DomainState : public State {
 
     void decanonize_block(BlockNum /*block_num*/) override {}
 
-    void insert_txn_receipts(std::vector<Receipt>& receipts, const std::vector<std::pair<TxnId, Transaction>>& transactions) override;
-
     void insert_receipt(const Receipt& receipt, uint64_t current_log_index, uint64_t cumulative_blob_gas_used) override;
 
     void insert_call_traces(BlockNum /*block_num*/, const CallTraces& /*traces*/) override {}


### PR DESCRIPTION
This simplifies interface to `State` - we don't have to implement `insert_receipts()` anymore since these are properly populated every time a new transaction is executed. 