### PR TITLE
cmake: fix protobuf macOS link warning in libutf8_validity

### DIFF
--- a/cmake/conan.cmake
+++ b/cmake/conan.cmake
@@ -95,6 +95,7 @@ endif()
 
 if(OS_VERSION_MIN_CXXFLAG AND NOT SILKWORM_SANITIZE_COMPILER_OPTIONS)
   list(APPEND CONAN_CONF "tools.build:cxxflags=[\"${OS_VERSION_MIN_CXXFLAG}\"]")
+  list(APPEND CONAN_CONF "tools.build:cflags=[\"${OS_VERSION_MIN_CXXFLAG}\"]")
 endif()
 
 if(SILKWORM_SANITIZE_COMPILER_OPTIONS)
@@ -102,7 +103,11 @@ if(SILKWORM_SANITIZE_COMPILER_OPTIONS)
 
   if(OS_VERSION_MIN_CXXFLAG)
     list(APPEND CONAN_CXXFLAGS ${OS_VERSION_MIN_CXXFLAG})
+    list(APPEND CONAN_CONF "tools.build:cflags=[\"${OS_VERSION_MIN_CXXFLAG}\"]")
   endif()
+
+  format_list_as_json_array(CONAN_CXXFLAGS CONAN_CXXFLAGS_STR)
+  list(APPEND CONAN_CONF "tools.build:cxxflags=${CONAN_CXXFLAGS_STR}")
 
   list(APPEND CONAN_OPTIONS "boost/*:zlib=False")
   list(APPEND CONAN_OPTIONS "grpc/*:with_libsystemd=False")
@@ -118,9 +123,6 @@ if(SILKWORM_SANITIZE_COMPILER_OPTIONS)
   )
   list(APPEND CONAN_BUILD "missing")
   # cmake-format: on
-
-  format_list_as_json_array(CONAN_CXXFLAGS CONAN_CXXFLAGS_STR)
-  list(APPEND CONAN_CONF "tools.build:cxxflags=${CONAN_CXXFLAGS_STR}")
 endif()
 
 if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")


### PR DESCRIPTION
ld: warning: object file (.../libutf8_validity.a[3](utf8_range.c.o)) was built for newer 'macOS' version (15.0) than being linked (14.0)

This is a pure C library, and "cxxflags" are not respected, need to pass "cflags".