### PR TITLE
rpcdaemon: http chunking

### DIFF
--- a/silkworm/rpc/core/evm_debug_test.cpp
+++ b/silkworm/rpc/core/evm_debug_test.cpp
@@ -30,7 +30,7 @@ struct DebugExecutorTest : public test_util::ServiceContextTestBase {
     WorkerPool workers{1};
     StringWriter writer{4096};
     boost::asio::any_io_executor io_executor{ioc_.get_executor()};
-    json::Stream stream{io_executor, writer};
+    json::Stream stream{io_executor, writer, /* request_id */ 0};
     test::BackEndMock backend;
     RemoteChainStorage chain_storage{transaction, ethdb::kv::make_backend_providers(&backend)};
 };

--- a/silkworm/rpc/http/chunker.hpp
+++ b/silkworm/rpc/http/chunker.hpp
@@ -1,0 +1,77 @@
+// Copyright 2025 The Silkworm Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <algorithm>
+#include <memory>
+#include <queue>
+
+namespace silkworm::rpc::http {
+
+inline constexpr int kDefaultMaxChunkSize = 2048;
+
+class Chunker {
+  public:
+    Chunker(const Chunker&) = delete;
+
+    Chunker() {
+        current_chunk_.reserve(kDefaultMaxChunkSize);
+    }
+
+    ~Chunker() {}
+
+    void queue_data(const std::string& new_buffer) {
+        size_t position = 0;
+
+        // creates chunk: even if new:buffer is greater kDefaultMaxChunkSize
+        while (position < new_buffer.size()) {
+            size_t available_space = kDefaultMaxChunkSize - current_chunk_.size();
+            size_t chunk_size = std::min(available_space, new_buffer.size() - position);
+
+            current_chunk_.append(new_buffer, position, chunk_size);
+            position += chunk_size;
+
+            // one chunk is completed copy it in complet_chunk
+            if (current_chunk_.size() == kDefaultMaxChunkSize) {
+                complete_chunk_.push(current_chunk_);
+                current_chunk_.clear();
+                current_chunk_.reserve(kDefaultMaxChunkSize);
+            }
+        }
+    }
+
+    std::pair<std::string, bool> get_complete_chunk() {
+        if (!complete_chunk_.empty()) {
+            // at least one chunk is availble return it , indicating if first chunk or not
+            auto ret_first_chunk = !first_chunk_completed_;
+            first_chunk_completed_ = true;
+            std::string chunk = complete_chunk_.front();
+            complete_chunk_.pop();
+            return std::make_pair(chunk, ret_first_chunk);
+        }
+        // queue is empty no chunk are available
+        return std::make_pair("", false);
+    }
+
+    bool has_chunks() const {
+        return !complete_chunk_.empty();
+    }
+
+    std::pair<std::string, bool> get_remainder() const {
+        if (current_chunk_.empty()) {
+            // no bytes are present on current_chunk so return empty string and indication if first chunk or not
+            // we are in two possible cases: at least one completed chunk is already produced, or any chunk are produced
+            return std::make_pair("", !first_chunk_completed_);
+        }
+        // returns the chunk
+        return std::make_pair(current_chunk_, !first_chunk_completed_);
+    }
+
+  private:
+    std::queue<std::string> complete_chunk_;
+    std::string current_chunk_;
+    bool first_chunk_completed_{false};
+};
+
+};  // namespace silkworm::rpc::http

--- a/silkworm/rpc/http/connection.hpp
+++ b/silkworm/rpc/http/connection.hpp
@@ -19,6 +19,7 @@
 #include <silkworm/rpc/common/constants.hpp>
 #include <silkworm/rpc/common/interface_log.hpp>
 #include <silkworm/rpc/common/worker_pool.hpp>
+#include <silkworm/rpc/http/chunker.hpp>
 #include <silkworm/rpc/transport/request_handler.hpp>
 #include <silkworm/rpc/transport/stream_writer.hpp>
 #include <silkworm/rpc/ws/connection.hpp>
@@ -28,6 +29,16 @@ namespace silkworm::rpc::http {
 using RequestWithStringBody = boost::beast::http::request<boost::beast::http::string_body>;
 
 inline constexpr size_t kDefaultCapacity = 4 * 1024;
+
+struct RequestData {
+    bool request_keep_alive_{false};
+    unsigned int request_http_version_{11};
+    bool gzip_encoding_requested_{false};
+    std::string vary_;
+    std::string origin_;
+    boost::beast::http::verb method_{boost::beast::http::verb::unknown};
+    std::unique_ptr<Chunker> chunk_;
+};
 
 //! Represents a single connection from a client.
 class Connection : public StreamWriter {
@@ -52,10 +63,10 @@ class Connection : public StreamWriter {
     ~Connection() override;
 
     /* StreamWriter Interface */
-    Task<void> open_stream() override;
-    Task<void> close_stream() override;
+    Task<void> open_stream(uint64_t request_id) override;
+    Task<void> close_stream(uint64_t request_id) override;
     size_t get_capacity() const noexcept override { return kDefaultCapacity; }
-    Task<size_t> write(std::string_view content, bool last) override;
+    Task<size_t> write(uint64_t request_id, std::string_view content, bool last) override;
 
   protected:
     //! Start the asynchronous read loop for the connection
@@ -65,9 +76,9 @@ class Connection : public StreamWriter {
     using AuthorizationResult = tl::expected<void, AuthorizationError>;
     AuthorizationResult is_request_authorized(const RequestWithStringBody& req);
 
-    Task<void> handle_request(const RequestWithStringBody& req);
-    Task<void> handle_actual_request(const RequestWithStringBody& req);
-    Task<void> handle_preflight(const RequestWithStringBody& req);
+    Task<void> handle_request(const RequestWithStringBody& req, RequestData& request_data);
+    Task<void> handle_actual_request(const RequestWithStringBody& req, RequestData& request_data);
+    Task<void> handle_preflight(const RequestWithStringBody& req, RequestData& request_data);
 
     bool is_origin_allowed(const std::vector<std::string>& allowed_origins, const std::string& origin);
     bool is_method_allowed(boost::beast::http::verb method);
@@ -76,17 +87,19 @@ class Connection : public StreamWriter {
     Task<void> do_upgrade(const RequestWithStringBody& req);
 
     template <class Body>
-    void set_cors(boost::beast::http::response<Body>& res);
+    void set_cors(boost::beast::http::response<Body>& res, RequestData& request_data);
 
     //! Perform an asynchronous read operation.
     Task<bool> do_read();
 
     //! Perform an asynchronous write operation.
-    Task<void> do_write(const std::string& content, boost::beast::http::status http_status, std::string_view content_encoding = "");
+    Task<void> do_write(const std::string& content, boost::beast::http::status http_status, RequestData& request_data, std::string_view content_encoding = "", bool to_be_compressed = false);
 
     static std::string get_date_time();
 
     Task<void> compress(const std::string& clear_data, std::string& compressed_data);
+    Task<void> create_chunk_header(RequestData& request_data);
+    Task<size_t> send_chunk(const std::string& content);
 
     //! Socket for the connection.
     boost::asio::ip::tcp::socket socket_;
@@ -99,9 +112,6 @@ class Connection : public StreamWriter {
     const std::vector<std::string>& allowed_origins_;
     const std::optional<std::string> jwt_secret_;
 
-    bool request_keep_alive_{false};
-    unsigned int request_http_version_{11};
-
     boost::beast::flat_buffer data_;
 
     bool ws_upgrade_enabled_;
@@ -111,13 +121,11 @@ class Connection : public StreamWriter {
     bool http_compression_;
 
     WorkerPool& workers_;
-    bool gzip_encoding_requested_{false};
-
-    std::string vary_;
-    std::string origin_;
-    boost::beast::http::verb method_{boost::beast::http::verb::unknown};
 
     bool erigon_json_rpc_compatibility_{false};
+    uint64_t request_id_{0};
+
+    std::map<uint64_t, RequestData> request_map_;
 };
 
 }  // namespace silkworm::rpc::http

--- a/silkworm/rpc/json/stream.hpp
+++ b/silkworm/rpc/json/stream.hpp
@@ -30,7 +30,7 @@ struct DataChunk {
 //! Stream can be used to send big JSON data split into multiple fragments.
 class Stream {
   public:
-    Stream(boost::asio::any_io_executor& executor, StreamWriter& writer, size_t buffer_capacity = 0);
+    Stream(boost::asio::any_io_executor& executor, StreamWriter& writer, uint64_t request_id, size_t buffer_capacity = 0);
     Stream(const Stream& stream) = delete;
     Stream& operator=(const Stream&) = delete;
 
@@ -75,6 +75,8 @@ class Stream {
 
     StreamWriter& writer_;
     std::stack<std::uint8_t> stack_;
+
+    uint64_t request_id_{0};
 
     const size_t buffer_capacity_;
     std::string buffer_;

--- a/silkworm/rpc/json/stream_test.cpp
+++ b/silkworm/rpc/json/stream_test.cpp
@@ -25,7 +25,7 @@ TEST_CASE_METHOD(StreamTest, "json::Stream writing JSON", "[rpc][json]") {
     StringWriter string_writer;
 
     SECTION("write_json in string") {
-        Stream stream(io_executor, string_writer);
+        Stream stream(io_executor, string_writer, /* request_id */ 0);
 
         nlohmann::json json = R"({
             "test": "test"
@@ -38,7 +38,7 @@ TEST_CASE_METHOD(StreamTest, "json::Stream writing JSON", "[rpc][json]") {
         CHECK((string_writer.get_content() == "{\"test\":\"test\"}"));
     }
     SECTION("write_json in 1 chunk") {
-        Stream stream(io_executor, string_writer);
+        Stream stream(io_executor, string_writer, /* request_id */ 0);
 
         nlohmann::json json = R"({
             "test": "test"
@@ -50,7 +50,7 @@ TEST_CASE_METHOD(StreamTest, "json::Stream writing JSON", "[rpc][json]") {
         CHECK((string_writer.get_content() == "{\"test\":\"test\"}"));
     }
     SECTION("write_json in 2 chunks") {
-        Stream stream(io_executor, string_writer);
+        Stream stream(io_executor, string_writer, /* request_id */ 0);
 
         nlohmann::json json = R"({
             "check": "check",
@@ -68,7 +68,7 @@ TEST_CASE_METHOD(StreamTest, "json::Stream API", "[rpc][json]") {
     boost::asio::any_io_executor io_executor = ioc_.get_executor();
 
     StringWriter string_writer;
-    Stream stream(io_executor, string_writer);
+    Stream stream(io_executor, string_writer, /* request_id */ 0);
 
     SECTION("write_json json") {
         nlohmann::json json = R"({
@@ -318,7 +318,7 @@ TEST_CASE_METHOD(StreamTest, "json::Stream threading", "[rpc][json]") {
     constexpr std::string_view kData{R"({"test":"test"})"};
 
     StringWriter string_writer;
-    Stream stream(io_executor, string_writer, 1);  // tiny buffer capacity
+    Stream stream(io_executor, string_writer, /* request_id */ 0, 1);  // tiny buffer capacity
 
     const nlohmann::json json = R"({"test":"test"})"_json;
 

--- a/silkworm/rpc/json_rpc/request_handler.hpp
+++ b/silkworm/rpc/json_rpc/request_handler.hpp
@@ -34,10 +34,10 @@ class RequestHandler : public rpc::RequestHandler {
     RequestHandler(const RequestHandler&) = delete;
     RequestHandler& operator=(const RequestHandler&) = delete;
 
-    Task<std::optional<std::string>> handle(const std::string& request) override;
+    Task<std::optional<std::string>> handle(const std::string& request, uint64_t request_id) override;
 
   protected:
-    Task<bool> handle_request_and_create_reply(const nlohmann::json& request_json, std::string& response);
+    Task<bool> handle_request_and_create_reply(const nlohmann::json& request_json, std::string& response, uint64_t request_id);
 
   private:
     nlohmann::json prevalidate_and_parse(const std::string& request);
@@ -51,7 +51,7 @@ class RequestHandler : public rpc::RequestHandler {
         commands::RpcApiTable::HandleMethodGlaze handler,
         const nlohmann::json& request_json,
         std::string& response);
-    Task<void> handle_request(commands::RpcApiTable::HandleStream handler, const nlohmann::json& request_json);
+    Task<void> handle_request(commands::RpcApiTable::HandleStream handler, const nlohmann::json& request_json, uint64_t request_id);
 
     StreamWriter* stream_writer_;
 

--- a/silkworm/rpc/test_util/api_test_database.hpp
+++ b/silkworm/rpc/test_util/api_test_database.hpp
@@ -29,10 +29,10 @@ inline constexpr size_t kDefaultCapacity = 4 * 1024;
 
 class ChannelForTest : public StreamWriter {
   public:
-    Task<void> open_stream() override { co_return; }
+    Task<void> open_stream(uint64_t /* request_id */) override { co_return; }
     size_t get_capacity() const noexcept override { return kDefaultCapacity; }
-    Task<void> close_stream() override { co_return; }
-    Task<size_t> write(std::string_view /* content */, bool /* last */) override { co_return 0; }
+    Task<void> close_stream(uint64_t /* request_id */) override { co_return; }
+    Task<size_t> write(uint64_t /* request_id */, std::string_view /* content */, bool /* last */) override { co_return 0; }
 };
 
 class RequestHandlerForTest : public json_rpc::RequestHandler {
@@ -43,11 +43,11 @@ class RequestHandlerForTest : public json_rpc::RequestHandler {
         : json_rpc::RequestHandler(channel, rpc_api, rpc_api_table) {}
 
     Task<void> request_and_create_reply(const nlohmann::json& request_json, std::string& response) {
-        co_await RequestHandler::handle_request_and_create_reply(request_json, response);
+        co_await RequestHandler::handle_request_and_create_reply(request_json, response, /* request_id */ 0);
     }
 
     Task<void> handle_request(const std::string& request, std::string& response) {
-        auto answer = co_await RequestHandler::handle(request);
+        auto answer = co_await RequestHandler::handle(request, /* request_id */ 0);
         if (answer) {
             response = *answer;
         }

--- a/silkworm/rpc/transport/request_handler.hpp
+++ b/silkworm/rpc/transport/request_handler.hpp
@@ -26,7 +26,7 @@ class RequestHandler {
     RequestHandler(const RequestHandler&) = delete;
     RequestHandler& operator=(const RequestHandler&) = delete;
 
-    virtual Task<std::optional<Response>> handle(const Request& request) = 0;
+    virtual Task<std::optional<Response>> handle(const Request& request, uint64_t request_id) = 0;
 };
 
 using RequestHandlerPtr = std::unique_ptr<RequestHandler>;

--- a/silkworm/rpc/transport/stream_writer.hpp
+++ b/silkworm/rpc/transport/stream_writer.hpp
@@ -15,13 +15,13 @@ class StreamWriter {
   public:
     virtual ~StreamWriter() = default;
 
-    virtual Task<void> open_stream() = 0;
-    virtual Task<void> close_stream() = 0;
-    virtual Task<size_t> write(std::string_view content, bool last) = 0;
+    virtual Task<void> open_stream(uint64_t request_id) = 0;
+    virtual Task<void> close_stream(uint64_t request_id) = 0;
+    virtual Task<size_t> write(uint64_t request_id, std::string_view content, bool last) = 0;
     virtual size_t get_capacity() const noexcept = 0;
 };
 
-inline constexpr size_t kDefaultCapacity = 4096;
+inline constexpr size_t kDefaultCapacity = 2048;
 
 class StringWriter : public StreamWriter {
   public:
@@ -33,11 +33,11 @@ class StringWriter : public StreamWriter {
 
     size_t get_capacity() const noexcept override { return kDefaultCapacity; }
 
-    Task<void> open_stream() override { co_return; }
+    Task<void> open_stream(uint64_t /* request_id */) override { co_return; }
 
-    Task<void> close_stream() override { co_return; }
+    Task<void> close_stream(uint64_t /* request_id */) override { co_return; }
 
-    Task<size_t> write(std::string_view content, bool /*last*/) override {
+    Task<size_t> write(uint64_t /* request_id */, std::string_view content, bool /*last*/) override {
         content_.append(content);
         co_return content.size();
     }

--- a/silkworm/rpc/ws/connection.cpp
+++ b/silkworm/rpc/ws/connection.cpp
@@ -76,13 +76,13 @@ Task<void> Connection::do_read() {
 
     SILK_TRACE << "ws::Connection::do_read bytes_read: " << bytes_read << " [" << req_content << "]";
 
-    auto rsp_content = co_await handler_->handle(req_content);
+    auto rsp_content = co_await handler_->handle(req_content, request_id_++);
     if (rsp_content) {
         co_await do_write(*rsp_content);
     }
 }
 
-Task<size_t> Connection::write(std::string_view content, bool last) {
+Task<size_t> Connection::write(uint64_t /* request_id */, std::string_view content, bool last) {
     try {
         const auto written = co_await stream_.async_write_some(last, boost::asio::buffer(content.data(), content.size()), boost::asio::use_awaitable);
 

--- a/silkworm/rpc/ws/connection.hpp
+++ b/silkworm/rpc/ws/connection.hpp
@@ -43,10 +43,10 @@ class Connection : public StreamWriter {
     Task<void> read_loop();
 
     // Methods of StreamWriter interface
-    Task<void> open_stream() override { co_return; }
-    Task<void> close_stream() override { co_return; }
+    Task<void> open_stream(uint64_t /* request_id */) override { co_return; }
+    Task<void> close_stream(uint64_t /* request_id */) override { co_return; }
     size_t get_capacity() const noexcept override { return kDefaultCapacity; }
-    Task<size_t> write(std::string_view content, bool last) override;
+    Task<size_t> write(uint64_t request_id, std::string_view content, bool last) override;
 
   private:
     Task<void> do_read();
@@ -62,6 +62,8 @@ class Connection : public StreamWriter {
 
     //! enable compress flag
     bool compression_{false};
+
+    uint64_t request_id_{0};
 };
 
 }  // namespace silkworm::rpc::ws


### PR DESCRIPTION
This PR for streaming API:
- add http chunking indipendent to json chunking
- add "\n" at last chr
- in case of message shorter than 2048 are transmitted without chunking
- limitation: the compression is done at json-chunking no streaming compression because it is not supported by deflater library